### PR TITLE
Add Tags and TagsComponent classes to the 'tags' package.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContextFactory.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextFactory.java
@@ -16,6 +16,7 @@ package io.opencensus.tags;
 /**
  * Factory for new {@link TagContext}s and {@code TagContext}s based on the current context.
  */
+// TODO(sebright): Pick a more descriptive name for this class.
 public abstract class TagContextFactory {
   // TODO(sebright): Add TagContext related methods to this class.
 }

--- a/core/src/main/java/io/opencensus/tags/TagContextFactory.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextFactory.java
@@ -17,4 +17,5 @@ package io.opencensus.tags;
  * Factory for new {@link TagContext}s and {@code TagContext}s based on the current context.
  */
 public abstract class TagContextFactory {
+  // TODO(sebright): Add TagContext related methods to this class.
 }

--- a/core/src/main/java/io/opencensus/tags/TagContextFactory.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextFactory.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+/**
+ * Factory for new {@link TagContext}s and {@code TagContext}s based on the current context.
+ */
+public abstract class TagContextFactory {
+}

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -34,7 +34,7 @@ public final class Tags {
    * @return the default {@code TagContextFactory}.
    */
   public static TagContextFactory getTagContextFactory() {
-    return tagsComponent.getTagContextFactory();
+    return tagsComponent == null ? null : tagsComponent.getTagContextFactory();
   }
 
   // Any provider that may be used for TagsComponent can be added here.

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.internal.Provider;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Class for accessing the default {@link TagsComponent}. */
+public final class Tags {
+  private static final Logger logger = Logger.getLogger(Tags.class.getName());
+
+  private static final TagsComponent tagsComponent =
+      loadTagsComponent(Provider.getCorrectClassLoader(TagsComponent.class));
+
+  private Tags() {}
+
+  public static TagContextFactory getTagContextFactory() {
+    return tagsComponent.getTagContextFactory();
+  }
+
+  // Any provider that may be used for TagsComponent can be added here.
+  @VisibleForTesting
+  @Nullable
+  static TagsComponent loadTagsComponent(ClassLoader classLoader) {
+    try {
+      // Call Class.forName with literal string name of the class to help shading tools.
+      return Provider.createInstance(
+          Class.forName("io.opencensus.tags.TagsComponentImpl", true, classLoader),
+          TagsComponent.class);
+    } catch (ClassNotFoundException e) {
+      logger.log(
+          Level.FINE,
+          "Couldn't load full implementation for TagsComponent, now trying to load lite "
+              + "implementation.",
+          e);
+    }
+    try {
+      // Call Class.forName with literal string name of the class to help shading tools.
+      return Provider.createInstance(
+          Class.forName("io.opencensus.tags.TagsComponentImplLite", true, classLoader),
+          TagsComponent.class);
+    } catch (ClassNotFoundException e) {
+      logger.log(
+          Level.FINE,
+          "Couldn't load lite implementation for TagsComponent, now using "
+              + "default implementation for TagsComponent.",
+          e);
+    }
+    // TODO: Add a no-op implementation.
+    return null;
+  }
+}

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -28,6 +28,11 @@ public final class Tags {
 
   private Tags() {}
 
+  /**
+   * Returns the default {@code TagContextFactory}.
+   *
+   * @return the default {@code TagContextFactory}.
+   */
   public static TagContextFactory getTagContextFactory() {
     return tagsComponent.getTagContextFactory();
   }

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -20,6 +20,6 @@ package io.opencensus.tags;
  */
 public abstract class TagsComponent {
 
-  /** Returns the default {@link TagContextFactory}. */
+  /** Returns the {@link TagContextFactory} for this implementation. */
   abstract TagContextFactory getTagContextFactory();
 }

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -14,7 +14,7 @@
 package io.opencensus.tags;
 
 /**
- * Class that holds the implementations for {@link TagContextFactory}.
+ * Class that holds the implementation for {@link TagContextFactory}.
  *
  * <p>All objects returned by methods on {@code TagsComponent} are cacheable.
  */

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+/**
+ * Class that holds the implementations for {@link TagContextFactory}.
+ *
+ * <p>All objects returned by methods on {@code TagsComponent} are cacheable.
+ */
+public abstract class TagsComponent {
+
+  /** Returns the default {@link TagContextFactory}. */
+  abstract TagContextFactory getTagContextFactory();
+}

--- a/core/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagsTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Tags}. */
+@RunWith(JUnit4.class)
+public class TagsTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void loadTagsComponent_UsesProvidedClassLoader() {
+    final RuntimeException toThrow = new RuntimeException("UseClassLoader");
+    thrown.expect(RuntimeException.class);
+    thrown.expectMessage("UseClassLoader");
+    Tags.loadTagsComponent(
+        new ClassLoader() {
+          @Override
+          public Class<?> loadClass(String name) {
+            throw toThrow;
+          }
+        });
+  }
+
+  @Test
+  public void loadTagsComponent_IgnoresMissingClasses() {
+    ClassLoader classLoader =
+        new ClassLoader() {
+          @Override
+          public Class<?> loadClass(String name) throws ClassNotFoundException {
+            throw new ClassNotFoundException();
+          }
+        };
+    assertThat(Tags.loadTagsComponent(classLoader)).isNull();
+  }
+
+  @Test
+  public void defaultTagContextFactory() {
+    assertThat(Tags.getTagContextFactory()).isNull();
+  }
+}

