### PR TITLE
Fix Travis build on the v0.5.x branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: precise
 
 language: java
 


### PR DESCRIPTION
Work around Java 7 Travis build failure by specifying "dist: precise".

The Java 7 build job started failing when Travis switched to Ubuntu Trusty.
This commit sets the version back to Precise to fix the build while we determine
how to upgrade or decide to remove the Java 7 job.

(cherry picked from commit 93ca8e0471eb3b5d9f05c53d59edde6c86cb4be5)

____________________________________________________

/cc @bogdandrutu @dinooliva 
This PR applies #474 to the v0.5.x branch.