### PR TITLE
Rename Measure and Measurement subclasses.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/Measure.java
+++ b/core/src/main/java/io/opencensus/stats/Measure.java
@@ -27,8 +27,8 @@ public abstract class Measure {
    * Applies the given match function to the underlying data type.
    */
   public abstract <T> T match(
-      Function<? super DoubleMeasure, T> p0,
-      Function<? super LongMeasure, T> p1);
+      Function<? super MeasureDouble, T> p0,
+      Function<? super MeasureLong, T> p1);
 
   /**
    * Name of measure, as a {@code String}.
@@ -59,22 +59,22 @@ public abstract class Measure {
 
   @Immutable
   @AutoValue
-  public abstract static class DoubleMeasure extends Measure {
+  public abstract static class MeasureDouble extends Measure {
 
-    DoubleMeasure() {
+    MeasureDouble() {
     }
 
     /**
-     * Constructs a new {@link DoubleMeasure}.
+     * Constructs a new {@link MeasureDouble}.
      */
-    public static DoubleMeasure create(String name, String description, String unit) {
+    public static MeasureDouble create(String name, String description, String unit) {
       // TODO(dpo): ensure that measure names are unique, and consider if there should be any
       // restricitons on name (e.g. size, characters).
-      return new AutoValue_Measure_DoubleMeasure(name, description, unit);
+      return new AutoValue_Measure_MeasureDouble(name, description, unit);
     }
 
     @Override
-    public <T> T match(Function<? super DoubleMeasure, T> p0, Function<? super LongMeasure, T> p1) {
+    public <T> T match(Function<? super MeasureDouble, T> p0, Function<? super MeasureLong, T> p1) {
       return p0.apply(this);
     }
 
@@ -90,23 +90,23 @@ public abstract class Measure {
 
   @Immutable
   @AutoValue
-  // TODO: determine whether we want to support LongMeasure in V0.1
-  public abstract static class LongMeasure extends Measure {
+  // TODO: determine whether we want to support MeasureLong in V0.1
+  public abstract static class MeasureLong extends Measure {
 
-    LongMeasure() {
+    MeasureLong() {
     }
 
     /**
-     * Constructs a new {@link LongMeasure}.
+     * Constructs a new {@link MeasureLong}.
      */
-    public static LongMeasure create(String name, String description, String unit) {
+    public static MeasureLong create(String name, String description, String unit) {
       // TODO(dpo): ensure that measure names are unique, and consider if there should be any
       // restricitons on name (e.g. size, characters).
-      return new AutoValue_Measure_LongMeasure(name, description, unit);
+      return new AutoValue_Measure_MeasureLong(name, description, unit);
     }
 
     @Override
-    public <T> T match(Function<? super DoubleMeasure, T> p0, Function<? super LongMeasure, T> p1) {
+    public <T> T match(Function<? super MeasureDouble, T> p0, Function<? super MeasureLong, T> p1) {
       return p1.apply(this);
     }
 

--- a/core/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/core/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -13,8 +13,8 @@
 
 package io.opencensus.stats;
 
-import io.opencensus.stats.Measure.DoubleMeasure;
-import io.opencensus.stats.Measure.LongMeasure;
+import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.Measure.MeasureLong;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -50,28 +50,28 @@ public final class MeasureMap {
    */
   public static class Builder {
     /**
-     * Associates the {@link DoubleMeasure} with the given value. Subsequent updates to the
-     * same {@link DoubleMeasure} are ignored.
+     * Associates the {@link MeasureDouble} with the given value. Subsequent updates to the
+     * same {@link MeasureDouble} are ignored.
      *
-     * @param measure the {@link DoubleMeasure}
+     * @param measure the {@link MeasureDouble}
      * @param value the value to be associated with {@code measure}
      * @return this
      */
-    public Builder set(DoubleMeasure measure, double value) {
-      measurements.add(Measurement.DoubleMeasurement.create(measure, value));
+    public Builder set(MeasureDouble measure, double value) {
+      measurements.add(Measurement.MeasurementDouble.create(measure, value));
       return this;
     }
 
     /**
-     * Associates the {@link LongMeasure} with the given value. Subsequent updates to the
-     * same {@link LongMeasure} are ignored.
+     * Associates the {@link MeasureLong} with the given value. Subsequent updates to the
+     * same {@link MeasureLong} are ignored.
      *
-     * @param measure the {@link LongMeasure}
+     * @param measure the {@link MeasureLong}
      * @param value the value to be associated with {@code measure}
      * @return this
      */
-    public Builder set(LongMeasure measure, long value) {
-      measurements.add(Measurement.LongMeasurement.create(measure, value));
+    public Builder set(MeasureLong measure, long value) {
+      measurements.add(Measurement.MeasurementLong.create(measure, value));
       return this;
     }
 

--- a/core/src/main/java/io/opencensus/stats/Measurement.java
+++ b/core/src/main/java/io/opencensus/stats/Measurement.java
@@ -15,8 +15,8 @@ package io.opencensus.stats;
 
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Function;
-import io.opencensus.stats.Measure.DoubleMeasure;
-import io.opencensus.stats.Measure.LongMeasure;
+import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.Measure.MeasureLong;
 import javax.annotation.concurrent.Immutable;
 
 /** Immutable representation of a Measurement. */
@@ -27,7 +27,7 @@ public abstract class Measurement {
    * Applies the given match function to the underlying data type.
    */
   public abstract <T> T match(
-      Function<? super DoubleMeasurement, T> p0, Function<? super LongMeasurement, T> p1);
+      Function<? super MeasurementDouble, T> p0, Function<? super MeasurementLong, T> p1);
 
   /**
    * Extracts the measured {@link Measure}.
@@ -40,52 +40,48 @@ public abstract class Measurement {
 
   @Immutable
   @AutoValue
-  public abstract static class DoubleMeasurement extends Measurement {
-
-    DoubleMeasurement() {
-    }
+  public abstract static class MeasurementDouble extends Measurement {
+    MeasurementDouble() {}
 
     /**
-     * Constructs a new {@link DoubleMeasurement}.
+     * Constructs a new {@link MeasurementDouble}.
      */
-    public static DoubleMeasurement create(DoubleMeasure measure, double value) {
-      return new AutoValue_Measurement_DoubleMeasurement(measure, value);
+    public static MeasurementDouble create(MeasureDouble measure, double value) {
+      return new AutoValue_Measurement_MeasurementDouble(measure, value);
     }
 
     @Override
-    public abstract DoubleMeasure getMeasure();
+    public abstract MeasureDouble getMeasure();
 
     public abstract Double getValue();
 
     @Override
     public <T> T match(
-        Function<? super DoubleMeasurement, T> p0, Function<? super LongMeasurement, T> p1) {
+        Function<? super MeasurementDouble, T> p0, Function<? super MeasurementLong, T> p1) {
       return p0.apply(this);
     }
   }
 
   @Immutable
   @AutoValue
-  public abstract static class LongMeasurement extends Measurement {
-
-    LongMeasurement() {
-    }
+  public abstract static class MeasurementLong extends Measurement {
+    MeasurementLong() {}
 
     /**
-     * Constructs a new {@link LongMeasurement}.
+     * Constructs a new {@link MeasurementLong}.
      */
-    public static LongMeasurement create(LongMeasure measure, long value) {
-      return new AutoValue_Measurement_LongMeasurement(measure, value);
+    public static MeasurementLong create(MeasureLong measure, long value) {
+      return new AutoValue_Measurement_MeasurementLong(measure, value);
     }
 
     @Override
-    public abstract LongMeasure getMeasure();
+    public abstract MeasureLong getMeasure();
 
     public abstract Long getValue();
 
     @Override
     public <T> T match(
-        Function<? super DoubleMeasurement, T> p0, Function<? super LongMeasurement, T> p1) {
+        Function<? super MeasurementDouble, T> p0, Function<? super MeasurementLong, T> p1) {
       return p1.apply(this);
     }
   }

--- a/core/src/main/java/io/opencensus/stats/RpcMeasurementConstants.java
+++ b/core/src/main/java/io/opencensus/stats/RpcMeasurementConstants.java
@@ -31,57 +31,57 @@ public final class RpcMeasurementConstants {
 
   // RPC client Measures.
   public static final Measure RPC_CLIENT_ERROR_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/error_count",
           "RPC Errors",
           COUNT);
   public static final Measure RPC_CLIENT_REQUEST_BYTES =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/request_bytes",
           "Request bytes",
           BYTE);
   public static final Measure RPC_CLIENT_RESPONSE_BYTES =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/response_bytes",
           "Response bytes",
           BYTE);
   public static final Measure RPC_CLIENT_ROUNDTRIP_LATENCY =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/roundtrip_latency",
           "RPC roundtrip latency msec",
           MILLISECOND);
   public static final Measure RPC_CLIENT_SERVER_ELAPSED_TIME =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/server_elapsed_time",
           "Server elapsed time in msecs",
           MILLISECOND);
   public static final Measure RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/uncompressed_request_bytes",
           "Uncompressed Request bytes",
           BYTE);
   public static final Measure RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/uncompressed_response_bytes",
           "Uncompressed Response bytes",
           BYTE);
   public static final Measure RPC_CLIENT_STARTED_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/started_count",
           "Number of client RPCs (streams) started",
           COUNT);
   public static final Measure RPC_CLIENT_FINISHED_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/finished_count",
           "Number of client RPCs (streams) finished",
           COUNT);
   public static final Measure RPC_CLIENT_REQUEST_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/request_count",
           "Number of client RPC request messages",
           COUNT);
   public static final Measure RPC_CLIENT_RESPONSE_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/client/response_count",
           "Number of client RPC response messages",
           COUNT);
@@ -89,57 +89,57 @@ public final class RpcMeasurementConstants {
 
   // RPC server Measures.
   public static final Measure RPC_SERVER_ERROR_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/error_count",
           "RPC Errors",
           COUNT);
   public static final Measure RPC_SERVER_REQUEST_BYTES =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/request_bytes",
           "Request bytes",
           BYTE);
   public static final Measure RPC_SERVER_RESPONSE_BYTES =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/response_bytes",
           "Response bytes",
           BYTE);
   public static final Measure RPC_SERVER_SERVER_ELAPSED_TIME =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/server_elapsed_time",
           "Server elapsed time in msecs",
           MILLISECOND);
   public static final Measure RPC_SERVER_SERVER_LATENCY =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/server_latency",
           "Latency in msecs",
           MILLISECOND);
   public static final Measure RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/uncompressed_request_bytes",
           "Uncompressed Request bytes",
           BYTE);
   public static final Measure RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/uncompressed_response_bytes",
           "Uncompressed Response bytes",
           BYTE);
   public static final Measure RPC_SERVER_STARTED_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/started_count",
           "Number of server RPCs (streams) started",
           COUNT);
   public static final Measure RPC_SERVER_FINISHED_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/finished_count",
           "Number of server RPCs (streams) finished",
           COUNT);
   public static final Measure RPC_SERVER_REQUEST_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/request_count",
           "Number of server RPC request messages",
           COUNT);
   public static final Measure RPC_SERVER_RESPONSE_COUNT =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "grpc.io/server/response_count",
           "Number of server RPC response messages",
           COUNT);

