### PR TITLE
Change tracer API names to create a SpanBuilder.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/SpanBuilder.java
+++ b/api/src/main/java/io/opencensus/trace/SpanBuilder.java
@@ -87,7 +87,7 @@ import javax.annotation.Nullable;
  * class MyClass {
  *   private static final Tracer tracer = Tracing.getTracer();
  *   void DoWork(Span parent) {
- *     Span childSpan = tracer.spanBuilderWithParent("MyRootSpan", parent).startSpan();
+ *     Span childSpan = tracer.spanBuilderWithExplicitParent("MyChildSpan", parent).startSpan();
  *     childSpan.addAnnotation("my annotation");
  *     try {
  *       doSomeWork(childSpan); // Manually propagate the new span down the stack.
@@ -146,7 +146,7 @@ public abstract class SpanBuilder {
    * class MyClass {
    *   private static final Tracer tracer = Tracing.getTracer();
    *   void DoWork(Span parent) {
-   *     Span childSpan = tracer.spanBuilderWithParent("MyRootSpan", parent).startSpan();
+   *     Span childSpan = tracer.spanBuilderWithExplicitParent("MyChildSpan", parent).startSpan();
    *     childSpan.addAnnotation("my annotation");
    *     try {
    *       doSomeWork(childSpan); // Manually propagate the new span down the stack.

--- a/api/src/main/java/io/opencensus/trace/SpanBuilder.java
+++ b/api/src/main/java/io/opencensus/trace/SpanBuilder.java
@@ -87,7 +87,7 @@ import javax.annotation.Nullable;
  * class MyClass {
  *   private static final Tracer tracer = Tracing.getTracer();
  *   void DoWork() {
- *     Span span = tracer.spanBuilder(null, "MyRootSpan").startSpan();
+ *     Span span = tracer.spanBuilderWithParent(null, "MyRootSpan").startSpan();
  *     span.addAnnotation("my annotation");
  *     try {
  *       doSomeWork(span); // Manually propagate the new span down the stack.
@@ -146,7 +146,7 @@ public abstract class SpanBuilder {
    * class MyClass {
    *   private static final Tracer tracer = Tracing.getTracer();
    *   void DoWork() {
-   *     Span span = tracer.spanBuilder(null, "MyRootSpan").startSpan();
+   *     Span span = tracer.spanBuilderWithParent(null, "MyRootSpan").startSpan();
    *     span.addAnnotation("my annotation");
    *     try {
    *       doSomeWork(span); // Manually propagate the new span down the stack.
@@ -222,13 +222,13 @@ public abstract class SpanBuilder {
   }
 
   static final class NoopSpanBuilder extends SpanBuilder {
-    NoopSpanBuilder(@Nullable Span parentSpan, String name) {
-      checkNotNull(name, "name");
+    static NoopSpanBuilder createWithParent(@Nullable Span parentSpan, String name) {
+      return new NoopSpanBuilder(name);
     }
 
-    NoopSpanBuilder(SpanContext remoteParentSpanContext, String name) {
-      checkNotNull(remoteParentSpanContext, "remoteParentSpanContext");
-      checkNotNull(name, "name");
+    static NoopSpanBuilder createWithRemoteParent(
+        @Nullable SpanContext remoteParentSpanContext, String name) {
+      return new NoopSpanBuilder(name);
     }
 
     @Override
@@ -249,6 +249,10 @@ public abstract class SpanBuilder {
     @Override
     public SpanBuilder setRecordEvents(boolean recordEvents) {
       return this;
+    }
+
+    private NoopSpanBuilder(String name) {
+      checkNotNull(name, "name");
     }
   }
 }

--- a/api/src/main/java/io/opencensus/trace/SpanBuilder.java
+++ b/api/src/main/java/io/opencensus/trace/SpanBuilder.java
@@ -86,14 +86,14 @@ import javax.annotation.Nullable;
  * <pre>{@code
  * class MyClass {
  *   private static final Tracer tracer = Tracing.getTracer();
- *   void DoWork() {
- *     Span span = tracer.spanBuilderWithParent(null, "MyRootSpan").startSpan();
- *     span.addAnnotation("my annotation");
+ *   void DoWork(Span parent) {
+ *     Span childSpan = tracer.spanBuilderWithParent("MyRootSpan", parent).startSpan();
+ *     childSpan.addAnnotation("my annotation");
  *     try {
- *       doSomeWork(span); // Manually propagate the new span down the stack.
+ *       doSomeWork(childSpan); // Manually propagate the new span down the stack.
  *     } finally {
  *       // To make sure we end the span even in case of an exception.
- *       span.end();  // Manually end the span.
+ *       childSpan.end();  // Manually end the span.
  *     }
  *   }
  * }
@@ -145,14 +145,14 @@ public abstract class SpanBuilder {
    * <pre>{@code
    * class MyClass {
    *   private static final Tracer tracer = Tracing.getTracer();
-   *   void DoWork() {
-   *     Span span = tracer.spanBuilderWithParent(null, "MyRootSpan").startSpan();
-   *     span.addAnnotation("my annotation");
+   *   void DoWork(Span parent) {
+   *     Span childSpan = tracer.spanBuilderWithParent("MyRootSpan", parent).startSpan();
+   *     childSpan.addAnnotation("my annotation");
    *     try {
-   *       doSomeWork(span); // Manually propagate the new span down the stack.
+   *       doSomeWork(childSpan); // Manually propagate the new span down the stack.
    *     } finally {
    *       // To make sure we end the span even in case of an exception.
-   *       span.end();  // Manually end the span.
+   *       childSpan.end();  // Manually end the span.
    *     }
    *   }
    * }
@@ -222,13 +222,13 @@ public abstract class SpanBuilder {
   }
 
   static final class NoopSpanBuilder extends SpanBuilder {
-    static NoopSpanBuilder createWithParent(@Nullable Span parentSpan, String name) {
-      return new NoopSpanBuilder(name);
+    static NoopSpanBuilder createWithParent(String spanName, @Nullable Span parent) {
+      return new NoopSpanBuilder(spanName);
     }
 
     static NoopSpanBuilder createWithRemoteParent(
-        @Nullable SpanContext remoteParentSpanContext, String name) {
-      return new NoopSpanBuilder(name);
+        String spanName, @Nullable SpanContext remoteParentSpanContext) {
+      return new NoopSpanBuilder(spanName);
     }
 
     @Override

--- a/api/src/main/java/io/opencensus/trace/Tracer.java
+++ b/api/src/main/java/io/opencensus/trace/Tracer.java
@@ -51,7 +51,7 @@ import javax.annotation.Nullable;
  * class MyClass {
  *   private static final Tracer tracer = Tracing.getTracer();
  *   void doWork(Span parent) {
- *     Span childSpan = tracer.spanBuilderWithParent("MyRootSpan", parent).startSpan();
+ *     Span childSpan = tracer.spanBuilderWithExplicitParent("MyChildSpan", parent).startSpan();
  *     childSpan.addAnnotation("Starting the work.");
  *     try {
  *       doSomeWork(childSpan); // Manually propagate the new span down the stack.
@@ -157,15 +157,15 @@ public abstract class Tracer {
    * <p>This is equivalent with:
    *
    * <pre>{@code
-   * tracer.spanBuilderWithParent("MySpanName",tracer.getCurrentSpan());
+   * tracer.spanBuilderWithExplicitParent("MySpanName",tracer.getCurrentSpan());
    * }</pre>
    *
-   * @param name The name of the returned Span.
+   * @param spanName The name of the returned Span.
    * @return a {@code SpanBuilder} to create and start a new {@code Span}.
-   * @throws NullPointerException if {@code name} is {@code null}.
+   * @throws NullPointerException if {@code spanName} is {@code null}.
    */
-  public final SpanBuilder spanBuilder(String name) {
-    return spanBuilderWithParent(name, ContextUtils.getCurrentSpan());
+  public final SpanBuilder spanBuilder(String spanName) {
+    return spanBuilderWithExplicitParent(spanName, ContextUtils.getCurrentSpan());
   }
 
   /**
@@ -178,13 +178,13 @@ public abstract class Tracer {
    * <p>This <b>must</b> be used to create a {@code Span} when manual Context propagation is used OR
    * when creating a root {@code Span} with a {@code null} parent.
    *
-   * @param spanName The spanName of the returned Span.
+   * @param spanName The name of the returned Span.
    * @param parent The parent of the returned Span. If {@code null} the {@code SpanBuilder} will
    *     build a root {@code Span}.
    * @return a {@code SpanBuilder} to create and start a new {@code Span}.
    * @throws NullPointerException if {@code spanName} is {@code null}.
    */
-  public abstract SpanBuilder spanBuilderWithParent(String spanName, @Nullable Span parent);
+  public abstract SpanBuilder spanBuilderWithExplicitParent(String spanName, @Nullable Span parent);
 
   /**
    * Returns a {@link SpanBuilder} to create and start a new child {@link Span} (or root if parent
@@ -199,7 +199,7 @@ public abstract class Tracer {
    * <p>If no {@link SpanContext} OR fail to parse the {@link SpanContext} on the server side, users
    * must call this method with a {@code null} remote parent {@code SpanContext}.
    *
-   * @param spanName The spanName of the returned Span.
+   * @param spanName The name of the returned Span.
    * @param remoteParentSpanContext The remote parent of the returned Span.
    * @return a {@code SpanBuilder} to create and start a new {@code Span}.
    * @throws NullPointerException if {@code spanName} is {@code null}.
@@ -211,7 +211,7 @@ public abstract class Tracer {
   private static final class NoopTracer extends Tracer {
 
     @Override
-    public SpanBuilder spanBuilderWithParent(String spanName, @Nullable Span parent) {
+    public SpanBuilder spanBuilderWithExplicitParent(String spanName, @Nullable Span parent) {
       return NoopSpanBuilder.createWithParent(spanName, parent);
     }
 

--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -52,7 +52,7 @@ import java.text.ParseException;
  *     // Maybe log the exception.
  *   }
  *   try (NonThrowingCloseable ss =
- *            tracer.spanBuilderWithRemoteParent(spanContext, "Recv.MyRequest").startScopedSpan()) {
+ *            tracer.spanBuilderWithRemoteParent("Recv.MyRequest", spanContext).startScopedSpan()) {
  *     // Handle request and send response back.
  *   }
  * }

--- a/api/src/test/java/io/opencensus/trace/TracerTest.java
+++ b/api/src/test/java/io/opencensus/trace/TracerTest.java
@@ -101,12 +101,12 @@ public class TracerTest {
 
   @Test(expected = NullPointerException.class)
   public void spanBuilderWithParentAndName_NullName() {
-    noopTracer.spanBuilderWithParent(null, null);
+    noopTracer.spanBuilderWithExplicitParent(null, null);
   }
 
   @Test
   public void defaultSpanBuilderWithParentAndName() {
-    assertThat(noopTracer.spanBuilderWithParent(SPAN_NAME, null).startSpan())
+    assertThat(noopTracer.spanBuilderWithExplicitParent(SPAN_NAME, null).startSpan())
         .isSameAs(BlankSpan.INSTANCE);
   }
 
@@ -132,7 +132,8 @@ public class TracerTest {
     NonThrowingCloseable ws = tracer.withSpan(span);
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);
-      when(tracer.spanBuilderWithParent(same(SPAN_NAME), same(span))).thenReturn(spanBuilder);
+      when(tracer.spanBuilderWithExplicitParent(same(SPAN_NAME), same(span)))
+          .thenReturn(spanBuilder);
       assertThat(tracer.spanBuilder(SPAN_NAME)).isSameAs(spanBuilder);
     } finally {
       ws.close();
@@ -144,7 +145,7 @@ public class TracerTest {
     NonThrowingCloseable ws = tracer.withSpan(BlankSpan.INSTANCE);
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
-      when(tracer.spanBuilderWithParent(same(SPAN_NAME), same(BlankSpan.INSTANCE)))
+      when(tracer.spanBuilderWithExplicitParent(same(SPAN_NAME), same(BlankSpan.INSTANCE)))
           .thenReturn(spanBuilder);
       assertThat(tracer.spanBuilder(SPAN_NAME)).isSameAs(spanBuilder);
     } finally {

--- a/api/src/test/java/io/opencensus/trace/TracerTest.java
+++ b/api/src/test/java/io/opencensus/trace/TracerTest.java
@@ -101,12 +101,13 @@ public class TracerTest {
 
   @Test(expected = NullPointerException.class)
   public void spanBuilderWithParentAndName_NullName() {
-    noopTracer.spanBuilder(null, null);
+    noopTracer.spanBuilderWithParent(null, null);
   }
 
   @Test
   public void defaultSpanBuilderWithParentAndName() {
-    assertThat(noopTracer.spanBuilder(null, SPAN_NAME).startSpan()).isSameAs(BlankSpan.INSTANCE);
+    assertThat(noopTracer.spanBuilderWithParent(null, SPAN_NAME).startSpan())
+        .isSameAs(BlankSpan.INSTANCE);
   }
 
   @Test(expected = NullPointerException.class)
@@ -114,9 +115,10 @@ public class TracerTest {
     noopTracer.spanBuilderWithRemoteParent(null, null);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void defaultSpanBuilderWitRemoteParent_NullParent() {
-    noopTracer.spanBuilderWithRemoteParent(null, SPAN_NAME);
+    assertThat(noopTracer.spanBuilderWithRemoteParent(null, SPAN_NAME).startSpan())
+        .isSameAs(BlankSpan.INSTANCE);
   }
 
   @Test
@@ -130,7 +132,7 @@ public class TracerTest {
     NonThrowingCloseable ws = tracer.withSpan(span);
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);
-      when(tracer.spanBuilder(same(span), same(SPAN_NAME))).thenReturn(spanBuilder);
+      when(tracer.spanBuilderWithParent(same(span), same(SPAN_NAME))).thenReturn(spanBuilder);
       assertThat(tracer.spanBuilder(SPAN_NAME)).isSameAs(spanBuilder);
     } finally {
       ws.close();
@@ -142,7 +144,8 @@ public class TracerTest {
     NonThrowingCloseable ws = tracer.withSpan(BlankSpan.INSTANCE);
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
-      when(tracer.spanBuilder(same(BlankSpan.INSTANCE), same(SPAN_NAME))).thenReturn(spanBuilder);
+      when(tracer.spanBuilderWithParent(same(BlankSpan.INSTANCE), same(SPAN_NAME)))
+          .thenReturn(spanBuilder);
       assertThat(tracer.spanBuilder(SPAN_NAME)).isSameAs(spanBuilder);
     } finally {
       ws.close();

--- a/api/src/test/java/io/opencensus/trace/TracerTest.java
+++ b/api/src/test/java/io/opencensus/trace/TracerTest.java
@@ -106,7 +106,7 @@ public class TracerTest {
 
   @Test
   public void defaultSpanBuilderWithParentAndName() {
-    assertThat(noopTracer.spanBuilderWithParent(null, SPAN_NAME).startSpan())
+    assertThat(noopTracer.spanBuilderWithParent(SPAN_NAME, null).startSpan())
         .isSameAs(BlankSpan.INSTANCE);
   }
 
@@ -116,14 +116,14 @@ public class TracerTest {
   }
 
   @Test
-  public void defaultSpanBuilderWitRemoteParent_NullParent() {
-    assertThat(noopTracer.spanBuilderWithRemoteParent(null, SPAN_NAME).startSpan())
+  public void defaultSpanBuilderWithRemoteParent_NullParent() {
+    assertThat(noopTracer.spanBuilderWithRemoteParent(SPAN_NAME, null).startSpan())
         .isSameAs(BlankSpan.INSTANCE);
   }
 
   @Test
   public void defaultSpanBuilderWithRemoteParent() {
-    assertThat(noopTracer.spanBuilderWithRemoteParent(SpanContext.INVALID, SPAN_NAME).startSpan())
+    assertThat(noopTracer.spanBuilderWithRemoteParent(SPAN_NAME, SpanContext.INVALID).startSpan())
         .isSameAs(BlankSpan.INSTANCE);
   }
 
@@ -132,7 +132,7 @@ public class TracerTest {
     NonThrowingCloseable ws = tracer.withSpan(span);
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(span);
-      when(tracer.spanBuilderWithParent(same(span), same(SPAN_NAME))).thenReturn(spanBuilder);
+      when(tracer.spanBuilderWithParent(same(SPAN_NAME), same(span))).thenReturn(spanBuilder);
       assertThat(tracer.spanBuilder(SPAN_NAME)).isSameAs(spanBuilder);
     } finally {
       ws.close();
@@ -144,7 +144,7 @@ public class TracerTest {
     NonThrowingCloseable ws = tracer.withSpan(BlankSpan.INSTANCE);
     try {
       assertThat(tracer.getCurrentSpan()).isSameAs(BlankSpan.INSTANCE);
-      when(tracer.spanBuilderWithParent(same(BlankSpan.INSTANCE), same(SPAN_NAME)))
+      when(tracer.spanBuilderWithParent(same(SPAN_NAME), same(BlankSpan.INSTANCE)))
           .thenReturn(spanBuilder);
       assertThat(tracer.spanBuilder(SPAN_NAME)).isSameAs(spanBuilder);
     } finally {

--- a/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsNonSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsNonSampledSpanBenchmark.java
@@ -36,9 +36,9 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
   private static final String ATTRIBUTE_KEY = "MyAttributeKey";
   private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
   private Span linkedSpan =
-      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.neverSample()).startSpan();
   private Span span =
-      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.neverSample()).startSpan();
 
   /** TearDown method. */
   @TearDown

--- a/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsNonSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsNonSampledSpanBenchmark.java
@@ -36,9 +36,15 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
   private static final String ATTRIBUTE_KEY = "MyAttributeKey";
   private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
   private Span linkedSpan =
-      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.neverSample()).startSpan();
+      tracer
+          .spanBuilderWithExplicitParent(SPAN_NAME, null)
+          .setSampler(Samplers.neverSample())
+          .startSpan();
   private Span span =
-      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.neverSample()).startSpan();
+      tracer
+          .spanBuilderWithExplicitParent(SPAN_NAME, null)
+          .setSampler(Samplers.neverSample())
+          .startSpan();
 
   /** TearDown method. */
   @TearDown

--- a/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsNonSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsNonSampledSpanBenchmark.java
@@ -36,9 +36,9 @@ public class RecordTraceEventsNonSampledSpanBenchmark {
   private static final String ATTRIBUTE_KEY = "MyAttributeKey";
   private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
   private Span linkedSpan =
-      tracer.spanBuilder(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
   private Span span =
-      tracer.spanBuilder(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
 
   /** TearDown method. */
   @TearDown

--- a/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsSampledSpanBenchmark.java
@@ -36,9 +36,9 @@ public class RecordTraceEventsSampledSpanBenchmark {
   private static final String ATTRIBUTE_KEY = "MyAttributeKey";
   private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
   private Span linkedSpan =
-      tracer.spanBuilder(null, SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
+      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
   private Span span =
-      tracer.spanBuilder(null, SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
+      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
 
   /** TearDown method. */
   @TearDown

--- a/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsSampledSpanBenchmark.java
@@ -36,9 +36,15 @@ public class RecordTraceEventsSampledSpanBenchmark {
   private static final String ATTRIBUTE_KEY = "MyAttributeKey";
   private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
   private Span linkedSpan =
-      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.alwaysSample()).startSpan();
+      tracer
+          .spanBuilderWithExplicitParent(SPAN_NAME, null)
+          .setSampler(Samplers.alwaysSample())
+          .startSpan();
   private Span span =
-      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.alwaysSample()).startSpan();
+      tracer
+          .spanBuilderWithExplicitParent(SPAN_NAME, null)
+          .setSampler(Samplers.alwaysSample())
+          .startSpan();
 
   /** TearDown method. */
   @TearDown

--- a/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsSampledSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/RecordTraceEventsSampledSpanBenchmark.java
@@ -36,9 +36,9 @@ public class RecordTraceEventsSampledSpanBenchmark {
   private static final String ATTRIBUTE_KEY = "MyAttributeKey";
   private static final String ATTRIBUTE_VALUE = "MyAttributeValue";
   private Span linkedSpan =
-      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
+      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.alwaysSample()).startSpan();
   private Span span =
-      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
+      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.alwaysSample()).startSpan();
 
   /** TearDown method. */
   @TearDown

--- a/benchmarks/src/jmh/java/io/opencensus/trace/StartEndSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/StartEndSpanBenchmark.java
@@ -29,7 +29,7 @@ public class StartEndSpanBenchmark {
   private static final Tracer tracer = Tracing.getTracer();
   private static final String SPAN_NAME = "MySpanName";
   private Span rootSpan =
-      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.neverSample()).startSpan();
 
   @TearDown
   public void doTearDown() {
@@ -46,7 +46,7 @@ public class StartEndSpanBenchmark {
   public Span startEndNonSampledRootSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(null, SPAN_NAME)
+            .spanBuilderWithParent(SPAN_NAME, null)
             .setSampler(Samplers.neverSample())
             .startSpan();
     span.end();
@@ -63,7 +63,7 @@ public class StartEndSpanBenchmark {
   public Span startEndRecordEventsRootSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(null, SPAN_NAME)
+            .spanBuilderWithParent(SPAN_NAME, null)
             .setSampler(Samplers.neverSample())
             .setRecordEvents(true)
             .startSpan();
@@ -93,7 +93,7 @@ public class StartEndSpanBenchmark {
   public Span startEndNonSampledChildSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(rootSpan, SPAN_NAME)
+            .spanBuilderWithParent(SPAN_NAME, rootSpan)
             .setSampler(Samplers.neverSample())
             .startSpan();
     span.end();
@@ -110,7 +110,7 @@ public class StartEndSpanBenchmark {
   public Span startEndRecordEventsChildSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(rootSpan, SPAN_NAME)
+            .spanBuilderWithParent(SPAN_NAME, rootSpan)
             .setSampler(Samplers.neverSample())
             .setRecordEvents(true)
             .startSpan();
@@ -127,7 +127,7 @@ public class StartEndSpanBenchmark {
   public Span startEndSampledChildSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(rootSpan, SPAN_NAME)
+            .spanBuilderWithParent(SPAN_NAME, rootSpan)
             .setSampler(Samplers.alwaysSample())
             .startSpan();
     span.end();

--- a/benchmarks/src/jmh/java/io/opencensus/trace/StartEndSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/StartEndSpanBenchmark.java
@@ -29,7 +29,10 @@ public class StartEndSpanBenchmark {
   private static final Tracer tracer = Tracing.getTracer();
   private static final String SPAN_NAME = "MySpanName";
   private Span rootSpan =
-      tracer.spanBuilderWithParent(SPAN_NAME, null).setSampler(Samplers.neverSample()).startSpan();
+      tracer
+          .spanBuilderWithExplicitParent(SPAN_NAME, null)
+          .setSampler(Samplers.neverSample())
+          .startSpan();
 
   @TearDown
   public void doTearDown() {
@@ -46,7 +49,7 @@ public class StartEndSpanBenchmark {
   public Span startEndNonSampledRootSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(SPAN_NAME, null)
+            .spanBuilderWithExplicitParent(SPAN_NAME, null)
             .setSampler(Samplers.neverSample())
             .startSpan();
     span.end();
@@ -63,7 +66,7 @@ public class StartEndSpanBenchmark {
   public Span startEndRecordEventsRootSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(SPAN_NAME, null)
+            .spanBuilderWithExplicitParent(SPAN_NAME, null)
             .setSampler(Samplers.neverSample())
             .setRecordEvents(true)
             .startSpan();
@@ -93,7 +96,7 @@ public class StartEndSpanBenchmark {
   public Span startEndNonSampledChildSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(SPAN_NAME, rootSpan)
+            .spanBuilderWithExplicitParent(SPAN_NAME, rootSpan)
             .setSampler(Samplers.neverSample())
             .startSpan();
     span.end();
@@ -110,7 +113,7 @@ public class StartEndSpanBenchmark {
   public Span startEndRecordEventsChildSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(SPAN_NAME, rootSpan)
+            .spanBuilderWithExplicitParent(SPAN_NAME, rootSpan)
             .setSampler(Samplers.neverSample())
             .setRecordEvents(true)
             .startSpan();
@@ -127,7 +130,7 @@ public class StartEndSpanBenchmark {
   public Span startEndSampledChildSpan() {
     Span span =
         tracer
-            .spanBuilderWithParent(SPAN_NAME, rootSpan)
+            .spanBuilderWithExplicitParent(SPAN_NAME, rootSpan)
             .setSampler(Samplers.alwaysSample())
             .startSpan();
     span.end();

--- a/benchmarks/src/jmh/java/io/opencensus/trace/StartEndSpanBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/StartEndSpanBenchmark.java
@@ -29,7 +29,7 @@ public class StartEndSpanBenchmark {
   private static final Tracer tracer = Tracing.getTracer();
   private static final String SPAN_NAME = "MySpanName";
   private Span rootSpan =
-      tracer.spanBuilder(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+      tracer.spanBuilderWithParent(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
 
   @TearDown
   public void doTearDown() {
@@ -45,7 +45,10 @@ public class StartEndSpanBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public Span startEndNonSampledRootSpan() {
     Span span =
-        tracer.spanBuilder(null, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+        tracer
+            .spanBuilderWithParent(null, SPAN_NAME)
+            .setSampler(Samplers.neverSample())
+            .startSpan();
     span.end();
     return span;
   }
@@ -60,7 +63,7 @@ public class StartEndSpanBenchmark {
   public Span startEndRecordEventsRootSpan() {
     Span span =
         tracer
-            .spanBuilder(null, SPAN_NAME)
+            .spanBuilderWithParent(null, SPAN_NAME)
             .setSampler(Samplers.neverSample())
             .setRecordEvents(true)
             .startSpan();
@@ -89,7 +92,10 @@ public class StartEndSpanBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public Span startEndNonSampledChildSpan() {
     Span span =
-        tracer.spanBuilder(rootSpan, SPAN_NAME).setSampler(Samplers.neverSample()).startSpan();
+        tracer
+            .spanBuilderWithParent(rootSpan, SPAN_NAME)
+            .setSampler(Samplers.neverSample())
+            .startSpan();
     span.end();
     return span;
   }
@@ -104,7 +110,7 @@ public class StartEndSpanBenchmark {
   public Span startEndRecordEventsChildSpan() {
     Span span =
         tracer
-            .spanBuilder(rootSpan, SPAN_NAME)
+            .spanBuilderWithParent(rootSpan, SPAN_NAME)
             .setSampler(Samplers.neverSample())
             .setRecordEvents(true)
             .startSpan();
@@ -120,7 +126,10 @@ public class StartEndSpanBenchmark {
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public Span startEndSampledChildSpan() {
     Span span =
-        tracer.spanBuilder(rootSpan, SPAN_NAME).setSampler(Samplers.alwaysSample()).startSpan();
+        tracer
+            .spanBuilderWithParent(rootSpan, SPAN_NAME)
+            .setSampler(Samplers.alwaysSample())
+            .startSpan();
     span.end();
     return span;
   }

--- a/benchmarks/src/jmh/java/io/opencensus/trace/propagation/BinaryPropagationImplBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/propagation/BinaryPropagationImplBenchmark.java
@@ -38,8 +38,7 @@ public class BinaryPropagationImplBenchmark {
   private static final TraceOptions traceOptions = TraceOptions.fromBytes(traceOptionsBytes);
   private static final SpanContext spanContext = SpanContext.create(traceId, spanId, traceOptions);
   private static final BinaryFormat BINARY_PROPAGATION = new BinaryFormatImpl();
-  private static final byte[] spanContextBinary =
-      BINARY_PROPAGATION.toBinaryValue(spanContext);
+  private static final byte[] spanContextBinary = BINARY_PROPAGATION.toBinaryValue(spanContext);
 
   /**
    * This benchmark attempts to measure performance of {@link
@@ -72,7 +71,6 @@ public class BinaryPropagationImplBenchmark {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public SpanContext toFromBinarySpanContext() throws ParseException {
-    return BINARY_PROPAGATION.fromBinaryValue(
-        BINARY_PROPAGATION.toBinaryValue(spanContext));
+    return BINARY_PROPAGATION.fromBinaryValue(BINARY_PROPAGATION.toBinaryValue(spanContext));
   }
 }

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansContextTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansContextTracing.java
@@ -49,7 +49,7 @@ public final class MultiSpansContextTracing {
   /** Main method. */
   public static void main(String[] args) {
     LoggingHandler.register(Tracing.getExportComponent().getSpanExporter());
-    Span span = tracer.spanBuilder(null,"MyRootSpan").startSpan();
+    Span span = tracer.spanBuilderWithParent(null,"MyRootSpan").startSpan();
     try (NonThrowingCloseable ws = tracer.withSpan(span)) {
       doWork();
     }

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansContextTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansContextTracing.java
@@ -49,7 +49,7 @@ public final class MultiSpansContextTracing {
   /** Main method. */
   public static void main(String[] args) {
     LoggingHandler.register(Tracing.getExportComponent().getSpanExporter());
-    Span span = tracer.spanBuilderWithParent("MyRootSpan", null).startSpan();
+    Span span = tracer.spanBuilderWithExplicitParent("MyRootSpan", null).startSpan();
     try (NonThrowingCloseable ws = tracer.withSpan(span)) {
       doWork();
     }

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansContextTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansContextTracing.java
@@ -49,7 +49,7 @@ public final class MultiSpansContextTracing {
   /** Main method. */
   public static void main(String[] args) {
     LoggingHandler.register(Tracing.getExportComponent().getSpanExporter());
-    Span span = tracer.spanBuilderWithParent(null,"MyRootSpan").startSpan();
+    Span span = tracer.spanBuilderWithParent("MyRootSpan", null).startSpan();
     try (NonThrowingCloseable ws = tracer.withSpan(span)) {
       doWork();
     }

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansScopedTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansScopedTracing.java
@@ -48,7 +48,7 @@ public final class MultiSpansScopedTracing {
   public static void main(String[] args) {
     LoggingHandler.register(Tracing.getExportComponent().getSpanExporter());
     try (NonThrowingCloseable ss =
-        tracer.spanBuilderWithParent("MyRootSpan", null).startScopedSpan()) {
+        tracer.spanBuilderWithExplicitParent("MyRootSpan", null).startScopedSpan()) {
       doWork();
     }
   }

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansScopedTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansScopedTracing.java
@@ -48,7 +48,7 @@ public final class MultiSpansScopedTracing {
   public static void main(String[] args) {
     LoggingHandler.register(Tracing.getExportComponent().getSpanExporter());
     try (NonThrowingCloseable ss =
-        tracer.spanBuilderWithParent(null,"MyRootSpan").startScopedSpan()) {
+        tracer.spanBuilderWithParent("MyRootSpan", null).startScopedSpan()) {
       doWork();
     }
   }

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansScopedTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansScopedTracing.java
@@ -48,7 +48,7 @@ public final class MultiSpansScopedTracing {
   public static void main(String[] args) {
     LoggingHandler.register(Tracing.getExportComponent().getSpanExporter());
     try (NonThrowingCloseable ss =
-        tracer.spanBuilder(null,"MyRootSpan").startScopedSpan()) {
+        tracer.spanBuilderWithParent(null,"MyRootSpan").startScopedSpan()) {
       doWork();
     }
   }

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansTracing.java
@@ -24,9 +24,9 @@ public final class MultiSpansTracing {
   private static final Tracer tracer = Tracing.getTracer();
 
   private static void doWork() {
-    Span rootSpan = tracer.spanBuilderWithParent("MyRootSpan", null).startSpan();
+    Span rootSpan = tracer.spanBuilderWithExplicitParent("MyRootSpan", null).startSpan();
     rootSpan.addAnnotation("Annotation to the root Span before child is created.");
-    Span childSpan = tracer.spanBuilderWithParent("MyChildSpan", rootSpan).startSpan();
+    Span childSpan = tracer.spanBuilderWithExplicitParent("MyChildSpan", rootSpan).startSpan();
     childSpan.addAnnotation("Annotation to the child Span");
     childSpan.end();
     rootSpan.addAnnotation("Annotation to the root Span after child is ended.");

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansTracing.java
@@ -24,9 +24,9 @@ public final class MultiSpansTracing {
   private static final Tracer tracer = Tracing.getTracer();
 
   private static void doWork() {
-    Span rootSpan = tracer.spanBuilder(null, "MyRootSpan").startSpan();
+    Span rootSpan = tracer.spanBuilderWithParent(null, "MyRootSpan").startSpan();
     rootSpan.addAnnotation("Annotation to the root Span before child is created.");
-    Span childSpan = tracer.spanBuilder(rootSpan, "MyChildSpan").startSpan();
+    Span childSpan = tracer.spanBuilderWithParent(rootSpan, "MyChildSpan").startSpan();
     childSpan.addAnnotation("Annotation to the child Span");
     childSpan.end();
     rootSpan.addAnnotation("Annotation to the root Span after child is ended.");

--- a/examples/src/main/java/io/opencensus/examples/trace/MultiSpansTracing.java
+++ b/examples/src/main/java/io/opencensus/examples/trace/MultiSpansTracing.java
@@ -24,9 +24,9 @@ public final class MultiSpansTracing {
   private static final Tracer tracer = Tracing.getTracer();
 
   private static void doWork() {
-    Span rootSpan = tracer.spanBuilderWithParent(null, "MyRootSpan").startSpan();
+    Span rootSpan = tracer.spanBuilderWithParent("MyRootSpan", null).startSpan();
     rootSpan.addAnnotation("Annotation to the root Span before child is created.");
-    Span childSpan = tracer.spanBuilderWithParent(rootSpan, "MyChildSpan").startSpan();
+    Span childSpan = tracer.spanBuilderWithParent("MyChildSpan", rootSpan).startSpan();
     childSpan.addAnnotation("Annotation to the child Span");
     childSpan.end();
     rootSpan.addAnnotation("Annotation to the root Span after child is ended.");

--- a/impl_core/src/main/java/io/opencensus/trace/SpanBuilderImpl.java
+++ b/impl_core/src/main/java/io/opencensus/trace/SpanBuilderImpl.java
@@ -43,7 +43,7 @@ final class SpanBuilderImpl extends SpanBuilder {
   private List<Span> parentLinks = Collections.<Span>emptyList();
   private Boolean recordEvents;
 
-  private Span startSpanInternal(
+  private SpanImpl startSpanInternal(
       @Nullable SpanContext parent,
       boolean hasRemoteParent,
       String name,
@@ -80,7 +80,7 @@ final class SpanBuilderImpl extends SpanBuilder {
     if (traceOptions.isSampled() || Boolean.TRUE.equals(recordEvents)) {
       spanOptions.add(Span.Options.RECORD_EVENTS);
     }
-    Span span =
+    SpanImpl span =
         SpanImpl.startSpan(
             SpanContext.create(traceId, spanId, traceOptions),
             spanOptions,
@@ -105,14 +105,13 @@ final class SpanBuilderImpl extends SpanBuilder {
     }
   }
 
-  static SpanBuilder createBuilder(@Nullable Span parentSpan, String name, Options options) {
+  static SpanBuilderImpl createWithParent(@Nullable Span parentSpan, String name, Options options) {
     return new SpanBuilderImpl(parentSpan, null, name, options);
   }
 
-  static SpanBuilder createBuilderWithRemoteParent(
-      SpanContext remoteParentSpanContext, String name, Options options) {
-    return new SpanBuilderImpl(null, checkNotNull(remoteParentSpanContext,
-        "remoteParentSpanContext"), name, options);
+  static SpanBuilderImpl createWithRemoteParent(
+      @Nullable SpanContext remoteParentSpanContext, String name, Options options) {
+    return new SpanBuilderImpl(null, remoteParentSpanContext, name, options);
   }
 
   private SpanBuilderImpl(
@@ -127,7 +126,7 @@ final class SpanBuilderImpl extends SpanBuilder {
   }
 
   @Override
-  public Span startSpan() {
+  public SpanImpl startSpan() {
     SpanContext parentContext = remoteParentSpanContext;
     boolean hasRemoteParent = parentContext != null;
     TimestampConverter timestampConverter = null;
@@ -173,19 +172,19 @@ final class SpanBuilderImpl extends SpanBuilder {
   }
 
   @Override
-  public SpanBuilder setSampler(Sampler sampler) {
+  public SpanBuilderImpl setSampler(Sampler sampler) {
     this.sampler = checkNotNull(sampler, "sampler");
     return this;
   }
 
   @Override
-  public SpanBuilder setParentLinks(List<Span> parentLinks) {
+  public SpanBuilderImpl setParentLinks(List<Span> parentLinks) {
     this.parentLinks = checkNotNull(parentLinks, "parentLinks");
     return this;
   }
 
   @Override
-  public SpanBuilder setRecordEvents(boolean recordEvents) {
+  public SpanBuilderImpl setRecordEvents(boolean recordEvents) {
     this.recordEvents = recordEvents;
     return this;
   }

--- a/impl_core/src/main/java/io/opencensus/trace/SpanBuilderImpl.java
+++ b/impl_core/src/main/java/io/opencensus/trace/SpanBuilderImpl.java
@@ -37,7 +37,7 @@ final class SpanBuilderImpl extends SpanBuilder {
   private final Options options;
 
   private final String name;
-  private final Span parentSpan;
+  private final Span parent;
   private final SpanContext remoteParentSpanContext;
   private Sampler sampler;
   private List<Span> parentLinks = Collections.<Span>emptyList();
@@ -105,22 +105,22 @@ final class SpanBuilderImpl extends SpanBuilder {
     }
   }
 
-  static SpanBuilderImpl createWithParent(@Nullable Span parentSpan, String name, Options options) {
-    return new SpanBuilderImpl(parentSpan, null, name, options);
+  static SpanBuilderImpl createWithParent(String spanName, @Nullable Span parent, Options options) {
+    return new SpanBuilderImpl(spanName, null, parent, options);
   }
 
   static SpanBuilderImpl createWithRemoteParent(
-      @Nullable SpanContext remoteParentSpanContext, String name, Options options) {
-    return new SpanBuilderImpl(null, remoteParentSpanContext, name, options);
+      String spanName, @Nullable SpanContext remoteParentSpanContext, Options options) {
+    return new SpanBuilderImpl(spanName, remoteParentSpanContext, null, options);
   }
 
   private SpanBuilderImpl(
-      @Nullable Span parentSpan,
-      @Nullable SpanContext remoteParentSpanContext,
       String name,
+      @Nullable SpanContext remoteParentSpanContext,
+      @Nullable Span parent,
       Options options) {
     this.name = checkNotNull(name, "name");
-    this.parentSpan = parentSpan;
+    this.parent = parent;
     this.remoteParentSpanContext = remoteParentSpanContext;
     this.options = options;
   }
@@ -133,7 +133,7 @@ final class SpanBuilderImpl extends SpanBuilder {
     if (!hasRemoteParent) {
       // This is not a child of a remote Span. Get the parent SpanContext from the parent Span if
       // any.
-      Span parent = parentSpan;
+      Span parent = this.parent;
       if (parent != null) {
         parentContext = parent.getContext();
         // Pass the timestamp converter from the parent to ensure that the recorded events are in

--- a/impl_core/src/main/java/io/opencensus/trace/TracerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/trace/TracerImpl.java
@@ -32,7 +32,7 @@ final class TracerImpl extends Tracer {
   }
 
   @Override
-  public SpanBuilder spanBuilderWithParent(String spanName, @Nullable Span parent) {
+  public SpanBuilder spanBuilderWithExplicitParent(String spanName, @Nullable Span parent) {
     return SpanBuilderImpl.createWithParent(spanName, parent, spanBuilderOptions);
   }
 

--- a/impl_core/src/main/java/io/opencensus/trace/TracerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/trace/TracerImpl.java
@@ -32,14 +32,14 @@ final class TracerImpl extends Tracer {
   }
 
   @Override
-  public SpanBuilder spanBuilder(@Nullable Span parent, String name) {
-    return SpanBuilderImpl.createBuilder(parent, name, spanBuilderOptions);
+  public SpanBuilder spanBuilderWithParent(@Nullable Span parent, String name) {
+    return SpanBuilderImpl.createWithParent(parent, name, spanBuilderOptions);
   }
 
   @Override
   public SpanBuilder spanBuilderWithRemoteParent(
-      SpanContext remoteParentSpanContext, String name) {
-    return SpanBuilderImpl.createBuilderWithRemoteParent(
+      @Nullable SpanContext remoteParentSpanContext, String name) {
+    return SpanBuilderImpl.createWithRemoteParent(
         remoteParentSpanContext, name, spanBuilderOptions);
   }
 }

--- a/impl_core/src/main/java/io/opencensus/trace/TracerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/trace/TracerImpl.java
@@ -32,14 +32,14 @@ final class TracerImpl extends Tracer {
   }
 
   @Override
-  public SpanBuilder spanBuilderWithParent(@Nullable Span parent, String name) {
-    return SpanBuilderImpl.createWithParent(parent, name, spanBuilderOptions);
+  public SpanBuilder spanBuilderWithParent(String spanName, @Nullable Span parent) {
+    return SpanBuilderImpl.createWithParent(spanName, parent, spanBuilderOptions);
   }
 
   @Override
   public SpanBuilder spanBuilderWithRemoteParent(
-      @Nullable SpanContext remoteParentSpanContext, String name) {
+      String spanName, @Nullable SpanContext remoteParentSpanContext) {
     return SpanBuilderImpl.createWithRemoteParent(
-        remoteParentSpanContext, name, spanBuilderOptions);
+        spanName, remoteParentSpanContext, spanBuilderOptions);
   }
 }

--- a/impl_core/src/test/java/io/opencensus/trace/SpanBuilderImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/trace/SpanBuilderImplTest.java
@@ -58,7 +58,7 @@ public class SpanBuilderImplTest {
   @Test
   public void startSpanNullParent() {
     SpanImpl span =
-        SpanBuilderImpl.createWithParent(null, SPAN_NAME, spanBuilderOptions).startSpan();
+        SpanBuilderImpl.createWithParent(SPAN_NAME, null, spanBuilderOptions).startSpan();
     assertThat(span.getContext().isValid()).isTrue();
     assertThat(span.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
     assertThat(span.getContext().getTraceOptions().isSampled()).isTrue();
@@ -72,7 +72,7 @@ public class SpanBuilderImplTest {
   @Test
   public void startSpanNullParentWithRecordEvents() {
     SpanImpl span =
-        SpanBuilderImpl.createWithParent(null, SPAN_NAME, spanBuilderOptions)
+        SpanBuilderImpl.createWithParent(SPAN_NAME, null, spanBuilderOptions)
             .setSampler(Samplers.neverSample())
             .setRecordEvents(true)
             .startSpan();
@@ -87,7 +87,7 @@ public class SpanBuilderImplTest {
   @Test
   public void startSpanNullParentNoRecordOptions() {
     Span span =
-        SpanBuilderImpl.createWithParent(null, SPAN_NAME, spanBuilderOptions)
+        SpanBuilderImpl.createWithParent(SPAN_NAME, null, spanBuilderOptions)
             .setSampler(Samplers.neverSample())
             .startSpan();
     assertThat(span.getContext().isValid()).isTrue();
@@ -98,12 +98,12 @@ public class SpanBuilderImplTest {
   @Test
   public void startChildSpan() {
     Span rootSpan =
-        SpanBuilderImpl.createWithParent(null, SPAN_NAME, spanBuilderOptions).startSpan();
+        SpanBuilderImpl.createWithParent(SPAN_NAME, null, spanBuilderOptions).startSpan();
     assertThat(rootSpan.getContext().isValid()).isTrue();
     assertThat(rootSpan.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
     assertThat(rootSpan.getContext().getTraceOptions().isSampled()).isTrue();
     Span childSpan =
-        SpanBuilderImpl.createWithParent(rootSpan, SPAN_NAME, spanBuilderOptions).startSpan();
+        SpanBuilderImpl.createWithParent(SPAN_NAME, rootSpan, spanBuilderOptions).startSpan();
     assertThat(childSpan.getContext().isValid()).isTrue();
     assertThat(childSpan.getContext().getTraceId()).isEqualTo(rootSpan.getContext().getTraceId());
     assertThat(((SpanImpl) childSpan).toSpanData().getParentSpanId())
@@ -115,7 +115,7 @@ public class SpanBuilderImplTest {
   @Test
   public void startRemoteSpan_NullParent() {
     SpanImpl span =
-        SpanBuilderImpl.createWithRemoteParent(null, SPAN_NAME, spanBuilderOptions).startSpan();
+        SpanBuilderImpl.createWithRemoteParent(SPAN_NAME, null, spanBuilderOptions).startSpan();
     assertThat(span.getContext().isValid()).isTrue();
     assertThat(span.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
     assertThat(span.getContext().getTraceOptions().isSampled()).isTrue();
@@ -127,7 +127,7 @@ public class SpanBuilderImplTest {
   @Test
   public void startRemoteSpanInvalidParent() {
     SpanImpl span =
-        SpanBuilderImpl.createWithRemoteParent(SpanContext.INVALID, SPAN_NAME, spanBuilderOptions)
+        SpanBuilderImpl.createWithRemoteParent(SPAN_NAME, SpanContext.INVALID, spanBuilderOptions)
             .startSpan();
     assertThat(span.getContext().isValid()).isTrue();
     assertThat(span.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
@@ -145,7 +145,7 @@ public class SpanBuilderImplTest {
             SpanId.generateRandomId(randomHandler.current()),
             TraceOptions.DEFAULT);
     SpanImpl span =
-        SpanBuilderImpl.createWithRemoteParent(spanContext, SPAN_NAME, spanBuilderOptions)
+        SpanBuilderImpl.createWithRemoteParent(SPAN_NAME, spanContext, spanBuilderOptions)
             .startSpan();
     assertThat(span.getContext().isValid()).isTrue();
     assertThat(span.getContext().getTraceId()).isEqualTo(spanContext.getTraceId());

--- a/impl_core/src/test/java/io/opencensus/trace/SpanBuilderImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/trace/SpanBuilderImplTest.java
@@ -57,12 +57,12 @@ public class SpanBuilderImplTest {
 
   @Test
   public void startSpanNullParent() {
-    Span span = SpanBuilderImpl.createBuilder(null, SPAN_NAME, spanBuilderOptions).startSpan();
+    SpanImpl span =
+        SpanBuilderImpl.createWithParent(null, SPAN_NAME, spanBuilderOptions).startSpan();
     assertThat(span.getContext().isValid()).isTrue();
     assertThat(span.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
     assertThat(span.getContext().getTraceOptions().isSampled()).isTrue();
-    assertThat(span instanceof SpanImpl).isTrue();
-    SpanData spanData = ((SpanImpl) span).toSpanData();
+    SpanData spanData = span.toSpanData();
     assertThat(spanData.getParentSpanId()).isNull();
     assertThat(spanData.getHasRemoteParent()).isFalse();
     assertThat(spanData.getStartTimestamp()).isEqualTo(testClock.now());
@@ -71,16 +71,15 @@ public class SpanBuilderImplTest {
 
   @Test
   public void startSpanNullParentWithRecordEvents() {
-    Span span =
-        SpanBuilderImpl.createBuilder(null, SPAN_NAME, spanBuilderOptions)
+    SpanImpl span =
+        SpanBuilderImpl.createWithParent(null, SPAN_NAME, spanBuilderOptions)
             .setSampler(Samplers.neverSample())
             .setRecordEvents(true)
             .startSpan();
     assertThat(span.getContext().isValid()).isTrue();
     assertThat(span.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
     assertThat(span.getContext().getTraceOptions().isSampled()).isFalse();
-    assertThat(span instanceof SpanImpl).isTrue();
-    SpanData spanData = ((SpanImpl) span).toSpanData();
+    SpanData spanData = span.toSpanData();
     assertThat(spanData.getParentSpanId()).isNull();
     assertThat(spanData.getHasRemoteParent()).isFalse();
   }
@@ -88,7 +87,7 @@ public class SpanBuilderImplTest {
   @Test
   public void startSpanNullParentNoRecordOptions() {
     Span span =
-        SpanBuilderImpl.createBuilder(null, SPAN_NAME, spanBuilderOptions)
+        SpanBuilderImpl.createWithParent(null, SPAN_NAME, spanBuilderOptions)
             .setSampler(Samplers.neverSample())
             .startSpan();
     assertThat(span.getContext().isValid()).isTrue();
@@ -98,12 +97,13 @@ public class SpanBuilderImplTest {
 
   @Test
   public void startChildSpan() {
-    Span rootSpan = SpanBuilderImpl.createBuilder(null, SPAN_NAME, spanBuilderOptions).startSpan();
+    Span rootSpan =
+        SpanBuilderImpl.createWithParent(null, SPAN_NAME, spanBuilderOptions).startSpan();
     assertThat(rootSpan.getContext().isValid()).isTrue();
     assertThat(rootSpan.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
     assertThat(rootSpan.getContext().getTraceOptions().isSampled()).isTrue();
     Span childSpan =
-        SpanBuilderImpl.createBuilder(rootSpan, SPAN_NAME, spanBuilderOptions).startSpan();
+        SpanBuilderImpl.createWithParent(rootSpan, SPAN_NAME, spanBuilderOptions).startSpan();
     assertThat(childSpan.getContext().isValid()).isTrue();
     assertThat(childSpan.getContext().getTraceId()).isEqualTo(rootSpan.getContext().getTraceId());
     assertThat(((SpanImpl) childSpan).toSpanData().getParentSpanId())
@@ -112,22 +112,27 @@ public class SpanBuilderImplTest {
         .isEqualTo(((SpanImpl) rootSpan).getTimestampConverter());
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void startRemoteSpan_NullParent() {
-    SpanBuilderImpl.createBuilderWithRemoteParent(null, SPAN_NAME, spanBuilderOptions);
+    SpanImpl span =
+        SpanBuilderImpl.createWithRemoteParent(null, SPAN_NAME, spanBuilderOptions).startSpan();
+    assertThat(span.getContext().isValid()).isTrue();
+    assertThat(span.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
+    assertThat(span.getContext().getTraceOptions().isSampled()).isTrue();
+    SpanData spanData = span.toSpanData();
+    assertThat(spanData.getParentSpanId()).isNull();
+    assertThat(spanData.getHasRemoteParent()).isFalse();
   }
 
   @Test
   public void startRemoteSpanInvalidParent() {
-    Span span =
-        SpanBuilderImpl.createBuilderWithRemoteParent(
-                SpanContext.INVALID, SPAN_NAME, spanBuilderOptions)
+    SpanImpl span =
+        SpanBuilderImpl.createWithRemoteParent(SpanContext.INVALID, SPAN_NAME, spanBuilderOptions)
             .startSpan();
     assertThat(span.getContext().isValid()).isTrue();
     assertThat(span.getOptions().contains(Options.RECORD_EVENTS)).isTrue();
     assertThat(span.getContext().getTraceOptions().isSampled()).isTrue();
-    assertThat(span instanceof SpanImpl).isTrue();
-    SpanData spanData = ((SpanImpl) span).toSpanData();
+    SpanData spanData = span.toSpanData();
     assertThat(spanData.getParentSpanId()).isNull();
     assertThat(spanData.getHasRemoteParent()).isFalse();
   }
@@ -139,14 +144,13 @@ public class SpanBuilderImplTest {
             TraceId.generateRandomId(randomHandler.current()),
             SpanId.generateRandomId(randomHandler.current()),
             TraceOptions.DEFAULT);
-    Span span =
-        SpanBuilderImpl.createBuilderWithRemoteParent(spanContext, SPAN_NAME, spanBuilderOptions)
+    SpanImpl span =
+        SpanBuilderImpl.createWithRemoteParent(spanContext, SPAN_NAME, spanBuilderOptions)
             .startSpan();
     assertThat(span.getContext().isValid()).isTrue();
     assertThat(span.getContext().getTraceId()).isEqualTo(spanContext.getTraceId());
     assertThat(span.getContext().getTraceOptions().isSampled()).isTrue();
-    assertThat(span instanceof SpanImpl).isTrue();
-    SpanData spanData = ((SpanImpl) span).toSpanData();
+    SpanData spanData = span.toSpanData();
     assertThat(spanData.getParentSpanId()).isEqualTo(spanContext.getSpanId());
     assertThat(spanData.getHasRemoteParent()).isTrue();
   }

--- a/impl_core/src/test/java/io/opencensus/trace/TracerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/trace/TracerImplTest.java
@@ -43,13 +43,13 @@ public class TracerImplTest {
 
   @Test
   public void createSpanBuilder() {
-    SpanBuilder spanBuilder = tracer.spanBuilderWithParent(BlankSpan.INSTANCE, SPAN_NAME);
+    SpanBuilder spanBuilder = tracer.spanBuilderWithParent(SPAN_NAME, BlankSpan.INSTANCE);
     assertThat(spanBuilder).isInstanceOf(SpanBuilderImpl.class);
   }
 
   @Test
   public void createSpanBuilderWithRemoteParet() {
-    SpanBuilder spanBuilder = tracer.spanBuilderWithRemoteParent(SpanContext.INVALID, SPAN_NAME);
+    SpanBuilder spanBuilder = tracer.spanBuilderWithRemoteParent(SPAN_NAME, SpanContext.INVALID);
     assertThat(spanBuilder).isInstanceOf(SpanBuilderImpl.class);
   }
 }

--- a/impl_core/src/test/java/io/opencensus/trace/TracerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/trace/TracerImplTest.java
@@ -43,7 +43,7 @@ public class TracerImplTest {
 
   @Test
   public void createSpanBuilder() {
-    SpanBuilder spanBuilder = tracer.spanBuilder(BlankSpan.INSTANCE, SPAN_NAME);
+    SpanBuilder spanBuilder = tracer.spanBuilderWithParent(BlankSpan.INSTANCE, SPAN_NAME);
     assertThat(spanBuilder).isInstanceOf(SpanBuilderImpl.class);
   }
 

--- a/impl_core/src/test/java/io/opencensus/trace/TracerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/trace/TracerImplTest.java
@@ -43,7 +43,7 @@ public class TracerImplTest {
 
   @Test
   public void createSpanBuilder() {
-    SpanBuilder spanBuilder = tracer.spanBuilderWithParent(SPAN_NAME, BlankSpan.INSTANCE);
+    SpanBuilder spanBuilder = tracer.spanBuilderWithExplicitParent(SPAN_NAME, BlankSpan.INSTANCE);
     assertThat(spanBuilder).isInstanceOf(SpanBuilderImpl.class);
   }
 


### PR DESCRIPTION
This is a followup after https://github.com/census-instrumentation/opencensus-java/pull/380.

* Rollback the change to not accept null for remote parent. It is better for our users to pass null there in case no context received or unable to parse.

* Rename the spanBuilder method that accepts an explicit parent to spanBuilderWithParent, this is consistent with spanBuilderWithRemoteParent.

* NoopSpanBuilder changed to have factory methods.

* Update SpanBuilderImpl factory methods to be consistent with NoopSpanBuilder.