### PR TITLE
Revert "Remove Scope.close() method."

### DIFF
--- a/api/src/main/java/io/opencensus/common/Scope.java
+++ b/api/src/main/java/io/opencensus/common/Scope.java
@@ -26,4 +26,7 @@ package io.opencensus.common;
  * </pre>
  */
 @SuppressWarnings("deprecation")
-public interface Scope extends NonThrowingCloseable {}
+public interface Scope extends NonThrowingCloseable {
+  @Override
+  void close();
+}


### PR DESCRIPTION
This reverts commit 969f95088a3a1e490460ad53931b24e46e6ca907.

The close() override is necessary to suppress a deprecation warning from
NonThrowingCloseable.close().