### PR TITLE
Remove "sudo: required" and "dist: trusty" from .travis.yml.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
-sudo: required
-dist: trusty
+sudo: false
+
 language: java
 
 matrix:


### PR DESCRIPTION
These settings are no longer required, because we aren't using Bazel.

This commit fixes the build after Travis updated the environment: https://travis-ci.org/census-instrumentation/opencensus-java/jobs/247751414

/cc @dinooliva @bogdandrutu 