### PR TITLE
Fix a bug in the implementation that causes all Spans with RECORD_EVE…

### DIFF
--- a/impl_core/src/main/java/io/opencensus/trace/StartEndHandlerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/trace/StartEndHandlerImpl.java
@@ -110,7 +110,9 @@ public final class StartEndHandlerImpl implements StartEndHandler {
 
     @Override
     public void process() {
-      spanExporter.addSpan(span);
+      if (span.getContext().getTraceOptions().isSampled()) {
+        spanExporter.addSpan(span);
+      }
       if (runningSpanStore != null) {
         runningSpanStore.onEnd(span);
       }


### PR DESCRIPTION
…NTS options to also be exported. (#458)

* Fix a bug in the implementation that causes all Spans with RECORD_EVENTS options to also be exported.

* Make startEndHandler final

(cherry picked from commit 37df029de0462ff421a34f8c5610e09015e953fa)