### PR TITLE
Add a no-op StatsComponent to return when no implementation is available.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/Stats.java
+++ b/core/src/main/java/io/opencensus/stats/Stats.java
@@ -46,7 +46,6 @@ public final class Stats {
 
   // Any provider that may be used for StatsComponent can be added here.
   @VisibleForTesting
-  @Nullable
   static StatsComponent loadStatsComponent(ClassLoader classLoader) {
     try {
       // Call Class.forName with literal string name of the class to help shading tools.
@@ -72,8 +71,7 @@ public final class Stats {
               + "default implementation for StatsComponent.",
           e);
     }
-    // TODO: Add a no-op implementation.
-    return null;
+    return StatsComponent.getNoopStatsComponent();
   }
 
   private Stats() {}

--- a/core/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/core/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -52,6 +52,7 @@ public abstract class StatsComponent {
     @Override
     @Nullable
     public ViewManager getViewManager() {
+      // TODO(sebright): Decide whether to also provide a no-op implementation for the ViewManager.
       return null;
     }
 

--- a/core/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/core/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -13,15 +13,20 @@
 
 package io.opencensus.stats;
 
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
 /**
  * Class that holds the implementations for {@link ViewManager}, {@link StatsRecorder}, and {@link
  * StatsContextFactory}.
  *
  * <p>All objects returned by methods on {@code StatsComponent} are cacheable.
  */
-// TODO(sebright): Add a no-op StatsComponent.
 public abstract class StatsComponent {
+  private static final StatsComponent NOOP_STATS_COMPONENT = new NoopStatsComponent();
+
   /** Returns the default {@link ViewManager}. */
+  @Nullable
   public abstract ViewManager getViewManager();
 
   /** Returns the default {@link StatsRecorder}. */
@@ -29,5 +34,36 @@ public abstract class StatsComponent {
 
   /** Returns the default {@link StatsContextFactory}. */
   // TODO(sebright): Remove this method once StatsContext is replaced by TagContext.
+  @Nullable
   abstract StatsContextFactory getStatsContextFactory();
+
+  /**
+   * Returns a {@code StatsComponent} that has a no-op implementation for the {@link StatsRecorder}.
+   *
+   * @return a {@code StatsComponent} that has a no-op implementation for the {@code StatsRecorder}.
+   */
+  static StatsComponent getNoopStatsComponent() {
+    return NOOP_STATS_COMPONENT;
+  }
+
+  @Immutable
+  private static final class NoopStatsComponent extends StatsComponent {
+
+    @Override
+    @Nullable
+    public ViewManager getViewManager() {
+      return null;
+    }
+
+    @Override
+    public StatsRecorder getStatsRecorder() {
+      return StatsRecorder.getNoopStatsRecorder();
+    }
+
+    @Override
+    @Nullable
+    StatsContextFactory getStatsContextFactory() {
+      return null;
+    }
+  }
 }

--- a/core/src/main/java/io/opencensus/stats/StatsRecorder.java
+++ b/core/src/main/java/io/opencensus/stats/StatsRecorder.java
@@ -13,6 +13,7 @@
 
 package io.opencensus.stats;
 
+import com.google.common.base.Preconditions;
 import javax.annotation.concurrent.Immutable;
 
 /** Provides methods to record stats against tags. */
@@ -46,6 +47,9 @@ public abstract class StatsRecorder {
   private static final class NoopStatsRecorder extends StatsRecorder {
 
     @Override
-    void record(StatsContext tags, MeasureMap measurementValues) {}
+    void record(StatsContext tags, MeasureMap measurementValues) {
+      Preconditions.checkNotNull(tags);
+      Preconditions.checkNotNull(measurementValues);
+    }
   }
 }

--- a/core/src/main/java/io/opencensus/stats/StatsRecorder.java
+++ b/core/src/main/java/io/opencensus/stats/StatsRecorder.java
@@ -13,8 +13,12 @@
 
 package io.opencensus.stats;
 
+import javax.annotation.concurrent.Immutable;
+
 /** Provides methods to record stats against tags. */
 public abstract class StatsRecorder {
+  private static final StatsRecorder NOOP_STATS_RECORDER = new NoopStatsRecorder();
+
   //  // TODO(sebright): Add a "record" method for implicit propagation:
   //
   //  public void record(MeasurementMap measurementValues) {
@@ -28,4 +32,20 @@ public abstract class StatsRecorder {
    * @param measurementValues the measurements to record.
    */
   abstract void record(StatsContext tags, MeasureMap measurementValues);
+
+  /**
+   * Returns a {@code StatsRecorder} that does not record any data.
+   *
+   * @return a {@code StatsRecorder} that does not record any data.
+   */
+  static StatsRecorder getNoopStatsRecorder() {
+    return NOOP_STATS_RECORDER;
+  }
+
+  @Immutable
+  private static final class NoopStatsRecorder extends StatsRecorder {
+
+    @Override
+    void record(StatsContext tags, MeasureMap measurementValues) {}
+  }
 }

--- a/core/src/test/java/io/opencensus/stats/StatsRecorderTest.java
+++ b/core/src/test/java/io/opencensus/stats/StatsRecorderTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link StatsRecorder}. */
+@RunWith(JUnit4.class)
+public final class StatsRecorderTest {
+
+  private final StatsContext statsContext =
+      new StatsContext() {
+
+        @Override
+        public void serialize(OutputStream output) throws IOException {
+        }
+
+        @Override
+        public StatsContext record(MeasureMap measurements) {
+          return null;
+        }
+
+        @Override
+        public Builder builder() {
+          return null;
+        }
+      };
+
+  @Test
+  public void defaultRecord() {
+    StatsRecorder.getNoopStatsRecorder().record(statsContext, MeasureMap.builder().build());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void defaultRecord_DisallowNullStatsContext() {
+    StatsRecorder.getNoopStatsRecorder().record(null, MeasureMap.builder().build());
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void defaultRecord_DisallowNullMeasureMap() {
+    StatsRecorder.getNoopStatsRecorder().record(statsContext, null);
+  }
+}

--- a/core/src/test/java/io/opencensus/stats/StatsTest.java
+++ b/core/src/test/java/io/opencensus/stats/StatsTest.java
@@ -49,14 +49,16 @@ public final class StatsTest {
                       public Class<?> loadClass(String name) throws ClassNotFoundException {
                         throw new ClassNotFoundException();
                       }
-                    }))
-        .isNull();
+                    })
+                .getClass()
+                .getName())
+        .isEqualTo("io.opencensus.stats.StatsComponent$NoopStatsComponent");
   }
 
   @Test
   public void defaultValues() {
     assertThat(Stats.getStatsContextFactory()).isNull();
-    assertThat(Stats.getStatsRecorder()).isNull();
+    assertThat(Stats.getStatsRecorder()).isEqualTo(StatsRecorder.getNoopStatsRecorder());
     assertThat(Stats.getViewManager()).isNull();
   }
 }


### PR DESCRIPTION
The no-op StatsComponent returns a no-op StatsRecorder and a null ViewManager.
The StatsRecorder is non-null so that code that only records stats doesn't need
to check for null.  NoopStatsRecorder.record(...) simply ignores the stats.
However, the ViewManager is null to avoid returning misleading empty results
from NoopStatsComponent.getViewManager().getView(...).