### PR TITLE
Add StatsTester class for creating test instances of StatsManager.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/Stats.java
+++ b/core/src/main/java/io/opencensus/stats/Stats.java
@@ -13,18 +13,12 @@
 
 package io.opencensus.stats;
 
-import com.google.common.annotations.VisibleForTesting;
-import io.opencensus.internal.Provider;
-import java.util.logging.Level;
-import java.util.logging.Logger;
+import io.opencensus.stats.internal.StatsInternal;
 import javax.annotation.Nullable;
 
 /** {@link Stats}. */
 public final class Stats {
-  private static final Logger logger = Logger.getLogger(Stats.class.getName());
-
-  private static final StatsManager statsManager =
-      loadStatsManager(Provider.getCorrectClassLoader(StatsManager.class));
+  private static final StatsManager statsManager = StatsInternal.getStatsManager();
 
   /** Returns the default {@link StatsContextFactory}. */
   @Nullable
@@ -36,38 +30,6 @@ public final class Stats {
   @Nullable
   public static StatsManager getStatsManager() {
     return statsManager;
-  }
-
-  // Any provider that may be used for StatsManager can be added here.
-  @VisibleForTesting
-  @Nullable
-  static StatsManager loadStatsManager(ClassLoader classLoader) {
-    try {
-      // Call Class.forName with literal string name of the class to help shading tools.
-      return Provider.createInstance(
-          Class.forName("io.opencensus.stats.StatsManagerImpl", true, classLoader),
-          StatsManager.class);
-    } catch (ClassNotFoundException e) {
-      logger.log(
-          Level.FINE,
-          "Couldn't load full implementation for StatsManager, now trying to load lite "
-              + "implementation.",
-          e);
-    }
-    try {
-      // Call Class.forName with literal string name of the class to help shading tools.
-      return Provider.createInstance(
-          Class.forName("io.opencensus.stats.StatsManagerImplLite", true, classLoader),
-          StatsManager.class);
-    } catch (ClassNotFoundException e) {
-      logger.log(
-          Level.FINE,
-          "Couldn't load lite implementation for StatsManager, now using "
-              + "default implementation for StatsManager.",
-          e);
-    }
-    // TODO: Add a no-op implementation.
-    return null;
   }
 
   private Stats() {}

--- a/core/src/main/java/io/opencensus/stats/Stats.java
+++ b/core/src/main/java/io/opencensus/stats/Stats.java
@@ -18,7 +18,13 @@ import javax.annotation.Nullable;
 
 /** {@link Stats}. */
 public final class Stats {
-  private static final StatsManager statsManager = StatsInternal.getStatsManager();
+  @Nullable
+  private static final StatsManagerFactory statsManagerFactory =
+      StatsInternal.getStatsManagerFactory();
+
+  @Nullable
+  private static final StatsManager statsManager =
+      statsManagerFactory == null ? null : statsManagerFactory.getDefaultStatsManager();
 
   /** Returns the default {@link StatsContextFactory}. */
   @Nullable

--- a/core/src/main/java/io/opencensus/stats/StatsManager.java
+++ b/core/src/main/java/io/opencensus/stats/StatsManager.java
@@ -32,5 +32,5 @@ public abstract class StatsManager {
   /**
    * Returns the default {@link StatsContextFactory}.
    */
-  abstract StatsContextFactory getStatsContextFactory();
+  public abstract StatsContextFactory getStatsContextFactory();
 }

--- a/core/src/main/java/io/opencensus/stats/StatsManagerFactory.java
+++ b/core/src/main/java/io/opencensus/stats/StatsManagerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats;
+
+import io.opencensus.common.Clock;
+
+/**
+ * Object that determines which implementation of the {@link StatsManager} to use.
+ */
+public abstract class StatsManagerFactory {
+
+  /**
+   * Returns the default {@link StatsManager}.
+   */
+  public abstract StatsManager getDefaultStatsManager();
+
+  /**
+   * Creates a new {@link StatsManager} for testing.
+   */
+  public abstract StatsManager createTestStatsManager();
+
+  /**
+   * Creates a new {@link StatsManager} for testing.
+   *
+   * @param clock The clock that the {@code StatsManager} should use.
+   */
+  public abstract StatsManager createTestStatsManager(Clock clock);
+}

--- a/core/src/main/java/io/opencensus/stats/internal/StatsInternal.java
+++ b/core/src/main/java/io/opencensus/stats/internal/StatsInternal.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats.internal;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.internal.Provider;
+import io.opencensus.stats.StatsManager;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Class for instantiating the {@link StatsManager}. */
+public final class StatsInternal {
+  private static final Logger logger = Logger.getLogger(StatsInternal.class.getName());
+
+  private static final StatsManager statsManager =
+      loadStatsManager(Provider.getCorrectClassLoader(StatsManager.class));
+
+  /** Returns the default {@link StatsManager}. */
+  @Nullable
+  public static StatsManager getStatsManager() {
+    return statsManager;
+  }
+
+  // Any provider that may be used for StatsManager can be added here.
+  @VisibleForTesting
+  @Nullable
+  static StatsManager loadStatsManager(ClassLoader classLoader) {
+    try {
+      // Call Class.forName with literal string name of the class to help shading tools.
+      return Provider.createInstance(
+          Class.forName("io.opencensus.stats.StatsManagerImpl", true, classLoader),
+          StatsManager.class);
+    } catch (ClassNotFoundException e) {
+      logger.log(
+          Level.FINE,
+          "Couldn't load full implementation for StatsManager, now trying to load lite "
+              + "implementation.",
+          e);
+    }
+    try {
+      // Call Class.forName with literal string name of the class to help shading tools.
+      return Provider.createInstance(
+          Class.forName("io.opencensus.stats.StatsManagerImplLite", true, classLoader),
+          StatsManager.class);
+    } catch (ClassNotFoundException e) {
+      logger.log(
+          Level.FINE,
+          "Couldn't load lite implementation for StatsManager, now using "
+              + "default implementation for StatsManager.",
+          e);
+    }
+    // TODO: Add a no-op implementation.
+    return null;
+  }
+
+  private StatsInternal() {}
+}

--- a/core/src/main/java/io/opencensus/stats/internal/StatsInternal.java
+++ b/core/src/main/java/io/opencensus/stats/internal/StatsInternal.java
@@ -15,50 +15,51 @@ package io.opencensus.stats.internal;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.internal.Provider;
-import io.opencensus.stats.StatsManager;
+import io.opencensus.stats.StatsManagerFactory;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-/** Class for instantiating the {@link StatsManager}. */
+/** Class for instantiating the {@link StatsManagerFactory}. */
 public final class StatsInternal {
   private static final Logger logger = Logger.getLogger(StatsInternal.class.getName());
 
-  private static final StatsManager statsManager =
-      loadStatsManager(Provider.getCorrectClassLoader(StatsManager.class));
+  private static final StatsManagerFactory statsManagerFactory =
+      loadStatsManagerFactory(Provider.getCorrectClassLoader(StatsManagerFactory.class));
 
-  /** Returns the default {@link StatsManager}. */
+  /** Returns the {@link StatsManagerFactory} singleton. */
   @Nullable
-  public static StatsManager getStatsManager() {
-    return statsManager;
+  public static StatsManagerFactory getStatsManagerFactory() {
+    return statsManagerFactory;
   }
 
-  // Any provider that may be used for StatsManager can be added here.
+  // Any provider that may be used for StatsManagerFactory can be added here.
   @VisibleForTesting
   @Nullable
-  static StatsManager loadStatsManager(ClassLoader classLoader) {
+  static StatsManagerFactory loadStatsManagerFactory(ClassLoader classLoader) {
     try {
       // Call Class.forName with literal string name of the class to help shading tools.
       return Provider.createInstance(
-          Class.forName("io.opencensus.stats.StatsManagerImpl", true, classLoader),
-          StatsManager.class);
+          Class.forName("io.opencensus.stats.StatsManagerFactoryImpl", true, classLoader),
+          StatsManagerFactory.class);
     } catch (ClassNotFoundException e) {
       logger.log(
           Level.FINE,
-          "Couldn't load full implementation for StatsManager, now trying to load lite "
+          "Couldn't load full implementation for StatsManagerFactory, now trying to load lite "
               + "implementation.",
           e);
     }
     try {
       // Call Class.forName with literal string name of the class to help shading tools.
       return Provider.createInstance(
-          Class.forName("io.opencensus.stats.StatsManagerImplLite", true, classLoader),
-          StatsManager.class);
+          Class.forName(
+              "io.opencensus.stats.StatsManagerFactoryImplLite", true, classLoader),
+          StatsManagerFactory.class);
     } catch (ClassNotFoundException e) {
       logger.log(
           Level.FINE,
-          "Couldn't load lite implementation for StatsManager, now using "
-              + "default implementation for StatsManager.",
+          "Couldn't load lite implementation for StatsManagerFactory, now using "
+              + "default implementation for StatsManagerFactory.",
           e);
     }
     // TODO: Add a no-op implementation.

--- a/core/src/main/java/io/opencensus/testing/stats/StatsTester.java
+++ b/core/src/main/java/io/opencensus/testing/stats/StatsTester.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.testing.stats;
+
+import io.opencensus.common.Clock;
+import io.opencensus.stats.StatsManager;
+import io.opencensus.stats.internal.StatsInternal;
+import javax.annotation.Nullable;
+
+/**
+ * Stats testing utilities.
+ */
+public final class StatsTester {
+  private StatsTester() {}
+
+  /**
+   * Creates a new {@link StatsManager} for testing.
+   */
+  @Nullable
+  public static StatsManager createTestStatsManager() {
+    return StatsInternal.getStatsManagerFactory().createTestStatsManager();
+  }
+
+  /**
+   * Creates a new {@link StatsManager} for testing.
+   *
+   * @param clock The clock that the {@code StatsManager} should use.
+   */
+  @Nullable
+  public static StatsManager createTestStatsManager(Clock clock) {
+    return StatsInternal.getStatsManagerFactory().createTestStatsManager(clock);
+  }
+}

--- a/core/src/test/java/io/opencensus/stats/StatsTest.java
+++ b/core/src/test/java/io/opencensus/stats/StatsTest.java
@@ -15,43 +15,13 @@ package io.opencensus.stats;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link Stats}. */
 @RunWith(JUnit4.class)
 public final class StatsTest {
-  @Rule public ExpectedException thrown = ExpectedException.none();
-
-  @Test
-  public void loadStatsManager_UsesProvidedClassLoader() {
-    final RuntimeException toThrow = new RuntimeException("UseClassLoader");
-    thrown.expect(RuntimeException.class);
-    thrown.expectMessage("UseClassLoader");
-    Stats.loadStatsManager(
-        new ClassLoader() {
-          @Override
-          public Class<?> loadClass(String name) {
-            throw toThrow;
-          }
-        });
-  }
-
-  @Test
-  public void loadStatsManager_IgnoresMissingClasses() {
-    assertThat(
-            Stats.loadStatsManager(
-                    new ClassLoader() {
-                      @Override
-                      public Class<?> loadClass(String name) throws ClassNotFoundException {
-                        throw new ClassNotFoundException();
-                      }
-                    }))
-        .isNull();
-  }
 
   @Test
   public void defaultValues() {

--- a/core/src/test/java/io/opencensus/stats/internal/StatsInternalTest.java
+++ b/core/src/test/java/io/opencensus/stats/internal/StatsInternalTest.java
@@ -31,7 +31,7 @@ public final class StatsInternalTest {
     final RuntimeException toThrow = new RuntimeException("UseClassLoader");
     thrown.expect(RuntimeException.class);
     thrown.expectMessage("UseClassLoader");
-    StatsInternal.loadStatsManager(
+    StatsInternal.loadStatsManagerFactory(
         new ClassLoader() {
           @Override
           public Class<?> loadClass(String name) {
@@ -43,7 +43,7 @@ public final class StatsInternalTest {
   @Test
   public void loadStatsManager_IgnoresMissingClasses() {
     assertThat(
-            StatsInternal.loadStatsManager(
+            StatsInternal.loadStatsManagerFactory(
                     new ClassLoader() {
                       @Override
                       public Class<?> loadClass(String name) throws ClassNotFoundException {
@@ -55,6 +55,6 @@ public final class StatsInternalTest {
 
   @Test
   public void defaultValues() {
-    assertThat(StatsInternal.getStatsManager()).isNull();
+    assertThat(StatsInternal.getStatsManagerFactory()).isNull();
   }
 }

--- a/core/src/test/java/io/opencensus/stats/internal/StatsInternalTest.java
+++ b/core/src/test/java/io/opencensus/stats/internal/StatsInternalTest.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link StatsInternal}. */
+@RunWith(JUnit4.class)
+public final class StatsInternalTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void loadStatsManager_UsesProvidedClassLoader() {
+    final RuntimeException toThrow = new RuntimeException("UseClassLoader");
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("UseClassLoader");
+    StatsInternal.loadStatsManager(
+        new ClassLoader() {
+          @Override
+          public Class<?> loadClass(String name) {
+            throw toThrow;
+          }
+        });
+  }
+
+  @Test
+  public void loadStatsManager_IgnoresMissingClasses() {
+    assertThat(
+            StatsInternal.loadStatsManager(
+                    new ClassLoader() {
+                      @Override
+                      public Class<?> loadClass(String name) throws ClassNotFoundException {
+                        throw new ClassNotFoundException();
+                      }
+                    }))
+        .isNull();
+  }
+
+  @Test
+  public void defaultValues() {
+    assertThat(StatsInternal.getStatsManager()).isNull();
+  }
+}

--- a/core_impl/src/main/java/io/opencensus/stats/StatsContextFactoryImpl.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsContextFactoryImpl.java
@@ -22,10 +22,10 @@ import java.util.Collections;
  * Native Implementation of {@link StatsContextFactory}.
  */
 final class StatsContextFactoryImpl extends StatsContextFactory {
-  private final StatsManagerImplBase statsManager;
+  private final StatsManagerImpl statsManager;
   private final StatsContextImpl defaultStatsContext;
 
-  StatsContextFactoryImpl(StatsManagerImplBase statsManager) {
+  StatsContextFactoryImpl(StatsManagerImpl statsManager) {
     this.statsManager = Preconditions.checkNotNull(statsManager);
     this.defaultStatsContext =
         new StatsContextImpl(statsManager, Collections.<TagKey, TagValue>emptyMap());

--- a/core_impl/src/main/java/io/opencensus/stats/StatsContextImpl.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsContextImpl.java
@@ -24,10 +24,10 @@ import java.util.Map;
  * Native Implementation of {@link StatsContext}.
  */
 final class StatsContextImpl extends StatsContext {
-  private final StatsManagerImplBase statsManager;
+  private final StatsManagerImpl statsManager;
   final Map<TagKey, TagValue> tags;
 
-  StatsContextImpl(StatsManagerImplBase statsManager, Map<TagKey, TagValue> tags) {
+  StatsContextImpl(StatsManagerImpl statsManager, Map<TagKey, TagValue> tags) {
     this.statsManager = Preconditions.checkNotNull(statsManager);
     this.tags = Preconditions.checkNotNull(tags);
   }
@@ -69,10 +69,10 @@ final class StatsContextImpl extends StatsContext {
   }
 
   static final class Builder extends StatsContext.Builder {
-    private final StatsManagerImplBase statsManager;
+    private final StatsManagerImpl statsManager;
     private final HashMap<TagKey, TagValue> tags;
 
-    private Builder(StatsManagerImplBase statsManager, Map<TagKey, TagValue> tags) {
+    private Builder(StatsManagerImpl statsManager, Map<TagKey, TagValue> tags) {
       this.statsManager = statsManager;
       this.tags = new HashMap<TagKey, TagValue>(tags);
     }

--- a/core_impl/src/main/java/io/opencensus/stats/StatsManagerFactoryImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsManagerFactoryImplBase.java
@@ -13,16 +13,16 @@
 
 package io.opencensus.stats;
 
-import io.opencensus.common.MillisClock;
+import io.opencensus.common.Clock;
 import io.opencensus.internal.SimpleEventQueue;
+import io.opencensus.stats.StatsManager;
+import io.opencensus.stats.StatsManagerFactory;
 
-/**
- * Android-compatible implementation of {@link StatsManager}.
- */
-public final class StatsManagerImplLite extends StatsManagerImplBase {
+/** Base implementation of {@link StatsManagerFactory}. */
+public abstract class StatsManagerFactoryImplBase extends StatsManagerFactory {
 
-  public StatsManagerImplLite() {
-    // TODO(sebright): Use a more efficient queue implementation.
-    super(new SimpleEventQueue(), MillisClock.getInstance());
+  @Override
+  public final StatsManager createTestStatsManager(Clock clock) {
+    return new StatsManagerImpl(new SimpleEventQueue(), clock);
   }
 }

--- a/core_impl/src/main/java/io/opencensus/stats/StatsManagerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsManagerImpl.java
@@ -19,7 +19,7 @@ import io.opencensus.internal.EventQueue;
 /**
  * Base implementation of {@link StatsManager}.
  */
-class StatsManagerImplBase extends StatsManager {
+public final class StatsManagerImpl extends StatsManager {
 
   // StatsManagerImplBase delegates all operations related to stats to ViewManager in order to keep
   // StatsManagerImplBase simple.
@@ -29,7 +29,7 @@ class StatsManagerImplBase extends StatsManager {
   // created in the constructor.  Multiple initializations are okay.
   private volatile StatsContextFactoryImpl statsContextFactory;
 
-  StatsManagerImplBase(EventQueue queue, Clock clock) {
+  public StatsManagerImpl(EventQueue queue, Clock clock) {
     this.viewManager = new ViewManager(queue, clock);
   }
 
@@ -50,7 +50,7 @@ class StatsManagerImplBase extends StatsManager {
   }
 
   @Override
-  StatsContextFactoryImpl getStatsContextFactory() {
+  public StatsContextFactoryImpl getStatsContextFactory() {
     StatsContextFactoryImpl factory = statsContextFactory;
     if (factory == null) {
       statsContextFactory = factory = new StatsContextFactoryImpl(this);

--- a/core_impl/src/main/java/io/opencensus/stats/StatsSerializer.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsSerializer.java
@@ -89,7 +89,7 @@ final class StatsSerializer {
 
   // Deserializes input to StatsContext based on the binary format standard.
   // The encoded tags are of the form: <version_id><encoded_tags>
-  static StatsContextImpl deserialize(StatsManagerImplBase statsManager, InputStream input)
+  static StatsContextImpl deserialize(StatsManagerImpl statsManager, InputStream input)
       throws IOException {
     try {
       byte[] bytes = ByteStreams.toByteArray(input);

--- a/core_impl/src/test/java/io/opencensus/stats/StatsContextFactoryTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsContextFactoryTest.java
@@ -39,8 +39,8 @@ public class StatsContextFactoryTest {
   private static final String VALUE_STRING = "String";
   private static final int VALUE_INT = 10;
 
-  private final StatsManagerImplBase statsManager =
-      new StatsManagerImplBase(new SimpleEventQueue(), TestClock.create());
+  private final StatsManagerImpl statsManager =
+      new StatsManagerImpl(new SimpleEventQueue(), TestClock.create());
   private final StatsContextFactory factory = new StatsContextFactoryImpl(statsManager);
   private final HashMap<TagKey, TagValue> sampleTags = new HashMap<TagKey, TagValue>();
   private final StatsContext defaultCtx = factory.getDefault();

--- a/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
@@ -41,8 +41,8 @@ import org.junit.runners.JUnit4;
 public class StatsContextTest {
   private static final double TOLERANCE = 1e-6;
 
-  private final StatsManagerImplBase statsManager =
-      new StatsManagerImplBase(new SimpleEventQueue(), TestClock.create());
+  private final StatsManagerImpl statsManager =
+      new StatsManagerImpl(new SimpleEventQueue(), TestClock.create());
   private final StatsContextFactory factory = statsManager.getStatsContextFactory();
   private final StatsContext defaultStatsContext = factory.getDefault();
 

--- a/core_impl/src/test/java/io/opencensus/stats/StatsManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsManagerImplTest.java
@@ -34,7 +34,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link StatsManagerImplBase}. */
+/** Tests for {@link StatsManagerImpl}. */
 @RunWith(JUnit4.class)
 public class StatsManagerImplTest {
 
@@ -74,8 +74,8 @@ public class StatsManagerImplTest {
 
   private final TestClock clock = TestClock.create();
 
-  private final StatsManagerImplBase statsManager =
-      new StatsManagerImplBase(new SimpleEventQueue(), clock);
+  private final StatsManagerImpl statsManager =
+      new StatsManagerImpl(new SimpleEventQueue(), clock);
 
   private final StatsContextFactoryImpl factory = new StatsContextFactoryImpl(statsManager);
 

--- a/core_impl_android/src/main/java/io/opencensus/stats/StatsManagerFactoryImplLite.java
+++ b/core_impl_android/src/main/java/io/opencensus/stats/StatsManagerFactoryImplLite.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats;
+
+import io.opencensus.common.MillisClock;
+import io.opencensus.internal.SimpleEventQueue;
+
+/** Android-compatible implementation of {@link StatsManagerFactory}. */
+public final class StatsManagerFactoryImplLite extends StatsManagerFactoryImplBase {
+
+  /** Public constructor to be used with reflection loading. */
+  public StatsManagerFactoryImplLite() {}
+
+  private final StatsManager defaultStatsManager = createStatsManager();
+
+  @Override
+  public final StatsManager createTestStatsManager() {
+    return createStatsManager();
+  }
+
+  @Override
+  public StatsManager getDefaultStatsManager() {
+    return defaultStatsManager;
+  }
+
+  private static StatsManager createStatsManager() {
+    // TODO(sebright): Use a more efficient queue implementation.
+    return new StatsManagerImpl(new SimpleEventQueue(), MillisClock.getInstance());
+  }
+}

--- a/core_impl_android/src/test/java/io/opencensus/stats/StatsTest.java
+++ b/core_impl_android/src/test/java/io/opencensus/stats/StatsTest.java
@@ -26,7 +26,7 @@ import org.junit.runners.JUnit4;
 public final class StatsTest {
   @Test
   public void getStatsManager() {
-    assertThat(Stats.getStatsManager()).isInstanceOf(StatsManagerImplLite.class);
+    assertThat(Stats.getStatsManager()).isInstanceOf(StatsManagerImpl.class);
   }
 
   @Test

--- a/core_impl_java/src/main/java/io/opencensus/stats/StatsManagerFactoryImpl.java
+++ b/core_impl_java/src/main/java/io/opencensus/stats/StatsManagerFactoryImpl.java
@@ -16,11 +16,25 @@ package io.opencensus.stats;
 import io.opencensus.common.MillisClock;
 import io.opencensus.internal.DisruptorEventQueue;
 
-/** Java 7 and 8 implementation of {@link StatsManager}. */
-public final class StatsManagerImpl extends StatsManagerImplBase {
+/** Java 7 and 8 implementation of {@link StatsManagerFactory}. */
+public final class StatsManagerFactoryImpl extends StatsManagerFactoryImplBase {
 
   /** Public constructor to be used with reflection loading. */
-  public StatsManagerImpl() {
-    super(DisruptorEventQueue.getInstance(), MillisClock.getInstance());
+  public StatsManagerFactoryImpl() {}
+
+  private final StatsManager defaultStatsManager = createStatsManager();
+
+  @Override
+  public final StatsManager createTestStatsManager() {
+    return createStatsManager();
+  }
+
+  @Override
+  public StatsManager getDefaultStatsManager() {
+    return defaultStatsManager;
+  }
+
+  private static StatsManager createStatsManager() {
+    return new StatsManagerImpl(DisruptorEventQueue.getInstance(), MillisClock.getInstance());
   }
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -10,7 +10,8 @@ dependencies {
             project(':core_impl'),
             project(':core_impl_java'),
             project(':opencensus-api'),
-            project(':opencensus-impl')
+            project(':opencensus-impl'),
+            project(':opencensus-testing')
 }
 
 // Provide convenience executables for trying out the examples.
@@ -21,6 +22,13 @@ startScripts.enabled = false
 task statsRunner(type: CreateStartScripts) {
     mainClassName = 'io.opencensus.examples.stats.StatsRunner'
     applicationName = 'StatsRunner'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
+
+task statsTesting(type: CreateStartScripts) {
+    mainClassName = 'io.opencensus.examples.stats.StatsTesting'
+    applicationName = 'StatsTesting'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }
@@ -51,5 +59,6 @@ applicationDistribution.into('bin') {
     from(multiSpansScopedTracing)
     from(multiSpansContextTracing)
     from(statsRunner)
+    from(statsTesting)
     fileMode = 0755
 }

--- a/examples/src/main/java/io/opencensus/examples/stats/StatsTesting.java
+++ b/examples/src/main/java/io/opencensus/examples/stats/StatsTesting.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.examples.stats;
+
+import io.opencensus.common.Clock;
+import io.opencensus.common.NonThrowingCloseable;
+import io.opencensus.common.Timestamp;
+import io.opencensus.stats.MeasurementMap;
+import io.opencensus.stats.RpcMeasurementConstants;
+import io.opencensus.stats.RpcViewConstants;
+import io.opencensus.stats.Stats;
+import io.opencensus.stats.StatsContextFactory;
+import io.opencensus.stats.StatsManager;
+import io.opencensus.stats.TagValue;
+import io.opencensus.testing.common.TestClock;
+import io.opencensus.testing.stats.StatsTester;
+
+/** Simple program that demonstrates the use of a test {@code StatsManager}. */
+public final class StatsTesting {
+
+  /**
+   * This main method runs {@code MyProgram.run()} twice, once with a test {@code StatsManager}, and
+   * again with the default {@code StatsManager}.
+   */
+  public static void main(String[] args) throws InterruptedException {
+    System.out.println("Test run:");
+    Clock testClock = TestClock.create(Timestamp.create(1L, 0));
+    MyProgram test = new MyProgram(StatsTester.createTestStatsManager(testClock));
+    test.run();
+
+    System.out.println();
+    System.out.println("Non-test run:");
+    MyProgram nonTest = new MyProgram(Stats.getStatsManager());
+    nonTest.run();
+
+    // TODO(sebright): Prevent EventQueue from blocking shutdown and then remove this call to exit.
+    System.exit(0);
+  }
+
+  /** A simple instrumented program. */
+  public static final class MyProgram {
+    private final StatsManager statsManager;
+    private final StatsContextFactory ctxFactory;
+
+    public MyProgram(StatsManager statsManager) {
+      this.statsManager = statsManager;
+      this.ctxFactory = statsManager.getStatsContextFactory();
+    }
+
+    /** Runs the example instrumented program. */
+    public void run() throws InterruptedException {
+      statsManager.registerView(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
+      try (NonThrowingCloseable ctx =
+          ctxFactory.withStatsContext(
+              ctxFactory
+                  .getDefault()
+                  .with(RpcMeasurementConstants.RPC_CLIENT_METHOD, TagValue.create("my method")))) {
+        ctxFactory
+            .getCurrentStatsContext()
+            .record(MeasurementMap.of(RpcMeasurementConstants.RPC_CLIENT_ROUNDTRIP_LATENCY, 0.5));
+      }
+
+      // TODO(sebright): Add a method to shut down or flush the EventQueue, and remove this call to
+      // sleep().
+      Thread.sleep(1);  // Wait for EventQueue to process the measurement.
+
+      System.out.println(statsManager.getView(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW));
+    }
+  }
+}


### PR DESCRIPTION
This commit changes the way that StatsManagers are created.  Instead of
instantiating one StatsManager with reflection, the Stats class now instantiates
a StatsManagerFactory, which can provide the default StatsManager instance
and parameterized test StatsManager instances.  The test instances are exposed
through a new class, StatsTester.  I added an example program, StatsTesting,
that demonstrates how to use a test StatsManager.

This commit makes several API changes:
- StatsManager.getStatsContextFactory() is now public.
- Stats implementations must extend StatsManagerFactory instead of StatsManager.
- It adds StatsTester.
~~- It renames Stats.getStatsManager() to Stats.getDefaultStatsManager().~~

_____________________________________

/cc @dinooliva @songy23 

EDIT: Here is an example of the test utilities in use: https://github.com/census-instrumentation/instrumentation-java/pull/334/files#diff-b5bd8381d56f10b3e53baa24771eb840R30