### PR TITLE
Modify stats-impl to use the new APIs and data models

### DIFF
--- a/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
@@ -80,13 +80,7 @@ final class MeasureToViewMap {
       }
     }
     registeredViews.put(view.getName(), view);
-    // TODO(songya): update to use refactored implementation.
-    //    MutableViewData mutableViewData =
-    //        view.match(
-    //            new CreateMutableDistributionViewDataFunction(clock),
-    //            new CreateMutableIntervalViewDataFunction());
-    //    mutableMap.put(
-    //        view.getMeasure().getName(), mutableViewData);
+    mutableMap.put(view.getMeasure().getName(), MutableViewData.create(view, clock.now()));
   }
 
   // Records stats with a set of tags.

--- a/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
@@ -14,180 +14,233 @@
 package io.opencensus.stats;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import io.opencensus.common.Clock;
+import io.opencensus.common.Function;
+import io.opencensus.common.Functions;
+import io.opencensus.common.Timestamp;
+import io.opencensus.stats.Aggregation.Count;
+import io.opencensus.stats.Aggregation.Histogram;
+import io.opencensus.stats.Aggregation.Mean;
+import io.opencensus.stats.Aggregation.Range;
+import io.opencensus.stats.Aggregation.StdDev;
+import io.opencensus.stats.Aggregation.Sum;
+import io.opencensus.stats.AggregationData.CountData;
+import io.opencensus.stats.AggregationData.HistogramData;
+import io.opencensus.stats.AggregationData.MeanData;
+import io.opencensus.stats.AggregationData.RangeData;
+import io.opencensus.stats.AggregationData.StdDevData;
+import io.opencensus.stats.AggregationData.SumData;
+import io.opencensus.stats.MutableAggregation.MutableCount;
+import io.opencensus.stats.MutableAggregation.MutableHistogram;
+import io.opencensus.stats.MutableAggregation.MutableMean;
+import io.opencensus.stats.MutableAggregation.MutableRange;
+import io.opencensus.stats.MutableAggregation.MutableStdDev;
+import io.opencensus.stats.MutableAggregation.MutableSum;
+import io.opencensus.stats.View.Window.Interval;
+import io.opencensus.stats.ViewData.WindowData.CumulativeData;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import javax.annotation.Nullable;
 
 /**
  * A mutable version of {@link ViewData}, used for recording stats and start/end time.
  */
