### PR TITLE
Refactor to use more generic View and ViewData.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/BucketBoundaries.java
+++ b/core/src/main/java/io/opencensus/stats/BucketBoundaries.java
@@ -23,14 +23,15 @@ import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * The optional histogram bucket boundaries for a {@link Distribution}.
+ * The optional histogram bucket boundaries for an {@link Aggregation.Histogram}.
  */
 @Immutable
 @AutoValue
 public abstract class BucketBoundaries {
 
   /**
-   * @param bucketBoundaries the boundaries for the buckets in the underlying {@link Distribution}.
+   * @param bucketBoundaries the boundaries for the buckets in the underlying
+   * {@link Aggregation.Histogram}.
    * @return a new {@code BucketBoundaries} with the specified boundaries.
    * @throws NullPointerException if {@code bucketBoundaries} is null.
    * @throws IllegalArgumentException if {@code bucketBoundaries} is not sorted.

--- a/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
+++ b/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
@@ -42,9 +42,6 @@ import static io.opencensus.stats.RpcMeasureConstants.RPC_STATUS;
 import io.opencensus.common.Duration;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Histogram;
-import io.opencensus.stats.Aggregation.Mean;
-import io.opencensus.stats.Aggregation.Range;
-import io.opencensus.stats.Aggregation.StdDev;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.View.Window;
 import io.opencensus.stats.View.Window.CumulativeWindow;
@@ -75,22 +72,19 @@ public final class RpcViewConstants {
           4096.0, 8192.0, 16384.0, 32768.0, 65536.0));
 
   static final List<Aggregation> AGGREGATION_NO_HISTOGRAM = Collections.unmodifiableList(
-      Arrays.asList(Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create()));
+          Arrays.asList(Sum.create(), Count.create()));
 
   static final List<Aggregation> AGGREGATION_WITH_BYTES_HISTOGRAM = Collections.unmodifiableList(
-      Arrays.asList(Sum.create(), Count.create(), Range.create(),
-          Histogram.create(BucketBoundaries.create(RPC_BYTES_BUCKET_BOUNDARIES)),
-          Mean.create(), StdDev.create()));
+      Arrays.asList(Sum.create(), Count.create(),
+          Histogram.create(BucketBoundaries.create(RPC_BYTES_BUCKET_BOUNDARIES))));
 
   static final List<Aggregation> AGGREGATION_WITH_MILLIS_HISTOGRAM = Collections.unmodifiableList(
-      Arrays.asList(Sum.create(), Count.create(), Range.create(),
-          Histogram.create(BucketBoundaries.create(RPC_MILLIS_BUCKET_BOUNDARIES)),
-          Mean.create(), StdDev.create()));
+      Arrays.asList(Sum.create(), Count.create(),
+          Histogram.create(BucketBoundaries.create(RPC_MILLIS_BUCKET_BOUNDARIES))));
 
   static final List<Aggregation> AGGREGATION_WITH_COUNT_HISTOGRAM = Collections.unmodifiableList(
-      Arrays.asList(Sum.create(), Count.create(), Range.create(),
-          Histogram.create(BucketBoundaries.create(RPC_COUNT_BUCKET_BOUNDARIES)),
-          Mean.create(), StdDev.create()));
+      Arrays.asList(Sum.create(), Count.create(),
+          Histogram.create(BucketBoundaries.create(RPC_COUNT_BUCKET_BOUNDARIES))));
 
   static final Duration MINUTE = Duration.create(60, 0);
   static final Duration HOUR = Duration.create(60 * 60, 0);
@@ -98,7 +92,7 @@ public final class RpcViewConstants {
   static final Window INTERVAL_MINUTE = IntervalWindow.create(MINUTE);
   static final Window INTERVAL_HOUR = IntervalWindow.create(HOUR);
 
-  // Rpc client {@link View}s.
+  // Rpc client cumulative {@link View}s.
   public static final View RPC_CLIENT_ERROR_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/client/error_count/distribution_cumulative"),
@@ -173,7 +167,7 @@ public final class RpcViewConstants {
           CUMULATIVE);
 
 
-  // Rpc server {@link View}s.
+  // Rpc server cumulative {@link View}s.
   public static final View RPC_SERVER_ERROR_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/server/error_count/distribution_cumulative"),
@@ -249,11 +243,11 @@ public final class RpcViewConstants {
 
   // Interval Stats
 
-  // RPC client {@link View}s.
+  // RPC client interval {@link View}s.
   public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/roundtrip_latency/interval"),
-          "Minute and Hour stats for latency in msecs",
+          "Minute stats for latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -262,7 +256,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_REQUEST_BYTES_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/request_bytes/interval"),
-          "Minute and Hour stats for request size in bytes",
+          "Minute stats for request size in bytes",
           RPC_CLIENT_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -271,7 +265,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_RESPONSE_BYTES_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/response_bytes/interval"),
-          "Minute and Hour stats for response size in bytes",
+          "Minute stats for response size in bytes",
           RPC_CLIENT_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -280,7 +274,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_ERROR_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/error_count/interval"),
-          "Minute and Hour stats for rpc errors",
+          "Minute stats for rpc errors",
           RPC_CLIENT_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -289,7 +283,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/uncompressed_request_bytes/interval"),
-          "Minute and Hour stats for uncompressed request size in bytes",
+          "Minute stats for uncompressed request size in bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -298,7 +292,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/uncompressed_response_bytes/interval"),
-          "Minute and Hour stats for uncompressed response size in bytes",
+          "Minute stats for uncompressed response size in bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -307,7 +301,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/server_elapsed_time/interval"),
-          "Minute and Hour stats for server elapsed time in msecs",
+          "Minute stats for server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -316,7 +310,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_STARTED_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/started_count/interval"),
-          "Minute and Hour stats on the number of client RPCs started",
+          "Minute stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -325,7 +319,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_FINISHED_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/finished_count/interval"),
-          "Minute and Hour stats on the number of client RPCs finished",
+          "Minute stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -334,7 +328,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_REQUEST_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/request_count/interval"),
-          "Minute and Hour stats on the count of request messages per client RPC",
+          "Minute stats on the count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -343,7 +337,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_RESPONSE_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/response_count/interval"),
-          "Minute and Hour stats on the count of response messages per client RPC",
+          "Minute stats on the count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -352,7 +346,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/roundtrip_latency/interval"),
-          "Minute and Hour stats for latency in msecs",
+          "Hour stats for latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -361,7 +355,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_REQUEST_BYTES_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/request_bytes/interval"),
-          "Minute and Hour stats for request size in bytes",
+          "Hour stats for request size in bytes",
           RPC_CLIENT_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -370,7 +364,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_RESPONSE_BYTES_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/response_bytes/interval"),
-          "Minute and Hour stats for response size in bytes",
+          "Hour stats for response size in bytes",
           RPC_CLIENT_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -379,7 +373,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_ERROR_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/error_count/interval"),
-          "Minute and Hour stats for rpc errors",
+          "Hour stats for rpc errors",
           RPC_CLIENT_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -388,7 +382,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/uncompressed_request_bytes/interval"),
-          "Minute and Hour stats for uncompressed request size in bytes",
+          "Hour stats for uncompressed request size in bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -397,7 +391,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/uncompressed_response_bytes/interval"),
-          "Minute and Hour stats for uncompressed response size in bytes",
+          "Hour stats for uncompressed response size in bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -406,7 +400,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/server_elapsed_time/interval"),
-          "Minute and Hour stats for server elapsed time in msecs",
+          "Hour stats for server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -415,7 +409,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_STARTED_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/started_count/interval"),
-          "Minute and Hour stats on the number of client RPCs started",
+          "Hour stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -424,7 +418,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_FINISHED_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/finished_count/interval"),
-          "Minute and Hour stats on the number of client RPCs finished",
+          "Hour stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -433,7 +427,7 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_REQUEST_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/request_count/interval"),
-          "Minute and Hour stats on the count of request messages per client RPC",
+          "Hour stats on the count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
@@ -442,17 +436,17 @@ public final class RpcViewConstants {
   public static final View RPC_CLIENT_RESPONSE_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/client/response_count/interval"),
-          "Minute and Hour stats on the count of response messages per client RPC",
+          "Hour stats on the count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
-  // RPC server {@link View}s.
+  // RPC server interval {@link View}s.
   public static final View RPC_SERVER_SERVER_LATENCY_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/server_latency/interval"),
-          "Minute and Hour stats for server latency in msecs",
+          "Minute stats for server latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -461,7 +455,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_REQUEST_BYTES_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/request_bytes/interval"),
-          "Minute and Hour stats for request size in bytes",
+          "Minute stats for request size in bytes",
           RPC_SERVER_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -470,7 +464,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_RESPONSE_BYTES_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/response_bytes/interval"),
-          "Minute and Hour stats for response size in bytes",
+          "Minute stats for response size in bytes",
           RPC_SERVER_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -479,7 +473,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_ERROR_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/error_count/interval"),
-          "Minute and Hour stats for rpc errors",
+          "Minute stats for rpc errors",
           RPC_SERVER_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -488,7 +482,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/uncompressed_request_bytes/interval"),
-          "Minute and Hour stats for uncompressed request size in bytes",
+          "Minute stats for uncompressed request size in bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -497,7 +491,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/uncompressed_response_bytes/interval"),
-          "Minute and Hour stats for uncompressed response size in bytes",
+          "Minute stats for uncompressed response size in bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -506,7 +500,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_SERVER_ELAPSED_TIME_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/server_elapsed_time/interval"),
-          "Minute and Hour stats for server elapsed time in msecs",
+          "Minute stats for server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -515,7 +509,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_STARTED_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/started_count/interval"),
-          "Minute and Hour stats on the number of server RPCs started",
+          "Minute stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -524,7 +518,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_FINISHED_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/finished_count/interval"),
-          "Minute and Hour stats on the number of server RPCs finished",
+          "Minute stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -533,7 +527,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_REQUEST_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/request_count/interval"),
-          "Minute and Hour stats on the count of request messages per server RPC",
+          "Minute stats on the count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -542,7 +536,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_RESPONSE_COUNT_MINUTE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/response_count/interval"),
-          "Minute and Hour stats on the count of response messages per server RPC",
+          "Minute stats on the count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -551,7 +545,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_SERVER_LATENCY_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/server_latency/interval"),
-          "Minute and Hour stats for server latency in msecs",
+          "Hour stats for server latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -560,7 +554,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_REQUEST_BYTES_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/request_bytes/interval"),
-          "Minute and Hour stats for request size in bytes",
+          "Hour stats for request size in bytes",
           RPC_SERVER_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -569,7 +563,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_RESPONSE_BYTES_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/response_bytes/interval"),
-          "Minute and Hour stats for response size in bytes",
+          "Hour stats for response size in bytes",
           RPC_SERVER_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -578,7 +572,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_ERROR_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/error_count/interval"),
-          "Minute and Hour stats for rpc errors",
+          "Hour stats for rpc errors",
           RPC_SERVER_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -587,7 +581,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/uncompressed_request_bytes/interval"),
-          "Minute and Hour stats for uncompressed request size in bytes",
+          "Hour stats for uncompressed request size in bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -596,7 +590,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/uncompressed_response_bytes/interval"),
-          "Minute and Hour stats for uncompressed response size in bytes",
+          "Hour stats for uncompressed response size in bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -605,7 +599,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_SERVER_ELAPSED_TIME_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/server_elapsed_time/interval"),
-          "Minute and Hour stats for server elapsed time in msecs",
+          "Hour stats for server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -614,7 +608,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_STARTED_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/started_count/interval"),
-          "Minute and Hour stats on the number of server RPCs started",
+          "Hour stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -623,7 +617,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_FINISHED_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/finished_count/interval"),
-          "Minute and Hour stats on the number of server RPCs finished",
+          "Hour stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -632,7 +626,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_REQUEST_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/request_count/interval"),
-          "Minute and Hour stats on the count of request messages per server RPC",
+          "Hour stats on the count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
@@ -641,7 +635,7 @@ public final class RpcViewConstants {
   public static final View RPC_SERVER_RESPONSE_COUNT_HOUR_VIEW =
       View.create(
           View.Name.create("grpc.io/server/response_count/interval"),
-          "Minute and Hour stats on the count of response messages per server RPC",
+          "Hour stats on the count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),

--- a/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
+++ b/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
@@ -44,8 +44,8 @@ import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Histogram;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.View.Window;
-import io.opencensus.stats.View.Window.CumulativeWindow;
-import io.opencensus.stats.View.Window.IntervalWindow;
+import io.opencensus.stats.View.Window.Cumulative;
+import io.opencensus.stats.View.Window.Interval;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -88,9 +88,9 @@ public final class RpcViewConstants {
 
   static final Duration MINUTE = Duration.create(60, 0);
   static final Duration HOUR = Duration.create(60 * 60, 0);
-  static final Window CUMULATIVE = CumulativeWindow.create();
-  static final Window INTERVAL_MINUTE = IntervalWindow.create(MINUTE);
-  static final Window INTERVAL_HOUR = IntervalWindow.create(HOUR);
+  static final Window CUMULATIVE = Cumulative.create();
+  static final Window INTERVAL_MINUTE = Interval.create(MINUTE);
+  static final Window INTERVAL_HOUR = Interval.create(HOUR);
 
   // Rpc client cumulative {@link View}s.
   public static final View RPC_CLIENT_ERROR_COUNT_VIEW =

--- a/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
+++ b/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
@@ -46,6 +46,9 @@ import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Aggregation.Range;
 import io.opencensus.stats.Aggregation.StdDev;
 import io.opencensus.stats.Aggregation.Sum;
+import io.opencensus.stats.View.Window;
+import io.opencensus.stats.View.Window.CumulativeWindow;
+import io.opencensus.stats.View.Window.IntervalWindow;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -89,6 +92,12 @@ public final class RpcViewConstants {
           Histogram.create(BucketBoundaries.create(RPC_COUNT_BUCKET_BOUNDARIES)),
           Mean.create(), StdDev.create()));
 
+  static final Duration MINUTE = Duration.create(60, 0);
+  static final Duration HOUR = Duration.create(60 * 60, 0);
+  static final Window CUMULATIVE = CumulativeWindow.create();
+  static final Window INTERVAL_MINUTE = IntervalWindow.create(MINUTE);
+  static final Window INTERVAL_HOUR = IntervalWindow.create(HOUR);
+
   // Rpc client {@link View}s.
   public static final View RPC_CLIENT_ERROR_COUNT_VIEW =
       View.create(
@@ -97,7 +106,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_STATUS, RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
       View.create(
           View.Name.create("grpc.io/client/roundtrip_latency/distribution_cumulative"),
@@ -105,7 +114,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_ROUNDTRIP_LATENCY,
           AGGREGATION_WITH_MILLIS_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW =
       View.create(
           View.Name.create("grpc.io/client/server_elapsed_time/distribution_cumulative"),
@@ -113,7 +122,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_SERVER_ELAPSED_TIME,
           AGGREGATION_WITH_MILLIS_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_CLIENT_REQUEST_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/client/request_bytes/distribution_cumulative"),
@@ -121,7 +130,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_REQUEST_BYTES,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_CLIENT_RESPONSE_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/client/response_bytes/distribution_cumulative"),
@@ -129,7 +138,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_RESPONSE_BYTES,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/client/uncompressed_request_bytes/distribution_cumulative"),
@@ -137,7 +146,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/client/uncompressed_response_bytes/distribution_cumulative"),
@@ -145,7 +154,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_CLIENT_REQUEST_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/client/request_count/distribution_cumulative"),
@@ -153,7 +162,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_REQUEST_COUNT,
           AGGREGATION_WITH_COUNT_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_CLIENT_RESPONSE_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/client/response_count/distribution_cumulative"),
@@ -161,7 +170,7 @@ public final class RpcViewConstants {
           RPC_CLIENT_RESPONSE_COUNT,
           AGGREGATION_WITH_COUNT_HISTOGRAM,
           Arrays.asList(RPC_CLIENT_METHOD),
-          null);
+          CUMULATIVE);
 
 
   // Rpc server {@link View}s.
@@ -172,7 +181,7 @@ public final class RpcViewConstants {
           RPC_SERVER_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
           Arrays.asList(RPC_STATUS, RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_SERVER_SERVER_LATENCY_VIEW =
       View.create(
           View.Name.create("grpc.io/server/server_latency/distribution_cumulative"),
@@ -180,7 +189,7 @@ public final class RpcViewConstants {
           RPC_SERVER_SERVER_LATENCY,
           AGGREGATION_WITH_MILLIS_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_SERVER_SERVER_ELAPSED_TIME_VIEW =
       View.create(
           View.Name.create("grpc.io/server/elapsed_time/distribution_cumulative"),
@@ -188,7 +197,7 @@ public final class RpcViewConstants {
           RPC_SERVER_SERVER_ELAPSED_TIME,
           AGGREGATION_WITH_MILLIS_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_SERVER_REQUEST_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/server/request_bytes/distribution_cumulative"),
@@ -196,7 +205,7 @@ public final class RpcViewConstants {
           RPC_SERVER_REQUEST_BYTES,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_SERVER_RESPONSE_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/server/response_bytes/distribution_cumulative"),
@@ -204,7 +213,7 @@ public final class RpcViewConstants {
           RPC_SERVER_RESPONSE_BYTES,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/server/uncompressed_request_bytes/distribution_cumulative"),
@@ -212,7 +221,7 @@ public final class RpcViewConstants {
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/server/uncompressed_response_bytes/distribution_cumulative"),
@@ -220,7 +229,7 @@ public final class RpcViewConstants {
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_WITH_BYTES_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_SERVER_REQUEST_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/server/request_count/distribution_cumulative"),
@@ -228,7 +237,7 @@ public final class RpcViewConstants {
           RPC_SERVER_REQUEST_COUNT,
           AGGREGATION_WITH_COUNT_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
   public static final View RPC_SERVER_RESPONSE_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/server/response_count/distribution_cumulative"),
@@ -236,11 +245,9 @@ public final class RpcViewConstants {
           RPC_SERVER_RESPONSE_COUNT,
           AGGREGATION_WITH_COUNT_HISTOGRAM,
           Arrays.asList(RPC_SERVER_METHOD),
-          null);
+          CUMULATIVE);
 
   // Interval Stats
-  static final Duration MINUTE = Duration.create(60, 0);
-  static final Duration HOUR = Duration.create(60 * 60, 0);
 
   // RPC client {@link View}s.
   public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_MINUTE_VIEW =
@@ -249,7 +256,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_REQUEST_BYTES_MINUTE_VIEW =
       View.create(
@@ -257,7 +265,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for request size in bytes",
           RPC_CLIENT_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_RESPONSE_BYTES_MINUTE_VIEW =
       View.create(
@@ -265,7 +274,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for response size in bytes",
           RPC_CLIENT_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_ERROR_COUNT_MINUTE_VIEW =
       View.create(
@@ -273,7 +283,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for rpc errors",
           RPC_CLIENT_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_MINUTE_VIEW =
       View.create(
@@ -281,7 +292,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for uncompressed request size in bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_MINUTE_VIEW =
       View.create(
@@ -289,7 +301,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for uncompressed response size in bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_MINUTE_VIEW =
       View.create(
@@ -297,7 +310,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_STARTED_COUNT_MINUTE_VIEW =
       View.create(
@@ -305,7 +319,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_FINISHED_COUNT_MINUTE_VIEW =
       View.create(
@@ -313,7 +328,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_REQUEST_COUNT_MINUTE_VIEW =
       View.create(
@@ -321,7 +337,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_RESPONSE_COUNT_MINUTE_VIEW =
       View.create(
@@ -329,7 +346,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_HOUR_VIEW =
       View.create(
@@ -337,7 +355,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_REQUEST_BYTES_HOUR_VIEW =
       View.create(
@@ -345,7 +364,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for request size in bytes",
           RPC_CLIENT_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_RESPONSE_BYTES_HOUR_VIEW =
       View.create(
@@ -353,7 +373,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for response size in bytes",
           RPC_CLIENT_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_ERROR_COUNT_HOUR_VIEW =
       View.create(
@@ -361,7 +382,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for rpc errors",
           RPC_CLIENT_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_HOUR_VIEW =
       View.create(
@@ -369,7 +391,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for uncompressed request size in bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_HOUR_VIEW =
       View.create(
@@ -377,7 +400,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for uncompressed response size in bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_HOUR_VIEW =
       View.create(
@@ -385,7 +409,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_STARTED_COUNT_HOUR_VIEW =
       View.create(
@@ -393,7 +418,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_FINISHED_COUNT_HOUR_VIEW =
       View.create(
@@ -401,7 +427,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_REQUEST_COUNT_HOUR_VIEW =
       View.create(
@@ -409,7 +436,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_CLIENT_RESPONSE_COUNT_HOUR_VIEW =
       View.create(
@@ -417,7 +445,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+          Arrays.asList(RPC_CLIENT_METHOD),
+          INTERVAL_HOUR);
 
   // RPC server {@link View}s.
   public static final View RPC_SERVER_SERVER_LATENCY_MINUTE_VIEW =
@@ -426,7 +455,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for server latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_REQUEST_BYTES_MINUTE_VIEW =
       View.create(
@@ -434,7 +464,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for request size in bytes",
           RPC_SERVER_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_RESPONSE_BYTES_MINUTE_VIEW =
       View.create(
@@ -442,7 +473,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for response size in bytes",
           RPC_SERVER_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_ERROR_COUNT_MINUTE_VIEW =
       View.create(
@@ -450,7 +482,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for rpc errors",
           RPC_SERVER_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_MINUTE_VIEW =
       View.create(
@@ -458,7 +491,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for uncompressed request size in bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_MINUTE_VIEW =
       View.create(
@@ -466,7 +500,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for uncompressed response size in bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_SERVER_ELAPSED_TIME_MINUTE_VIEW =
       View.create(
@@ -474,7 +509,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_STARTED_COUNT_MINUTE_VIEW =
       View.create(
@@ -482,7 +518,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_FINISHED_COUNT_MINUTE_VIEW =
       View.create(
@@ -490,7 +527,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_REQUEST_COUNT_MINUTE_VIEW =
       View.create(
@@ -498,7 +536,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_RESPONSE_COUNT_MINUTE_VIEW =
       View.create(
@@ -506,7 +545,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_MINUTE);
 
   public static final View RPC_SERVER_SERVER_LATENCY_HOUR_VIEW =
       View.create(
@@ -514,7 +554,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for server latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_REQUEST_BYTES_HOUR_VIEW =
       View.create(
@@ -522,7 +563,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for request size in bytes",
           RPC_SERVER_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_RESPONSE_BYTES_HOUR_VIEW =
       View.create(
@@ -530,7 +572,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for response size in bytes",
           RPC_SERVER_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_ERROR_COUNT_HOUR_VIEW =
       View.create(
@@ -538,7 +581,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for rpc errors",
           RPC_SERVER_ERROR_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_HOUR_VIEW =
       View.create(
@@ -546,7 +590,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for uncompressed request size in bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_HOUR_VIEW =
       View.create(
@@ -554,7 +599,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for uncompressed response size in bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_SERVER_ELAPSED_TIME_HOUR_VIEW =
       View.create(
@@ -562,7 +608,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats for server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_STARTED_COUNT_HOUR_VIEW =
       View.create(
@@ -570,7 +617,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_FINISHED_COUNT_HOUR_VIEW =
       View.create(
@@ -578,7 +626,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_REQUEST_COUNT_HOUR_VIEW =
       View.create(
@@ -586,7 +635,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   public static final View RPC_SERVER_RESPONSE_COUNT_HOUR_VIEW =
       View.create(
@@ -594,7 +644,8 @@ public final class RpcViewConstants {
           "Minute and Hour stats on the count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
           AGGREGATION_NO_HISTOGRAM,
-          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+          Arrays.asList(RPC_SERVER_METHOD),
+          INTERVAL_HOUR);
 
   // Visible for testing.
   RpcViewConstants() {

--- a/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
+++ b/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
@@ -40,8 +40,12 @@ import static io.opencensus.stats.RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_RE
 import static io.opencensus.stats.RpcMeasureConstants.RPC_STATUS;
 
 import io.opencensus.common.Duration;
-import io.opencensus.stats.View.DistributionView;
-import io.opencensus.stats.View.IntervalView;
+import io.opencensus.stats.Aggregation.Count;
+import io.opencensus.stats.Aggregation.Histogram;
+import io.opencensus.stats.Aggregation.Mean;
+import io.opencensus.stats.Aggregation.Range;
+import io.opencensus.stats.Aggregation.StdDev;
+import io.opencensus.stats.Aggregation.Sum;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -51,329 +55,546 @@ import java.util.List;
  */
 public final class RpcViewConstants {
 
-  // Common histogram bucket boundaries for bytes received/sets DistributionViews.
+  // Common histogram bucket boundaries for bytes received/sets Views.
   static final List<Double> RPC_BYTES_BUCKET_BOUNDARIES = Collections.unmodifiableList(
       Arrays.asList(0.0, 1024.0, 2048.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 4194304.0,
           16777216.0, 67108864.0, 268435456.0, 1073741824.0, 4294967296.0));
 
-  // Common histogram bucket boundaries for latency and elapsed-time DistributionViews.
+  // Common histogram bucket boundaries for latency and elapsed-time Views.
   static final List<Double> RPC_MILLIS_BUCKET_BOUNDARIES = Collections.unmodifiableList(
       Arrays.asList(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 13.0, 16.0, 20.0, 25.0, 30.0,
           40.0, 50.0, 65.0, 80.0, 100.0, 130.0, 160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0,
           800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0));
 
+  // Common histogram bucket boundaries for request/response count Views.
+  static final List<Double> RPC_COUNT_BUCKET_BOUNDARIES = Collections.unmodifiableList(
+      Arrays.asList(0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0,
+          4096.0, 8192.0, 16384.0, 32768.0, 65536.0));
+
+  static final List<Aggregation> AGGREGATION_NO_HISTOGRAM = Collections.unmodifiableList(
+      Arrays.asList(Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create()));
+
+  static final List<Aggregation> AGGREGATION_WITH_BYTES_HISTOGRAM = Collections.unmodifiableList(
+      Arrays.asList(Sum.create(), Count.create(), Range.create(),
+          Histogram.create(BucketBoundaries.create(RPC_BYTES_BUCKET_BOUNDARIES)),
+          Mean.create(), StdDev.create()));
+
+  static final List<Aggregation> AGGREGATION_WITH_MILLIS_HISTOGRAM = Collections.unmodifiableList(
+      Arrays.asList(Sum.create(), Count.create(), Range.create(),
+          Histogram.create(BucketBoundaries.create(RPC_MILLIS_BUCKET_BOUNDARIES)),
+          Mean.create(), StdDev.create()));
+
+  static final List<Aggregation> AGGREGATION_WITH_COUNT_HISTOGRAM = Collections.unmodifiableList(
+      Arrays.asList(Sum.create(), Count.create(), Range.create(),
+          Histogram.create(BucketBoundaries.create(RPC_COUNT_BUCKET_BOUNDARIES)),
+          Mean.create(), StdDev.create()));
+
   // Rpc client {@link View}s.
-  public static final DistributionView RPC_CLIENT_ERROR_COUNT_VIEW =
-      DistributionView.create(
+  public static final View RPC_CLIENT_ERROR_COUNT_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/error_count/distribution_cumulative"),
           "RPC Errors",
           RPC_CLIENT_ERROR_COUNT,
-          DistributionAggregation.create(),
-          Arrays.asList(RPC_STATUS, RPC_CLIENT_METHOD));
-  public static final DistributionView RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
-      DistributionView.create(
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_STATUS, RPC_CLIENT_METHOD),
+          null);
+  public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/roundtrip_latency/distribution_cumulative"),
           "Latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
-          DistributionAggregation.create(RPC_MILLIS_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_CLIENT_METHOD));
-  public static final DistributionView RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD),
+          null);
+  public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/server_elapsed_time/distribution_cumulative"),
           "Server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
