### PR TITLE
Remove View 'getName' and factory methods that use Strings for view name.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
+++ b/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
@@ -65,63 +65,63 @@ public final class RpcViewConstants {
   // Rpc client {@link View}s.
   public static final DistributionView RPC_CLIENT_ERROR_COUNT_VIEW =
       DistributionView.create(
-          "grpc.io/client/error_count/distribution_cumulative",
+          View.Name.create("grpc.io/client/error_count/distribution_cumulative"),
           "RPC Errors",
           RPC_CLIENT_ERROR_COUNT,
           DistributionAggregation.create(),
           Arrays.asList(RPC_STATUS, RPC_CLIENT_METHOD));
   public static final DistributionView RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
       DistributionView.create(
-          "grpc.io/client/roundtrip_latency/distribution_cumulative",
+          View.Name.create("grpc.io/client/roundtrip_latency/distribution_cumulative"),
           "Latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
           DistributionAggregation.create(RPC_MILLIS_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_CLIENT_METHOD));
   public static final DistributionView RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW =
       DistributionView.create(
-          "grpc.io/client/server_elapsed_time/distribution_cumulative",
+          View.Name.create("grpc.io/client/server_elapsed_time/distribution_cumulative"),
           "Server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
           DistributionAggregation.create(RPC_MILLIS_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_CLIENT_METHOD));
   public static final DistributionView RPC_CLIENT_REQUEST_BYTES_VIEW =
       DistributionView.create(
-          "grpc.io/client/request_bytes/distribution_cumulative",
+          View.Name.create("grpc.io/client/request_bytes/distribution_cumulative"),
           "Request bytes",
           RPC_CLIENT_REQUEST_BYTES,
           DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_CLIENT_METHOD));
   public static final DistributionView RPC_CLIENT_RESPONSE_BYTES_VIEW =
       DistributionView.create(
-          "grpc.io/client/response_bytes/distribution_cumulative",
+          View.Name.create("grpc.io/client/response_bytes/distribution_cumulative"),
           "Response bytes",
           RPC_CLIENT_RESPONSE_BYTES,
           DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_CLIENT_METHOD));
   public static final DistributionView RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW =
       DistributionView.create(
-          "grpc.io/client/uncompressed_request_bytes/distribution_cumulative",
+          View.Name.create("grpc.io/client/uncompressed_request_bytes/distribution_cumulative"),
           "Uncompressed Request bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
           DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_CLIENT_METHOD));
   public static final DistributionView RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
       DistributionView.create(
-          "grpc.io/client/uncompressed_response_bytes/distribution_cumulative",
+          View.Name.create("grpc.io/client/uncompressed_response_bytes/distribution_cumulative"),
           "Uncompressed Response bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
           DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_CLIENT_METHOD));
   public static final DistributionView RPC_CLIENT_REQUEST_COUNT_VIEW =
       DistributionView.create(
-          "grpc.io/client/request_count/distribution_cumulative",
+          View.Name.create("grpc.io/client/request_count/distribution_cumulative"),
           "Count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
           DistributionAggregation.create(),
           Arrays.asList(RPC_CLIENT_METHOD));
   public static final DistributionView RPC_CLIENT_RESPONSE_COUNT_VIEW =
       DistributionView.create(
-          "grpc.io/client/response_count/distribution_cumulative",
+          View.Name.create("grpc.io/client/response_count/distribution_cumulative"),
           "Count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
           DistributionAggregation.create(),
@@ -131,63 +131,63 @@ public final class RpcViewConstants {
   // Rpc server {@link View}s.
   public static final DistributionView RPC_SERVER_ERROR_COUNT_VIEW =
       DistributionView.create(
-          "grpc.io/server/error_count/distribution_cumulative",
+          View.Name.create("grpc.io/server/error_count/distribution_cumulative"),
           "RPC Errors",
           RPC_SERVER_ERROR_COUNT,
           DistributionAggregation.create(),
           Arrays.asList(RPC_STATUS, RPC_SERVER_METHOD));
   public static final DistributionView RPC_SERVER_SERVER_LATENCY_VIEW =
       DistributionView.create(
-          "grpc.io/server/server_latency/distribution_cumulative",
+          View.Name.create("grpc.io/server/server_latency/distribution_cumulative"),
           "Latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
           DistributionAggregation.create(RPC_MILLIS_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_SERVER_METHOD));
   public static final DistributionView RPC_SERVER_SERVER_ELAPSED_TIME_VIEW =
       DistributionView.create(
-          "grpc.io/server/elapsed_time/distribution_cumulative",
+          View.Name.create("grpc.io/server/elapsed_time/distribution_cumulative"),
           "Server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
           DistributionAggregation.create(RPC_MILLIS_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_SERVER_METHOD));
   public static final DistributionView RPC_SERVER_REQUEST_BYTES_VIEW =
       DistributionView.create(
-          "grpc.io/server/request_bytes/distribution_cumulative",
+          View.Name.create("grpc.io/server/request_bytes/distribution_cumulative"),
           "Request bytes",
           RPC_SERVER_REQUEST_BYTES,
           DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_SERVER_METHOD));
   public static final DistributionView RPC_SERVER_RESPONSE_BYTES_VIEW =
       DistributionView.create(
-          "grpc.io/server/response_bytes/distribution_cumulative",
+          View.Name.create("grpc.io/server/response_bytes/distribution_cumulative"),
           "Response bytes",
           RPC_SERVER_RESPONSE_BYTES,
           DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_SERVER_METHOD));
   public static final DistributionView RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW =
       DistributionView.create(
-          "grpc.io/server/uncompressed_request_bytes/distribution_cumulative",
+          View.Name.create("grpc.io/server/uncompressed_request_bytes/distribution_cumulative"),
           "Uncompressed Request bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
           DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_SERVER_METHOD));
   public static final DistributionView RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
       DistributionView.create(
-          "grpc.io/server/uncompressed_response_bytes/distribution_cumulative",
+          View.Name.create("grpc.io/server/uncompressed_response_bytes/distribution_cumulative"),
           "Uncompressed Response bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
           DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
           Arrays.asList(RPC_SERVER_METHOD));
   public static final DistributionView RPC_SERVER_REQUEST_COUNT_VIEW =
       DistributionView.create(
-          "grpc.io/server/request_count/distribution_cumulative",
+          View.Name.create("grpc.io/server/request_count/distribution_cumulative"),
           "Count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
           DistributionAggregation.create(),
           Arrays.asList(RPC_SERVER_METHOD));
   public static final DistributionView RPC_SERVER_RESPONSE_COUNT_VIEW =
       DistributionView.create(
-          "grpc.io/server/response_count/distribution_cumulative",
+          View.Name.create("grpc.io/server/response_count/distribution_cumulative"),
           "Count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
           DistributionAggregation.create(),
@@ -200,7 +200,7 @@ public final class RpcViewConstants {
   // RPC client {@link IntervalView}s.
   public static final IntervalView RPC_CLIENT_ROUNDTRIP_LATENCY_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/roundtrip_latency/interval",
+          View.Name.create("grpc.io/client/roundtrip_latency/interval"),
           "Minute and Hour stats for latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -208,7 +208,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_REQUEST_BYTES_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/request_bytes/interval",
+          View.Name.create("grpc.io/client/request_bytes/interval"),
           "Minute and Hour stats for request size in bytes",
           RPC_CLIENT_REQUEST_BYTES,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -216,7 +216,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_RESPONSE_BYTES_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/response_bytes/interval",
+          View.Name.create("grpc.io/client/response_bytes/interval"),
           "Minute and Hour stats for response size in bytes",
           RPC_CLIENT_RESPONSE_BYTES,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -224,7 +224,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_ERROR_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/error_count/interval",
+          View.Name.create("grpc.io/client/error_count/interval"),
           "Minute and Hour stats for rpc errors",
           RPC_CLIENT_ERROR_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -232,7 +232,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/uncompressed_request_bytes/interval",
+          View.Name.create("grpc.io/client/uncompressed_request_bytes/interval"),
           "Minute and Hour stats for uncompressed request size in bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -240,7 +240,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/uncompressed_response_bytes/interval",
+          View.Name.create("grpc.io/client/uncompressed_response_bytes/interval"),
           "Minute and Hour stats for uncompressed response size in bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -248,7 +248,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_SERVER_ELAPSED_TIME_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/server_elapsed_time/interval",
+          View.Name.create("grpc.io/client/server_elapsed_time/interval"),
           "Minute and Hour stats for server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -256,7 +256,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_STARTED_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/started_count/interval",
+          View.Name.create("grpc.io/client/started_count/interval"),
           "Minute and Hour stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -264,7 +264,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_FINISHED_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/finished_count/interval",
+          View.Name.create("grpc.io/client/finished_count/interval"),
           "Minute and Hour stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -272,7 +272,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_REQUEST_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/request_count/interval",
+          View.Name.create("grpc.io/client/request_count/interval"),
           "Minute and Hour stats on the count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -280,7 +280,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_CLIENT_RESPONSE_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/client/response_count/interval",
+          View.Name.create("grpc.io/client/response_count/interval"),
           "Minute and Hour stats on the count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -289,7 +289,7 @@ public final class RpcViewConstants {
   // RPC server {@link IntervalView}s.
   public static final IntervalView RPC_SERVER_SERVER_LATENCY_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/server_latency/interval",
+          View.Name.create("grpc.io/server/server_latency/interval"),
           "Minute and Hour stats for server latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -297,7 +297,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_REQUEST_BYTES_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/request_bytes/interval",
+          View.Name.create("grpc.io/server/request_bytes/interval"),
           "Minute and Hour stats for request size in bytes",
           RPC_SERVER_REQUEST_BYTES,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -305,7 +305,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_RESPONSE_BYTES_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/response_bytes/interval",
+          View.Name.create("grpc.io/server/response_bytes/interval"),
           "Minute and Hour stats for response size in bytes",
           RPC_SERVER_RESPONSE_BYTES,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -313,7 +313,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_ERROR_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/error_count/interval",
+          View.Name.create("grpc.io/server/error_count/interval"),
           "Minute and Hour stats for rpc errors",
           RPC_SERVER_ERROR_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -321,7 +321,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/uncompressed_request_bytes/interval",
+          View.Name.create("grpc.io/server/uncompressed_request_bytes/interval"),
           "Minute and Hour stats for uncompressed request size in bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -329,7 +329,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/uncompressed_response_bytes/interval",
+          View.Name.create("grpc.io/server/uncompressed_response_bytes/interval"),
           "Minute and Hour stats for uncompressed response size in bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -337,7 +337,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_SERVER_ELAPSED_TIME_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/server_elapsed_time/interval",
+          View.Name.create("grpc.io/server/server_elapsed_time/interval"),
           "Minute and Hour stats for server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -345,7 +345,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_STARTED_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/started_count/interval",
+          View.Name.create("grpc.io/server/started_count/interval"),
           "Minute and Hour stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -353,7 +353,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_FINISHED_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/finished_count/interval",
+          View.Name.create("grpc.io/server/finished_count/interval"),
           "Minute and Hour stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -361,7 +361,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_REQUEST_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/request_count/interval",
+          View.Name.create("grpc.io/server/request_count/interval"),
           "Minute and Hour stats on the count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
@@ -369,7 +369,7 @@ public final class RpcViewConstants {
 
   public static final IntervalView RPC_SERVER_RESPONSE_COUNT_INTERVAL_VIEW =
       IntervalView.create(
-          "grpc.io/server/response_count/interval",
+          View.Name.create("grpc.io/server/response_count/interval"),
           "Minute and Hour stats on the count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
           IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -29,14 +29,7 @@ public abstract class View {
   /**
    * Name of view. Must be unique.
    */
-  public abstract Name getViewName();
-
-  /**
-   * Name of view, as a {@code String}.
-   */
-  public final String getName() {
-    return getViewName().asString();
-  }
+  public abstract Name getName();
 
   /**
    * More detailed description, for documentation purposes.

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -95,23 +95,6 @@ public abstract class View {
      * Constructs a new {@link DistributionView}.
      */
     public static DistributionView create(
-        String name,
-        String description,
-        Measure measure,
-        DistributionAggregation distributionAggregation,
-        List<TagKey> tagKeys) {
-      return create(
-          Name.create(name),
-          description,
-          measure,
-          distributionAggregation,
-          tagKeys);
-    }
-
-    /**
-     * Constructs a new {@link DistributionView}.
-     */
-    public static DistributionView create(
         Name name,
         String description,
         Measure measure,
@@ -145,23 +128,6 @@ public abstract class View {
   @Immutable
   @AutoValue
   public abstract static class IntervalView extends View {
-    /**
-     * Constructs a new {@link IntervalView}.
-     */
-    public static IntervalView create(
-        String name,
-        String description,
-        Measure measure,
-        IntervalAggregation intervalAggregation,
-        List<TagKey> tagKeys) {
-      return create(
-          Name.create(name),
-          description,
-          measure,
-          intervalAggregation,
-          tagKeys);
-    }
-
     /**
      * Constructs a new {@link IntervalView}.
      */

--- a/core/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -167,7 +167,7 @@ public final class ViewDataTest {
   List<Tag> tags2 = Arrays.asList(Tag.create(K1, V10), Tag.create(K2, V20));
 
   // name
-  private final String name = "test-view";
+  private final View.Name name = View.Name.create("test-view");
   // description
   private final String description = "test-view-descriptor description";
   // measurement descriptor

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -36,8 +36,7 @@ public final class ViewTest {
     final View view = DistributionView.create(
         name, description, measure, dAggr, keys);
 
-    assertThat(view.getViewName()).isEqualTo(name);
-    assertThat(view.getName()).isEqualTo(name.asString());
+    assertThat(view.getName()).isEqualTo(name);
     assertThat(view.getDescription()).isEqualTo(description);
     assertThat(view.getMeasure().getName()).isEqualTo(measure.getName());
     assertThat(view.getDimensions()).hasSize(2);
@@ -63,8 +62,7 @@ public final class ViewTest {
     final View view = IntervalView.create(
         name, description, measure, iAggr, keys);
 
-    assertThat(view.getViewName()).isEqualTo(name);
-    assertThat(view.getName()).isEqualTo(name.asString());
+    assertThat(view.getName()).isEqualTo(name);
     assertThat(view.getDescription()).isEqualTo(description);
     assertThat(view.getMeasure().getName())
         .isEqualTo(measure.getName());

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -110,17 +110,7 @@ public final class ViewTest {
   @Test(expected = NullPointerException.class)
   public void preventNullDistributionViewName() {
     DistributionView.create(
-        (View.Name) null,
-        description,
-        measure,
-        DistributionAggregation.create(),
-        keys);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void preventNullDistributionViewStringName() {
-    DistributionView.create(
-        (String) null,
+        null,
         description,
         measure,
         DistributionAggregation.create(),
@@ -130,17 +120,7 @@ public final class ViewTest {
   @Test(expected = NullPointerException.class)
   public void preventNullIntervalViewName() {
     IntervalView.create(
-        (View.Name) null,
-        description,
-        measure,
-        IntervalAggregation.create(Arrays.asList(Duration.fromMillis(1))),
-        keys);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void preventNullIntervalViewStringName() {
-    IntervalView.create(
-        (String) null,
+        null,
         description,
         measure,
         IntervalAggregation.create(Arrays.asList(Duration.fromMillis(1))),

--- a/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
@@ -63,7 +63,7 @@ final class MeasureToViewMap {
     Collection<MutableViewData> views =
         mutableMap.get(view.getMeasure().getName());
     for (MutableViewData viewData : views) {
-      if (viewData.getView().getViewName().equals(viewName)) {
+      if (viewData.getView().getName().equals(viewName)) {
         return viewData;
       }
     }
@@ -73,7 +73,7 @@ final class MeasureToViewMap {
 
   /** Enable stats collection for the given {@link View}. */
   synchronized void registerView(View view, Clock clock) {
-    View existing = registeredViews.get(view.getViewName());
+    View existing = registeredViews.get(view.getName());
     if (existing != null) {
       if (existing.equals(view)) {
         // Ignore views that are already registered.
@@ -83,7 +83,7 @@ final class MeasureToViewMap {
             "A different view with the same name is already registered: " + existing);
       }
     }
-    registeredViews.put(view.getViewName(), view);
+    registeredViews.put(view.getName(), view);
     MutableViewData mutableViewData =
         view.match(
             new CreateMutableDistributionViewDataFunction(clock),

--- a/core_impl/src/main/java/io/opencensus/stats/ViewManagerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/stats/ViewManagerImpl.java
@@ -34,6 +34,6 @@ final class ViewManagerImpl extends ViewManager {
   // TODO(sebright): Replace this method with the View.Name version.
   @Override
   public ViewData getView(View view) {
-    return statsManager.getView(view.getViewName());
+    return statsManager.getView(view.getName());
   }
 }

--- a/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
@@ -174,8 +174,12 @@ public class StatsContextTest {
   @Test
   public void testRecordLong() {
     MeasureLong measure = MeasureLong.create("long measure", "description", "1");
-    viewManager.registerView(View.DistributionView
-        .create("name", "description", measure, DistributionAggregation.create(),
+    viewManager.registerView(
+        View.DistributionView.create(
+            View.Name.create("name"),
+            "description",
+            measure,
+            DistributionAggregation.create(),
             Arrays.asList(K1)));
     thrown.expect(UnsupportedOperationException.class);
     defaultStatsContext.with(K1, V1).record(MeasureMap.builder().set(measure,1L).build());


### PR DESCRIPTION
The View `getName` and factory methods had different versions for handling names as type `String` and `View.Name`.  This PR removes the String versions, since they are no longer needed for backwards compatibility.  View.Name can be used to look up views when only the name is known.

/cc @bogdandrutu