-// TODO(songya): update to use refactored implementation.
-abstract class MutableViewData {
+final class MutableViewData {
 
   // TODO(songya): might want to update the default tag value later.
   @VisibleForTesting
   static final TagValue UNKNOWN_TAG_VALUE = TagValue.create("unknown/not set");
 
+  private final View view;
+  private final Map<List<TagValue>, List<MutableAggregation>> tagValueAggregationMap =
+      Maps.newHashMap();
+  @Nullable private final Timestamp start;
+
+  private MutableViewData(View view, @Nullable Timestamp start) {
+    this.view = view;
+    this.start = start;
+  }
+
+  /**
+   * Constructs a new {@link MutableViewData}.
+   */
+  static MutableViewData create(View view, Timestamp start) {
+    if (view.getWindow() instanceof Interval) {
+      // TODO(songya): support IntervalView.
+      throw new UnsupportedOperationException("Interval views not supported yet.");
+    }
+    return new MutableViewData(view, start);
+  }
+
   /**
    * The {@link View} associated with this {@link ViewData}.
    */
-  abstract View getView();
+  View getView() {
+    return view;
+  }
 
   /**
    * Record double stats with the given tags.
    */
-  abstract void record(StatsContextImpl tags, double value);
+  void record(StatsContextImpl context, double value) {
+    List<TagValue> tagValues = getTagValues(context.tags, view.getColumns());
+    if (!tagValueAggregationMap.containsKey(tagValues)) {
+      List<MutableAggregation> aggregations = Lists.newArrayList();
+      for (Aggregation aggregation : view.getAggregations()) {
+        aggregations.add(createMutableAggregation(aggregation));
+      }
+      tagValueAggregationMap.put(tagValues, aggregations);
+    }
+    for (MutableAggregation aggregation : tagValueAggregationMap.get(tagValues)) {
+      aggregation.add(value);
+    }
+  }
 
   /**
    * Record long stats with the given tags.
    */
-  abstract void record(StatsContextImpl tags, long value);
+  void record(StatsContextImpl tags, long value) {
+    // TODO(songya): modify MutableDistribution to support long values.
+    throw new UnsupportedOperationException("Not implemented.");
+  }
 
   /**
    * Convert this {@link MutableViewData} to {@link ViewData}.
    */
-  abstract ViewData toViewData(Clock clock);
-
-  private MutableViewData() {
+  ViewData toViewData(Clock clock) {
+    Map<List<TagValue>, List<AggregationData>> map = Maps.newHashMap();
+    for (Entry<List<TagValue>, List<MutableAggregation>> entry :
+        tagValueAggregationMap.entrySet()) {
+      List<AggregationData> aggregates = Lists.newArrayList();
+      for (MutableAggregation aggregation : entry.getValue()) {
+        aggregates.add(createAggregationData(aggregation));
+      }
+      map.put(entry.getKey(), aggregates);
+    }
+    return ViewData.create(view, map, CumulativeData.create(start, clock.now()));
   }
 
-//  /**
-//   * A {@link MutableViewData} for recording stats on distribution-based aggregations.
-//   */
-//  static final class MutableDistributionViewData extends MutableViewData {
-//
-//    /**
-//     * Constructs a new {@link MutableDistributionViewData}.
-//     */
-//    static MutableDistributionViewData create(
-//        DistributionView distributionView, Timestamp start) {
-//      return new MutableDistributionViewData(distributionView, start);
-//    }
-//
-//    @Override
-//    View getView() {
-//      return distributionView;
-//    }
-//
-//    @Override
-//    void record(StatsContextImpl context, double value) {
-//      Map<TagKey, TagValue> tags = context.tags;
-//      // TagKeys need to be unique within one view descriptor.
-//      final List<TagKey> tagKeys = this.distributionView.getColumns();
-//      final List<TagValue> tagValues = new ArrayList<TagValue>(tagKeys.size());
-//
-//      // Record all the measures in a "Greedy" way.
-//      // Every view aggregates every measure. This is similar to doing a GROUPBY view’s keys.
-//      for (int i = 0; i < tagKeys.size(); ++i) {
-//        TagKey tagKey = tagKeys.get(i);
-//        if (!tags.containsKey(tagKey)) {
-//          // replace not found key values by “unknown/not set”.
-//          tagValues.add(UNKNOWN_TAG_VALUE);
-//        } else {
-//          tagValues.add(tags.get(tagKey));
-//        }
-//      }
-//
-//      if (!tagValueDistributionMap.containsKey(tagValues)) {
-//        final List<Double> bucketBoundaries =
-//            this.distributionView.getDistributionAggregation()
-//                .getBucketBoundaries();
-//        final MutableDistribution distribution =
-//            bucketBoundaries == null ? MutableDistribution.create()
-//                : MutableDistribution.create(BucketBoundaries.create(bucketBoundaries));
-//        tagValueDistributionMap.put(tagValues, distribution);
-//      }
-//      tagValueDistributionMap.get(tagValues).add(value);
-//    }
-//
-//    @Override
-//    void record(StatsContextImpl tags, long value) {
-//      // TODO(songya): modify MutableDistribution to support long values.
-//      throw new UnsupportedOperationException("Not implemented.");
-//    }
-//
-//    @Override
-//    final ViewData toViewData(Clock clock) {
-//      final List<DistributionAggregate> distributionAggregations =
-//          new ArrayList<DistributionAggregate>();
-//      for (Entry<List<TagValue>, MutableDistribution> entry : tagValueDistributionMap.entrySet()){
-//        MutableDistribution distribution = entry.getValue();
-//        DistributionAggregate distributionAggregation = distribution.getBucketCounts() == null
-//            ? DistributionAggregate.create(distribution.getCount(), distribution.getMean(),
-//            distribution.getSum(), convertRange(distribution.getRange()),
-//            generateTags(entry.getKey()))
-//            : DistributionAggregate.create(distribution.getCount(), distribution.getMean(),
-//                distribution.getSum(), convertRange(distribution.getRange()),
-//                generateTags(entry.getKey()), distribution.getBucketCounts());
-//        distributionAggregations.add(distributionAggregation);
-//      }
-//      return DistributionViewData.create(distributionView, distributionAggregations, start,
-//          clock.now());
-//    }
-//
-//    /**
-//     * Returns start timestamp for this aggregation.
-//     */
-//    Timestamp getStart() {
-//      return start;
-//    }
-//
-//    private final DistributionView distributionView;
-//    private final Map<List<TagValue>, MutableDistribution> tagValueDistributionMap =
-//        new HashMap<List<TagValue>, MutableDistribution>();
-//    private final Timestamp start;
-//
-//    private MutableDistributionViewData(
-//        DistributionView distributionView, Timestamp start) {
-//      this.distributionView = distributionView;
-//      this.start = start;
-//    }
-//
-//    private final List<Tag> generateTags(List<TagValue> tagValues) {
-//      final List<Tag> tags = new ArrayList<Tag>(tagValues.size());
-//      int i = 0;
-//      for (TagKey tagKey : this.distributionView.getColumns()) {
-//        tags.add(Tag.create(tagKey, tagValues.get(i)));
-//        ++i;
-//      }
-//      return tags;
-//    }
-//
-//    // TODO(songya): remove DistributionAggregate.Range, then remove this method
-//    private static final DistributionAggregate.Range convertRange(
-//        MutableDistribution.Range range) {
-//      return DistributionAggregate.Range.create(range.getMin(), range.getMax());
-//    }
-//  }
-//
-//  /**
-//   * A {@link MutableViewData} for recording stats on interval-based aggregations.
-//   */
-//  static final class MutableIntervalViewData extends MutableViewData {
-//
-//    /**
-//     * Constructs a new {@link MutableIntervalViewData}.
-//     */
-//    static MutableIntervalViewData create(IntervalView view) {
-//      throw new UnsupportedOperationException("Not implemented.");
-//    }
-//
-//    @Override
-//    View getView() {
-//      throw new UnsupportedOperationException("Not implemented.");
-//    }
-//
-//    @Override
-//    void record(StatsContextImpl tags, double value) {
-//      throw new UnsupportedOperationException("Not implemented.");
-//    }
-//
-//    @Override
-//    void record(StatsContextImpl tags, long value) {
-//      throw new UnsupportedOperationException("Not implemented.");
-//    }
-//
-//    @Override
-//    final ViewData toViewData(Clock clock) {
-//      throw new UnsupportedOperationException("Not implemented.");
-//    }
-//  }
+  /**
+   * Returns start timestamp for this aggregation.
+   */
+  @Nullable
+  Timestamp getStart() {
+    return start;
+  }
+
+  @VisibleForTesting
+  static List<TagValue> getTagValues(Map<TagKey, TagValue> tags, List<TagKey> columns) {
+    List<TagValue> tagValues = new ArrayList<TagValue>(columns.size());
+    // Record all the measures in a "Greedy" way.
+    // Every view aggregates every measure. This is similar to doing a GROUPBY view’s keys.
+    for (int i = 0; i < columns.size(); ++i) {
+      TagKey tagKey = columns.get(i);
+      if (!tags.containsKey(tagKey)) {
+        // replace not found key values by “unknown/not set”.
+        tagValues.add(UNKNOWN_TAG_VALUE);
+      } else {
+        tagValues.add(tags.get(tagKey));
+      }
+    }
+    return tagValues;
+  }
+
+  /**
+   * Create an empty {@link MutableAggregation} based on the given {@link Aggregation}.
+   *
+   * @param aggregation {@code Aggregation}.
+   * @return an empty {@code MutableAggregation}.
+   */
+  @VisibleForTesting
+  static MutableAggregation createMutableAggregation(Aggregation aggregation) {
+    return aggregation.match(
+        new Function<Sum, MutableAggregation>() {
+          @Override
+          public MutableAggregation apply(Sum arg) {
+            return MutableSum.create();
+          }
+        },
+        new Function<Count, MutableAggregation>() {
+          @Override
+          public MutableAggregation apply(Count arg) {
+            return MutableCount.create();
+          }
+        },
+        new Function<Histogram, MutableAggregation>() {
+          @Override
+          public MutableAggregation apply(Histogram arg) {
+            return MutableHistogram.create(arg.getBucketBoundaries());
+          }
+        },
+        new Function<Range, MutableAggregation>() {
+          @Override
+          public MutableAggregation apply(Range arg) {
+            return MutableRange.create();
+          }
+        },
+        new Function<Mean, MutableAggregation>() {
+          @Override
+          public MutableAggregation apply(Mean arg) {
+            return MutableMean.create();
+          }
+        },
+        new Function<StdDev, MutableAggregation>() {
+          @Override
+          public MutableAggregation apply(StdDev arg) {
+            return MutableStdDev.create();
+          }
+        },
+        Functions.<MutableAggregation>throwIllegalArgumentException());
+  }
+
+  /**
+   * Create an {@link AggregationData} snapshot based on the given {@link MutableAggregation}.
+   *
+   * @param aggregation {@code MutableAggregation}
+   * @return an {@code AggregationData} which is the snapshot of current summary statistics.
+   */
+  @VisibleForTesting
+  static AggregationData createAggregationData(MutableAggregation aggregation) {
+    return aggregation.match(
+        new Function<MutableSum, AggregationData>() {
+          @Override
+          public AggregationData apply(MutableSum arg) {
+            return SumData.create(arg.getSum());
+          }
+        },
+        new Function<MutableCount, AggregationData>() {
+          @Override
+          public AggregationData apply(MutableCount arg) {
+            return CountData.create(arg.getCount());
+          }
+        },
+        new Function<MutableHistogram, AggregationData>() {
+          @Override
+          public AggregationData apply(MutableHistogram arg) {
+            return HistogramData.create(arg.getBucketCounts());
+          }
+        },
+        new Function<MutableRange, AggregationData>() {
+          @Override
+          public AggregationData apply(MutableRange arg) {
+            return RangeData.create(arg.getMin(), arg.getMax());
+          }
+        },
+        new Function<MutableMean, AggregationData>() {
+          @Override
+          public AggregationData apply(MutableMean arg) {
+            return MeanData.create(arg.getMean());
+          }
+        },
+        new Function<MutableStdDev, AggregationData>() {
+          @Override
+          public AggregationData apply(MutableStdDev arg) {
+            return StdDevData.create(arg.getStdDev());
+          }
+        });
+  }
 }

--- a/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
@@ -207,8 +207,6 @@ final class MutableViewData {
       return MutableSum.create();
     }
     
-    private CreateMutableSum() {}
-    
     private static final CreateMutableSum INSTANCE = new CreateMutableSum();
   }
 
@@ -217,8 +215,6 @@ final class MutableViewData {
     public MutableAggregation apply(Count arg) {
       return MutableCount.create();
     }
-
-    private CreateMutableCount() {}
 
     private static final CreateMutableCount INSTANCE = new CreateMutableCount();
   }
@@ -230,8 +226,6 @@ final class MutableViewData {
       return MutableHistogram.create(arg.getBucketBoundaries());
     }
 
-    private CreateMutableHistogram() {}
-
     private static final CreateMutableHistogram INSTANCE = new CreateMutableHistogram();
   }
 