--- a/core_impl/src/main/java/io/opencensus/tags/TagContextFactoryImpl.java
+++ b/core_impl/src/main/java/io/opencensus/tags/TagContextFactoryImpl.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+final class TagContextFactoryImpl extends TagContextFactory {
+}

--- a/core_impl/src/main/java/io/opencensus/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/tags/TagsComponentImplBase.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+/** Base implementation of {@link TagsComponent}. */
+public abstract class TagsComponentImplBase extends TagsComponent {
+  private final TagContextFactory tagContextFactory = new TagContextFactoryImpl();
+
+  @Override
+  public TagContextFactory getTagContextFactory() {
+    return tagContextFactory;
+  }
+}

--- a/core_impl_android/src/main/java/io/opencensus/tags/TagsComponentImplLite.java
+++ b/core_impl_android/src/main/java/io/opencensus/tags/TagsComponentImplLite.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+/** Android-compatible implementation of {@link TagsComponent}. */
+public final class TagsComponentImplLite extends TagsComponentImplBase {}

--- a/core_impl_android/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core_impl_android/src/test/java/io/opencensus/tags/TagsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test for accessing the {@link TagsComponent} through the {@link Tags} class. */
+@RunWith(JUnit4.class)
+public final class TagsTest {
+  @Test
+  public void getTagContextFactory() {
+    assertThat(Tags.getTagContextFactory()).isInstanceOf(TagContextFactoryImpl.class);
+  }
+}

--- a/core_impl_java/src/main/java/io/opencensus/tags/TagsComponentImpl.java
+++ b/core_impl_java/src/main/java/io/opencensus/tags/TagsComponentImpl.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+/** Java 7 and 8 implementation of {@link TagsComponent}. */
+public final class TagsComponentImpl extends TagsComponentImplBase {}

--- a/core_impl_java/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core_impl_java/src/test/java/io/opencensus/tags/TagsTest.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test for accessing the {@link TagsComponent} through the {@link Tags} class. */
+@RunWith(JUnit4.class)
+public final class TagsTest {
+  @Test
+  public void getTagContextFactory() {
+    assertThat(Tags.getTagContextFactory()).isInstanceOf(TagContextFactoryImpl.class);
+  }
+}


### PR DESCRIPTION
TagsComponent is an abstract class that holds the implementations for different
parts of the 'tags' package.  The class currently has one field, which is a
skeleton for a new TagContextFactory class.  It allows the implementation
library to determine the implementation of TagContext, which could be important
for performance.

This commit also adds a Tags class, which instantiates the TagsComponent with
reflection.  The design is very similar to the 'stats' package.  Tags
corresponds to the Stats class, and TagsComponent corresponds to StatsComponent.

___________________________________________________________________

/cc @adriancole

This PR is part of #464.