--- a/core/src/test/java/io/opencensus/stats/MeasureMapTest.java
+++ b/core/src/test/java/io/opencensus/stats/MeasureMapTest.java
@@ -16,8 +16,8 @@ package io.opencensus.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.Lists;
-import io.opencensus.stats.Measure.DoubleMeasure;
-import io.opencensus.stats.Measure.LongMeasure;
+import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.Measure.MeasureLong;
 import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -30,15 +30,15 @@ public class MeasureMapTest {
   @Test
   public void testPutDouble() {
     MeasureMap metrics = MeasureMap.builder().set(M1, 44.4).build();
-    assertContains(metrics, Measurement.DoubleMeasurement.create(M1, 44.4));
+    assertContains(metrics, Measurement.MeasurementDouble.create(M1, 44.4));
   }
 
   @Test
   public void testPutLong() {
     MeasureMap metrics = MeasureMap.builder().set(M3, 9999L).set(M4, 8888L).build();
     assertContains(metrics,
-        Measurement.LongMeasurement.create(M3, 9999L),
-        Measurement.LongMeasurement.create(M4, 8888L));
+        Measurement.MeasurementLong.create(M3, 9999L),
+        Measurement.MeasurementLong.create(M4, 8888L));
   }
 
   @Test
@@ -46,10 +46,10 @@ public class MeasureMapTest {
     MeasureMap metrics =
         MeasureMap.builder().set(M1, 44.4).set(M2, 66.6).set(M3, 9999L).set(M4, 8888L).build();
     assertContains(metrics,
-        Measurement.DoubleMeasurement.create(M1, 44.4),
-        Measurement.DoubleMeasurement.create(M2, 66.6),
-        Measurement.LongMeasurement.create(M3, 9999L),
-        Measurement.LongMeasurement.create(M4, 8888L));
+        Measurement.MeasurementDouble.create(M1, 44.4),
+        Measurement.MeasurementDouble.create(M2, 66.6),
+        Measurement.MeasurementLong.create(M3, 9999L),
+        Measurement.MeasurementLong.create(M4, 8888L));
   }
 
   @Test