@@ -240,8 +234,6 @@ final class MutableViewData {
     public MutableAggregation apply(Range arg) {
       return MutableRange.create();
     }
-
-    private CreateMutableRange() {}
 
     private static final CreateMutableRange INSTANCE = new CreateMutableRange();
   }
@@ -252,8 +244,6 @@ final class MutableViewData {
       return MutableMean.create();
     }
 
-    private CreateMutableMean() {}
-
     private static final CreateMutableMean INSTANCE = new CreateMutableMean();
   }
 
@@ -262,8 +252,6 @@ final class MutableViewData {
     public MutableAggregation apply(StdDev arg) {
       return MutableStdDev.create();
     }
-
-    private CreateMutableStdDev() {}
 
     private static final CreateMutableStdDev INSTANCE = new CreateMutableStdDev();
   }
@@ -275,8 +263,6 @@ final class MutableViewData {
       return SumData.create(arg.getSum());
     }
 
-    private CreateSumData() {}
-
     private static final CreateSumData INSTANCE = new CreateSumData();
   }
 
@@ -285,8 +271,6 @@ final class MutableViewData {
     public AggregationData apply(MutableCount arg) {
       return CountData.create(arg.getCount());
     }
-
-    private CreateCountData() {}
 
     private static final CreateCountData INSTANCE = new CreateCountData();
   }
