### PR TITLE
Add automatic context propagation for Executors.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ subprojects {
 
         libraries = [
                 auto_value     : "com.google.auto.value:auto-value:${autoValueVersion}",
+                byte_buddy   : 'net.bytebuddy:byte-buddy:1.7.1',
                 disruptor    : 'com.lmax:disruptor:3.3.6',
                 errorprone   : 'com.google.errorprone:error_prone_annotations:2.0.11',
                 findbugs_annotations : "com.google.code.findbugs:annotations:${findBugsVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ subprojects {
                 auto_value     : "com.google.auto.value:auto-value:${autoValueVersion}",
                 disruptor    : 'com.lmax:disruptor:3.3.6',
                 errorprone   : 'com.google.errorprone:error_prone_annotations:2.0.11',
+                findbugs_annotations : "com.google.code.findbugs:annotations:${findBugsVersion}",
                 grpc_context : "io.grpc:grpc-context:${grpcContextVersion}",
                 guava        : "com.google.guava:guava:${guavaVersion}",
                 jsr305       : "com.google.code.findbugs:jsr305:${findBugsVersion}",

--- a/contrib/agent/README.md
+++ b/contrib/agent/README.md
@@ -14,6 +14,12 @@ currently implemented:
 TODO(stschmidt): Update README.md along with implementation.
 
 
+### Automatic context propagation for Executors
+
+The context of the caller of [Executor#execute](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executor.html#execute-java.lang.Runnable-)
+is automatically propagated to the submitted Runnable.
+
+
 ## Design Ideas
 
 We see tracing as a cross-cutting concern which the *OpenCensus Agent for Java* weaves into

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -30,6 +30,9 @@ def agentBootstrapClasses = agentBootstrapPackageDir + '**'
 def agentRepackaged = "${agentPackage}.deps"
 
 dependencies {
+  compileOnly libraries.grpc_context
+  testCompile libraries.grpc_context
+  compile group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.1u2'
   compile libraries.guava
   compile group: 'net.bytebuddy', name: 'byte-buddy', version: '1.7.1'
 
@@ -119,3 +122,9 @@ shadowJar {
 jar.finalizedBy shadowJar
 
 // TODO(stschmidt): Proguard-shrink the agent JAR.
+
+// TODO(stschmidt): Move the integration tests to a separate SourceSet once
+// https://github.com/johnrengelman/shadow/issues/297 is fixed.
+test {
+  jvmArgs "-javaagent:${shadowJar.archivePath}"
+}

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   testCompile libraries.grpc_context
   compile libraries.findbugs_annotations
   compile libraries.guava
-  compile group: 'net.bytebuddy', name: 'byte-buddy', version: '1.7.1'
+  compile libraries.byte_buddy
 
   signature 'org.codehaus.mojo.signature:java16:+@signature'
 }

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -32,7 +32,7 @@ def agentRepackaged = "${agentPackage}.deps"
 dependencies {
   compileOnly libraries.grpc_context
   testCompile libraries.grpc_context
-  compile group: 'com.google.code.findbugs', name: 'annotations', version: '3.0.1u2'
+  compile libraries.findbugs_annotations
   compile libraries.guava
   compile group: 'net.bytebuddy', name: 'byte-buddy', version: '1.7.1'
 

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -94,7 +94,7 @@ public final class AgentMain {
     static AgentBuilder addGrpcContextPropagation(AgentBuilder agentBuilder) {
       // TODO(stschmidt): Gracefully handle the case of missing io.grpc.Context at runtime.
 
-      // Initialize the ContextManager singleton with the concrete GrpcContextStrategy.
+      // Initialize the ContextManager with the concrete GrpcContextStrategy.
       ContextManager.setContextStrategy(new GrpcContextStrategy());
 
       // Add automatic context propagation to Executor#execute.

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -60,8 +60,9 @@ public final class AgentMain {
 
     logger.info("Initializing.");
 
-    // The classes in bootstrap.jar will be referenced from classes loaded by the bootstrap
-    // classloader. Thus, these classes have to be loaded by the bootstrap classloader, too.
+    // The classes in bootstrap.jar, such as ContextManger and ContextStrategy, will be referenced
+    // from classes loaded by the bootstrap classloader. Thus, these classes have to be loaded by
+    // the bootstrap classloader, too.
     instrumentation.appendToBootstrapClassLoaderSearch(
             new JarFile(Resources.getResourceAsTempFile("bootstrap.jar")));
 

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -94,8 +94,8 @@ public final class AgentMain {
     static AgentBuilder addContextPropagation(AgentBuilder agentBuilder) {
       // TODO(stschmidt): Gracefully handle the case of missing io.grpc.Context at runtime.
 
-      // Initialize the ContextManager with the concrete GrpcContextStrategy.
-      ContextManager.setContextStrategy(new GrpcContextStrategy());
+      // Initialize the ContextManager with the concrete ContextStrategy.
+      ContextManager.setContextStrategy(new ContextStrategyImpl());
 
       // Add automatic context propagation to Executor#execute.
       agentBuilder = agentBuilder

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -99,8 +99,8 @@ public final class AgentMain {
 
       // Add automatic context propagation to Executor#execute.
       agentBuilder = agentBuilder
-              .type(ExecutorInstrumentation.matcher())
-              .transform(ExecutorInstrumentation.transformer());
+              .type(ExecutorInstrumentation.createMatcher())
+              .transform(ExecutorInstrumentation.createTransformer());
 
       // TODO(stschmidt): Add automatic context propagation to Thread#start.
 

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -73,7 +73,7 @@ public final class AgentMain {
             .with(AgentBuilder.RedefinitionStrategy.RETRANSFORMATION)
             .with(new AgentBuilderListener())
             .ignore(none());
-    agentBuilder = LazyLoaded.addGrpcContextPropagation(agentBuilder);
+    agentBuilder = LazyLoaded.addContextPropagation(agentBuilder);
     // TODO: Add more instrumentation, potentially introducing a plugin mechanism.
     agentBuilder.installOn(instrumentation);
 
@@ -91,7 +91,7 @@ public final class AgentMain {
     /**
      * Adds automatic context propagation.
      */
-    static AgentBuilder addGrpcContextPropagation(AgentBuilder agentBuilder) {
+    static AgentBuilder addContextPropagation(AgentBuilder agentBuilder) {
       // TODO(stschmidt): Gracefully handle the case of missing io.grpc.Context at runtime.
 
       // Initialize the ContextManager with the concrete GrpcContextStrategy.

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/ContextStrategyImpl.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/ContextStrategyImpl.java
@@ -20,7 +20,7 @@ import io.opencensus.contrib.agent.bootstrap.ContextStrategy;
  * Implementation of {@link ContextStrategy} for accessing and manipulating the
  * {@link io.grpc.Context}.
  */
-final class GrpcContextStrategy implements ContextStrategy {
+final class ContextStrategyImpl implements ContextStrategy {
 
   @Override
   public Runnable wrapInCurrentContext(Runnable runnable) {

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/ExecutorInstrumentation.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/ExecutorInstrumentation.java
@@ -44,13 +44,13 @@ final class ExecutorInstrumentation {
     }
   }
 
-  static ElementMatcher.Junction<TypeDescription> matcher() {
+  static ElementMatcher.Junction<TypeDescription> createMatcher() {
     // TODO(stschmidt): Exclude known call sites that already propagate the context.
 
     return isSubTypeOf(Executor.class).and(not(isAbstract()));
   }
 
-  static AgentBuilder.Transformer transformer() {
+  static AgentBuilder.Transformer createTransformer() {
     return new Transformer();
   }
 

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/ExecutorInstrumentation.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/ExecutorInstrumentation.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.agent;
+
+import static net.bytebuddy.matcher.ElementMatchers.isAbstract;
+import static net.bytebuddy.matcher.ElementMatchers.isSubTypeOf;
+import static net.bytebuddy.matcher.ElementMatchers.named;
+import static net.bytebuddy.matcher.ElementMatchers.not;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.opencensus.contrib.agent.bootstrap.ContextManager;
+import java.util.concurrent.Executor;
+import net.bytebuddy.agent.builder.AgentBuilder;
+import net.bytebuddy.asm.Advice;
+import net.bytebuddy.description.type.TypeDescription;
+import net.bytebuddy.dynamic.DynamicType;
+import net.bytebuddy.matcher.ElementMatcher;
+import net.bytebuddy.utility.JavaModule;
+
+/**
+ * Propagates the context of the caller of {@link Executor#execute} to the submitted
+ * {@link Runnable}, just like the Microsoft .Net Framework propagates the <a
+ * href="https://msdn.microsoft.com/en-us/library/system.threading.executioncontext(v=vs.110).aspx">System.Threading.ExecutionContext</a>.
+ */
+final class ExecutorInstrumentation {
+
+  private static class Transformer implements AgentBuilder.Transformer {
+
+    @Override
+    public DynamicType.Builder<?> transform(DynamicType.Builder<?> builder,
+            TypeDescription typeDescription, ClassLoader classLoader, JavaModule module) {
+      return builder.visit(Advice.to(Execute.class).on(named("execute")));
+    }
+  }
+
+  static ElementMatcher.Junction<TypeDescription> matcher() {
+    // TODO(stschmidt): Exclude known call sites that already propagate the context.
+
+    return isSubTypeOf(Executor.class).and(not(isAbstract()));
+  }
+
+  static AgentBuilder.Transformer transformer() {
+    return new Transformer();
+  }
+
+  private static class Execute {
+
+    @Advice.OnMethodEnter
+    @SuppressWarnings(value = "UnusedAssignment")
+    @SuppressFBWarnings(value = {"DLS_DEAD_LOCAL_STORE", "UPM_UNCALLED_PRIVATE_METHOD",})
+    private static void enter(@Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
+      runnable = ContextManager.wrapInCurrentContext(runnable);
+    }
+  }
+}

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/ExecutorInstrumentation.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/ExecutorInstrumentation.java
@@ -56,6 +56,15 @@ final class ExecutorInstrumentation {
 
   private static class Execute {
 
+    /**
+     * Wraps a {@link Runnable} so that it executes with the context that is associated with the
+     * current scope.
+     *
+     * <p>NB: This method is never called as is. Instead, Byte Buddy copies the method's bytecode
+     * into Executor#execute.
+     *
+     * @see Advice
+     */
     @Advice.OnMethodEnter
     @SuppressWarnings(value = "UnusedAssignment")
     @SuppressFBWarnings(value = {"DLS_DEAD_LOCAL_STORE", "UPM_UNCALLED_PRIVATE_METHOD",})

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/GrpcContextStrategy.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/GrpcContextStrategy.java
@@ -11,12 +11,19 @@
  * limitations under the License.
  */
 
-package io.opencensus.contrib.agent.bootstrap;
+package io.opencensus.contrib.agent;
+
+import io.grpc.Context;
+import io.opencensus.contrib.agent.bootstrap.ContextStrategy;
 
 /**
- * Contains classes that need to be loaded by the bootstrap classloader because they are used from
- * classes loaded by the bootstrap classloader.
- *
- * <p>NB: Do not add direct dependencies on classes that are not loaded by the bootstrap
- * classloader. Keep this package small.
+ * Implementation of {@link ContextStrategy} for accessing and manipulating the
+ * {@link io.grpc.Context}.
  */
+final class GrpcContextStrategy implements ContextStrategy {
+
+  @Override
+  public Runnable wrapInCurrentContext(Runnable runnable) {
+    return Context.current().wrap(runnable);
+  }
+}

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextManager.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextManager.java
@@ -22,7 +22,7 @@ package io.opencensus.contrib.agent.bootstrap;
  *
  * <p>Both {@link ContextManager} and {@link ContextStrategy} are loaded by the bootstrap
  * classloader so that they can be used from classes loaded by the bootstrap classloader.
- * A concrete implementations of {@link ContextStrategy} will be loaded by the system classloader.
+ * A concrete implementation of {@link ContextStrategy} will be loaded by the system classloader.
  * This allows for using the same context implementation as the instrumented application.
  *
  * <p>{@code ContextManager} is implemented as a static class to allow for easy and fast use from

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextManager.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextManager.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.agent.bootstrap;
+
+/**
+ * {@code ContextManager} provides methods for accessing and manipulating the context from
+ * instrumented bytecode.
+ *
+ * <p>{@code ContextManager} avoids tight coupling with the concrete implementation of the context
+ * (such as {@link io.grpc.Context}) by accessing and manipulating the context through the
+ * {@link ContextStrategy} interface.
+ *
+ * <p>Both {@link ContextManager} and {@link ContextStrategy} are loaded by the bootstrap
+ * classloader so that they can be used from classes loaded by the bootstrap classloader.
+ * A concrete implementations of {@link ContextStrategy} will be loaded by the system classloader.
+ * This allows for using the same context implementation as the instrumented application.
+ */
+public final class ContextManager {
+
+  private static ContextStrategy contextStrategy;
+
+  /**
+   * Sets the concrete strategy for accessing and manipulating the context.
+   *
+   * <p>Must be called before any other method in this class.
+   *
+   * @param contextStrategy the concrete strategy for accessing and manipulating the context
+   */
+  public static void setContextHandler(ContextStrategy contextStrategy) {
+    if (contextStrategy == null) {
+      throw new NullPointerException("contextStrategy");
+    }
+
+    ContextManager.contextStrategy = contextStrategy;
+  }
+
+  /**
+   * @see ContextStrategy#wrapInCurrentContext(java.lang.Runnable)
+   */
+  public static Runnable wrapInCurrentContext(Runnable runnable) {
+    return contextStrategy.wrapInCurrentContext(runnable);
+  }
+}

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextManager.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextManager.java
@@ -32,8 +32,8 @@ package io.opencensus.contrib.agent.bootstrap;
 public final class ContextManager {
 
   // Not synchronized to avoid any synchronization costs after initialization.
-  // The agent is responsible to initialize this once (through #setContextStrategy) before any other
-  // method of this class is called.
+  // The agent is responsible for initializing this once (through #setContextStrategy) before any
+  // other method of this class is called.
   private static ContextStrategy contextStrategy;
 
   private ContextManager() {
@@ -42,8 +42,8 @@ public final class ContextManager {
   /**
    * Sets the concrete strategy for accessing and manipulating the context.
    *
-   * <p>NB: The agent is responsible to set the context strategy once before any other method of
-   * this class is called.
+   * <p>NB: The agent is responsible for setting the context strategy once before any other method
+   * of this class is called.
    *
    * @param contextStrategy the concrete strategy for accessing and manipulating the context
    */

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextManager.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextManager.java
@@ -18,8 +18,7 @@ package io.opencensus.contrib.agent.bootstrap;
  * instrumented bytecode.
  *
  * <p>{@code ContextManager} avoids tight coupling with the concrete implementation of the context
- * (such as {@link io.grpc.Context}) by accessing and manipulating the context through the
- * {@link ContextStrategy} interface.
+ * by accessing and manipulating the context through the {@link ContextStrategy} interface.
  *
  * <p>Both {@link ContextManager} and {@link ContextStrategy} are loaded by the bootstrap
  * classloader so that they can be used from classes loaded by the bootstrap classloader.

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextStrategy.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextStrategy.java
@@ -14,9 +14,16 @@
 package io.opencensus.contrib.agent.bootstrap;
 
 /**
- * Contains classes that need to be loaded by the bootstrap classloader because they are used from
- * classes loaded by the bootstrap classloader.
- *
- * <p>NB: Do not add direct dependencies on classes that are not loaded by the bootstrap
- * classloader. Keep this package small.
+ * Strategy interface for accessing and manipulating the context.
  */
+public interface ContextStrategy {
+
+  /**
+   * Wraps a {@link Runnable} so that it executes with the context that is associated with the
+   * current scope.
+   *
+   * @param runnable a {@link Runnable} object
+   * @return the wrapped {@link Runnable} object
+   */
+  Runnable wrapInCurrentContext(Runnable runnable);
+}

--- a/contrib/agent/src/test/java/io/opencensus/contrib/agent/ExecutorInstrumentationTest.java
+++ b/contrib/agent/src/test/java/io/opencensus/contrib/agent/ExecutorInstrumentationTest.java
@@ -29,6 +29,9 @@ import org.junit.runners.JUnit4;
 
 /**
  * Integration tests for {@link ExecutorInstrumentation}.
+ *
+ * <p>The integration tests are executed in a separate JVM that has the OpenCensus agent enabled
+ * via the {@code -javaagent} command line option.
  */
 @RunWith(JUnit4.class)
 public class ExecutorInstrumentationTest {

--- a/contrib/agent/src/test/java/io/opencensus/contrib/agent/ExecutorInstrumentationTest.java
+++ b/contrib/agent/src/test/java/io/opencensus/contrib/agent/ExecutorInstrumentationTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.agent;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.Context;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Integration tests for {@link ExecutorInstrumentation}.
+ */
+@RunWith(JUnit4.class)
+public class ExecutorInstrumentationTest {
+
+  private static final Context.Key<String> KEY = Context.key("mykey");
+
+  private ExecutorService executor;
+  private Context previousContext;
+
+  @Before
+  public void beforeMethod() {
+    executor = Executors.newCachedThreadPool();
+  }
+
+  @After
+  public void afterMethod() {
+    Context.current().detach(previousContext);
+    executor.shutdown();
+  }
+
+  @Test(timeout = 5000)
+  public void execute() throws Exception {
+    final Thread callerThread = Thread.currentThread();
+    final Context context = Context.current().withValue(KEY, "myvalue");
+    previousContext = context.attach();
+
+    final AtomicBoolean tested = new AtomicBoolean(false);
+
+    executor.execute(new Runnable() {
+      @Override
+      public void run() {
+        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+        assertThat(Context.current()).isSameAs(context);
+        assertThat(KEY.get()).isEqualTo("myvalue");
+        tested.set(true);
+
+        synchronized (tested) {
+          tested.notify();
+        }
+      }
+    });
+
+    synchronized (tested) {
+      tested.wait();
+    }
+
+    assertThat(tested.get()).isTrue();
+  }
+
+  @Test(timeout = 5000)
+  public void submit_Callable() throws Exception {
+    final Thread callerThread = Thread.currentThread();
+    final Context context = Context.current().withValue(KEY, "myvalue");
+    previousContext = context.attach();
+
+    final AtomicBoolean tested = new AtomicBoolean(false);
+
+    executor.submit(new Callable<Void>() {
+      @Override
+      public Void call() throws Exception {
+        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+        assertThat(Context.current()).isSameAs(context);
+        assertThat(KEY.get()).isEqualTo("myvalue");
+        tested.set(true);
+
+        return null;
+      }
+    }).get();
+
+    assertThat(tested.get()).isTrue();
+  }
+
+  @Test(timeout = 5000)
+  public void submit_Runnable() throws Exception {
+    final Thread callerThread = Thread.currentThread();
+    final Context context = Context.current().withValue(KEY, "myvalue");
+    previousContext = context.attach();
+
+    final AtomicBoolean tested = new AtomicBoolean(false);
+
+    executor.submit(new Runnable() {
+      @Override
+      public void run() {
+        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+        assertThat(Context.current()).isSameAs(context);
+        assertThat(KEY.get()).isEqualTo("myvalue");
+        tested.set(true);
+      }
+    }).get();
+
+    assertThat(tested.get()).isTrue();
+  }
+
+  @Test(timeout = 5000)
+  public void submit_RunnableWithResult() throws Exception {
+    final Thread callerThread = Thread.currentThread();
+    final Context context = Context.current().withValue(KEY, "myvalue");
+    previousContext = context.attach();
+
+    final AtomicBoolean tested = new AtomicBoolean(false);
+    Object result = new Object();
+
+    Future<Object> future = executor.submit(new Runnable() {
+      @Override
+      public void run() {
+        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+        assertThat(Context.current()).isNotSameAs(Context.ROOT);
+        assertThat(Context.current()).isSameAs(context);
+        assertThat(KEY.get()).isEqualTo("myvalue");
+        tested.set(true);
+      }
+    }, result);
+
+    assertThat(future.get()).isSameAs(result);
+    assertThat(tested.get()).isTrue();
+  }
+}


### PR DESCRIPTION
This change adds the required plumbing for accessing/manipulating the
context from the instrumented code. This completes the underlying infrastructure
for the executor instrumentation, which is also included in this change.