@@ -64,24 +64,27 @@ public class MeasureMapTest {
     MeasureMap.Builder builder = MeasureMap.builder();
     for (int i = 1; i <= 10; i++) {
       expected
-          .add(Measurement.DoubleMeasurement.create(makeSimpleDoubleMeasure("m" + i), i * 11.1));
-      builder.set(makeSimpleDoubleMeasure("m" + i), i * 11.1);
+          .add(Measurement.MeasurementDouble.create(makeSimpleMeasureDouble("m" + i), i * 11.1));
+      builder.set(makeSimpleMeasureDouble("m" + i), i * 11.1);
       assertContains(builder.build(), expected.toArray(new Measurement[i]));
     }
   }
 
   @Test
-  public void testDuplicateDoubleMeasures() {
+  public void testDuplicateMeasureDoubles() {
     assertContains(MeasureMap.builder().set(M1, 1.0).set(M1, 2.0).build(), MEASUREMENT_1);
-    assertContains(MeasureMap.builder().set(M1, 1.0).set(M1, 2.0).set(M1, 3.0).build(), MEASUREMENT_1);
-    assertContains(MeasureMap.builder().set(M1, 1.0).set(M2, 2.0).set(M1, 3.0).build(), MEASUREMENT_1,
+    assertContains(MeasureMap.builder().set(M1, 1.0).set(M1, 2.0).set(M1, 3.0).build(),
+        MEASUREMENT_1);
+    assertContains(MeasureMap.builder().set(M1, 1.0).set(M2, 2.0).set(M1, 3.0).build(),
+        MEASUREMENT_1,
         MEASUREMENT_2);
-    assertContains(MeasureMap.builder().set(M1, 1.0).set(M1, 2.0).set(M2, 2.0).build(), MEASUREMENT_1,
+    assertContains(MeasureMap.builder().set(M1, 1.0).set(M1, 2.0).set(M2, 2.0).build(),
+        MEASUREMENT_1,
         MEASUREMENT_2);
   }
 
   @Test
-  public void testDuplicateLongMeasures() {
+  public void testDuplicateMeasureLongs() {
     assertContains(MeasureMap.builder().set(M3, 100L).set(M3, 100L).build(), MEASUREMENT_3);
     assertContains(MeasureMap.builder().set(M3, 100L).set(M3, 200L).set(M3, 300L).build(),
         MEASUREMENT_3);
@@ -99,22 +102,22 @@ public class MeasureMapTest {
         MEASUREMENT_2, MEASUREMENT_3);
   }
 
-  private static final DoubleMeasure M1 = makeSimpleDoubleMeasure("m1");
-  private static final DoubleMeasure M2 = makeSimpleDoubleMeasure("m2");
-  private static final LongMeasure M3 = makeSimpleLongMeasure("m3");
-  private static final LongMeasure M4 = makeSimpleLongMeasure("m4");
+  private static final MeasureDouble M1 = makeSimpleMeasureDouble("m1");
+  private static final MeasureDouble M2 = makeSimpleMeasureDouble("m2");
+  private static final MeasureLong M3 = makeSimpleMeasureLong("m3");
+  private static final MeasureLong M4 = makeSimpleMeasureLong("m4");
 
-  private static final Measurement MEASUREMENT_1 = Measurement.DoubleMeasurement.create(M1, 1.0);
-  private static final Measurement MEASUREMENT_2 = Measurement.DoubleMeasurement.create(M2, 2.0);
-  private static final Measurement MEASUREMENT_3 = Measurement.LongMeasurement.create(M3, 100L);
-  private static final Measurement MEASUREMENT_4 = Measurement.LongMeasurement.create(M4, 200L);
+  private static final Measurement MEASUREMENT_1 = Measurement.MeasurementDouble.create(M1, 1.0);
+  private static final Measurement MEASUREMENT_2 = Measurement.MeasurementDouble.create(M2, 2.0);
+  private static final Measurement MEASUREMENT_3 = Measurement.MeasurementLong.create(M3, 100L);
+  private static final Measurement MEASUREMENT_4 = Measurement.MeasurementLong.create(M4, 200L);
 
-  private static DoubleMeasure makeSimpleDoubleMeasure(String measure) {
-    return Measure.DoubleMeasure.create(measure, measure + " description", "1");
+  private static MeasureDouble makeSimpleMeasureDouble(String measure) {
+    return Measure.MeasureDouble.create(measure, measure + " description", "1");
   }
 
-  private static LongMeasure makeSimpleLongMeasure(String measure) {
-    return Measure.LongMeasure.create(measure, measure + " description", "1");
+  private static MeasureLong makeSimpleMeasureLong(String measure) {
+    return Measure.MeasureLong.create(measure, measure + " description", "1");
   }
 
   private static void assertContains(MeasureMap metrics, Measurement... measurements) {

--- a/core/src/test/java/io/opencensus/stats/MeasureTest.java
+++ b/core/src/test/java/io/opencensus/stats/MeasureTest.java
@@ -49,8 +49,8 @@ public final class MeasureTest {
   }
 
   @Test
-  public void testDoubleMeasureComponents() {
-    Measure measurement = Measure.DoubleMeasure.create(
+  public void testMeasureDoubleComponents() {
+    Measure measurement = Measure.MeasureDouble.create(
         "Foo",
         "The description of Foo",
         "Mbit/s");
@@ -60,8 +60,8 @@ public final class MeasureTest {
   }
 
   @Test
-  public void testLongMeasureComponents() {
-    Measure measurement = Measure.LongMeasure.create(
+  public void testMeasureLongComponents() {
+    Measure measurement = Measure.MeasureLong.create(
         "Bar",
         "The description of Bar",
         "1");
@@ -71,19 +71,19 @@ public final class MeasureTest {
   }
 
   @Test
-  public void testDoubleMeasureEquals() {
+  public void testMeasureDoubleEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            Measure.DoubleMeasure.create(
+            Measure.MeasureDouble.create(
                 "name",
                 "description",
                 "bit/s"),
-            Measure.DoubleMeasure.create(
+            Measure.MeasureDouble.create(
                 "name",
                 "description",
                 "bit/s"))
         .addEqualityGroup(
-            Measure.DoubleMeasure.create(
+            Measure.MeasureDouble.create(
                 "name",
                 "description 2",
                 "bit/s"))
@@ -91,19 +91,19 @@ public final class MeasureTest {
   }
 
   @Test
-  public void testLongMeasureEquals() {
+  public void testMeasureLongEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            Measure.LongMeasure.create(
+            Measure.MeasureLong.create(
                 "name",
                 "description",
                 "bit/s"),
-            Measure.LongMeasure.create(
+            Measure.MeasureLong.create(
                 "name",
                 "description",
                 "bit/s"))
         .addEqualityGroup(
-            Measure.LongMeasure.create(
+            Measure.MeasureLong.create(
                 "name",
                 "description 2",
                 "bit/s"))
@@ -111,12 +111,12 @@ public final class MeasureTest {
   }
 
   @Test
-  public void testDoubleMeasureIsNotEqualToLongMeasure() {
-    assertThat(Measure.DoubleMeasure.create("name", "description", "bit/s"))
-        .isNotEqualTo(Measure.LongMeasure.create("name", "description", "bit/s"));
+  public void testMeasureDoubleIsNotEqualToMeasureLong() {
+    assertThat(Measure.MeasureDouble.create("name", "description", "bit/s"))
+        .isNotEqualTo(Measure.MeasureLong.create("name", "description", "bit/s"));
   }
 
   private static final Measure makeSimpleMeasure(String name) {
-    return Measure.DoubleMeasure.create(name, name + " description", "1");
+    return Measure.MeasureDouble.create(name, name + " description", "1");
   }
 }

--- a/core/src/test/java/io/opencensus/stats/ViewDescriptorTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewDescriptorTest.java
@@ -173,7 +173,7 @@ public final class ViewDescriptorTest {
 
   private final ViewDescriptor.Name name = ViewDescriptor.Name.create("test-view-name");
   private final String description = "test-view-name description";
-  private final Measure measure = Measure.DoubleMeasure.create(
+  private final Measure measure = Measure.MeasureDouble.create(
       "measurement",
       "measurement description",
       "1");

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -173,7 +173,7 @@ public final class ViewTest {
   // description
   private final String description = "test-view-descriptor description";
   // measurement descriptor
-  private final Measure measure = Measure.DoubleMeasure.create(
+  private final Measure measure = Measure.MeasureDouble.create(
       "measurement-descriptor",
       "measurement-descriptor description",
       "1");

--- a/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
@@ -17,8 +17,8 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import io.opencensus.common.Clock;
 import io.opencensus.common.Function;
-import io.opencensus.stats.Measurement.DoubleMeasurement;
-import io.opencensus.stats.Measurement.LongMeasurement;
+import io.opencensus.stats.Measurement.MeasurementDouble;
+import io.opencensus.stats.Measurement.MeasurementLong;
 import io.opencensus.stats.MutableView.MutableDistributionView;
 import io.opencensus.stats.MutableView.MutableIntervalView;
 import io.opencensus.stats.ViewDescriptor.DistributionViewDescriptor;
@@ -129,9 +129,9 @@ final class MeasureToViewMap {
     }
   }
 
-  private static final class RecordDoubleValueFunc implements Function<DoubleMeasurement, Void> {
+  private static final class RecordDoubleValueFunc implements Function<MeasurementDouble, Void> {
     @Override
-    public Void apply(DoubleMeasurement arg) {
+    public Void apply(MeasurementDouble arg) {
       view.record(tags, arg.getValue());
       return null;
     }
@@ -145,9 +145,9 @@ final class MeasureToViewMap {
     }
   }
 
-  private static final class RecordLongValueFunc implements Function<LongMeasurement, Void> {
+  private static final class RecordLongValueFunc implements Function<MeasurementLong, Void> {
     @Override
-    public Void apply(LongMeasurement arg) {
+    public Void apply(MeasurementLong arg) {
       // TODO: determine if we want to support LongMeasure in v0.1
       throw new UnsupportedOperationException("Long measurements not supported.");
     }

--- a/core_impl/src/test/java/io/opencensus/stats/MeasureToViewMapTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/MeasureToViewMapTest.java
@@ -32,7 +32,7 @@ import org.junit.runners.JUnit4;
 public class MeasureToViewMapTest {
 
   private static final Measure MEASUREMENT_DESCRIPTOR =
-      Measure.DoubleMeasure.create(
+      Measure.MeasureDouble.create(
           "my measurement",
           "measurement description",
           "By");

--- a/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
@@ -21,8 +21,8 @@ import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Function;
 import io.opencensus.internal.SimpleEventQueue;
 import io.opencensus.internal.VarInt;
-import io.opencensus.stats.Measure.DoubleMeasure;
-import io.opencensus.stats.Measure.LongMeasure;
+import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.stats.View.DistributionView;
 import io.opencensus.stats.View.IntervalView;
 import io.opencensus.testing.common.TestClock;
@@ -144,7 +144,7 @@ public class StatsContextTest {
             RpcMeasurementConstants.RPC_CLIENT_METHOD, TagValue.create("myMethod"));
     MeasureMap measurements =
         MeasureMap.builder()
-            .set((DoubleMeasure) RpcMeasurementConstants.RPC_CLIENT_ROUNDTRIP_LATENCY, 5.1).build();
+            .set((MeasureDouble) RpcMeasurementConstants.RPC_CLIENT_ROUNDTRIP_LATENCY, 5.1).build();
     context.record(measurements);
     View afterView =
         viewManager.getView(
@@ -175,7 +175,7 @@ public class StatsContextTest {
 
   @Test
   public void testRecordLong() {
-    LongMeasure measure = LongMeasure.create("long measure", "description", "1");
+    MeasureLong measure = MeasureLong.create("long measure", "description", "1");
     viewManager.registerView(ViewDescriptor.DistributionViewDescriptor
         .create("name", "description", measure, DistributionAggregationDescriptor.create(),
             Arrays.asList(K1)));

--- a/core_impl/src/test/java/io/opencensus/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/ViewManagerImplTest.java
@@ -19,7 +19,7 @@ import static io.opencensus.stats.StatsTestUtil.createContext;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Timestamp;
 import io.opencensus.internal.SimpleEventQueue;
-import io.opencensus.stats.Measure.DoubleMeasure;
+import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View.DistributionView;
 import io.opencensus.stats.ViewDescriptor.DistributionViewDescriptor;
 import io.opencensus.stats.ViewDescriptor.IntervalViewDescriptor;
@@ -53,8 +53,8 @@ public class ViewManagerImplTest {
 
   private static final String MEASUREMENT_DESCRIPTION = "measurement description";
 
-  private static final DoubleMeasure MEASUREMENT_DESCRIPTOR =
-      Measure.DoubleMeasure.create(MEASUREMENT_NAME, MEASUREMENT_DESCRIPTION, MEASUREMENT_UNIT);
+  private static final MeasureDouble MEASUREMENT_DESCRIPTOR =
+      Measure.MeasureDouble.create(MEASUREMENT_NAME, MEASUREMENT_DESCRIPTION, MEASUREMENT_UNIT);
 
   private static final ViewDescriptor.Name VIEW_NAME = ViewDescriptor.Name.create("my view");
   private static final ViewDescriptor.Name VIEW_NAME_2 = ViewDescriptor.Name.create("my view 2");
@@ -284,11 +284,11 @@ public class ViewManagerImplTest {
     viewManager.registerView(
         createDistributionViewDescriptor(
             VIEW_NAME,
-            Measure.DoubleMeasure.create(MEASUREMENT_NAME, "measurement", MEASUREMENT_UNIT),
+            Measure.MeasureDouble.create(MEASUREMENT_NAME, "measurement", MEASUREMENT_UNIT),
             DISTRIBUTION_AGGREGATION_DESCRIPTOR,
             Arrays.asList(KEY)));
-    DoubleMeasure measure2 =
-        Measure.DoubleMeasure.create(MEASUREMENT_NAME_2, "measurement", MEASUREMENT_UNIT);
+    MeasureDouble measure2 =
+        Measure.MeasureDouble.create(MEASUREMENT_NAME_2, "measurement", MEASUREMENT_UNIT);
     statsRecorder.record(createContext(factory, KEY, VALUE),
         MeasureMap.builder().set(measure2, 10.0).build());
     DistributionView view = (DistributionView) viewManager.getView(VIEW_NAME);
@@ -407,10 +407,10 @@ public class ViewManagerImplTest {
 
   @Test
   public void testMultipleViewsDifferentMeasures() {
-    DoubleMeasure measureDescr1 =
-        Measure.DoubleMeasure.create(MEASUREMENT_NAME, MEASUREMENT_DESCRIPTION, MEASUREMENT_UNIT);
-    DoubleMeasure measureDescr2 =
-        Measure.DoubleMeasure.create(MEASUREMENT_NAME_2, MEASUREMENT_DESCRIPTION, MEASUREMENT_UNIT);
+    MeasureDouble measureDescr1 =
+        Measure.MeasureDouble.create(MEASUREMENT_NAME, MEASUREMENT_DESCRIPTION, MEASUREMENT_UNIT);
+    MeasureDouble measureDescr2 =
+        Measure.MeasureDouble.create(MEASUREMENT_NAME_2, MEASUREMENT_DESCRIPTION, MEASUREMENT_UNIT);
     ViewDescriptor viewDescr1 =
         createDistributionViewDescriptor(
             VIEW_NAME, measureDescr1, DISTRIBUTION_AGGREGATION_DESCRIPTOR, Arrays.asList(KEY));

--- a/examples/src/main/java/io/opencensus/examples/stats/StatsRunner.java
+++ b/examples/src/main/java/io/opencensus/examples/stats/StatsRunner.java
@@ -14,7 +14,7 @@
 package io.opencensus.examples.stats;
 
 import io.opencensus.common.NonThrowingCloseable;
-import io.opencensus.stats.Measure.DoubleMeasure;
+import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.MeasureMap;
 import io.opencensus.stats.Stats;
 import io.opencensus.stats.StatsContext;
@@ -38,10 +38,10 @@ public class StatsRunner {
   private static final TagValue V4 = TagValue.create("v4");
 
   private static final String UNIT = "1";
-  private static final DoubleMeasure M1 =
-      DoubleMeasure.create("m1", "1st test metric", UNIT);
-  private static final DoubleMeasure M2 =
-      DoubleMeasure.create("m2", "2nd test metric", UNIT);
+  private static final MeasureDouble M1 =
+      MeasureDouble.create("m1", "1st test metric", UNIT);
+  private static final MeasureDouble M2 =
+      MeasureDouble.create("m2", "2nd test metric", UNIT);
 
   private static final StatsContextFactory factory = Stats.getStatsContextFactory();
   private static final StatsContext DEFAULT = factory.getDefault();


### PR DESCRIPTION
Rename to follow the name convention on Tag/TagKey:
- DoubleMeasure -> MeasureDouble
- LongMeasure -> MeasureLong
- DoubleMeasurement -> MeasurementDouble
- LongMeasure -> MeasurementLong 

This PR is built on top of https://github.com/census-instrumentation/opencensus-java/pull/405, I'll rebase this PR once I've merged PR https://github.com/census-instrumentation/opencensus-java/pull/405.