### PR TITLE
Refactor AttributeValue to use a "match" method.

### DIFF
--- a/api/src/main/java/io/opencensus/common/Function.java
+++ b/api/src/main/java/io/opencensus/common/Function.java
@@ -14,13 +14,12 @@
 package io.opencensus.common;
 
 /**
- * Used to specify matching functions for use encoding tagged unions (i.e. sum types) in Java.
+ * Used to specify matching functions for use encoding tagged unions (i.e. sum types) in Java. See
+ * {@link io.opencensus.trace.AttributeValue#match} for an example of its use.
  *
  * <p>Note: This class is based on the java.util.Function class added in Java 1.8. We cannot use the
  * Function from Java 1.8 because this library is Java 1.6 compatible.
  */
-// TODO(bdrutu): Add back "See {@link io.opencensus.stats.ViewDescriptor} for an example of its
-// use."
 public interface Function<A, B> {
   B apply(A arg);
 }

--- a/api/src/main/java/io/opencensus/common/Functions.java
+++ b/api/src/main/java/io/opencensus/common/Functions.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.common;
+
+/** Commonly used {@link Function} instances. */
+public final class Functions {
+  private Functions() {}
+
+  private static final Function<Object, Void> RETURN_NULL =
+      new Function<Object, Void>() {
+        @Override
+        public Void apply(Object ignored) {
+          return null;
+        }
+      };
+
+  private static final Function<Object, Void> THROW_ILLEGAL_ARGUMENT_EXCEPTION =
+      new Function<Object, Void>() {
+        @Override
+        public Void apply(Object ignored) {
+          throw new IllegalArgumentException();
+        }
+      };
+
+  /**
+   * A {@code Function} that always ignores its argument and returns {@code null}.
+   *
+   * @return a {@code Function} that always ignores its argument and returns {@code null}.
+   */
+  public static <T> Function<Object, T> returnNull() {
+    // It is safe to cast a producer of Void to anything, because Void is always null.
+    @SuppressWarnings("unchecked")
+    Function<Object, T> function = (Function<Object, T>) RETURN_NULL;
+    return function;
+  }
+
+  /**
+   * A {@code Function} that always ignores its argument and returns a constant value.
+   *
+   * @return a {@code Function} that always ignores its argument and returns a constant value.
+   */
+  public static <T> Function<Object, T> returnConstant(final T constant) {
+    return new Function<Object, T>() {
+      @Override
+      public T apply(Object ignored) {
+        return constant;
+      }
+    };
+  }
+
+  /**
+   * A {@code Function} that always ignores its argument and throws an {@link
+   * IllegalArgumentException}.
+   *
+   * @return a {@code Function} that always ignores its argument and throws an {@link
+   *     IllegalArgumentException}.
+   */
+  public static <T> Function<Object, T> throwIllegalArgumentException() {
+    // It is safe to cast a producer of Void to anything, because Void is always null.
+    @SuppressWarnings("unchecked")
+    Function<Object, T> function = (Function<Object, T>) THROW_ILLEGAL_ARGUMENT_EXCEPTION;
+    return function;
+  }
+}

--- a/api/src/test/java/io/opencensus/common/FunctionsTest.java
+++ b/api/src/test/java/io/opencensus/common/FunctionsTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.common;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/** Tests for {@link Functions}. */
+public class FunctionsTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testReturnNull() {
+    assertThat(Functions.returnNull().apply("ignored")).isNull();
+  }
+
+  @Test
+  public void testReturnConstant() {
+    assertThat(Functions.returnConstant(123).apply("ignored")).isEqualTo(123);
+  }
+
+  @Test
+  public void testThrowIllegalArgumentException() {
+    Function<Object, Void> f = Functions.throwIllegalArgumentException();
+    thrown.expect(IllegalArgumentException.class);
+    f.apply("ignored");
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/AttributeValueTest.java
+++ b/api/src/test/java/io/opencensus/trace/AttributeValueTest.java
@@ -14,8 +14,11 @@
 package io.opencensus.trace;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
 
 import com.google.common.testing.EqualsTester;
+import io.opencensus.common.Function;
+import io.opencensus.common.Functions;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,25 +29,82 @@ public class AttributeValueTest {
   @Test
   public void stringAttributeValue() {
     AttributeValue attribute = AttributeValue.stringAttributeValue("MyStringAttributeValue");
-    assertThat(attribute.getStringValue()).isEqualTo("MyStringAttributeValue");
-    assertThat(attribute.getBooleanValue()).isNull();
-    assertThat(attribute.getLongValue()).isNull();
+    attribute.match(
+        new Function<String, Object>() {
+          @Override
+          public Object apply(String stringValue) {
+            assertThat(stringValue).isEqualTo("MyStringAttributeValue");
+            return null;
+          }
+        },
+        new Function<Boolean, Object>() {
+          @Override
+          public Object apply(Boolean booleanValue) {
+            fail("Expected a String");
+            return null;
+          }
+        },
+        new Function<Long, Object>() {
+          @Override
+          public Object apply(Long longValue) {
+            fail("Expected a String");
+            return null;
+          }
+        }, Functions.throwIllegalArgumentException());
   }
 
   @Test
   public void booleanAttributeValue() {
     AttributeValue attribute = AttributeValue.booleanAttributeValue(true);
-    assertThat(attribute.getStringValue()).isNull();
-    assertThat(attribute.getBooleanValue()).isTrue();
-    assertThat(attribute.getLongValue()).isNull();
+    attribute.match(
+        new Function<String, Object>() {
+          @Override
+          public Object apply(String stringValue) {
+            fail("Expected a Boolean");
+            return null;
+          }
+        },
+        new Function<Boolean, Object>() {
+          @Override
+          public Object apply(Boolean booleanValue) {
+            assertThat(booleanValue).isTrue();
+            return null;
+          }
+        },
+        new Function<Long, Object>() {
+          @Override
+          public Object apply(Long longValue) {
+            fail("Expected a Boolean");
+            return null;
+          }
+        }, Functions.throwIllegalArgumentException());
   }
 
   @Test
   public void longAttributeValue() {
     AttributeValue attribute = AttributeValue.longAttributeValue(123456L);
-    assertThat(attribute.getStringValue()).isNull();
-    assertThat(attribute.getBooleanValue()).isNull();
-    assertThat(attribute.getLongValue()).isEqualTo(123456L);
+    attribute.match(
+        new Function<String, Object>() {
+          @Override
+          public Object apply(String stringValue) {
+            fail("Expected a Long");
+            return null;
+          }
+        },
+        new Function<Boolean, Object>() {
+          @Override
+          public Object apply(Boolean booleanValue) {
+            fail("Expected a Long");
+            return null;
+          }
+        },
+        new Function<Long, Object>() {
+          @Override
+          public Object apply(Long longValue) {
+            assertThat(longValue).isEqualTo(123456L);
+            return null;
+          }
+        }, Functions.throwIllegalArgumentException());
   }
 
   @Test


### PR DESCRIPTION
Two commits:

#### Add convenience functions for handling default case in "match" methods.

#### Refactor AttributeValue to use a "match" method.

AttributeValue.match takes four function arguments: functions for handling
String, Long, and Boolean values, and a function for handling any new types
that could be added in the future.

_____________________________________________
The `match` pattern is similar to the one used in #323 and #396.

/cc @dinooliva @songy23 
