### PR TITLE
Work around Java 7 Travis build failure by specifying "dist: precise".

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: precise
 
 language: java
 


### PR DESCRIPTION
The Java 7 build job started failing when Travis switched to Ubuntu Trusty.
This commit sets the version back to Precise to fix the build while we determine
how to upgrade or decide to remove the Java 7 job.

/cc @bogdandrutu @dinooliva 