-          DistributionAggregation.create(RPC_MILLIS_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_CLIENT_METHOD));
-  public static final DistributionView RPC_CLIENT_REQUEST_BYTES_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD),
+          null);
+  public static final View RPC_CLIENT_REQUEST_BYTES_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/request_bytes/distribution_cumulative"),
           "Request bytes",
           RPC_CLIENT_REQUEST_BYTES,
-          DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_CLIENT_METHOD));
-  public static final DistributionView RPC_CLIENT_RESPONSE_BYTES_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD),
+          null);
+  public static final View RPC_CLIENT_RESPONSE_BYTES_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/response_bytes/distribution_cumulative"),
           "Response bytes",
           RPC_CLIENT_RESPONSE_BYTES,
-          DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_CLIENT_METHOD));
-  public static final DistributionView RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD),
+          null);
+  public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/uncompressed_request_bytes/distribution_cumulative"),
           "Uncompressed Request bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
-          DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_CLIENT_METHOD));
-  public static final DistributionView RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD),
+          null);
+  public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/uncompressed_response_bytes/distribution_cumulative"),
           "Uncompressed Response bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
-          DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_CLIENT_METHOD));
-  public static final DistributionView RPC_CLIENT_REQUEST_COUNT_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD),
+          null);
+  public static final View RPC_CLIENT_REQUEST_COUNT_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/request_count/distribution_cumulative"),
           "Count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
-          DistributionAggregation.create(),
-          Arrays.asList(RPC_CLIENT_METHOD));
-  public static final DistributionView RPC_CLIENT_RESPONSE_COUNT_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD),
+          null);
+  public static final View RPC_CLIENT_RESPONSE_COUNT_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/response_count/distribution_cumulative"),
           "Count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
-          DistributionAggregation.create(),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD),
+          null);
 
 
   // Rpc server {@link View}s.
-  public static final DistributionView RPC_SERVER_ERROR_COUNT_VIEW =
-      DistributionView.create(
+  public static final View RPC_SERVER_ERROR_COUNT_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/error_count/distribution_cumulative"),
           "RPC Errors",
           RPC_SERVER_ERROR_COUNT,
-          DistributionAggregation.create(),
-          Arrays.asList(RPC_STATUS, RPC_SERVER_METHOD));
-  public static final DistributionView RPC_SERVER_SERVER_LATENCY_VIEW =
-      DistributionView.create(
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_STATUS, RPC_SERVER_METHOD),
+          null);
+  public static final View RPC_SERVER_SERVER_LATENCY_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/server_latency/distribution_cumulative"),
           "Latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
-          DistributionAggregation.create(RPC_MILLIS_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_SERVER_METHOD));
-  public static final DistributionView RPC_SERVER_SERVER_ELAPSED_TIME_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD),
+          null);
+  public static final View RPC_SERVER_SERVER_ELAPSED_TIME_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/elapsed_time/distribution_cumulative"),
           "Server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
-          DistributionAggregation.create(RPC_MILLIS_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_SERVER_METHOD));
-  public static final DistributionView RPC_SERVER_REQUEST_BYTES_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD),
+          null);
+  public static final View RPC_SERVER_REQUEST_BYTES_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/request_bytes/distribution_cumulative"),
           "Request bytes",
           RPC_SERVER_REQUEST_BYTES,
-          DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_SERVER_METHOD));
-  public static final DistributionView RPC_SERVER_RESPONSE_BYTES_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD),
+          null);
+  public static final View RPC_SERVER_RESPONSE_BYTES_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/response_bytes/distribution_cumulative"),
           "Response bytes",
           RPC_SERVER_RESPONSE_BYTES,
-          DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_SERVER_METHOD));
-  public static final DistributionView RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD),
+          null);
+  public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/uncompressed_request_bytes/distribution_cumulative"),
           "Uncompressed Request bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
-          DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_SERVER_METHOD));
-  public static final DistributionView RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD),
+          null);
+  public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/uncompressed_response_bytes/distribution_cumulative"),
           "Uncompressed Response bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
-          DistributionAggregation.create(RPC_BYTES_BUCKET_BOUNDARIES),
-          Arrays.asList(RPC_SERVER_METHOD));
-  public static final DistributionView RPC_SERVER_REQUEST_COUNT_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD),
+          null);
+  public static final View RPC_SERVER_REQUEST_COUNT_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/request_count/distribution_cumulative"),
           "Count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
-          DistributionAggregation.create(),
-          Arrays.asList(RPC_SERVER_METHOD));
-  public static final DistributionView RPC_SERVER_RESPONSE_COUNT_VIEW =
-      DistributionView.create(
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD),
+          null);
+  public static final View RPC_SERVER_RESPONSE_COUNT_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/response_count/distribution_cumulative"),
           "Count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
-          DistributionAggregation.create(),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD),
+          null);
 
   // Interval Stats
   static final Duration MINUTE = Duration.create(60, 0);
   static final Duration HOUR = Duration.create(60 * 60, 0);
 
-  // RPC client {@link IntervalView}s.
-  public static final IntervalView RPC_CLIENT_ROUNDTRIP_LATENCY_INTERVAL_VIEW =
-      IntervalView.create(
+  // RPC client {@link View}s.
+  public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/roundtrip_latency/interval"),
           "Minute and Hour stats for latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_REQUEST_BYTES_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_REQUEST_BYTES_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/request_bytes/interval"),
           "Minute and Hour stats for request size in bytes",
           RPC_CLIENT_REQUEST_BYTES,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_RESPONSE_BYTES_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_RESPONSE_BYTES_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/response_bytes/interval"),
           "Minute and Hour stats for response size in bytes",
           RPC_CLIENT_RESPONSE_BYTES,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_ERROR_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_ERROR_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/error_count/interval"),
           "Minute and Hour stats for rpc errors",
           RPC_CLIENT_ERROR_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/uncompressed_request_bytes/interval"),
           "Minute and Hour stats for uncompressed request size in bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/uncompressed_response_bytes/interval"),
           "Minute and Hour stats for uncompressed response size in bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_SERVER_ELAPSED_TIME_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/server_elapsed_time/interval"),
           "Minute and Hour stats for server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_STARTED_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_STARTED_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/started_count/interval"),
           "Minute and Hour stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_FINISHED_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_FINISHED_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/finished_count/interval"),
           "Minute and Hour stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_REQUEST_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_REQUEST_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/request_count/interval"),
           "Minute and Hour stats on the count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  public static final IntervalView RPC_CLIENT_RESPONSE_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_RESPONSE_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/client/response_count/interval"),
           "Minute and Hour stats on the count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_CLIENT_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), MINUTE);
 
