### PR TITLE
Move stats Context key to io.opencensus.tags.unsafe package.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/CurrentTagsUtils.java
+++ b/core/src/main/java/io/opencensus/stats/CurrentTagsUtils.java
@@ -21,6 +21,7 @@ import io.opencensus.tags.unsafe.ContextUtils;
 /**
  * Util methods/functionality to interact with the {@link io.grpc.Context}.
  */
+// TODO(sebright): Move this into the tags package.
 final class CurrentTagsUtils {
 
   // Static class.

--- a/core/src/main/java/io/opencensus/stats/CurrentTagsUtils.java
+++ b/core/src/main/java/io/opencensus/stats/CurrentTagsUtils.java
@@ -14,25 +14,17 @@
 package io.opencensus.stats;
 
 import io.grpc.Context;
+
 import io.opencensus.common.NonThrowingCloseable;
+import io.opencensus.tags.unsafe.ContextUtils;
 
 /**
  * Util methods/functionality to interact with the {@link io.grpc.Context}.
- *
- * <p>Users must interact with the current Context via the public APIs in {@link
- * StatsContextFactory} and avoid usages of the {@link #STATS_CONTEXT_KEY} directly.
  */
-public final class ContextUtils {
-
-  /**
-   * The {@link io.grpc.Context.Key} used to interact with {@link io.grpc.Context}.
-   */
-  // TODO(songya): Discourage the usage of STATS_CONTEXT_KEY for normal users if needed.
-  public static final Context.Key<StatsContext> STATS_CONTEXT_KEY = Context.key(
-      "instrumentation-stats-key");
+final class CurrentTagsUtils {
 
   // Static class.
-  private ContextUtils() {
+  private CurrentTagsUtils() {
   }
 
   /**
@@ -41,7 +33,7 @@ public final class ContextUtils {
    * @return The {@code StatsContext} from the current context.
    */
   static StatsContext getCurrentStatsContext() {
-    return STATS_CONTEXT_KEY.get(Context.current());
+    return ContextUtils.TAG_CONTEXT_KEY.get(Context.current());
   }
 
   /**
@@ -56,7 +48,7 @@ public final class ContextUtils {
    *     current context.
    */
   static NonThrowingCloseable withStatsContext(StatsContext statsContext) {
-    return new WithStatsContext(statsContext, STATS_CONTEXT_KEY);
+    return new WithStatsContext(statsContext, ContextUtils.TAG_CONTEXT_KEY);
   }
 
   // Supports try-with-resources idiom.

--- a/core/src/main/java/io/opencensus/stats/StatsContextFactory.java
+++ b/core/src/main/java/io/opencensus/stats/StatsContextFactory.java
@@ -48,7 +48,7 @@ public abstract class StatsContextFactory {
    * {@code io.grpc.Context}.
    */
   public final StatsContext getCurrentStatsContext() {
-    StatsContext statsContext = ContextUtils.getCurrentStatsContext();
+    StatsContext statsContext = CurrentTagsUtils.getCurrentStatsContext();
     return statsContext != null ? statsContext : getDefault();
   }
 
@@ -99,6 +99,6 @@ public abstract class StatsContextFactory {
    * @throws NullPointerException if statsContext is null.
    */
   public final NonThrowingCloseable withStatsContext(StatsContext statsContext) {
-    return ContextUtils.withStatsContext(checkNotNull(statsContext, "statsContext"));
+    return CurrentTagsUtils.withStatsContext(checkNotNull(statsContext, "statsContext"));
   }
 }

--- a/core/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
+++ b/core/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags.unsafe;
+
+import io.grpc.Context;
+import io.opencensus.stats.StatsContext;
+import io.opencensus.tags.TagContext;
+
+/**
+ * Utility methods for accessing the {@link TagContext} contained in the {@link io.grpc.Context}.
+ *
+ * <p>Most code should interact with the current context via the public APIs in {@link
+ * io.opencensus.stats.StatsContextFactory} and avoid accessing {@link #TAG_CONTEXT_KEY} directly.
+ */
+// TODO(sebright): Update this Javadoc to reference the class in the tags package that provides
+// methods for interacting with the current context, once TAG_CONTEXT_KEY uses TagContext.
+public final class ContextUtils {
+  private ContextUtils() {}
+
+  /**
+   * The {@link io.grpc.Context.Key} used to interact with the {@code TagContext} contained in the
+   * {@link io.grpc.Context}.
+   */
+  public static final Context.Key<StatsContext> TAG_CONTEXT_KEY =
+      Context.key("opencensus-tag-context-key");
+}

--- a/core/src/test/java/io/opencensus/stats/CurrentTagsUtilsTest.java
+++ b/core/src/test/java/io/opencensus/stats/CurrentTagsUtilsTest.java
@@ -25,10 +25,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
 /**
- * Unit tests for {@link ContextUtils}.
+ * Unit tests for {@link CurrentTagsUtils}.
  */
 @RunWith(JUnit4.class)
-public class ContextUtilsTest {
+public class CurrentTagsUtilsTest {
 
   @Mock
   private StatsContext statsContext;
@@ -40,38 +40,38 @@ public class ContextUtilsTest {
 
   @Test
   public void testGetCurrentStatsContext_WhenNoContext() {
-    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+    assertThat(CurrentTagsUtils.getCurrentStatsContext()).isNull();
   }
 
   @Test
   public void testWithStatsContext() {
-    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
-    NonThrowingCloseable scopedStatsCtx = ContextUtils.withStatsContext(statsContext);
+    assertThat(CurrentTagsUtils.getCurrentStatsContext()).isNull();
+    NonThrowingCloseable scopedStatsCtx = CurrentTagsUtils.withStatsContext(statsContext);
     try {
-      assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+      assertThat(CurrentTagsUtils.getCurrentStatsContext()).isSameAs(statsContext);
     } finally {
       scopedStatsCtx.close();
     }
-    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+    assertThat(CurrentTagsUtils.getCurrentStatsContext()).isNull();
   }
 
   @Test
   public void testWithStatsContextUsingWrap() {
     Runnable runnable;
-    NonThrowingCloseable scopedStatsCtx = ContextUtils.withStatsContext(statsContext);
+    NonThrowingCloseable scopedStatsCtx = CurrentTagsUtils.withStatsContext(statsContext);
     try {
-      assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+      assertThat(CurrentTagsUtils.getCurrentStatsContext()).isSameAs(statsContext);
       runnable = Context.current().wrap(
           new Runnable() {
             @Override
             public void run() {
-              assertThat(ContextUtils.getCurrentStatsContext()).isSameAs(statsContext);
+              assertThat(CurrentTagsUtils.getCurrentStatsContext()).isSameAs(statsContext);
             }
           });
     } finally {
       scopedStatsCtx.close();
     }
-    assertThat(ContextUtils.getCurrentStatsContext()).isNull();
+    assertThat(CurrentTagsUtils.getCurrentStatsContext()).isNull();
     // When we run the runnable we will have the statsContext in the current Context.
     runnable.run();
   }

--- a/core_impl/src/test/java/io/opencensus/stats/StatsContextFactoryTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsContextFactoryTest.java
@@ -15,11 +15,12 @@ package io.opencensus.stats;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.grpc.Context;
 import io.opencensus.common.NonThrowingCloseable;
 import io.opencensus.internal.SimpleEventQueue;
-import io.opencensus.testing.common.TestClock;
 import io.opencensus.internal.VarInt;
-import io.grpc.Context;
+import io.opencensus.tags.unsafe.ContextUtils;
+import io.opencensus.testing.common.TestClock;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -146,7 +147,7 @@ public class StatsContextFactoryTest {
   public void testGetCurrentStatsContext() {
     assertThat(factory.getCurrentStatsContext()).isEqualTo(defaultCtx);
     Context origContext = Context.current().withValue(
-        ContextUtils.STATS_CONTEXT_KEY, statsContext)
+        ContextUtils.TAG_CONTEXT_KEY, statsContext)
         .attach();
     // Make sure context is detached even if test fails.
     try {


### PR DESCRIPTION
This commit starts refactoring the stats io.grpc.Context key so that it can be
used to access a TagContext.  It also organizes the classes that interact with
the Context to be more similar to the tracing package.

The commit renames the constant from STATS_CONTEXT_KEY to TAG_CONTEXT_KEY and
moves it from io.opencensus.stats.ContextUtils to
io.opencensus.tags.unsafe.ContextUtils.  It also renames the
io.opencensus.stats.ContextUtils class to CurrentTagsUtils and makes it
package-private, since the only public member was the Context key.  The Context
key still has type Context.Key<StatsContext>, for now.