### PR TITLE
Add a function that always throws an AssertionError.

### DIFF
--- a/api/src/main/java/io/opencensus/common/Functions.java
+++ b/api/src/main/java/io/opencensus/common/Functions.java
@@ -33,6 +33,14 @@ public final class Functions {
         }
       };
 
+  private static final Function<Object, Void> THROW_ASSERTION_ERROR =
+      new Function<Object, Void>() {
+        @Override
+        public Void apply(Object ignored) {
+          throw new AssertionError();
+        }
+      };
+
   /**
    * A {@code Function} that always ignores its argument and returns {@code null}.
    *
@@ -70,6 +78,19 @@ public final class Functions {
     // It is safe to cast a producer of Void to anything, because Void is always null.
     @SuppressWarnings("unchecked")
     Function<Object, T> function = (Function<Object, T>) THROW_ILLEGAL_ARGUMENT_EXCEPTION;
+    return function;
+  }
+
+  /**
+   * A {@code Function} that always ignores its argument and throws an {@link AssertionError}.
+   *
+   * @return a {@code Function} that always ignores its argument and throws an {@code
+   *     AssertionError}.
+   */
+  public static <T> Function<Object, T> throwAssertionError() {
+    // It is safe to cast a producer of Void to anything, because Void is always null.
+    @SuppressWarnings("unchecked")
+    Function<Object, T> function = (Function<Object, T>) THROW_ASSERTION_ERROR;
     return function;
   }
 }

--- a/api/src/main/java/io/opencensus/common/Functions.java
+++ b/api/src/main/java/io/opencensus/common/Functions.java
@@ -75,7 +75,7 @@ public final class Functions {
    *     IllegalArgumentException}.
    */
   public static <T> Function<Object, T> throwIllegalArgumentException() {
-    // It is safe to cast a producer of Void to anything, because Void is always null.
+    // It is safe to cast this function to have any return type, since it never returns a result.
     @SuppressWarnings("unchecked")
     Function<Object, T> function = (Function<Object, T>) THROW_ILLEGAL_ARGUMENT_EXCEPTION;
     return function;
@@ -88,7 +88,7 @@ public final class Functions {
    *     AssertionError}.
    */
   public static <T> Function<Object, T> throwAssertionError() {
-    // It is safe to cast a producer of Void to anything, because Void is always null.
+    // It is safe to cast this function to have any return type, since it never returns a result.
     @SuppressWarnings("unchecked")
     Function<Object, T> function = (Function<Object, T>) THROW_ASSERTION_ERROR;
     return function;

--- a/api/src/test/java/io/opencensus/common/FunctionsTest.java
+++ b/api/src/test/java/io/opencensus/common/FunctionsTest.java
@@ -42,4 +42,12 @@ public class FunctionsTest {
     thrown.expect(IllegalArgumentException.class);
     f.apply("ignored");
   }
+
+  @Test
+  public void testThrowAssertionError() {
+    Function<Object, Void> f = Functions.throwAssertionError();
+    thrown.handleAssertionErrors();
+    thrown.expect(AssertionError.class);
+    f.apply("ignored");
+  }
 }


### PR DESCRIPTION
The function can be used for all default cases in calls to "match" functions in
the API library, since a version mismatch isn't possible, and the default case
cannot occur in "match" functions that take all subclasses.