-  // RPC server {@link IntervalView}s.
-  public static final IntervalView RPC_SERVER_SERVER_LATENCY_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/roundtrip_latency/interval"),
+          "Minute and Hour stats for latency in msecs",
+          RPC_CLIENT_ROUNDTRIP_LATENCY,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_REQUEST_BYTES_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/request_bytes/interval"),
+          "Minute and Hour stats for request size in bytes",
+          RPC_CLIENT_REQUEST_BYTES,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_RESPONSE_BYTES_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/response_bytes/interval"),
+          "Minute and Hour stats for response size in bytes",
+          RPC_CLIENT_RESPONSE_BYTES,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_ERROR_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/error_count/interval"),
+          "Minute and Hour stats for rpc errors",
+          RPC_CLIENT_ERROR_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/uncompressed_request_bytes/interval"),
+          "Minute and Hour stats for uncompressed request size in bytes",
+          RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/uncompressed_response_bytes/interval"),
+          "Minute and Hour stats for uncompressed response size in bytes",
+          RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/server_elapsed_time/interval"),
+          "Minute and Hour stats for server elapsed time in msecs",
+          RPC_CLIENT_SERVER_ELAPSED_TIME,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_STARTED_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/started_count/interval"),
+          "Minute and Hour stats on the number of client RPCs started",
+          RPC_CLIENT_STARTED_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_FINISHED_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/finished_count/interval"),
+          "Minute and Hour stats on the number of client RPCs finished",
+          RPC_CLIENT_FINISHED_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_REQUEST_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/request_count/interval"),
+          "Minute and Hour stats on the count of request messages per client RPC",
+          RPC_CLIENT_REQUEST_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  public static final View RPC_CLIENT_RESPONSE_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/response_count/interval"),
+          "Minute and Hour stats on the count of response messages per client RPC",
+          RPC_CLIENT_RESPONSE_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_CLIENT_METHOD), HOUR);
+
+  // RPC server {@link View}s.
+  public static final View RPC_SERVER_SERVER_LATENCY_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/server_latency/interval"),
           "Minute and Hour stats for server latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_REQUEST_BYTES_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_REQUEST_BYTES_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/request_bytes/interval"),
           "Minute and Hour stats for request size in bytes",
           RPC_SERVER_REQUEST_BYTES,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_RESPONSE_BYTES_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_RESPONSE_BYTES_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/response_bytes/interval"),
           "Minute and Hour stats for response size in bytes",
           RPC_SERVER_RESPONSE_BYTES,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_ERROR_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_ERROR_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/error_count/interval"),
           "Minute and Hour stats for rpc errors",
           RPC_SERVER_ERROR_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/uncompressed_request_bytes/interval"),
           "Minute and Hour stats for uncompressed request size in bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/uncompressed_response_bytes/interval"),
           "Minute and Hour stats for uncompressed response size in bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_SERVER_ELAPSED_TIME_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_SERVER_ELAPSED_TIME_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/server_elapsed_time/interval"),
           "Minute and Hour stats for server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_STARTED_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_STARTED_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/started_count/interval"),
           "Minute and Hour stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_FINISHED_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_FINISHED_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/finished_count/interval"),
           "Minute and Hour stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_REQUEST_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_REQUEST_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/request_count/interval"),
           "Minute and Hour stats on the count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
 