@@ -298,8 +282,6 @@ final class MutableViewData {
       return HistogramData.create(arg.getBucketCounts());
     }
 
-    private CreateHistogramData() {}
-
     private static final CreateHistogramData INSTANCE = new CreateHistogramData();
   }
 
@@ -308,8 +290,6 @@ final class MutableViewData {
     public AggregationData apply(MutableRange arg) {
       return RangeData.create(arg.getMin(), arg.getMax());
     }
-
-    private CreateRangeData() {}
 
     private static final CreateRangeData INSTANCE = new CreateRangeData();
   }
@@ -320,8 +300,6 @@ final class MutableViewData {
       return MeanData.create(arg.getMean());
     }
 
-    private CreateMeanData() {}
-
     private static final CreateMeanData INSTANCE = new CreateMeanData();
   }
 
@@ -330,8 +308,6 @@ final class MutableViewData {
     public AggregationData apply(MutableStdDev arg) {
       return StdDevData.create(arg.getStdDev());
     }
-
-    private CreateStdDevData() {}
 
     private static final CreateStdDevData INSTANCE = new CreateStdDevData();
   }


### PR DESCRIPTION
This PR is implementation level changes.

Modify the existing implementation to work with our new stats APIs and data models. As before, interval-based views and long measures are not supported at this time.