### PR TITLE
Change *_COUNT RPC constants to MeasureLong, add TODO to support long

### DIFF
--- a/core/src/main/java/io/opencensus/stats/Measure.java
+++ b/core/src/main/java/io/opencensus/stats/Measure.java
@@ -90,7 +90,6 @@ public abstract class Measure {
 
   @Immutable
   @AutoValue
-  // TODO: determine whether we want to support MeasureLong in V0.1
   public abstract static class MeasureLong extends Measure {
 
     MeasureLong() {

--- a/core/src/main/java/io/opencensus/stats/RpcMeasureConstants.java
+++ b/core/src/main/java/io/opencensus/stats/RpcMeasureConstants.java
@@ -14,11 +14,11 @@
 package io.opencensus.stats;
 
 import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.Measure.MeasureLong;
 
 /**
  * Constants for collecting rpc stats.
  */
-// TODO(songya): change *_COUNT constants to LongMeasure if it's supported in v0.1.
 public final class RpcMeasureConstants {
 
   // Rpc tag keys.
@@ -32,8 +32,8 @@ public final class RpcMeasureConstants {
   private static final String MILLISECOND = "ms";
 
   // RPC client Measures.
-  public static final MeasureDouble RPC_CLIENT_ERROR_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_CLIENT_ERROR_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/client/error_count",
           "RPC Errors",
           COUNT);
@@ -67,31 +67,31 @@ public final class RpcMeasureConstants {
           "grpc.io/client/uncompressed_response_bytes",
           "Uncompressed Response bytes",
           BYTE);
-  public static final MeasureDouble RPC_CLIENT_STARTED_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_CLIENT_STARTED_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/client/started_count",
           "Number of client RPCs (streams) started",
           COUNT);
-  public static final MeasureDouble RPC_CLIENT_FINISHED_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_CLIENT_FINISHED_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/client/finished_count",
           "Number of client RPCs (streams) finished",
           COUNT);
-  public static final MeasureDouble RPC_CLIENT_REQUEST_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_CLIENT_REQUEST_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/client/request_count",
           "Number of client RPC request messages",
           COUNT);
-  public static final MeasureDouble RPC_CLIENT_RESPONSE_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_CLIENT_RESPONSE_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/client/response_count",
           "Number of client RPC response messages",
           COUNT);
 
 
   // RPC server Measures.
-  public static final MeasureDouble RPC_SERVER_ERROR_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_SERVER_ERROR_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/server/error_count",
           "RPC Errors",
           COUNT);
@@ -125,23 +125,23 @@ public final class RpcMeasureConstants {
           "grpc.io/server/uncompressed_response_bytes",
           "Uncompressed Response bytes",
           BYTE);
-  public static final MeasureDouble RPC_SERVER_STARTED_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_SERVER_STARTED_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/server/started_count",
           "Number of server RPCs (streams) started",
           COUNT);
-  public static final MeasureDouble RPC_SERVER_FINISHED_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_SERVER_FINISHED_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/server/finished_count",
           "Number of server RPCs (streams) finished",
           COUNT);
-  public static final MeasureDouble RPC_SERVER_REQUEST_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_SERVER_REQUEST_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/server/request_count",
           "Number of server RPC request messages",
           COUNT);
-  public static final MeasureDouble RPC_SERVER_RESPONSE_COUNT =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong RPC_SERVER_RESPONSE_COUNT =
+      Measure.MeasureLong.create(
           "grpc.io/server/response_count",
           "Number of server RPC response messages",
           COUNT);

--- a/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
@@ -99,7 +99,8 @@ final class MeasureToViewMap {
       Measurement measurement = iterator.next();
       Collection<MutableViewData> views = mutableMap.get(measurement.getMeasure().getName());
       for (MutableViewData view : views) {
-        measurement.match(new RecordDoubleValueFunc(tags, view), new RecordLongValueFunc());
+        measurement.match(
+            new RecordDoubleValueFunc(tags, view), new RecordLongValueFunc(tags, view));
       }
     }
   }
@@ -146,8 +147,16 @@ final class MeasureToViewMap {
   private static final class RecordLongValueFunc implements Function<MeasurementLong, Void> {
     @Override
     public Void apply(MeasurementLong arg) {
-      // TODO: determine if we want to support LongMeasure in v0.1
-      throw new UnsupportedOperationException("Long measurements not supported.");
+      view.record(tags, arg.getValue());
+      return null;
+    }
+
+    private final StatsContextImpl tags;
+    private final MutableViewData view;
+
+    private RecordLongValueFunc(StatsContextImpl tags, MutableViewData view) {
+      this.tags = tags;
+      this.view = view;
     }
   }
 }

--- a/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
@@ -40,9 +40,14 @@ abstract class MutableViewData {
   abstract View getView();
 
   /**
-   * Record stats with the given tags.
+   * Record double stats with the given tags.
    */
   abstract void record(StatsContextImpl tags, double value);
+
+  /**
+   * Record long stats with the given tags.
+   */
+  abstract void record(StatsContextImpl tags, long value);
 
   /**
    * Convert this {@link MutableViewData} to {@link ViewData}.
@@ -99,6 +104,12 @@ abstract class MutableViewData {
         tagValueDistributionMap.put(tagValues, distribution);
       }
       tagValueDistributionMap.get(tagValues).add(value);
+    }
+
+    @Override
+    void record(StatsContextImpl tags, long value) {
+      // TODO(songya): modify MutableDistribution to support long values.
+      throw new UnsupportedOperationException("Not implemented.");
     }
 
     @Override
@@ -174,6 +185,11 @@ abstract class MutableViewData {
 
     @Override
     void record(StatsContextImpl tags, double value) {
+      throw new UnsupportedOperationException("Not implemented.");
+    }
+
+    @Override
+    void record(StatsContextImpl tags, long value) {
       throw new UnsupportedOperationException("Not implemented.");
     }
 


### PR DESCRIPTION
Based on our conversation, I think MeasureLong is needed for v0.1. I've changed a few RPC constants to use MeasureLong and add TODO to support record long values (which will be implemented in a separate PR),