### PR TITLE
Add a function that always throws an AssertionError.

### DIFF
--- a/api/src/main/java/io/opencensus/internal/InternalFunctions.java
+++ b/api/src/main/java/io/opencensus/internal/InternalFunctions.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.internal;
+
+import io.opencensus.common.Function;
+
+public final class InternalFunctions {
+  private InternalFunctions() {}
+
+  private static final Function<Object, Void> THROW_ASSERTION_ERROR =
+      new Function<Object, Void>() {
+        @Override
+        public Void apply(Object ignored) {
+          throw new AssertionError();
+        }
+      };
+
+  /**
+   * A {@code Function} that always ignores its argument and throws an {@link AssertionError}.
+   *
+   * @return a {@code Function} that always ignores its argument and throws an {@code
+   *     AssertionError}.
+   */
+  public static <T> Function<Object, T> throwAssertionError() {
+    // It is safe to cast a producer of Void to anything, because Void is always null.
+    @SuppressWarnings("unchecked")
+    Function<Object, T> function = (Function<Object, T>) THROW_ASSERTION_ERROR;
+    return function;
+  }
+}

--- a/api/src/test/java/io/opencensus/internal/InternalFunctionsTest.java
+++ b/api/src/test/java/io/opencensus/internal/InternalFunctionsTest.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.internal;
+
+import io.opencensus.common.Function;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link InternalFunctions}. */
+@RunWith(JUnit4.class)
+public final class InternalFunctionsTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testThrowAssertionError() {
+    Function<Object, Void> f = InternalFunctions.throwAssertionError();
+    thrown.handleAssertionErrors();
+    thrown.expect(AssertionError.class);
+    f.apply("ignored");
+  }
+}


### PR DESCRIPTION
The function is internal for now, in io.opencensus.internal.InternalFunctions.
It can be used for all default cases in calls to "match" functions in the API
library, since a version mismatch isn't possible, and the default case cannot
occur in the "match" function that takes all subclasses.