-  public static final IntervalView RPC_SERVER_RESPONSE_COUNT_INTERVAL_VIEW =
-      IntervalView.create(
+  public static final View RPC_SERVER_RESPONSE_COUNT_MINUTE_VIEW =
+      View.create(
           View.Name.create("grpc.io/server/response_count/interval"),
           "Minute and Hour stats on the count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
-          IntervalAggregation.create(Arrays.asList(MINUTE, HOUR)),
-          Arrays.asList(RPC_SERVER_METHOD));
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), MINUTE);
+
+  public static final View RPC_SERVER_SERVER_LATENCY_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/server_latency/interval"),
+          "Minute and Hour stats for server latency in msecs",
+          RPC_SERVER_SERVER_LATENCY,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_REQUEST_BYTES_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/request_bytes/interval"),
+          "Minute and Hour stats for request size in bytes",
+          RPC_SERVER_REQUEST_BYTES,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_RESPONSE_BYTES_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/response_bytes/interval"),
+          "Minute and Hour stats for response size in bytes",
+          RPC_SERVER_RESPONSE_BYTES,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_ERROR_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/error_count/interval"),
+          "Minute and Hour stats for rpc errors",
+          RPC_SERVER_ERROR_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/uncompressed_request_bytes/interval"),
+          "Minute and Hour stats for uncompressed request size in bytes",
+          RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/uncompressed_response_bytes/interval"),
+          "Minute and Hour stats for uncompressed response size in bytes",
+          RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_SERVER_ELAPSED_TIME_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/server_elapsed_time/interval"),
+          "Minute and Hour stats for server elapsed time in msecs",
+          RPC_SERVER_SERVER_ELAPSED_TIME,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_STARTED_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/started_count/interval"),
+          "Minute and Hour stats on the number of server RPCs started",
+          RPC_SERVER_STARTED_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_FINISHED_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/finished_count/interval"),
+          "Minute and Hour stats on the number of server RPCs finished",
+          RPC_SERVER_FINISHED_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_REQUEST_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/request_count/interval"),
+          "Minute and Hour stats on the count of request messages per server RPC",
+          RPC_SERVER_REQUEST_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
+
+  public static final View RPC_SERVER_RESPONSE_COUNT_HOUR_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/response_count/interval"),
+          "Minute and Hour stats on the count of response messages per server RPC",
+          RPC_SERVER_RESPONSE_COUNT,
+          AGGREGATION_NO_HISTOGRAM,
+          Arrays.asList(RPC_SERVER_METHOD), HOUR);
 
   // Visible for testing.
   RpcViewConstants() {

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -56,11 +56,7 @@ public abstract class View {
    * Columns (a.k.a Tag Keys) to match with the associated {@link Measure}.
    *
    * <p>{@link Measure} will be recorded in a "greedy" way. That is, every view aggregates every
-   * measure. This is similar to doing a GROUPBY on view’s columns. If no columns are specified,
-   * then all stats will be recorded. Columns must be unique.
-   *
-   * <p>Note: The returned list is unmodifiable, attempts to update it will throw an
-   * UnsupportedOperationException.
+   * measure. This is similar to doing a GROUPBY on view’s columns. Columns must be unique.
    */
   public abstract List<TagKey> getColumns();
 
@@ -132,7 +128,7 @@ public abstract class View {
         Function<? super IntervalWindow, T> p1,
         Function<? super Window, T> defaultFunction);
 
-    /** Cumulative time {@code Window.} */
+    /** Cumulative (infinite interval) time {@code Window}. */
     @Immutable
     @AutoValue
     public abstract static class CumulativeWindow extends Window {
@@ -140,7 +136,8 @@ public abstract class View {
       CumulativeWindow() {}
 
       /**
-       * Constructs a cumulative {@code Window} that does not have a {@code Duration}.
+       * Constructs a cumulative {@code Window} that does not have an explicit {@code Duration}.
+       * Instead, cumulative {@code Window} always has an interval of infinite {@code Duration}.
        *
        * @return a cumulative {@code Window}.
        */
@@ -157,7 +154,7 @@ public abstract class View {
       }
     }
 
-    /** Interval time {@code Window.} */
+    /** Interval (finite interval) time {@code Window.} */
     @Immutable
     @AutoValue
     public abstract static class IntervalWindow extends Window {
@@ -173,7 +170,7 @@ public abstract class View {
 
 
       /**
-       * Constructs an interval {@code Window} that has one {@code Duration}.
+       * Constructs an interval {@code Window} that has a finite explicit {@code Duration}.
        *
        * @return an interval {@code Window}.
        */

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -134,6 +134,8 @@ public abstract class View {
     @AutoValue
     public abstract static class Cumulative extends Window {
 
+      private static final Cumulative CUMULATIVE = new AutoValue_View_Window_Cumulative();
+
       Cumulative() {}
 
       /**
@@ -143,7 +145,7 @@ public abstract class View {
        * @return a cumulative {@code Window}.
        */
       public static Cumulative create() {
-        return new AutoValue_View_Window_Cumulative();
+        return CUMULATIVE;
       }
 
       @Override

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -80,7 +80,7 @@ public abstract class View {
    * @param aggregations basic {@link Aggregation}s that this view will support. The aggregation
    *     list should not contain duplicates.
    * @param columns the {@link TagKey}s that this view will aggregate on. Columns should not contain
-   *     duplicate.
+   *     duplicates.
    * @param window the {@link Window} of view.
    * @return a new {@link View}.
    */

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -73,6 +73,16 @@ public abstract class View {
 
   /**
    * Constructs a new {@link View}.
+   *
+   * @param name the {@link Name} of view. Must be unique.
+   * @param description the description of view.
+   * @param measure the {@link Measure} to be aggregated by this view.
+   * @param aggregations basic {@link Aggregation}s that this view will support. The aggregation
+   *     list should not contain duplicates.
+   * @param columns the {@link TagKey}s that this view will aggregate on. Columns should not contain
+   *     duplicate.
+   * @param window the {@link Window} of view.
+   * @return a new {@link View}.
    */
   public static View create(
       Name name,

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -13,11 +13,14 @@
 
 package io.opencensus.stats;
 
+import static com.google.common.base.Preconditions.checkArgument;
+
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
@@ -78,6 +81,11 @@ public abstract class View {
       List<Aggregation> aggregations,
       List<TagKey> columns,
       Window window) {
+    checkArgument(new HashSet<Aggregation>(aggregations).size() == aggregations.size(),
+        "Aggregations have duplicate.");
+    checkArgument(new HashSet<TagKey>(columns).size() == columns.size(),
+        "Columns have duplicate.");
+
     return new AutoValue_View(
         name,
         description,

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -48,7 +48,8 @@ public abstract class View {
   public abstract Measure getMeasure();
 
   /**
-   * The {@link Aggregation}s associated with this {@link View}.
+   * The {@link Aggregation}s associated with this {@link View}. {@link Aggregation}s should be
+   * unique within one view.
    */
   public abstract List<Aggregation> getAggregations();
 

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -125,16 +125,16 @@ public abstract class View {
      * Applies the given match function to the underlying data type.
      */
     public abstract <T> T match(
-        Function<? super CumulativeWindow, T> p0,
-        Function<? super IntervalWindow, T> p1,
+        Function<? super Cumulative, T> p0,
+        Function<? super Interval, T> p1,
         Function<? super Window, T> defaultFunction);
 
     /** Cumulative (infinite interval) time {@code Window}. */
     @Immutable
     @AutoValue
-    public abstract static class CumulativeWindow extends Window {
+    public abstract static class Cumulative extends Window {
 
-      CumulativeWindow() {}
+      Cumulative() {}
 
       /**
        * Constructs a cumulative {@code Window} that does not have an explicit {@code Duration}.
@@ -142,14 +142,14 @@ public abstract class View {
        *
        * @return a cumulative {@code Window}.
        */
-      public static CumulativeWindow create() {
-        return new AutoValue_View_Window_CumulativeWindow();
+      public static Cumulative create() {
+        return new AutoValue_View_Window_Cumulative();
       }
 
       @Override
       public final <T> T match(
-          Function<? super CumulativeWindow, T> p0,
-          Function<? super IntervalWindow, T> p1,
+          Function<? super Cumulative, T> p0,
+          Function<? super Interval, T> p1,
           Function<? super Window, T> defaultFunction) {
         return  p0.apply(this);
       }
@@ -158,12 +158,12 @@ public abstract class View {
     /** Interval (finite interval) time {@code Window.} */
     @Immutable
     @AutoValue
-    public abstract static class IntervalWindow extends Window {
+    public abstract static class Interval extends Window {
 
-      IntervalWindow() {}
+      Interval() {}
 
       /**
-       * Returns the {@code Duration} associated with this {@code IntervalWindow}.
+       * Returns the {@code Duration} associated with this {@code Interval}.
        *
        * @return a {@code Duration}.
        */
@@ -175,14 +175,14 @@ public abstract class View {
        *
        * @return an interval {@code Window}.
        */
-      public static IntervalWindow create(Duration duration) {
-        return new AutoValue_View_Window_IntervalWindow(duration);
+      public static Interval create(Duration duration) {
+        return new AutoValue_View_Window_Interval(duration);
       }
 
       @Override
       public final <T> T match(
-          Function<? super CumulativeWindow, T> p0,
-          Function<? super IntervalWindow, T> p1,
+          Function<? super Cumulative, T> p0,
+          Function<? super Interval, T> p1,
           Function<? super Window, T> defaultFunction) {
         return  p1.apply(this);
       }

--- a/core/src/main/java/io/opencensus/stats/ViewData.java
+++ b/core/src/main/java/io/opencensus/stats/ViewData.java
@@ -56,10 +56,10 @@ public abstract class ViewData {
       View view, Map<List<TagValue>, List<AggregationData>> map, final WindowData windowData) {
     view.getWindow()
         .match(
-            new Function<View.Window.CumulativeWindow, Void>() {
+            new Function<View.Window.Cumulative, Void>() {
               @Override
-              public Void apply(View.Window.CumulativeWindow arg) {
-                if (!(windowData instanceof WindowData.CumulativeWindowData)) {
+              public Void apply(View.Window.Cumulative arg) {
+                if (!(windowData instanceof WindowData.CumulativeData)) {
                   throw new IllegalArgumentException(
                       "Window and WindowData types mismatch. "
                           + "Window: "
@@ -70,10 +70,10 @@ public abstract class ViewData {
                 return null;
               }
             },
-            new Function<View.Window.IntervalWindow, Void>() {
+            new Function<View.Window.Interval, Void>() {
               @Override
-              public Void apply(View.Window.IntervalWindow arg) {
-                if (!(windowData instanceof WindowData.IntervalWindowData)) {
+              public Void apply(View.Window.Interval arg) {
+                if (!(windowData instanceof WindowData.IntervalData)) {
                   throw new IllegalArgumentException(
                       "Window and WindowData types mismatch. "
                           + "Window: "
@@ -105,26 +105,26 @@ public abstract class ViewData {
 
     /** Applies the given match function to the underlying data type. */
     public abstract <T> T match(
-        Function<? super CumulativeWindowData, T> p0,
-        Function<? super IntervalWindowData, T> p1,
+        Function<? super CumulativeData, T> p0,
+        Function<? super IntervalData, T> p1,
         Function<? super WindowData, T> defaultFunction);
 
     /** Cumulative {@code WindowData.} */
     @Immutable
     @AutoValue
-    public abstract static class CumulativeWindowData extends WindowData {
+    public abstract static class CumulativeData extends WindowData {
 
-      CumulativeWindowData() {}
+      CumulativeData() {}
 
       /**
-       * Returns the start {@code Timestamp} for a {@link CumulativeWindowData}.
+       * Returns the start {@code Timestamp} for a {@link CumulativeData}.
        *
        * @return the start {@code Timestamp}.
        */
       public abstract Timestamp getStart();
 
       /**
-       * Returns the end {@code Timestamp} for a {@link CumulativeWindowData}.
+       * Returns the end {@code Timestamp} for a {@link CumulativeData}.
        *
        * @return the end {@code Timestamp}.
        */
@@ -132,30 +132,30 @@ public abstract class ViewData {
 
       @Override
       public final <T> T match(
-          Function<? super CumulativeWindowData, T> p0,
-          Function<? super IntervalWindowData, T> p1,
+          Function<? super CumulativeData, T> p0,
+          Function<? super IntervalData, T> p1,
           Function<? super WindowData, T> defaultFunction) {
         return p0.apply(this);
       }
 
-      /** Constructs a new {@link CumulativeWindowData}. */
-      public static CumulativeWindowData create(Timestamp start, Timestamp end) {
+      /** Constructs a new {@link CumulativeData}. */
+      public static CumulativeData create(Timestamp start, Timestamp end) {
         if (start.compareTo(end) > 0) {
           throw new IllegalArgumentException("Start time is later than end time.");
         }
-        return new AutoValue_ViewData_WindowData_CumulativeWindowData(start, end);
+        return new AutoValue_ViewData_WindowData_CumulativeData(start, end);
       }
     }
 
     /** Interval {@code WindowData.} */
     @Immutable
     @AutoValue
-    public abstract static class IntervalWindowData extends WindowData {
+    public abstract static class IntervalData extends WindowData {
 
-      IntervalWindowData() {}
+      IntervalData() {}
 
       /**
-       * Returns the end {@code Timestamp} for an {@link IntervalWindowData}.
+       * Returns the end {@code Timestamp} for an {@link IntervalData}.
        *
        * @return the end {@code Timestamp}.
        */
@@ -163,15 +163,15 @@ public abstract class ViewData {
 
       @Override
       public final <T> T match(
-          Function<? super CumulativeWindowData, T> p0,
-          Function<? super IntervalWindowData, T> p1,
+          Function<? super CumulativeData, T> p0,
+          Function<? super IntervalData, T> p1,
           Function<? super WindowData, T> defaultFunction) {
         return p1.apply(this);
       }
 
-      /** Constructs a new {@link IntervalWindowData}. */
-      public static IntervalWindowData create(Timestamp end) {
-        return new AutoValue_ViewData_WindowData_IntervalWindowData(end);
+      /** Constructs a new {@link IntervalData}. */
+      public static IntervalData create(Timestamp end) {
+        return new AutoValue_ViewData_WindowData_IntervalData(end);
       }
     }
   }

--- a/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
+++ b/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
@@ -15,6 +15,16 @@ package io.opencensus.stats;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opencensus.common.Duration;
+import io.opencensus.stats.Aggregation.Count;
+import io.opencensus.stats.Aggregation.Histogram;
+import io.opencensus.stats.Aggregation.Mean;
+import io.opencensus.stats.Aggregation.Range;
+import io.opencensus.stats.Aggregation.StdDev;
+import io.opencensus.stats.Aggregation.Sum;
+import io.opencensus.stats.View.Window.CumulativeWindow;
+import io.opencensus.stats.View.Window.IntervalWindow;
+import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -27,6 +37,42 @@ public final class RpcViewConstantsTest {
 
   @Test
   public void testConstants() {
+
+    // Test bucket boundaries.
+    assertThat(RpcViewConstants.RPC_BYTES_BUCKET_BOUNDARIES).containsExactly(
+        0.0, 1024.0, 2048.0, 4096.0, 16384.0, 65536.0, 262144.0, 1048576.0, 4194304.0,
+        16777216.0, 67108864.0, 268435456.0, 1073741824.0, 4294967296.0).inOrder();
+    assertThat(RpcViewConstants.RPC_MILLIS_BUCKET_BOUNDARIES).containsExactly(
+        0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 13.0, 16.0, 20.0, 25.0, 30.0,
+        40.0, 50.0, 65.0, 80.0, 100.0, 130.0, 160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0,
+        800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0).inOrder();
+    assertThat(RpcViewConstants.RPC_COUNT_BUCKET_BOUNDARIES).containsExactly(
+        0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0,
+        4096.0, 8192.0, 16384.0, 32768.0, 65536.0).inOrder();
+
+    // Test Aggregations
+    assertThat(RpcViewConstants.AGGREGATION_NO_HISTOGRAM).containsExactly(
+        Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create());
+    assertThat(RpcViewConstants.AGGREGATION_WITH_BYTES_HISTOGRAM).containsExactly(
+        Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create(),
+        Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_BYTES_BUCKET_BOUNDARIES)));
+    assertThat(RpcViewConstants.AGGREGATION_WITH_COUNT_HISTOGRAM).containsExactly(
+        Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create(),
+        Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_COUNT_BUCKET_BOUNDARIES)));
+    assertThat(RpcViewConstants.AGGREGATION_WITH_MILLIS_HISTOGRAM).containsExactly(
+        Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create(),
+        Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_MILLIS_BUCKET_BOUNDARIES)));
+
+    // Test Duration and Window
+    assertThat(RpcViewConstants.MINUTE).isEqualTo(Duration.create(60, 0));
+    assertThat(RpcViewConstants.HOUR).isEqualTo(Duration.create(60 * 60, 0));
+    assertThat(RpcViewConstants.CUMULATIVE).isEqualTo(CumulativeWindow.create());
+    assertThat(RpcViewConstants.INTERVAL_MINUTE).isEqualTo(
+        IntervalWindow.create(RpcViewConstants.MINUTE));
+    assertThat(RpcViewConstants.INTERVAL_HOUR).isEqualTo(
+        IntervalWindow.create(RpcViewConstants.HOUR));
+
+
     // Test client distribution view descriptors.
     assertThat(RpcViewConstants.RPC_CLIENT_ERROR_COUNT_VIEW).isNotNull();
     assertThat(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW).isNotNull();

--- a/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
+++ b/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
@@ -17,8 +17,8 @@ import io.opencensus.common.Duration;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Histogram;
 import io.opencensus.stats.Aggregation.Sum;
-import io.opencensus.stats.View.Window.CumulativeWindow;
-import io.opencensus.stats.View.Window.IntervalWindow;
+import io.opencensus.stats.View.Window.Cumulative;
+import io.opencensus.stats.View.Window.Interval;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -73,11 +73,11 @@ public final class RpcViewConstantsTest {
     // Test Duration and Window
     assertThat(RpcViewConstants.MINUTE).isEqualTo(Duration.create(60, 0));
     assertThat(RpcViewConstants.HOUR).isEqualTo(Duration.create(60 * 60, 0));
-    assertThat(RpcViewConstants.CUMULATIVE).isEqualTo(CumulativeWindow.create());
+    assertThat(RpcViewConstants.CUMULATIVE).isEqualTo(Cumulative.create());
     assertThat(RpcViewConstants.INTERVAL_MINUTE).isEqualTo(
-        IntervalWindow.create(RpcViewConstants.MINUTE));
+        Interval.create(RpcViewConstants.MINUTE));
     assertThat(RpcViewConstants.INTERVAL_HOUR).isEqualTo(
-        IntervalWindow.create(RpcViewConstants.HOUR));
+        Interval.create(RpcViewConstants.HOUR));
 
 
     // Test client distribution view descriptors.

--- a/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
+++ b/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
@@ -13,20 +13,17 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.truth.Truth.assertThat;
-
 import io.opencensus.common.Duration;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Histogram;
-import io.opencensus.stats.Aggregation.Mean;
-import io.opencensus.stats.Aggregation.Range;
-import io.opencensus.stats.Aggregation.StdDev;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.View.Window.CumulativeWindow;
 import io.opencensus.stats.View.Window.IntervalWindow;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /**
  * Test for {@link RpcViewConstants}.
@@ -50,17 +47,28 @@ public final class RpcViewConstantsTest {
         4096.0, 8192.0, 16384.0, 32768.0, 65536.0).inOrder();
 
     // Test Aggregations
-    assertThat(RpcViewConstants.AGGREGATION_NO_HISTOGRAM).containsExactly(
-        Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create());
-    assertThat(RpcViewConstants.AGGREGATION_WITH_BYTES_HISTOGRAM).containsExactly(
-        Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create(),
-        Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_BYTES_BUCKET_BOUNDARIES)));
-    assertThat(RpcViewConstants.AGGREGATION_WITH_COUNT_HISTOGRAM).containsExactly(
-        Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create(),
-        Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_COUNT_BUCKET_BOUNDARIES)));
-    assertThat(RpcViewConstants.AGGREGATION_WITH_MILLIS_HISTOGRAM).containsExactly(
-        Sum.create(), Count.create(), Range.create(), Mean.create(), StdDev.create(),
-        Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_MILLIS_BUCKET_BOUNDARIES)));
+    assertThat(RpcViewConstants.AGGREGATION_NO_HISTOGRAM)
+        .containsExactly(Sum.create(), Count.create())
+        .inOrder();
+    assertThat(RpcViewConstants.AGGREGATION_WITH_BYTES_HISTOGRAM)
+        .containsExactly(
+            Sum.create(),
+            Count.create(),
+            Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_BYTES_BUCKET_BOUNDARIES)))
+        .inOrder();
+    assertThat(RpcViewConstants.AGGREGATION_WITH_COUNT_HISTOGRAM)
+        .containsExactly(
+            Sum.create(),
+            Count.create(),
+            Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_COUNT_BUCKET_BOUNDARIES)))
+        .inOrder();
+    assertThat(RpcViewConstants.AGGREGATION_WITH_MILLIS_HISTOGRAM)
+        .containsExactly(
+            Sum.create(),
+            Count.create(),
+            Histogram.create(
+                BucketBoundaries.create(RpcViewConstants.RPC_MILLIS_BUCKET_BOUNDARIES)))
+        .inOrder();
 
     // Test Duration and Window
     assertThat(RpcViewConstants.MINUTE).isEqualTo(Duration.create(60, 0));

--- a/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
+++ b/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
@@ -24,7 +24,6 @@ import io.opencensus.stats.Aggregation.StdDev;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.View.Window.CumulativeWindow;
 import io.opencensus.stats.View.Window.IntervalWindow;
-import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
+++ b/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
@@ -49,29 +49,52 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_COUNT_VIEW).isNotNull();
 
     // Test client interval view descriptors.
-    assertThat(RpcViewConstants.RPC_CLIENT_ERROR_COUNT_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_REQUEST_BYTES_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_RESPONSE_BYTES_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_STARTED_COUNT_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_FINISHED_COUNT_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_SERVER_ELAPSED_TIME_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_REQUEST_COUNT_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_CLIENT_RESPONSE_COUNT_INTERVAL_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_ERROR_COUNT_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_REQUEST_BYTES_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_RESPONSE_BYTES_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_STARTED_COUNT_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_FINISHED_COUNT_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_SERVER_ELAPSED_TIME_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_REQUEST_COUNT_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_RESPONSE_COUNT_MINUTE_VIEW).isNotNull();
+
+    assertThat(RpcViewConstants.RPC_CLIENT_ERROR_COUNT_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_REQUEST_BYTES_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_RESPONSE_BYTES_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_STARTED_COUNT_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_FINISHED_COUNT_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_SERVER_ELAPSED_TIME_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_REQUEST_COUNT_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_CLIENT_RESPONSE_COUNT_HOUR_VIEW).isNotNull();
 
     // Test server interval view descriptors.
-    assertThat(RpcViewConstants.RPC_SERVER_ERROR_COUNT_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_SERVER_LATENCY_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_REQUEST_BYTES_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_BYTES_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_STARTED_COUNT_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_FINISHED_COUNT_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_REQUEST_COUNT_INTERVAL_VIEW).isNotNull();
-    assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_COUNT_INTERVAL_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_ERROR_COUNT_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_SERVER_LATENCY_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_REQUEST_BYTES_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_BYTES_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_STARTED_COUNT_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_FINISHED_COUNT_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_REQUEST_COUNT_MINUTE_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_COUNT_MINUTE_VIEW).isNotNull();
+
+    assertThat(RpcViewConstants.RPC_SERVER_ERROR_COUNT_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_SERVER_LATENCY_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_REQUEST_BYTES_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_BYTES_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_STARTED_COUNT_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_FINISHED_COUNT_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_REQUEST_COUNT_HOUR_VIEW).isNotNull();
+    assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_COUNT_HOUR_VIEW).isNotNull();
   }
 
   @Test(expected = AssertionError.class)

--- a/core/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -13,6 +13,9 @@
 
 package io.opencensus.stats;
 
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Duration;
@@ -32,23 +35,19 @@ import io.opencensus.stats.AggregationData.RangeData;
 import io.opencensus.stats.AggregationData.StdDevData;
 import io.opencensus.stats.AggregationData.SumData;
 import io.opencensus.stats.View.Window;
-import io.opencensus.stats.View.Window.CumulativeWindow;
-import io.opencensus.stats.View.Window.IntervalWindow;
+import io.opencensus.stats.View.Window.Cumulative;
+import io.opencensus.stats.View.Window.Interval;
 import io.opencensus.stats.ViewData.WindowData;
-import io.opencensus.stats.ViewData.WindowData.CumulativeWindowData;
-import io.opencensus.stats.ViewData.WindowData.IntervalWindowData;
+import io.opencensus.stats.ViewData.WindowData.CumulativeData;
+import io.opencensus.stats.ViewData.WindowData.IntervalData;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
-
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
 
 /** Tests for class {@link ViewData}. */
 @RunWith(JUnit4.class)
@@ -63,7 +62,7 @@ public final class ViewDataTest {
         View.create(name, description, measure, AGGREGATIONS, tagKeys, CUMULATIVE);
     Timestamp start = Timestamp.fromMillis(1000);
     Timestamp end = Timestamp.fromMillis(2000);
-    WindowData windowData = CumulativeWindowData.create(start, end);
+    WindowData windowData = CumulativeData.create(start, end);
     ViewData viewData = ViewData.create(view, ENTRIES, windowData);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEqualTo(ENTRIES);
@@ -75,7 +74,7 @@ public final class ViewDataTest {
     View view = View.create(
         name, description, measure, AGGREGATIONS, tagKeys, INTERVAL_HOUR);
     Timestamp end = Timestamp.fromMillis(2000);
-    WindowData windowData = IntervalWindowData.create(end);
+    WindowData windowData = IntervalData.create(end);
     ViewData viewData = ViewData.create(view, ENTRIES, windowData);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEqualTo(ENTRIES);
@@ -93,30 +92,30 @@ public final class ViewDataTest {
         .addEqualityGroup(
             ViewData.create(
                 dView, ENTRIES,
-                CumulativeWindowData.create(
+                CumulativeData.create(
                     Timestamp.fromMillis(1000), Timestamp.fromMillis(2000))),
             ViewData.create(
                 dView,
                 ENTRIES,
-                CumulativeWindowData.create(
+                CumulativeData.create(
                     Timestamp.fromMillis(1000), Timestamp.fromMillis(2000))))
         .addEqualityGroup(
             ViewData.create(
                 dView,
                 ENTRIES,
-                CumulativeWindowData.create(
+                CumulativeData.create(
                     Timestamp.fromMillis(1000), Timestamp.fromMillis(3000))))
         .addEqualityGroup(
             ViewData.create(
                 iView, ENTRIES,
-                IntervalWindowData.create(Timestamp.fromMillis(2000))),
+                IntervalData.create(Timestamp.fromMillis(2000))),
             ViewData.create(
                 iView, ENTRIES,
-                IntervalWindowData.create(Timestamp.fromMillis(2000))))
+                IntervalData.create(Timestamp.fromMillis(2000))))
         .addEqualityGroup(
             ViewData.create(
                 iView, Collections.<List<TagValue>, List<AggregationData>>emptyMap(),
-                IntervalWindowData.create(Timestamp.fromMillis(2000))))
+                IntervalData.create(Timestamp.fromMillis(2000))))
         .testEquals();
   }
 
@@ -124,36 +123,36 @@ public final class ViewDataTest {
   public void testWindowDataMatch() {
     final Timestamp start = Timestamp.fromMillis(1000);
     final Timestamp end = Timestamp.fromMillis(2000);
-    final WindowData windowData1 = CumulativeWindowData.create(start, end);
-    final WindowData windowData2 = IntervalWindowData.create(end);
+    final WindowData windowData1 = CumulativeData.create(start, end);
+    final WindowData windowData2 = IntervalData.create(end);
     windowData1.match(
-        new Function<CumulativeWindowData, Void>() {
+        new Function<CumulativeData, Void>() {
           @Override
-          public Void apply(CumulativeWindowData windowData) {
+          public Void apply(CumulativeData windowData) {
             assertThat(windowData.getStart()).isEqualTo(start);
             assertThat(windowData.getEnd()).isEqualTo(end);
             return null;
           }
         },
-        new Function<IntervalWindowData, Void>() {
+        new Function<IntervalData, Void>() {
           @Override
-          public Void apply(IntervalWindowData windowData) {
-            fail("CumulativeWindowData expected.");
+          public Void apply(IntervalData windowData) {
+            fail("CumulativeData expected.");
             return null;
           }
         },
         Functions.<Void>throwIllegalArgumentException());
     windowData2.match(
-        new Function<CumulativeWindowData, Void>() {
+        new Function<CumulativeData, Void>() {
           @Override
-          public Void apply(CumulativeWindowData windowData) {
-            fail("IntervalWindowData expected.");
+          public Void apply(CumulativeData windowData) {
+            fail("IntervalData expected.");
             return null;
           }
         },
-        new Function<IntervalWindowData, Void>() {
+        new Function<IntervalData, Void>() {
           @Override
-          public Void apply(IntervalWindowData windowData) {
+          public Void apply(IntervalData windowData) {
             assertThat(windowData.getEnd()).isEqualTo(end);
             return null;
           }
@@ -167,7 +166,7 @@ public final class ViewDataTest {
     ViewData.create(
         View.create(name, description, measure, AGGREGATIONS, tagKeys, INTERVAL_HOUR),
         ENTRIES,
-        CumulativeWindowData.create(
+        CumulativeData.create(
             Timestamp.fromMillis(1000), Timestamp.fromMillis(2000)));
   }
 
@@ -177,13 +176,13 @@ public final class ViewDataTest {
     ViewData.create(
         View.create(name, description, measure, AGGREGATIONS, tagKeys, CUMULATIVE),
         ENTRIES,
-        IntervalWindowData.create(Timestamp.fromMillis(1000)));
+        IntervalData.create(Timestamp.fromMillis(1000)));
   }
 
   @Test
   public void preventStartTimeLaterThanEndTime() {
     thrown.expect(IllegalArgumentException.class);
-    CumulativeWindowData.create(Timestamp.fromMillis(3000), Timestamp.fromMillis(2000));
+    CumulativeData.create(Timestamp.fromMillis(3000), Timestamp.fromMillis(2000));
   }
 
   // tag keys
@@ -197,8 +196,8 @@ public final class ViewDataTest {
   private static final TagValue V10 = TagValue.create("v10");
   private static final TagValue V20 = TagValue.create("v20");
 
-  private static final Window CUMULATIVE = CumulativeWindow.create();
-  private static final Window INTERVAL_HOUR = IntervalWindow.create(Duration.create(3600, 0));
+  private static final Window CUMULATIVE = Cumulative.create();
+  private static final Window INTERVAL_HOUR = Interval.create(Duration.create(3600, 0));
 
   private static final BucketBoundaries BUCKET_BOUNDARIES = BucketBoundaries.create(
       Arrays.asList(10.0, 20.0, 30.0, 40.0));

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -17,6 +17,8 @@ import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Duration;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Sum;
+import io.opencensus.stats.View.Window.CumulativeWindow;
+import io.opencensus.stats.View.Window.IntervalWindow;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -31,7 +33,8 @@ import static com.google.common.truth.Truth.assertThat;
 public final class ViewTest {
   @Test
   public void testDistributionView() {
-    final View view = View.create(name, description, measure, aggregations, keys, null);
+    final View view = View.create(
+        name, description, measure, aggregations, keys, CumulativeWindow.create());
     assertThat(view.getName()).isEqualTo(name);
     assertThat(view.getDescription()).isEqualTo(description);
     assertThat(view.getMeasure().getName()).isEqualTo(measure.getName());
@@ -39,12 +42,13 @@ public final class ViewTest {
     assertThat(view.getColumns()).hasSize(2);
     assertThat(view.getColumns().get(0).toString()).isEqualTo("foo");
     assertThat(view.getColumns().get(1).toString()).isEqualTo("bar");
-    assertThat(view.getWindow()).isNull();
+    assertThat(view.getWindow()).isEqualTo(RpcViewConstants.CUMULATIVE);
   }
 
   @Test
   public void testIntervalView() {
-    final View view = View.create(name, description, measure, aggregations, keys, minute);
+    final View view = View.create(
+        name, description, measure, aggregations, keys, IntervalWindow.create(minute));
     assertThat(view.getName()).isEqualTo(name);
     assertThat(view.getDescription()).isEqualTo(description);
     assertThat(view.getMeasure().getName())
@@ -53,28 +57,34 @@ public final class ViewTest {
     assertThat(view.getColumns()).hasSize(2);
     assertThat(view.getColumns().get(0).toString()).isEqualTo("foo");
     assertThat(view.getColumns().get(1).toString()).isEqualTo("bar");
-    assertThat(view.getWindow()).isEqualTo(minute);
+    assertThat(view.getWindow()).isEqualTo(RpcViewConstants.INTERVAL_MINUTE);
   }
 
   @Test
   public void testViewEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            View.create(name, description, measure, aggregations, keys, null),
-            View.create(name, description, measure, aggregations, keys, null))
+            View.create(
+                name, description, measure, aggregations, keys, CumulativeWindow.create()),
+            View.create(
+                name, description, measure, aggregations, keys, CumulativeWindow.create()))
         .addEqualityGroup(
-            View.create(name, description + 2, measure, aggregations, keys, null))
+            View.create(
+                name, description + 2, measure, aggregations, keys, CumulativeWindow.create()))
         .addEqualityGroup(
-            View.create(name, description, measure, aggregations, keys, minute),
-            View.create(name, description, measure, aggregations, keys, minute))
+            View.create(
+                name, description, measure, aggregations, keys, IntervalWindow.create(minute)),
+            View.create(
+                name, description, measure, aggregations, keys, IntervalWindow.create(minute)))
         .addEqualityGroup(
-            View.create(name, description + 2, measure, aggregations, keys, minute))
+            View.create(
+                name, description + 2, measure, aggregations, keys, IntervalWindow.create(minute)))
         .testEquals();
   }
 
   @Test(expected = NullPointerException.class)
   public void preventNullViewName() {
-    View.create(null, description, measure, aggregations, keys, minute);
+    View.create(null, description, measure, aggregations, keys, IntervalWindow.create(minute));
   }
 
   @Test

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -79,6 +79,18 @@ public final class ViewTest {
         .testEquals();
   }
 
+  @Test(expected = IllegalArgumentException.class)
+  public void preventDuplicateAggregations() {
+    View.create(name, description, measure,
+        Arrays.asList(Sum.create(), Sum.create(), Count.create()), keys, Cumulative.create());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void preventDuplicateColumns() {
+    View.create(name, description, measure, aggregations,
+        Arrays.asList(TagKey.create("duplicate"), TagKey.create("duplicate")), Cumulative.create());
+  }
+
   @Test(expected = NullPointerException.class)
   public void preventNullViewName() {
     View.create(null, description, measure, aggregations, keys, Interval.create(minute));

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -42,7 +42,7 @@ public final class ViewTest {
     assertThat(view.getColumns()).hasSize(2);
     assertThat(view.getColumns().get(0).toString()).isEqualTo("foo");
     assertThat(view.getColumns().get(1).toString()).isEqualTo("bar");
-    assertThat(view.getWindow()).isEqualTo(RpcViewConstants.CUMULATIVE);
+    assertThat(view.getWindow()).isEqualTo(CumulativeWindow.create());
   }
 
   @Test
@@ -57,7 +57,7 @@ public final class ViewTest {
     assertThat(view.getColumns()).hasSize(2);
     assertThat(view.getColumns().get(0).toString()).isEqualTo("foo");
     assertThat(view.getColumns().get(1).toString()).isEqualTo("bar");
-    assertThat(view.getWindow()).isEqualTo(RpcViewConstants.INTERVAL_MINUTE);
+    assertThat(view.getWindow()).isEqualTo(IntervalWindow.create(minute));
   }
 
   @Test
@@ -78,7 +78,7 @@ public final class ViewTest {
                 name, description, measure, aggregations, keys, IntervalWindow.create(minute)))
         .addEqualityGroup(
             View.create(
-                name, description + 2, measure, aggregations, keys, IntervalWindow.create(minute)))
+                name, description, measure, aggregations, keys, IntervalWindow.create(twoMinutes)))
         .testEquals();
   }
 
@@ -113,4 +113,5 @@ public final class ViewTest {
   private final List<TagKey> keys = Arrays.asList(TagKey.create("foo"), TagKey.create("bar"));
   private final List<Aggregation> aggregations = Arrays.asList(Sum.create(), Count.create());
   private final Duration minute = Duration.create(60, 0);
+  private final Duration twoMinutes = Duration.create(120, 0);
 }

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -107,7 +107,9 @@ public final class ViewTest {
   private final String description = "test-view-name description";
   private final Measure measure = Measure.MeasureDouble.create(
       "measure", "measure description", "1");
-  private final List<TagKey> keys = Arrays.asList(TagKey.create("foo"), TagKey.create("bar"));
+  private static final TagKey FOO = TagKey.create("foo");
+  private static final TagKey BAR = TagKey.create("bar");
+  private final List<TagKey> keys = Arrays.asList(FOO, BAR);
   private final List<Aggregation> aggregations = Arrays.asList(Sum.create(), Count.create());
   private final Duration minute = Duration.create(60, 0);
   private final Duration twoMinutes = Duration.create(120, 0);

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -13,118 +13,68 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertTrue;
-
 import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Duration;
-import io.opencensus.common.Function;
-import io.opencensus.stats.View.DistributionView;
-import io.opencensus.stats.View.IntervalView;
-import java.util.Arrays;
-import java.util.List;
+import io.opencensus.stats.Aggregation.Count;
+import io.opencensus.stats.Aggregation.Sum;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static com.google.common.truth.Truth.assertThat;
 
 /** Tests for {@link View} */
 @RunWith(JUnit4.class)
 public final class ViewTest {
   @Test
   public void testDistributionView() {
-    DistributionAggregation dAggr = DistributionAggregation.create();
-    final View view = DistributionView.create(
-        name, description, measure, dAggr, keys);
-
+    final View view = View.create(name, description, measure, aggregations, keys, null);
     assertThat(view.getName()).isEqualTo(name);
     assertThat(view.getDescription()).isEqualTo(description);
     assertThat(view.getMeasure().getName()).isEqualTo(measure.getName());
+    assertThat(view.getAggregations()).isEqualTo(aggregations);
     assertThat(view.getColumns()).hasSize(2);
     assertThat(view.getColumns().get(0).toString()).isEqualTo("foo");
     assertThat(view.getColumns().get(1).toString()).isEqualTo("bar");
-    assertTrue(view.match(
-        new Function<DistributionView, Boolean> () {
-          @Override public Boolean apply(DistributionView dView) {
-            return dView == view;
-          }
-        },
-        new Function<IntervalView, Boolean> () {
-          @Override public Boolean apply(IntervalView iView) {
-            return false;
-          }
-        }));
+    assertThat(view.getWindow()).isNull();
   }
 
   @Test
   public void testIntervalView() {
-    IntervalAggregation iAggr = IntervalAggregation.create(
-        Arrays.asList(Duration.fromMillis(1), Duration.fromMillis(22), Duration.fromMillis(333)));
-    final View view = IntervalView.create(
-        name, description, measure, iAggr, keys);
-
+    final View view = View.create(name, description, measure, aggregations, keys, minute);
     assertThat(view.getName()).isEqualTo(name);
     assertThat(view.getDescription()).isEqualTo(description);
     assertThat(view.getMeasure().getName())
         .isEqualTo(measure.getName());
+    assertThat(view.getAggregations()).isEqualTo(aggregations);
     assertThat(view.getColumns()).hasSize(2);
     assertThat(view.getColumns().get(0).toString()).isEqualTo("foo");
     assertThat(view.getColumns().get(1).toString()).isEqualTo("bar");
-    assertTrue(view.match(
-        new Function<DistributionView, Boolean> () {
-          @Override public Boolean apply(DistributionView dView) {
-            return false;
-          }
-        },
-        new Function<IntervalView, Boolean> () {
-          @Override public Boolean apply(IntervalView iView) {
-            return iView == view;
-          }
-        }));
+    assertThat(view.getWindow()).isEqualTo(minute);
   }
 
   @Test
   public void testViewEquals() {
-    DistributionAggregation dAggr = DistributionAggregation.create();
-    IntervalAggregation iAggr = IntervalAggregation.create(
-        Arrays.asList(Duration.fromMillis(1), Duration.fromMillis(22), Duration.fromMillis(333)));
     new EqualsTester()
         .addEqualityGroup(
-            DistributionView.create(
-                name, description, measure, dAggr, keys),
-            DistributionView.create(
-                name, description, measure, dAggr, keys))
+            View.create(name, description, measure, aggregations, keys, null),
+            View.create(name, description, measure, aggregations, keys, null))
         .addEqualityGroup(
-            DistributionView.create(
-                name, description + 2, measure, dAggr, keys))
+            View.create(name, description + 2, measure, aggregations, keys, null))
         .addEqualityGroup(
-            IntervalView.create(
-                name, description, measure, iAggr, keys),
-            IntervalView.create(
-                name, description, measure, iAggr, keys))
+            View.create(name, description, measure, aggregations, keys, minute),
+            View.create(name, description, measure, aggregations, keys, minute))
         .addEqualityGroup(
-            IntervalView.create(
-                name, description + 2, measure, iAggr, keys))
+            View.create(name, description + 2, measure, aggregations, keys, minute))
         .testEquals();
   }
 
   @Test(expected = NullPointerException.class)
-  public void preventNullDistributionViewName() {
-    DistributionView.create(
-        null,
-        description,
-        measure,
-        DistributionAggregation.create(),
-        keys);
-  }
-
-  @Test(expected = NullPointerException.class)
-  public void preventNullIntervalViewName() {
-    IntervalView.create(
-        null,
-        description,
-        measure,
-        IntervalAggregation.create(Arrays.asList(Duration.fromMillis(1))),
-        keys);
+  public void preventNullViewName() {
+    View.create(null, description, measure, aggregations, keys, minute);
   }
 
   @Test
@@ -151,4 +101,6 @@ public final class ViewTest {
   private final Measure measure = Measure.MeasureDouble.create(
       "measure", "measure description", "1");
   private final List<TagKey> keys = Arrays.asList(TagKey.create("foo"), TagKey.create("bar"));
+  private final List<Aggregation> aggregations = Arrays.asList(Sum.create(), Count.create());
+  private final Duration minute = Duration.create(60, 0);
 }

--- a/core/src/test/java/io/opencensus/stats/ViewTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewTest.java
@@ -13,20 +13,19 @@
 
 package io.opencensus.stats;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Duration;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Sum;
-import io.opencensus.stats.View.Window.CumulativeWindow;
-import io.opencensus.stats.View.Window.IntervalWindow;
+import io.opencensus.stats.View.Window.Cumulative;
+import io.opencensus.stats.View.Window.Interval;
+import java.util.Arrays;
+import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import java.util.Arrays;
-import java.util.List;
-
-import static com.google.common.truth.Truth.assertThat;
 
 /** Tests for {@link View} */
 @RunWith(JUnit4.class)
@@ -34,30 +33,28 @@ public final class ViewTest {
   @Test
   public void testDistributionView() {
     final View view = View.create(
-        name, description, measure, aggregations, keys, CumulativeWindow.create());
+        name, description, measure, aggregations, keys, Cumulative.create());
     assertThat(view.getName()).isEqualTo(name);
     assertThat(view.getDescription()).isEqualTo(description);
     assertThat(view.getMeasure().getName()).isEqualTo(measure.getName());
     assertThat(view.getAggregations()).isEqualTo(aggregations);
     assertThat(view.getColumns()).hasSize(2);
-    assertThat(view.getColumns().get(0).toString()).isEqualTo("foo");
-    assertThat(view.getColumns().get(1).toString()).isEqualTo("bar");
-    assertThat(view.getWindow()).isEqualTo(CumulativeWindow.create());
+    assertThat(view.getColumns()).containsExactly(FOO, BAR).inOrder();
+    assertThat(view.getWindow()).isEqualTo(Cumulative.create());
   }
 
   @Test
   public void testIntervalView() {
     final View view = View.create(
-        name, description, measure, aggregations, keys, IntervalWindow.create(minute));
+        name, description, measure, aggregations, keys, Interval.create(minute));
     assertThat(view.getName()).isEqualTo(name);
     assertThat(view.getDescription()).isEqualTo(description);
     assertThat(view.getMeasure().getName())
         .isEqualTo(measure.getName());
     assertThat(view.getAggregations()).isEqualTo(aggregations);
     assertThat(view.getColumns()).hasSize(2);
-    assertThat(view.getColumns().get(0).toString()).isEqualTo("foo");
-    assertThat(view.getColumns().get(1).toString()).isEqualTo("bar");
-    assertThat(view.getWindow()).isEqualTo(IntervalWindow.create(minute));
+    assertThat(view.getColumns()).containsExactly(FOO, BAR).inOrder();
+    assertThat(view.getWindow()).isEqualTo(Interval.create(minute));
   }
 
   @Test
@@ -65,26 +62,26 @@ public final class ViewTest {
     new EqualsTester()
         .addEqualityGroup(
             View.create(
-                name, description, measure, aggregations, keys, CumulativeWindow.create()),
+                name, description, measure, aggregations, keys, Cumulative.create()),
             View.create(
-                name, description, measure, aggregations, keys, CumulativeWindow.create()))
+                name, description, measure, aggregations, keys, Cumulative.create()))
         .addEqualityGroup(
             View.create(
-                name, description + 2, measure, aggregations, keys, CumulativeWindow.create()))
+                name, description + 2, measure, aggregations, keys, Cumulative.create()))
         .addEqualityGroup(
             View.create(
-                name, description, measure, aggregations, keys, IntervalWindow.create(minute)),
+                name, description, measure, aggregations, keys, Interval.create(minute)),
             View.create(
-                name, description, measure, aggregations, keys, IntervalWindow.create(minute)))
+                name, description, measure, aggregations, keys, Interval.create(minute)))
         .addEqualityGroup(
             View.create(
-                name, description, measure, aggregations, keys, IntervalWindow.create(twoMinutes)))
+                name, description, measure, aggregations, keys, Interval.create(twoMinutes)))
         .testEquals();
   }
 
   @Test(expected = NullPointerException.class)
   public void preventNullViewName() {
-    View.create(null, description, measure, aggregations, keys, IntervalWindow.create(minute));
+    View.create(null, description, measure, aggregations, keys, Interval.create(minute));
   }
 
   @Test

--- a/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
@@ -19,10 +19,6 @@ import io.opencensus.common.Clock;
 import io.opencensus.common.Function;
 import io.opencensus.stats.Measurement.MeasurementDouble;
 import io.opencensus.stats.Measurement.MeasurementLong;
-import io.opencensus.stats.MutableViewData.MutableDistributionViewData;
-import io.opencensus.stats.MutableViewData.MutableIntervalViewData;
-import io.opencensus.stats.View.DistributionView;
-import io.opencensus.stats.View.IntervalView;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -84,12 +80,13 @@ final class MeasureToViewMap {
       }
     }
     registeredViews.put(view.getName(), view);
-    MutableViewData mutableViewData =
-        view.match(
-            new CreateMutableDistributionViewDataFunction(clock),
-            new CreateMutableIntervalViewDataFunction());
-    mutableMap.put(
-        view.getMeasure().getName(), mutableViewData);
+    // TODO(songya): update to use refactored implementation.
+    //    MutableViewData mutableViewData =
+    //        view.match(
+    //            new CreateMutableDistributionViewDataFunction(clock),
+    //            new CreateMutableIntervalViewDataFunction());
+    //    mutableMap.put(
+    //        view.getMeasure().getName(), mutableViewData);
   }
 
   // Records stats with a set of tags.
@@ -102,29 +99,6 @@ final class MeasureToViewMap {
         measurement.match(
             new RecordDoubleValueFunc(tags, view), new RecordLongValueFunc(tags, view));
       }
-    }
-  }
-
-  private static final class CreateMutableDistributionViewDataFunction
-      implements Function<DistributionView, MutableViewData> {
-    private final Clock clock;
-
-    CreateMutableDistributionViewDataFunction(Clock clock) {
-      this.clock = clock;
-    }
-
-    @Override
-    public MutableViewData apply(DistributionView view) {
-      return MutableDistributionViewData.create(view, clock.now());
-    }
-  }
-
-  private static final class CreateMutableIntervalViewDataFunction
-      implements Function<IntervalView, MutableViewData> {
-    @Override
-    public MutableViewData apply(IntervalView view) {
-      // TODO(songya): Create Interval Aggregations from internal Distributions.
-      return MutableIntervalViewData.create(view);
     }
   }
 

--- a/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
@@ -15,19 +15,11 @@ package io.opencensus.stats;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Clock;
-import io.opencensus.common.Timestamp;
-import io.opencensus.stats.View.DistributionView;
-import io.opencensus.stats.View.IntervalView;
-import io.opencensus.stats.ViewData.DistributionViewData;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 
 /**
  * A mutable version of {@link ViewData}, used for recording stats and start/end time.
  */
+// TODO(songya): update to use refactored implementation.
 abstract class MutableViewData {
 
   // TODO(songya): might want to update the default tag value later.
@@ -57,145 +49,145 @@ abstract class MutableViewData {
   private MutableViewData() {
   }
 
-  /**
-   * A {@link MutableViewData} for recording stats on distribution-based aggregations.
-   */
-  static final class MutableDistributionViewData extends MutableViewData {
-
-    /**
-     * Constructs a new {@link MutableDistributionViewData}.
-     */
-    static MutableDistributionViewData create(
-        DistributionView distributionView, Timestamp start) {
-      return new MutableDistributionViewData(distributionView, start);
-    }
-
-    @Override
-    View getView() {
-      return distributionView;
-    }
-
-    @Override
-    void record(StatsContextImpl context, double value) {
-      Map<TagKey, TagValue> tags = context.tags;
-      // TagKeys need to be unique within one view descriptor.
-      final List<TagKey> tagKeys = this.distributionView.getColumns();
-      final List<TagValue> tagValues = new ArrayList<TagValue>(tagKeys.size());
-
-      // Record all the measures in a "Greedy" way.
-      // Every view aggregates every measure. This is similar to doing a GROUPBY view’s keys.
-      for (int i = 0; i < tagKeys.size(); ++i) {
-        TagKey tagKey = tagKeys.get(i);
-        if (!tags.containsKey(tagKey)) {
-          // replace not found key values by “unknown/not set”.
-          tagValues.add(UNKNOWN_TAG_VALUE);
-        } else {
-          tagValues.add(tags.get(tagKey));
-        }
-      }
-
-      if (!tagValueDistributionMap.containsKey(tagValues)) {
-        final List<Double> bucketBoundaries =
-            this.distributionView.getDistributionAggregation()
-                .getBucketBoundaries();
-        final MutableDistribution distribution =
-            bucketBoundaries == null ? MutableDistribution.create()
-                : MutableDistribution.create(BucketBoundaries.create(bucketBoundaries));
-        tagValueDistributionMap.put(tagValues, distribution);
-      }
-      tagValueDistributionMap.get(tagValues).add(value);
-    }
-
-    @Override
-    void record(StatsContextImpl tags, long value) {
-      // TODO(songya): modify MutableDistribution to support long values.
-      throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
-    final ViewData toViewData(Clock clock) {
-      final List<DistributionAggregate> distributionAggregations =
-          new ArrayList<DistributionAggregate>();
-      for (Entry<List<TagValue>, MutableDistribution> entry : tagValueDistributionMap.entrySet()) {
-        MutableDistribution distribution = entry.getValue();
-        DistributionAggregate distributionAggregation = distribution.getBucketCounts() == null
-            ? DistributionAggregate.create(distribution.getCount(), distribution.getMean(),
-            distribution.getSum(), convertRange(distribution.getRange()),
-            generateTags(entry.getKey()))
-            : DistributionAggregate.create(distribution.getCount(), distribution.getMean(),
-                distribution.getSum(), convertRange(distribution.getRange()),
-                generateTags(entry.getKey()), distribution.getBucketCounts());
-        distributionAggregations.add(distributionAggregation);
-      }
-      return DistributionViewData.create(distributionView, distributionAggregations, start,
-          clock.now());
-    }
-
-    /**
-     * Returns start timestamp for this aggregation.
-     */
-    Timestamp getStart() {
-      return start;
-    }
-
-    private final DistributionView distributionView;
-    private final Map<List<TagValue>, MutableDistribution> tagValueDistributionMap =
-        new HashMap<List<TagValue>, MutableDistribution>();
-    private final Timestamp start;
-
-    private MutableDistributionViewData(
-        DistributionView distributionView, Timestamp start) {
-      this.distributionView = distributionView;
-      this.start = start;
-    }
-
-    private final List<Tag> generateTags(List<TagValue> tagValues) {
-      final List<Tag> tags = new ArrayList<Tag>(tagValues.size());
-      int i = 0;
-      for (TagKey tagKey : this.distributionView.getColumns()) {
-        tags.add(Tag.create(tagKey, tagValues.get(i)));
-        ++i;
-      }
-      return tags;
-    }
-
-    // TODO(songya): remove DistributionAggregate.Range, then remove this method
-    private static final DistributionAggregate.Range convertRange(
-        MutableDistribution.Range range) {
-      return DistributionAggregate.Range.create(range.getMin(), range.getMax());
-    }
-  }
-
-  /**
-   * A {@link MutableViewData} for recording stats on interval-based aggregations.
-   */
-  static final class MutableIntervalViewData extends MutableViewData {
-
-    /**
-     * Constructs a new {@link MutableIntervalViewData}.
-     */
-    static MutableIntervalViewData create(IntervalView view) {
-      throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
-    View getView() {
-      throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
-    void record(StatsContextImpl tags, double value) {
-      throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
-    void record(StatsContextImpl tags, long value) {
-      throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
-    final ViewData toViewData(Clock clock) {
-      throw new UnsupportedOperationException("Not implemented.");
-    }
-  }
+//  /**
+//   * A {@link MutableViewData} for recording stats on distribution-based aggregations.
+//   */
+//  static final class MutableDistributionViewData extends MutableViewData {
+//
+//    /**
+//     * Constructs a new {@link MutableDistributionViewData}.
+//     */
+//    static MutableDistributionViewData create(
+//        DistributionView distributionView, Timestamp start) {
+//      return new MutableDistributionViewData(distributionView, start);
+//    }
+//
+//    @Override
+//    View getView() {
+//      return distributionView;
+//    }
+//
+//    @Override
+//    void record(StatsContextImpl context, double value) {
+//      Map<TagKey, TagValue> tags = context.tags;
+//      // TagKeys need to be unique within one view descriptor.
+//      final List<TagKey> tagKeys = this.distributionView.getColumns();
+//      final List<TagValue> tagValues = new ArrayList<TagValue>(tagKeys.size());
+//
+//      // Record all the measures in a "Greedy" way.
+//      // Every view aggregates every measure. This is similar to doing a GROUPBY view’s keys.
+//      for (int i = 0; i < tagKeys.size(); ++i) {
+//        TagKey tagKey = tagKeys.get(i);
+//        if (!tags.containsKey(tagKey)) {
+//          // replace not found key values by “unknown/not set”.
+//          tagValues.add(UNKNOWN_TAG_VALUE);
+//        } else {
+//          tagValues.add(tags.get(tagKey));
+//        }
+//      }
+//
+//      if (!tagValueDistributionMap.containsKey(tagValues)) {
+//        final List<Double> bucketBoundaries =
+//            this.distributionView.getDistributionAggregation()
+//                .getBucketBoundaries();
+//        final MutableDistribution distribution =
+//            bucketBoundaries == null ? MutableDistribution.create()
+//                : MutableDistribution.create(BucketBoundaries.create(bucketBoundaries));
+//        tagValueDistributionMap.put(tagValues, distribution);
+//      }
+//      tagValueDistributionMap.get(tagValues).add(value);
+//    }
+//
+//    @Override
+//    void record(StatsContextImpl tags, long value) {
+//      // TODO(songya): modify MutableDistribution to support long values.
+//      throw new UnsupportedOperationException("Not implemented.");
+//    }
+//
+//    @Override
+//    final ViewData toViewData(Clock clock) {
+//      final List<DistributionAggregate> distributionAggregations =
+//          new ArrayList<DistributionAggregate>();
+//      for (Entry<List<TagValue>, MutableDistribution> entry : tagValueDistributionMap.entrySet()){
+//        MutableDistribution distribution = entry.getValue();
+//        DistributionAggregate distributionAggregation = distribution.getBucketCounts() == null
+//            ? DistributionAggregate.create(distribution.getCount(), distribution.getMean(),
+//            distribution.getSum(), convertRange(distribution.getRange()),
+//            generateTags(entry.getKey()))
+//            : DistributionAggregate.create(distribution.getCount(), distribution.getMean(),
+//                distribution.getSum(), convertRange(distribution.getRange()),
+//                generateTags(entry.getKey()), distribution.getBucketCounts());
+//        distributionAggregations.add(distributionAggregation);
+//      }
+//      return DistributionViewData.create(distributionView, distributionAggregations, start,
+//          clock.now());
+//    }
+//
+//    /**
+//     * Returns start timestamp for this aggregation.
+//     */
+//    Timestamp getStart() {
+//      return start;
+//    }
+//
+//    private final DistributionView distributionView;
+//    private final Map<List<TagValue>, MutableDistribution> tagValueDistributionMap =
+//        new HashMap<List<TagValue>, MutableDistribution>();
+//    private final Timestamp start;
+//
+//    private MutableDistributionViewData(
+//        DistributionView distributionView, Timestamp start) {
+//      this.distributionView = distributionView;
+//      this.start = start;
+//    }
+//
+//    private final List<Tag> generateTags(List<TagValue> tagValues) {
+//      final List<Tag> tags = new ArrayList<Tag>(tagValues.size());
+//      int i = 0;
+//      for (TagKey tagKey : this.distributionView.getColumns()) {
+//        tags.add(Tag.create(tagKey, tagValues.get(i)));
+//        ++i;
+//      }
+//      return tags;
+//    }
+//
+//    // TODO(songya): remove DistributionAggregate.Range, then remove this method
+//    private static final DistributionAggregate.Range convertRange(
+//        MutableDistribution.Range range) {
+//      return DistributionAggregate.Range.create(range.getMin(), range.getMax());
+//    }
+//  }
+//
+//  /**
+//   * A {@link MutableViewData} for recording stats on interval-based aggregations.
+//   */
+//  static final class MutableIntervalViewData extends MutableViewData {
+//
+//    /**
+//     * Constructs a new {@link MutableIntervalViewData}.
+//     */
+//    static MutableIntervalViewData create(IntervalView view) {
+//      throw new UnsupportedOperationException("Not implemented.");
+//    }
+//
+//    @Override
+//    View getView() {
+//      throw new UnsupportedOperationException("Not implemented.");
+//    }
+//
+//    @Override
+//    void record(StatsContextImpl tags, double value) {
+//      throw new UnsupportedOperationException("Not implemented.");
+//    }
+//
+//    @Override
+//    void record(StatsContextImpl tags, long value) {
+//      throw new UnsupportedOperationException("Not implemented.");
+//    }
+//
+//    @Override
+//    final ViewData toViewData(Clock clock) {
+//      throw new UnsupportedOperationException("Not implemented.");
+//    }
+//  }
 }

--- a/core_impl/src/main/java/io/opencensus/stats/StatsManager.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsManager.java
@@ -32,7 +32,7 @@ final class StatsManager {
   }
 
   void registerView(View view) {
-    if (view.getWindow() instanceof View.Window.IntervalWindow) {
+    if (view.getWindow() instanceof View.Window.Interval) {
       throw new UnsupportedOperationException("IntervalView not supported yet.");
     }
     measureToViewMap.registerView(view, clock);

--- a/core_impl/src/main/java/io/opencensus/stats/StatsManager.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsManager.java
@@ -15,7 +15,6 @@ package io.opencensus.stats;
 
 import io.opencensus.common.Clock;
 import io.opencensus.internal.EventQueue;
-import io.opencensus.stats.View.DistributionView;
 
 /** Object that stores all views and stats. */
 final class StatsManager {
@@ -33,12 +32,6 @@ final class StatsManager {
   }
 
   void registerView(View view) {
-    // Only DistributionViews are supported currently.
-    // TODO(sebright): Remove this once all views are supported.
-    if (!(view instanceof DistributionView)) {
-      throw new UnsupportedOperationException(
-          "The prototype will only support distribution views.");
-    }
     measureToViewMap.registerView(view, clock);
   }
 

--- a/core_impl/src/main/java/io/opencensus/stats/StatsManager.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsManager.java
@@ -32,6 +32,9 @@ final class StatsManager {
   }
 
   void registerView(View view) {
+    if (view.getWindow() instanceof View.Window.IntervalWindow) {
+      throw new UnsupportedOperationException("IntervalView not supported yet.");
+    }
     measureToViewMap.registerView(view, clock);
   }
 

--- a/core_impl/src/test/java/io/opencensus/stats/MeasureToViewMapTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/MeasureToViewMapTest.java
@@ -13,22 +13,14 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
-
-import io.opencensus.common.Function;
-import io.opencensus.common.Timestamp;
-import io.opencensus.stats.View.DistributionView;
-import io.opencensus.stats.ViewData.DistributionViewData;
-import io.opencensus.stats.ViewData.IntervalViewData;
-import io.opencensus.testing.common.TestClock;
-import java.util.Arrays;
-import org.junit.Test;
+import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link MeasureToViewMap}. */
+@Ignore
 @RunWith(JUnit4.class)
+// TODO(songya): re-enable the tests once implementation is done.
 public class MeasureToViewMapTest {
 
   private static final Measure MEASURE =
@@ -39,38 +31,38 @@ public class MeasureToViewMapTest {
 
   private static final View.Name VIEW_NAME = View.Name.create("my view");
 
-  private static final View VIEW =
-      DistributionView.create(
-          VIEW_NAME,
-          "view description",
-          MEASURE,
-          DistributionAggregation.create(),
-          Arrays.asList(TagKey.create("my key")));
+//  private static final View VIEW =
+//      DistributionView.create(
+//          VIEW_NAME,
+//          "view description",
+//          MEASURE,
+//          DistributionAggregation.create(),
+//          Arrays.asList(TagKey.create("my key")));
 
-  @Test
-  public void testRegisterAndGetDistributionView() {
-    MeasureToViewMap measureToViewMap = new MeasureToViewMap();
-    TestClock clock = TestClock.create(Timestamp.create(10, 20));
-    measureToViewMap.registerView(VIEW, clock);
-    clock.setTime(Timestamp.create(30, 40));
-    ViewData actual = measureToViewMap.getView(VIEW_NAME, clock);
-    actual.match(
-        new Function<ViewData.DistributionViewData, Void>() {
-          @Override
-          public Void apply(DistributionViewData view) {
-            assertThat(view.getView()).isEqualTo(VIEW);
-            assertThat(view.getStart()).isEqualTo(Timestamp.create(10, 20));
-            assertThat(view.getEnd()).isEqualTo(Timestamp.create(30, 40));
-            assertThat(view.getDistributionAggregates()).isEmpty();
-            return null;
-          }
-        },
-        new Function<ViewData.IntervalViewData, Void>() {
-          @Override
-          public Void apply(IntervalViewData view) {
-            fail("Wrong view type.");
-            return null;
-          }
-        });
-  }
+//  @Test
+//  public void testRegisterAndGetDistributionView() {
+//    MeasureToViewMap measureToViewMap = new MeasureToViewMap();
+//    TestClock clock = TestClock.create(Timestamp.create(10, 20));
+//    measureToViewMap.registerView(VIEW, clock);
+//    clock.setTime(Timestamp.create(30, 40));
+//    ViewData actual = measureToViewMap.getView(VIEW_NAME, clock);
+//    actual.match(
+//        new Function<ViewData.DistributionViewData, Void>() {
+//          @Override
+//          public Void apply(DistributionViewData view) {
+//            assertThat(view.getView()).isEqualTo(VIEW);
+//            assertThat(view.getStart()).isEqualTo(Timestamp.create(10, 20));
+//            assertThat(view.getEnd()).isEqualTo(Timestamp.create(30, 40));
+//            assertThat(view.getDistributionAggregates()).isEmpty();
+//            return null;
+//          }
+//        },
+//        new Function<ViewData.IntervalViewData, Void>() {
+//          @Override
+//          public Void apply(IntervalViewData view) {
+//            fail("Wrong view type.");
+//            return null;
+//          }
+//        });
+//  }
 }

--- a/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
@@ -14,16 +14,11 @@
 package io.opencensus.stats;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.fail;
 
 import com.google.common.collect.Collections2;
 import com.google.common.testing.EqualsTester;
-import io.opencensus.common.Function;
 import io.opencensus.internal.SimpleEventQueue;
 import io.opencensus.internal.VarInt;
-import io.opencensus.stats.Measure.MeasureLong;
-import io.opencensus.stats.ViewData.DistributionViewData;
-import io.opencensus.stats.ViewData.IntervalViewData;
 import io.opencensus.testing.common.TestClock;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -116,74 +111,75 @@ public class StatsContextTest {
         .isEqualTo(context4);
   }
 
-  // The main tests for stats recording are in ViewManagerImplTest.
-  @Test
-  public void testRecordDouble() {
-    viewManager.registerView(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
-    ViewData beforeViewData =
-        viewManager.getView(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
-    beforeViewData.match(
-        new Function<DistributionViewData, Void>() {
-          @Override
-          public Void apply(DistributionViewData view) {
-            assertThat(view.getDistributionAggregates()).isEmpty();
-            return null;
-          }
-        },
-        new Function<IntervalViewData, Void>() {
-          @Override
-          public Void apply(IntervalViewData view) {
-            fail("Expected a DistributionViewData");
-            return null;
-          }
-        });
-    StatsContext context =
-        defaultStatsContext.with(
-            RpcMeasureConstants.RPC_CLIENT_METHOD, TagValue.create("myMethod"));
-    MeasureMap measurements =
-        MeasureMap.builder()
-            .set(RpcMeasureConstants.RPC_CLIENT_ROUNDTRIP_LATENCY, 5.1).build();
-    context.record(measurements);
-    ViewData afterViewData =
-        viewManager.getView(
-            RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
-    afterViewData.match(
-        new Function<DistributionViewData, Void>() {
-          @Override
-          public Void apply(DistributionViewData view) {
-            assertThat(view.getDistributionAggregates()).hasSize(1);
-            DistributionAggregate agg = view.getDistributionAggregates().get(0);
-            assertThat(agg.getTags())
-                .containsExactly(
-                    Tag.create(
-                        RpcMeasureConstants.RPC_CLIENT_METHOD, TagValue.create("myMethod")));
-            assertThat(agg.getCount()).isEqualTo(1);
-            assertThat(agg.getMean()).isWithin(TOLERANCE).of(5.1);
-            return null;
-          }
-        },
-        new Function<IntervalViewData, Void>() {
-          @Override
-          public Void apply(IntervalViewData view) {
-            fail("Expected a DistributionViewData");
-            return null;
-          }
-        });
-  }
-
-  @Test
-  public void testRecordLong() {
-    MeasureLong measure = MeasureLong.create("long measure", "description", "1");
-    viewManager.registerView(
-        View.DistributionView.create(
-            View.Name.create("name"),
-            "description",
-            measure,
-            DistributionAggregation.create(),
-            Arrays.asList(K1)));
-    thrown.expect(UnsupportedOperationException.class);
-    defaultStatsContext.with(K1, V1).record(MeasureMap.builder().set(measure,1L).build());
-  }
+  // TODO(songya): re-enable the tests once implementation is done.
+//  // The main tests for stats recording are in ViewManagerImplTest.
+//  @Test
+//  public void testRecordDouble() {
+//    viewManager.registerView(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
+//    ViewData beforeViewData =
+//        viewManager.getView(RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
+//    beforeViewData.match(
+//        new Function<DistributionViewData, Void>() {
+//          @Override
+//          public Void apply(DistributionViewData view) {
+//            assertThat(view.getDistributionAggregates()).isEmpty();
+//            return null;
+//          }
+//        },
+//        new Function<IntervalViewData, Void>() {
+//          @Override
+//          public Void apply(IntervalViewData view) {
+//            fail("Expected a DistributionViewData");
+//            return null;
+//          }
+//        });
+//    StatsContext context =
+//        defaultStatsContext.with(
+//            RpcMeasureConstants.RPC_CLIENT_METHOD, TagValue.create("myMethod"));
+//    MeasureMap measurements =
+//        MeasureMap.builder()
+//            .set(RpcMeasureConstants.RPC_CLIENT_ROUNDTRIP_LATENCY, 5.1).build();
+//    context.record(measurements);
+//    ViewData afterViewData =
+//        viewManager.getView(
+//            RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW);
+//    afterViewData.match(
+//        new Function<DistributionViewData, Void>() {
+//          @Override
+//          public Void apply(DistributionViewData view) {
+//            assertThat(view.getDistributionAggregates()).hasSize(1);
+//            DistributionAggregate agg = view.getDistributionAggregates().get(0);
+//            assertThat(agg.getTags())
+//                .containsExactly(
+//                    Tag.create(
+//                        RpcMeasureConstants.RPC_CLIENT_METHOD, TagValue.create("myMethod")));
+//            assertThat(agg.getCount()).isEqualTo(1);
+//            assertThat(agg.getMean()).isWithin(TOLERANCE).of(5.1);
+//            return null;
+//          }
+//        },
+//        new Function<IntervalViewData, Void>() {
+//          @Override
+//          public Void apply(IntervalViewData view) {
+//            fail("Expected a DistributionViewData");
+//            return null;
+//          }
+//        });
+//  }
+//
+//  @Test
+//  public void testRecordLong() {
+//    MeasureLong measure = MeasureLong.create("long measure", "description", "1");
+//    viewManager.registerView(
+//        View.DistributionView.create(
+//            View.Name.create("name"),
+//            "description",
+//            measure,
+//            DistributionAggregation.create(),
+//            Arrays.asList(K1)));
+//    thrown.expect(UnsupportedOperationException.class);
+//    defaultStatsContext.with(K1, V1).record(MeasureMap.builder().set(measure,1L).build());
+//  }
 
   @Test
   public void testSerializeDefault() throws Exception {

--- a/core_impl/src/test/java/io/opencensus/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/ViewManagerImplTest.java
@@ -13,28 +13,21 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.truth.Truth.assertThat;
-import static io.opencensus.stats.StatsTestUtil.createContext;
-
-import io.opencensus.common.Duration;
-import io.opencensus.common.Timestamp;
 import io.opencensus.internal.SimpleEventQueue;
 import io.opencensus.stats.Measure.MeasureDouble;
-import io.opencensus.stats.ViewData.DistributionViewData;
-import io.opencensus.stats.View.DistributionView;
-import io.opencensus.stats.View.IntervalView;
 import io.opencensus.testing.common.TestClock;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.List;
+import org.junit.Ignore;
 import org.junit.Rule;
-import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link ViewManagerImpl}. */
+@Ignore
 @RunWith(JUnit4.class)
+// TODO(songya): re-enable the tests once implementation is done.
 public class ViewManagerImplTest {
 
   @Rule
@@ -79,393 +72,393 @@ public class ViewManagerImplTest {
   private final ViewManagerImpl viewManager = statsComponent.getViewManager();
   private final StatsRecorder statsRecorder = statsComponent.getStatsRecorder();
 
-  private static DistributionView createDistributionView() {
-    return createDistributionView(
-        VIEW_NAME, MEASURE, DISTRIBUTION_AGGREGATION_DESCRIPTOR, Arrays.asList(KEY));
-  }
-
-  private static DistributionView createDistributionView(
-      View.Name name,
-      Measure measure,
-      DistributionAggregation distributionAggregation,
-      List<TagKey> keys) {
-    return DistributionView.create(name, VIEW_DESCRIPTION, measure, distributionAggregation, keys);
-  }
-
-  @Test
-  public void testRegisterAndGetView() {
-    DistributionView view = createDistributionView();
-    viewManager.registerView(view);
-    assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view);
-  }
-
-  @Test
-  public void preventRegisteringIntervalView() {
-    View intervalView =
-        IntervalView.create(
-            VIEW_NAME,
-            VIEW_DESCRIPTION,
-            MEASURE,
-            IntervalAggregation.create(Arrays.asList(Duration.fromMillis(1000))),
-            Arrays.asList(KEY));
-    thrown.expect(UnsupportedOperationException.class);
-    viewManager.registerView(intervalView);
-  }
-
-  @Test
-  public void allowRegisteringSameViewTwice() {
-    DistributionView view = createDistributionView();
-    viewManager.registerView(view);
-    viewManager.registerView(view);
-    assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view);
-  }
-
-  @Test
-  public void preventRegisteringDifferentViewWithSameName() {
-    View view1 =
-        DistributionView.create(
-            VIEW_NAME,
-            "View description.",
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY));
-    viewManager.registerView(view1);
-    View view2 =
-        DistributionView.create(
-            VIEW_NAME,
-            "This is a different description.",
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY));
-    try {
-      thrown.expect(IllegalArgumentException.class);
-      thrown.expectMessage("A different view with the same name is already registered");
-      viewManager.registerView(view2);
-    } finally {
-      assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view1);
-    }
-  }
-
-  @Test
-  public void disallowGettingNonexistentViewData() {
-    thrown.expect(IllegalArgumentException.class);
-    viewManager.getView(VIEW_NAME);
-  }
-
-  @Test
-  public void testRecord() {
-    DistributionView view =
-        createDistributionView(
-            VIEW_NAME,
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY));
-    clock.setTime(Timestamp.create(1, 2));
-    viewManager.registerView(view);
-    StatsContextImpl tags = createContext(factory, KEY, VALUE);
-    for (double val : Arrays.asList(10.0, 20.0, 30.0, 40.0)) {
-      statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, val).build());
-    }
-    clock.setTime(Timestamp.create(3, 4));
-    DistributionViewData viewData = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    assertThat(viewData.getView()).isEqualTo(view);
-    assertThat(viewData.getStart()).isEqualTo(Timestamp.create(1, 2));
-    assertThat(viewData.getEnd()).isEqualTo(Timestamp.create(3, 4));
-    assertDistributionAggregatesEquivalent(
-        viewData.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE)),
-                BUCKET_BOUNDARIES,
-                Arrays.asList(10.0, 20.0, 30.0, 40.0))));
-  }
-
-  @Test
-  public void getViewDoesNotClearStats() {
-    DistributionView view =
-        createDistributionView(
-            VIEW_NAME,
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY));
-    clock.setTime(Timestamp.create(10, 0));
-    viewManager.registerView(view);
-    StatsContextImpl tags = createContext(factory, KEY, VALUE);
-    statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 0.1).build());
-    clock.setTime(Timestamp.create(11, 0));
-    DistributionViewData viewData1 = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    assertThat(viewData1.getStart()).isEqualTo(Timestamp.create(10, 0));
-    assertThat(viewData1.getEnd()).isEqualTo(Timestamp.create(11, 0));
-    assertDistributionAggregatesEquivalent(
-        viewData1.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(0.1))));
-    statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 0.2).build());
-    clock.setTime(Timestamp.create(12, 0));
-    DistributionViewData viewData2 = (DistributionViewData) viewManager.getView(VIEW_NAME);
-
-    // The second view should have the same start time as the first view, and it should include both
-    // recorded values:
-    assertThat(viewData2.getStart()).isEqualTo(Timestamp.create(10, 0));
-    assertThat(viewData2.getEnd()).isEqualTo(Timestamp.create(12, 0));
-    assertDistributionAggregatesEquivalent(
-        viewData2.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE)),
-                BUCKET_BOUNDARIES,
-                Arrays.asList(0.1, 0.2))));
-  }
-
-  @Test
-  public void testRecordMultipleTagValues() {
-    viewManager.registerView(
-        createDistributionView(
-            VIEW_NAME,
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY)));
-    statsRecorder.record(
-        createContext(factory, KEY, VALUE),
-        MeasureMap.builder().set(MEASURE, 10.0).build());
-    statsRecorder.record(
-        createContext(factory, KEY, VALUE_2),
-        MeasureMap.builder().set(MEASURE, 30.0).build());
-    statsRecorder.record(
-        createContext(factory, KEY, VALUE_2),
-        MeasureMap.builder().set(MEASURE, 50.0).build());
-    DistributionViewData viewData = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    assertDistributionAggregatesEquivalent(
-        viewData.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(10.0)),
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE_2)),
-                BUCKET_BOUNDARIES,
-                Arrays.asList(30.0, 50.0))));
-  }
-
-  // This test checks that StatsRecorder.record(...) does not throw an exception when no views are
-  // registered.
-  @Test
-  public void allowRecordingWithoutRegisteringMatchingViewData() {
-    statsRecorder.record(
-        createContext(factory, KEY, VALUE),
-        MeasureMap.builder().set(MEASURE, 10).build());
-  }
-
-  @Test
-  public void testRecordWithEmptyStatsContext() {
-    viewManager.registerView(
-        createDistributionView(
-            VIEW_NAME,
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY)));
-    // DEFAULT doesn't have tags, but the view has tag key "KEY".
-    statsRecorder.record(factory.getDefault(),
-        MeasureMap.builder().set(MEASURE, 10.0).build());
-    DistributionViewData viewData = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    assertDistributionAggregatesEquivalent(
-        viewData.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                // Tag is missing for associated measureValues, should use default tag value
-                // "unknown/not set"
-                Arrays.asList(Tag.create(KEY, MutableViewData.UNKNOWN_TAG_VALUE)),
-                BUCKET_BOUNDARIES,
-                // Should record stats with default tag value: "KEY" : "unknown/not set".
-                Arrays.asList(10.0))));
-  }
-
-  @Test
-  public void testRecordWithNonExistentMeasurement() {
-    viewManager.registerView(
-        createDistributionView(
-            VIEW_NAME,
-            Measure.MeasureDouble.create(MEASURE_NAME, "measure", MEASURE_UNIT),
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY)));
-    MeasureDouble measure2 =
-        Measure.MeasureDouble.create(MEASURE_NAME_2, "measure", MEASURE_UNIT);
-    statsRecorder.record(createContext(factory, KEY, VALUE),
-        MeasureMap.builder().set(measure2, 10.0).build());
-    DistributionViewData view = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    assertThat(view.getDistributionAggregates()).isEmpty();
-  }
-
-  @Test
-  public void testRecordWithTagsThatDoNotMatchViewData() {
-    viewManager.registerView(
-        createDistributionView(
-            VIEW_NAME,
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY)));
-    statsRecorder.record(
-        createContext(factory, TagKey.create("wrong key"), VALUE),
-        MeasureMap.builder().set(MEASURE, 10.0).build());
-    statsRecorder.record(
-        createContext(factory, TagKey.create("another wrong key"), VALUE),
-        MeasureMap.builder().set(MEASURE, 50.0).build());
-    DistributionViewData view = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    assertDistributionAggregatesEquivalent(
-        view.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                // Won't record the unregistered tag key, will use default tag instead:
-                // "KEY" : "unknown/not set".
-                Arrays.asList(Tag.create(KEY, MutableViewData.UNKNOWN_TAG_VALUE)),
-                BUCKET_BOUNDARIES,
-                // Should record stats with default tag value: "KEY" : "unknown/not set".
-                Arrays.asList(10.0, 50.0))));
-  }
-
-  @Test
-  public void testViewDataWithMultipleTagKeys() {
-    TagKey key1 = TagKey.create("Key-1");
-    TagKey key2 = TagKey.create("Key-2");
-    viewManager.registerView(
-        createDistributionView(
-            VIEW_NAME,
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(key1, key2)));
-    statsRecorder.record(
-        createContext(factory, key1, TagValue.create("v1"), key2, TagValue.create("v10")),
-        MeasureMap.builder().set(MEASURE, 1.1).build());
-    statsRecorder.record(
-        createContext(factory, key1, TagValue.create("v1"), key2, TagValue.create("v20")),
-        MeasureMap.builder().set(MEASURE, 2.2).build());
-    statsRecorder.record(
-        createContext(factory, key1, TagValue.create("v2"), key2, TagValue.create("v10")),
-        MeasureMap.builder().set(MEASURE, 3.3).build());
-    statsRecorder.record(
-        createContext(factory, key1, TagValue.create("v1"), key2, TagValue.create("v10")),
-        MeasureMap.builder().set(MEASURE, 4.4).build());
-    DistributionViewData view = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    assertDistributionAggregatesEquivalent(
-        view.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(
-                    Tag.create(key1, TagValue.create("v1")),
-                    Tag.create(key2, TagValue.create("v10"))),
-                BUCKET_BOUNDARIES,
-                Arrays.asList(1.1, 4.4)),
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(
-                    Tag.create(key1, TagValue.create("v1")),
-                    Tag.create(key2, TagValue.create("v20"))),
-                BUCKET_BOUNDARIES,
-                Arrays.asList(2.2)),
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(
-                    Tag.create(key1, TagValue.create("v2")),
-                    Tag.create(key2, TagValue.create("v10"))),
-                BUCKET_BOUNDARIES,
-                Arrays.asList(3.3))));
-  }
-
-  @Test
-  public void testMultipleViewDatasSameMeasure() {
-    View view1 =
-        createDistributionView(
-            VIEW_NAME,
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY));
-    View view2 =
-        createDistributionView(
-            VIEW_NAME_2,
-            MEASURE,
-            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
-            Arrays.asList(KEY));
-    clock.setTime(Timestamp.create(1, 1));
-    viewManager.registerView(view1);
-    clock.setTime(Timestamp.create(2, 2));
-    viewManager.registerView(view2);
-    statsRecorder.record(
-        createContext(factory, KEY, VALUE),
-        MeasureMap.builder().set(MEASURE, 5.0).build());
-    List<DistributionAggregate> expectedAggs =
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(5.0)));
-    clock.setTime(Timestamp.create(3, 3));
-    DistributionViewData viewData1 = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    clock.setTime(Timestamp.create(4, 4));
-    DistributionViewData viewData2 = (DistributionViewData) viewManager.getView(VIEW_NAME_2);
-    assertThat(viewData1.getStart()).isEqualTo(Timestamp.create(1, 1));
-    assertThat(viewData1.getEnd()).isEqualTo(Timestamp.create(3, 3));
-    assertDistributionAggregatesEquivalent(viewData1.getDistributionAggregates(), expectedAggs);
-    assertThat(viewData2.getStart()).isEqualTo(Timestamp.create(2, 2));
-    assertThat(viewData2.getEnd()).isEqualTo(Timestamp.create(4, 4));
-    assertDistributionAggregatesEquivalent(viewData2.getDistributionAggregates(), expectedAggs);
-  }
-
-  @Test
-  public void testMultipleViewsDifferentMeasures() {
-    MeasureDouble measure1 =
-        Measure.MeasureDouble.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT);
-    MeasureDouble measure2 =
-        Measure.MeasureDouble.create(MEASURE_NAME_2, MEASURE_DESCRIPTION, MEASURE_UNIT);
-    View view1 =
-        createDistributionView(
-            VIEW_NAME, measure1, DISTRIBUTION_AGGREGATION_DESCRIPTOR, Arrays.asList(KEY));
-    View view2 =
-        createDistributionView(
-            VIEW_NAME_2, measure2, DISTRIBUTION_AGGREGATION_DESCRIPTOR, Arrays.asList(KEY));
-    clock.setTime(Timestamp.create(1, 0));
-    viewManager.registerView(view1);
-    clock.setTime(Timestamp.create(2, 0));
-    viewManager.registerView(view2);
-    statsRecorder.record(
-        createContext(factory, KEY, VALUE),
-        MeasureMap.builder().set(measure1, 1.1).set(measure2, 2.2).build());
-    clock.setTime(Timestamp.create(3, 0));
-    DistributionViewData viewData1 = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    clock.setTime(Timestamp.create(4, 0));
-    DistributionViewData viewData2 = (DistributionViewData) viewManager.getView(VIEW_NAME_2);
-    assertThat(viewData1.getStart()).isEqualTo(Timestamp.create(1, 0));
-    assertThat(viewData1.getEnd()).isEqualTo(Timestamp.create(3, 0));
-    assertDistributionAggregatesEquivalent(
-        viewData1.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(1.1))));
-    assertThat(viewData2.getStart()).isEqualTo(Timestamp.create(2, 0));
-    assertThat(viewData2.getEnd()).isEqualTo(Timestamp.create(4, 0));
-    assertDistributionAggregatesEquivalent(
-        viewData2.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(2.2))));
-  }
-
-  @Test
-  public void testGetDistributionViewDataWithoutBucketBoundaries() {
-    View view =
-        createDistributionView(
-            VIEW_NAME, MEASURE, DistributionAggregation.create(),
-            Arrays.asList(KEY));
-    clock.setTime(Timestamp.create(1, 0));
-    viewManager.registerView(view);
-    statsRecorder.record(
-        createContext(factory, KEY, VALUE),
-        MeasureMap.builder().set(MEASURE, 1.1).build());
-    clock.setTime(Timestamp.create(3, 0));
-    DistributionViewData viewData = (DistributionViewData) viewManager.getView(VIEW_NAME);
-    assertThat(viewData.getStart()).isEqualTo(Timestamp.create(1, 0));
-    assertThat(viewData.getEnd()).isEqualTo(Timestamp.create(3, 0));
-    assertDistributionAggregatesEquivalent(
-        viewData.getDistributionAggregates(),
-        Arrays.asList(
-            StatsTestUtil.createDistributionAggregate(
-                Arrays.asList(Tag.create(KEY, VALUE)), Arrays.asList(1.1))));
-  }
+//  private static DistributionView createDistributionView() {
+//    return createDistributionView(
+//        VIEW_NAME, MEASURE, DISTRIBUTION_AGGREGATION_DESCRIPTOR, Arrays.asList(KEY));
+//  }
+//
+//  private static DistributionView createDistributionView(
+//      View.Name name,
+//      Measure measure,
+//      DistributionAggregation distributionAggregation,
+//      List<TagKey> keys) {
+//    return DistributionView.create(name, VIEW_DESCRIPTION, measure, distributionAggregation, keys);
+//  }
+//
+//  @Test
+//  public void testRegisterAndGetView() {
+//    DistributionView view = createDistributionView();
+//    viewManager.registerView(view);
+//    assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view);
+//  }
+//
+//  @Test
+//  public void preventRegisteringIntervalView() {
+//    View intervalView =
+//        IntervalView.create(
+//            VIEW_NAME,
+//            VIEW_DESCRIPTION,
+//            MEASURE,
+//            IntervalAggregation.create(Arrays.asList(Duration.fromMillis(1000))),
+//            Arrays.asList(KEY));
+//    thrown.expect(UnsupportedOperationException.class);
+//    viewManager.registerView(intervalView);
+//  }
+//
+//  @Test
+//  public void allowRegisteringSameViewTwice() {
+//    DistributionView view = createDistributionView();
+//    viewManager.registerView(view);
+//    viewManager.registerView(view);
+//    assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view);
+//  }
+//
+//  @Test
+//  public void preventRegisteringDifferentViewWithSameName() {
+//    View view1 =
+//        DistributionView.create(
+//            VIEW_NAME,
+//            "View description.",
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY));
+//    viewManager.registerView(view1);
+//    View view2 =
+//        DistributionView.create(
+//            VIEW_NAME,
+//            "This is a different description.",
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY));
+//    try {
+//      thrown.expect(IllegalArgumentException.class);
+//      thrown.expectMessage("A different view with the same name is already registered");
+//      viewManager.registerView(view2);
+//    } finally {
+//      assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view1);
+//    }
+//  }
+//
+//  @Test
+//  public void disallowGettingNonexistentViewData() {
+//    thrown.expect(IllegalArgumentException.class);
+//    viewManager.getView(VIEW_NAME);
+//  }
+//
+//  @Test
+//  public void testRecord() {
+//    DistributionView view =
+//        createDistributionView(
+//            VIEW_NAME,
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY));
+//    clock.setTime(Timestamp.create(1, 2));
+//    viewManager.registerView(view);
+//    StatsContextImpl tags = createContext(factory, KEY, VALUE);
+//    for (double val : Arrays.asList(10.0, 20.0, 30.0, 40.0)) {
+//      statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, val).build());
+//    }
+//    clock.setTime(Timestamp.create(3, 4));
+//    DistributionViewData viewData = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    assertThat(viewData.getView()).isEqualTo(view);
+//    assertThat(viewData.getStart()).isEqualTo(Timestamp.create(1, 2));
+//    assertThat(viewData.getEnd()).isEqualTo(Timestamp.create(3, 4));
+//    assertDistributionAggregatesEquivalent(
+//        viewData.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE)),
+//                BUCKET_BOUNDARIES,
+//                Arrays.asList(10.0, 20.0, 30.0, 40.0))));
+//  }
+//
+//  @Test
+//  public void getViewDoesNotClearStats() {
+//    DistributionView view =
+//        createDistributionView(
+//            VIEW_NAME,
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY));
+//    clock.setTime(Timestamp.create(10, 0));
+//    viewManager.registerView(view);
+//    StatsContextImpl tags = createContext(factory, KEY, VALUE);
+//    statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 0.1).build());
+//    clock.setTime(Timestamp.create(11, 0));
+//    DistributionViewData viewData1 = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    assertThat(viewData1.getStart()).isEqualTo(Timestamp.create(10, 0));
+//    assertThat(viewData1.getEnd()).isEqualTo(Timestamp.create(11, 0));
+//    assertDistributionAggregatesEquivalent(
+//        viewData1.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(0.1))));
+//    statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 0.2).build());
+//    clock.setTime(Timestamp.create(12, 0));
+//    DistributionViewData viewData2 = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//
+//    // The second view should have the same start time as the first view, and it should include both
+//    // recorded values:
+//    assertThat(viewData2.getStart()).isEqualTo(Timestamp.create(10, 0));
+//    assertThat(viewData2.getEnd()).isEqualTo(Timestamp.create(12, 0));
+//    assertDistributionAggregatesEquivalent(
+//        viewData2.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE)),
+//                BUCKET_BOUNDARIES,
+//                Arrays.asList(0.1, 0.2))));
+//  }
+//
+//  @Test
+//  public void testRecordMultipleTagValues() {
+//    viewManager.registerView(
+//        createDistributionView(
+//            VIEW_NAME,
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY)));
+//    statsRecorder.record(
+//        createContext(factory, KEY, VALUE),
+//        MeasureMap.builder().set(MEASURE, 10.0).build());
+//    statsRecorder.record(
+//        createContext(factory, KEY, VALUE_2),
+//        MeasureMap.builder().set(MEASURE, 30.0).build());
+//    statsRecorder.record(
+//        createContext(factory, KEY, VALUE_2),
+//        MeasureMap.builder().set(MEASURE, 50.0).build());
+//    DistributionViewData viewData = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    assertDistributionAggregatesEquivalent(
+//        viewData.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(10.0)),
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE_2)),
+//                BUCKET_BOUNDARIES,
+//                Arrays.asList(30.0, 50.0))));
+//  }
+//
+//  // This test checks that StatsRecorder.record(...) does not throw an exception when no views are
+//  // registered.
+//  @Test
+//  public void allowRecordingWithoutRegisteringMatchingViewData() {
+//    statsRecorder.record(
+//        createContext(factory, KEY, VALUE),
+//        MeasureMap.builder().set(MEASURE, 10).build());
+//  }
+//
+//  @Test
+//  public void testRecordWithEmptyStatsContext() {
+//    viewManager.registerView(
+//        createDistributionView(
+//            VIEW_NAME,
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY)));
+//    // DEFAULT doesn't have tags, but the view has tag key "KEY".
+//    statsRecorder.record(factory.getDefault(),
+//        MeasureMap.builder().set(MEASURE, 10.0).build());
+//    DistributionViewData viewData = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    assertDistributionAggregatesEquivalent(
+//        viewData.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                // Tag is missing for associated measureValues, should use default tag value
+//                // "unknown/not set"
+//                Arrays.asList(Tag.create(KEY, MutableViewData.UNKNOWN_TAG_VALUE)),
+//                BUCKET_BOUNDARIES,
+//                // Should record stats with default tag value: "KEY" : "unknown/not set".
+//                Arrays.asList(10.0))));
+//  }
+//
+//  @Test
+//  public void testRecordWithNonExistentMeasurement() {
+//    viewManager.registerView(
+//        createDistributionView(
+//            VIEW_NAME,
+//            Measure.MeasureDouble.create(MEASURE_NAME, "measure", MEASURE_UNIT),
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY)));
+//    MeasureDouble measure2 =
+//        Measure.MeasureDouble.create(MEASURE_NAME_2, "measure", MEASURE_UNIT);
+//    statsRecorder.record(createContext(factory, KEY, VALUE),
+//        MeasureMap.builder().set(measure2, 10.0).build());
+//    DistributionViewData view = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    assertThat(view.getDistributionAggregates()).isEmpty();
+//  }
+//
+//  @Test
+//  public void testRecordWithTagsThatDoNotMatchViewData() {
+//    viewManager.registerView(
+//        createDistributionView(
+//            VIEW_NAME,
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY)));
+//    statsRecorder.record(
+//        createContext(factory, TagKey.create("wrong key"), VALUE),
+//        MeasureMap.builder().set(MEASURE, 10.0).build());
+//    statsRecorder.record(
+//        createContext(factory, TagKey.create("another wrong key"), VALUE),
+//        MeasureMap.builder().set(MEASURE, 50.0).build());
+//    DistributionViewData view = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    assertDistributionAggregatesEquivalent(
+//        view.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                // Won't record the unregistered tag key, will use default tag instead:
+//                // "KEY" : "unknown/not set".
+//                Arrays.asList(Tag.create(KEY, MutableViewData.UNKNOWN_TAG_VALUE)),
+//                BUCKET_BOUNDARIES,
+//                // Should record stats with default tag value: "KEY" : "unknown/not set".
+//                Arrays.asList(10.0, 50.0))));
+//  }
+//
+//  @Test
+//  public void testViewDataWithMultipleTagKeys() {
+//    TagKey key1 = TagKey.create("Key-1");
+//    TagKey key2 = TagKey.create("Key-2");
+//    viewManager.registerView(
+//        createDistributionView(
+//            VIEW_NAME,
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(key1, key2)));
+//    statsRecorder.record(
+//        createContext(factory, key1, TagValue.create("v1"), key2, TagValue.create("v10")),
+//        MeasureMap.builder().set(MEASURE, 1.1).build());
+//    statsRecorder.record(
+//        createContext(factory, key1, TagValue.create("v1"), key2, TagValue.create("v20")),
+//        MeasureMap.builder().set(MEASURE, 2.2).build());
+//    statsRecorder.record(
+//        createContext(factory, key1, TagValue.create("v2"), key2, TagValue.create("v10")),
+//        MeasureMap.builder().set(MEASURE, 3.3).build());
+//    statsRecorder.record(
+//        createContext(factory, key1, TagValue.create("v1"), key2, TagValue.create("v10")),
+//        MeasureMap.builder().set(MEASURE, 4.4).build());
+//    DistributionViewData view = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    assertDistributionAggregatesEquivalent(
+//        view.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(
+//                    Tag.create(key1, TagValue.create("v1")),
+//                    Tag.create(key2, TagValue.create("v10"))),
+//                BUCKET_BOUNDARIES,
+//                Arrays.asList(1.1, 4.4)),
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(
+//                    Tag.create(key1, TagValue.create("v1")),
+//                    Tag.create(key2, TagValue.create("v20"))),
+//                BUCKET_BOUNDARIES,
+//                Arrays.asList(2.2)),
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(
+//                    Tag.create(key1, TagValue.create("v2")),
+//                    Tag.create(key2, TagValue.create("v10"))),
+//                BUCKET_BOUNDARIES,
+//                Arrays.asList(3.3))));
+//  }
+//
+//  @Test
+//  public void testMultipleViewDatasSameMeasure() {
+//    View view1 =
+//        createDistributionView(
+//            VIEW_NAME,
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY));
+//    View view2 =
+//        createDistributionView(
+//            VIEW_NAME_2,
+//            MEASURE,
+//            DISTRIBUTION_AGGREGATION_DESCRIPTOR,
+//            Arrays.asList(KEY));
+//    clock.setTime(Timestamp.create(1, 1));
+//    viewManager.registerView(view1);
+//    clock.setTime(Timestamp.create(2, 2));
+//    viewManager.registerView(view2);
+//    statsRecorder.record(
+//        createContext(factory, KEY, VALUE),
+//        MeasureMap.builder().set(MEASURE, 5.0).build());
+//    List<DistributionAggregate> expectedAggs =
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(5.0)));
+//    clock.setTime(Timestamp.create(3, 3));
+//    DistributionViewData viewData1 = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    clock.setTime(Timestamp.create(4, 4));
+//    DistributionViewData viewData2 = (DistributionViewData) viewManager.getView(VIEW_NAME_2);
+//    assertThat(viewData1.getStart()).isEqualTo(Timestamp.create(1, 1));
+//    assertThat(viewData1.getEnd()).isEqualTo(Timestamp.create(3, 3));
+//    assertDistributionAggregatesEquivalent(viewData1.getDistributionAggregates(), expectedAggs);
+//    assertThat(viewData2.getStart()).isEqualTo(Timestamp.create(2, 2));
+//    assertThat(viewData2.getEnd()).isEqualTo(Timestamp.create(4, 4));
+//    assertDistributionAggregatesEquivalent(viewData2.getDistributionAggregates(), expectedAggs);
+//  }
+//
+//  @Test
+//  public void testMultipleViewsDifferentMeasures() {
+//    MeasureDouble measure1 =
+//        Measure.MeasureDouble.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT);
+//    MeasureDouble measure2 =
+//        Measure.MeasureDouble.create(MEASURE_NAME_2, MEASURE_DESCRIPTION, MEASURE_UNIT);
+//    View view1 =
+//        createDistributionView(
+//            VIEW_NAME, measure1, DISTRIBUTION_AGGREGATION_DESCRIPTOR, Arrays.asList(KEY));
+//    View view2 =
+//        createDistributionView(
+//            VIEW_NAME_2, measure2, DISTRIBUTION_AGGREGATION_DESCRIPTOR, Arrays.asList(KEY));
+//    clock.setTime(Timestamp.create(1, 0));
+//    viewManager.registerView(view1);
+//    clock.setTime(Timestamp.create(2, 0));
+//    viewManager.registerView(view2);
+//    statsRecorder.record(
+//        createContext(factory, KEY, VALUE),
+//        MeasureMap.builder().set(measure1, 1.1).set(measure2, 2.2).build());
+//    clock.setTime(Timestamp.create(3, 0));
+//    DistributionViewData viewData1 = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    clock.setTime(Timestamp.create(4, 0));
+//    DistributionViewData viewData2 = (DistributionViewData) viewManager.getView(VIEW_NAME_2);
+//    assertThat(viewData1.getStart()).isEqualTo(Timestamp.create(1, 0));
+//    assertThat(viewData1.getEnd()).isEqualTo(Timestamp.create(3, 0));
+//    assertDistributionAggregatesEquivalent(
+//        viewData1.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(1.1))));
+//    assertThat(viewData2.getStart()).isEqualTo(Timestamp.create(2, 0));
+//    assertThat(viewData2.getEnd()).isEqualTo(Timestamp.create(4, 0));
+//    assertDistributionAggregatesEquivalent(
+//        viewData2.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE)), BUCKET_BOUNDARIES, Arrays.asList(2.2))));
+//  }
+//
+//  @Test
+//  public void testGetDistributionViewDataWithoutBucketBoundaries() {
+//    View view =
+//        createDistributionView(
+//            VIEW_NAME, MEASURE, DistributionAggregation.create(),
+//            Arrays.asList(KEY));
+//    clock.setTime(Timestamp.create(1, 0));
+//    viewManager.registerView(view);
+//    statsRecorder.record(
+//        createContext(factory, KEY, VALUE),
+//        MeasureMap.builder().set(MEASURE, 1.1).build());
+//    clock.setTime(Timestamp.create(3, 0));
+//    DistributionViewData viewData = (DistributionViewData) viewManager.getView(VIEW_NAME);
+//    assertThat(viewData.getStart()).isEqualTo(Timestamp.create(1, 0));
+//    assertThat(viewData.getEnd()).isEqualTo(Timestamp.create(3, 0));
+//    assertDistributionAggregatesEquivalent(
+//        viewData.getDistributionAggregates(),
+//        Arrays.asList(
+//            StatsTestUtil.createDistributionAggregate(
+//                Arrays.asList(Tag.create(KEY, VALUE)), Arrays.asList(1.1))));
+//  }
 
   // TODO(sebright) Consider making this helper method work with larger ranges of double values and
   // moving it to StatsTestUtil.


### PR DESCRIPTION
This PR is the API level changes.
- Updated `View` and `ViewData` based on our new data model. 
- Removed subclasses `DistributionView` and `IntervalView`, `DistributionViewData` and `IntervalViewData`, in favor of more generic `View` and `ViewData`.
- Comment out affected implementation and tests. Changes on implementations will be made after API changes.