### PR TITLE
Add a no-op TagsComponent to return when no implementation is available.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContextFactory.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextFactory.java
@@ -13,10 +13,27 @@
 
 package io.opencensus.tags;
 
+import javax.annotation.concurrent.Immutable;
+
 /**
  * Factory for new {@link TagContext}s and {@code TagContext}s based on the current context.
  */
 // TODO(sebright): Pick a more descriptive name for this class.
 public abstract class TagContextFactory {
+  private static final TagContextFactory NOOP_TAG_CONTEXT_FACTORY = new NoopTagContextFactory();
+
   // TODO(sebright): Add TagContext related methods to this class.
+
+  /**
+   * Returns a {@code TagContextFactory} that only produces {@link TagContext}s with no tags.
+   *
+   * @return a {@code TagContextFactory} that only produces {@code TagContext}s with no tags.
+   */
+  static TagContextFactory getNoopTagContextFactory() {
+    return NOOP_TAG_CONTEXT_FACTORY;
+  }
+
+  @Immutable
+  private static final class NoopTagContextFactory extends TagContextFactory {
+  }
 }

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -17,7 +17,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.internal.Provider;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 
 /** Class for accessing the default {@link TagsComponent}. */
 public final class Tags {
@@ -34,12 +33,11 @@ public final class Tags {
    * @return the default {@code TagContextFactory}.
    */
   public static TagContextFactory getTagContextFactory() {
-    return tagsComponent == null ? null : tagsComponent.getTagContextFactory();
+    return tagsComponent.getTagContextFactory();
   }
 
   // Any provider that may be used for TagsComponent can be added here.
   @VisibleForTesting
-  @Nullable
   static TagsComponent loadTagsComponent(ClassLoader classLoader) {
     try {
       // Call Class.forName with literal string name of the class to help shading tools.
@@ -65,7 +63,6 @@ public final class Tags {
               + "default implementation for TagsComponent.",
           e);
     }
-    // TODO: Add a no-op implementation.
-    return null;
+    return TagsComponent.getNoopTagsComponent();
   }
 }

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -13,13 +13,36 @@
 
 package io.opencensus.tags;
 
+import javax.annotation.concurrent.Immutable;
+
 /**
  * Class that holds the implementation for {@link TagContextFactory}.
  *
  * <p>All objects returned by methods on {@code TagsComponent} are cacheable.
  */
 public abstract class TagsComponent {
+  private static final TagsComponent NOOP_TAGS_COMPONENT = new NoopTagsComponent();
 
   /** Returns the {@link TagContextFactory} for this implementation. */
   abstract TagContextFactory getTagContextFactory();
+
+  /**
+   * Returns a {@code TagsComponent} that has a no-op implementation for the {@link
+   * TagContextFactory}.
+   *
+   * @return a {@code TagsComponent} that has a no-op implementation for the {@code
+   *     TagContextFactory}.
+   */
+  static TagsComponent getNoopTagsComponent() {
+    return NOOP_TAGS_COMPONENT;
+  }
+
+  @Immutable
+  private static final class NoopTagsComponent extends TagsComponent {
+
+    @Override
+    TagContextFactory getTagContextFactory() {
+      return TagContextFactory.getNoopTagContextFactory();
+    }
+  }
 }

--- a/core/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagsTest.java
@@ -49,11 +49,12 @@ public class TagsTest {
             throw new ClassNotFoundException();
           }
         };
-    assertThat(Tags.loadTagsComponent(classLoader)).isNull();
+    assertThat(Tags.loadTagsComponent(classLoader).getClass().getName())
+        .isEqualTo("io.opencensus.tags.TagsComponent$NoopTagsComponent");
   }
 
   @Test
   public void defaultTagContextFactory() {
-    assertThat(Tags.getTagContextFactory()).isNull();
+    assertThat(Tags.getTagContextFactory()).isEqualTo(TagContextFactory.getNoopTagContextFactory());
   }
 }


### PR DESCRIPTION
The no-op TagsComponent will allow users to record stats without checking for
null.  If no implementation is available, the tagging operations should be very
fast, because the no-op TagsComponent contains a no-op TagContextFactory, which
will only ever return an empty TagContext.

__________________________________________

~~This PR contains #465, so only the last commit is new.~~