### PR TITLE
Add MutableAggregation and tests.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/BucketBoundaries.java
+++ b/core/src/main/java/io/opencensus/stats/BucketBoundaries.java
@@ -22,16 +22,14 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
-/**
- * The optional histogram bucket boundaries for an {@link Aggregation.Histogram}.
- */
+/** The histogram bucket boundaries for an {@link Aggregation.Histogram}. */
 @Immutable
 @AutoValue
 public abstract class BucketBoundaries {
 
   /**
-   * @param bucketBoundaries the boundaries for the buckets in the underlying
-   * {@link Aggregation.Histogram}.
+   * @param bucketBoundaries the boundaries for the buckets in the underlying {@link
+   * Aggregation.Histogram}.
    * @return a new {@code BucketBoundaries} with the specified boundaries.
    * @throws NullPointerException if {@code bucketBoundaries} is null.
    * @throws IllegalArgumentException if {@code bucketBoundaries} is not sorted.

--- a/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
@@ -17,6 +17,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.opencensus.common.Function;
 
+import java.util.Arrays;
+
 /** Mutable version of {@link Aggregation} that supports adding values. */
 abstract class MutableAggregation {
 
@@ -39,8 +41,7 @@ abstract class MutableAggregation {
       Function<? super MutableHistogram, T> p2,
       Function<? super MutableRange, T> p3,
       Function<? super MutableMean, T> p4,
-      Function<? super MutableStdDev, T> p5,
-      Function<? super MutableAggregation, T> defaultFunction);
+      Function<? super MutableStdDev, T> p5);
 
   /** Calculate sum on aggregated {@code MeasureValue}s. */
   static final class MutableSum extends MutableAggregation {
@@ -80,8 +81,7 @@ abstract class MutableAggregation {
         Function<? super MutableHistogram, T> p2,
         Function<? super MutableRange, T> p3,
         Function<? super MutableMean, T> p4,
-        Function<? super MutableStdDev, T> p5,
-        Function<? super MutableAggregation, T> defaultFunction) {
+        Function<? super MutableStdDev, T> p5) {
       return p0.apply(this);
     }
   }
@@ -124,8 +124,7 @@ abstract class MutableAggregation {
         Function<? super MutableHistogram, T> p2,
         Function<? super MutableRange, T> p3,
         Function<? super MutableMean, T> p4,
-        Function<? super MutableStdDev, T> p5,
-        Function<? super MutableAggregation, T> defaultFunction) {
+        Function<? super MutableStdDev, T> p5) {
       return p1.apply(this);
     }
   }
@@ -168,7 +167,7 @@ abstract class MutableAggregation {
      * @return the aggregated bucket count.
      */
     long[] getBucketCounts() {
-      return bucketCounts;
+      return Arrays.copyOf(bucketCounts, bucketCounts.length);
     }
 
     @Override
@@ -178,8 +177,7 @@ abstract class MutableAggregation {
         Function<? super MutableHistogram, T> p2,
         Function<? super MutableRange, T> p3,
         Function<? super MutableMean, T> p4,
-        Function<? super MutableStdDev, T> p5,
-        Function<? super MutableAggregation, T> defaultFunction) {
+        Function<? super MutableStdDev, T> p5) {
       return p2.apply(this);
     }
   }
@@ -243,8 +241,7 @@ abstract class MutableAggregation {
         Function<? super MutableHistogram, T> p2,
         Function<? super MutableRange, T> p3,
         Function<? super MutableMean, T> p4,
-        Function<? super MutableStdDev, T> p5,
-        Function<? super MutableAggregation, T> defaultFunction) {
+        Function<? super MutableStdDev, T> p5) {
       return p3.apply(this);
     }
   }
@@ -290,8 +287,7 @@ abstract class MutableAggregation {
         Function<? super MutableHistogram, T> p2,
         Function<? super MutableRange, T> p3,
         Function<? super MutableMean, T> p4,
-        Function<? super MutableStdDev, T> p5,
-        Function<? super MutableAggregation, T> defaultFunction) {
+        Function<? super MutableStdDev, T> p5) {
       return p4.apply(this);
     }
   }
@@ -315,6 +311,14 @@ abstract class MutableAggregation {
       return new MutableStdDev();
     }
 
+    /**
+     * Update the sum of squared deviations from the mean with the given value. For values
+     * x_i this is Sum[i=1..n]((x_i - mean)^2)
+     *
+     * <p>Computed using Welfords method (see
+     * https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance, or Knuth, "The Art of
+     * Computer Programming", Vol. 2, page 323, 3rd edition)
+     */
     @Override
     void add(double value) {
       count++;
@@ -326,6 +330,8 @@ abstract class MutableAggregation {
 
     /**
      * Returns the aggregated standard deviations.
+     *
+     * <p>If count is zero then this value will also be zero.
      *
      * @return the aggregated standard deviations.
      */
@@ -340,8 +346,7 @@ abstract class MutableAggregation {
         Function<? super MutableHistogram, T> p2,
         Function<? super MutableRange, T> p3,
         Function<? super MutableMean, T> p4,
-        Function<? super MutableStdDev, T> p5,
-        Function<? super MutableAggregation, T> defaultFunction) {
+        Function<? super MutableStdDev, T> p5) {
       return p5.apply(this);
     }
   }

--- a/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
@@ -1,0 +1,348 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.opencensus.common.Function;
+
+/** Mutable version of {@link Aggregation} that supports adding values. */
+abstract class MutableAggregation {
+
+  private MutableAggregation() {
+  }
+
+  /**
+   * Put a new value into the MutableAggregation.
+   *
+   * @param value new value to be added to population
+   */
+  abstract void add(double value);
+
+  /**
+   * Applies the given match function to the underlying data type.
+   */
+  abstract <T> T match(
+      Function<? super MutableSum, T> p0,
+      Function<? super MutableCount, T> p1,
+      Function<? super MutableHistogram, T> p2,
+      Function<? super MutableRange, T> p3,
+      Function<? super MutableMean, T> p4,
+      Function<? super MutableStdDev, T> p5,
+      Function<? super MutableAggregation, T> defaultFunction);
+
+  /** Calculate sum on aggregated {@code MeasureValue}s. */
+  static final class MutableSum extends MutableAggregation {
+
+    private double sum = 0.0;
+
+    private MutableSum() {
+    }
+
+    /**
+     * Construct a {@code MutableSum}.
+     *
+     * @return an empty {@code MutableSum}.
+     */
+    static MutableSum create() {
+      return new MutableSum();
+    }
+
+    @Override
+    void add(double value) {
+      sum += value;
+    }
+
+    /**
+     * Returns the aggregated sum.
+     *
+     * @return the aggregated sum.
+     */
+    double getSum() {
+      return sum;
+    }
+
+    @Override
+    final <T> T match(
+        Function<? super MutableSum, T> p0,
+        Function<? super MutableCount, T> p1,
+        Function<? super MutableHistogram, T> p2,
+        Function<? super MutableRange, T> p3,
+        Function<? super MutableMean, T> p4,
+        Function<? super MutableStdDev, T> p5,
+        Function<? super MutableAggregation, T> defaultFunction) {
+      return p0.apply(this);
+    }
+  }
+
+  /** Calculate count on aggregated {@code MeasureValue}s. */
+  static final class MutableCount extends MutableAggregation {
+
+    private long count = 0;
+
+    private MutableCount() {
+    }
+
+    /**
+     * Construct a {@code MutableCount}.
+     *
+     * @return an empty {@code MutableCount}.
+     */
+    static MutableCount create() {
+      return new MutableCount();
+    }
+
+    @Override
+    void add(double value) {
+      count++;
+    }
+
+    /**
+     * Returns the aggregated count.
+     *
+     * @return the aggregated count.
+     */
+    long getCount() {
+      return count;
+    }
+
+    @Override
+    final <T> T match(
+        Function<? super MutableSum, T> p0,
+        Function<? super MutableCount, T> p1,
+        Function<? super MutableHistogram, T> p2,
+        Function<? super MutableRange, T> p3,
+        Function<? super MutableMean, T> p4,
+        Function<? super MutableStdDev, T> p5,
+        Function<? super MutableAggregation, T> defaultFunction) {
+      return p1.apply(this);
+    }
+  }
+
+  /** Calculate histogram on aggregated {@code MeasureValue}s. */
+  static final class MutableHistogram extends MutableAggregation {
+
+    private final BucketBoundaries bucketBoundaries;
+    private final long[] bucketCounts;
+
+    private MutableHistogram(BucketBoundaries bucketBoundaries) {
+      this.bucketBoundaries = bucketBoundaries;
+      this.bucketCounts = new long[bucketBoundaries.getBoundaries().size() + 1];
+    }
+
+    /**
+     * Construct a {@code MutableHistogram}.
+     *
+     * @return an empty {@code MutableHistogram}.
+     */
+    static MutableHistogram create(BucketBoundaries bucketBoundaries) {
+      checkNotNull(bucketBoundaries, "bucketBoundaries should not be null.");
+      return new MutableHistogram(bucketBoundaries);
+    }
+
+    @Override
+    void add(double value) {
+      for (int i = 0; i < bucketBoundaries.getBoundaries().size(); i++) {
+        if (value < bucketBoundaries.getBoundaries().get(i)) {
+          bucketCounts[i]++;
+          return;
+        }
+      }
+      bucketCounts[bucketCounts.length - 1]++;
+    }
+
+    /**
+     * Returns the aggregated bucket count.
+     *
+     * @return the aggregated bucket count.
+     */
+    long[] getBucketCounts() {
+      return bucketCounts;
+    }
+
+    @Override
+    final <T> T match(
+        Function<? super MutableSum, T> p0,
+        Function<? super MutableCount, T> p1,
+        Function<? super MutableHistogram, T> p2,
+        Function<? super MutableRange, T> p3,
+        Function<? super MutableMean, T> p4,
+        Function<? super MutableStdDev, T> p5,
+        Function<? super MutableAggregation, T> defaultFunction) {
+      return p2.apply(this);
+    }
+  }
+
+  /** Calculate range on aggregated {@code MeasureValue}s. */
+  static final class MutableRange extends MutableAggregation {
+
+    // Initial "impossible" values, that will get reset as soon as first value is added.
+    private double min = Double.POSITIVE_INFINITY;
+    private double max = Double.NEGATIVE_INFINITY;
+
+    private MutableRange() {
+    }
+
+    /**
+     * Construct a {@code MutableRange}.
+     *
+     * @return an empty {@code MutableRange}.
+     */
+    static MutableRange create() {
+      return new MutableRange();
+    }
+
+    /**
+     * The minimum of the population values.
+     *
+     * @return The minimum of the population values.
+     */
+    double getMin() {
+      return min;
+    }
+
+    /**
+     * The maximum of the population values.
+     *
+     * @return The maximum of the population values.
+     */
+    double getMax() {
+      return max;
+    }
+
+    /**
+     * Put a new value into the Range. Sets min and max values if appropriate.
+     *
+     * @param value the new value
+     */
+    @Override
+    void add(double value) {
+      if (value < min) {
+        min = value;
+      }
+      if (value > max) {
+        max = value;
+      }
+    }
+
+    @Override
+    final <T> T match(
+        Function<? super MutableSum, T> p0,
+        Function<? super MutableCount, T> p1,
+        Function<? super MutableHistogram, T> p2,
+        Function<? super MutableRange, T> p3,
+        Function<? super MutableMean, T> p4,
+        Function<? super MutableStdDev, T> p5,
+        Function<? super MutableAggregation, T> defaultFunction) {
+      return p3.apply(this);
+    }
+  }
+
+  /** Calculate mean on aggregated {@code MeasureValue}s. */
+  static final class MutableMean extends MutableAggregation {
+
+    private double mean = 0.0;
+    private long count = 0;
+
+    private MutableMean() {
+    }
+
+    /**
+     * Construct a {@code MutableMean}.
+     *
+     * @return an empty {@code MutableMean}.
+     */
+    static MutableMean create() {
+      return new MutableMean();
+    }
+
+    @Override
+    void add(double value) {
+      count++;
+      double deltaFromMean = value - mean;
+      mean += deltaFromMean / count;
+    }
+
+    /**
+     * Returns the aggregated mean.
+     *
+     * @return the aggregated mean.
+     */
+    double getMean() {
+      return mean;
+    }
+
+    @Override
+    final <T> T match(
+        Function<? super MutableSum, T> p0,
+        Function<? super MutableCount, T> p1,
+        Function<? super MutableHistogram, T> p2,
+        Function<? super MutableRange, T> p3,
+        Function<? super MutableMean, T> p4,
+        Function<? super MutableStdDev, T> p5,
+        Function<? super MutableAggregation, T> defaultFunction) {
+      return p4.apply(this);
+    }
+  }
+
+  /** Calculate standard deviation on aggregated {@code MeasureValue}s. */
+  static final class MutableStdDev extends MutableAggregation {
+
+    private double sumOfSquaredDeviations = 0.0;
+    private double mean = 0.0;
+    private long count = 0;
+
+    private MutableStdDev() {
+    }
+
+    /**
+     * Construct a {@code MutableStdDev}.
+     *
+     * @return an empty {@code MutableStdDev}.
+     */
+    static MutableStdDev create() {
+      return new MutableStdDev();
+    }
+
+    @Override
+    void add(double value) {
+      count++;
+      double deltaFromMean = value - mean;
+      mean += deltaFromMean / count;
+      double deltaFromMean2 = value - mean;
+      sumOfSquaredDeviations += deltaFromMean * deltaFromMean2;
+    }
+
+    /**
+     * Returns the aggregated standard deviations.
+     *
+     * @return the aggregated standard deviations.
+     */
+    double getStdDev() {
+      return count == 0 ? 0 : Math.sqrt(sumOfSquaredDeviations / count);
+    }
+
+    @Override
+    final <T> T match(
+        Function<? super MutableSum, T> p0,
+        Function<? super MutableCount, T> p1,
+        Function<? super MutableHistogram, T> p2,
+        Function<? super MutableRange, T> p3,
+        Function<? super MutableMean, T> p4,
+        Function<? super MutableStdDev, T> p5,
+        Function<? super MutableAggregation, T> defaultFunction) {
+      return p5.apply(this);
+    }
+  }
+}

--- a/core_impl/src/test/java/io/opencensus/stats/MutableAggregationTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/MutableAggregationTest.java
@@ -16,7 +16,6 @@ package io.opencensus.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Function;
-import io.opencensus.common.Functions;
 import io.opencensus.stats.MutableAggregation.MutableCount;
 import io.opencensus.stats.MutableAggregation.MutableHistogram;
 import io.opencensus.stats.MutableAggregation.MutableMean;
@@ -134,8 +133,7 @@ public class MutableAggregationTest {
               assertThat(arg.getStdDev()).isWithin(TOLERANCE).of(Math.sqrt(372 / 5.0));
               return null;
             }
-          },
-          Functions.<Void>throwIllegalArgumentException());
+          });
     }
   }
 
@@ -188,8 +186,7 @@ public class MutableAggregationTest {
             public String apply(MutableStdDev arg) {
               return "STDDEV";
             }
-          },
-          Functions.<String>throwIllegalArgumentException()));
+          }));
     }
 
     assertThat(actual)

--- a/core_impl/src/test/java/io/opencensus/stats/MutableAggregationTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/MutableAggregationTest.java
@@ -1,0 +1,198 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.common.Function;
+import io.opencensus.common.Functions;
+import io.opencensus.stats.MutableAggregation.MutableCount;
+import io.opencensus.stats.MutableAggregation.MutableHistogram;
+import io.opencensus.stats.MutableAggregation.MutableMean;
+import io.opencensus.stats.MutableAggregation.MutableRange;
+import io.opencensus.stats.MutableAggregation.MutableStdDev;
+import io.opencensus.stats.MutableAggregation.MutableSum;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link io.opencensus.stats.MutableAggregation}. */
+@RunWith(JUnit4.class)
+public class MutableAggregationTest {
+
+  @Rule
+  public ExpectedException thrown = ExpectedException.none();
+
+  private static final double TOLERANCE = 1e-6;
+
+  @Test
+  public void testCreateEmpty() {
+    BucketBoundaries bucketBoundaries = BucketBoundaries.create(Arrays.asList(0.1, 2.2, 33.3));
+
+    assertThat(MutableSum.create().getSum()).isWithin(TOLERANCE).of(0);
+    assertThat(MutableCount.create().getCount()).isEqualTo(0);
+    assertThat(MutableHistogram.create(bucketBoundaries).getBucketCounts())
+        .isEqualTo(new long[4]);
+    assertThat(MutableRange.create().getMin()).isPositiveInfinity();
+    assertThat(MutableRange.create().getMax()).isNegativeInfinity();
+    assertThat(MutableMean.create().getMean()).isWithin(TOLERANCE).of(0);
+    assertThat(MutableStdDev.create().getStdDev()).isWithin(TOLERANCE).of(0);
+  }
+
+  @Test
+  public void testNullBucketBoundaries() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("bucketBoundaries should not be null.");
+    MutableHistogram.create(null);
+  }
+
+  @Test
+  public void testNoBoundaries() {
+    List<Double> buckets = Arrays.asList();
+    MutableHistogram noBoundaries =
+        MutableHistogram.create(BucketBoundaries.create(buckets));
+    assertThat(noBoundaries.getBucketCounts().length).isEqualTo(1);
+    assertThat(noBoundaries.getBucketCounts()[0]).isEqualTo(0);
+  }
+
+  @Test
+  public void testAdd() {
+    List<MutableAggregation> aggregations = Arrays.asList(
+        MutableSum.create(),
+        MutableCount.create(),
+        MutableHistogram.create(
+            BucketBoundaries.create(Arrays.asList(-10.0, 0.0, 10.0))),
+        MutableRange.create(),
+        MutableMean.create(),
+        MutableStdDev.create());
+
+    List<Double> values = Arrays.asList(-1.0, 1.0, -5.0, 20.0, 5.0);
+
+    for (double value : values) {
+      for (MutableAggregation aggregation : aggregations) {
+        aggregation.add(value);
+      }
+    }
+
+    for (MutableAggregation aggregation : aggregations) {
+      aggregation.match(
+          new Function<MutableSum, Void>() {
+            @Override
+            public Void apply(MutableSum arg) {
+              assertThat(arg.getSum()).isWithin(TOLERANCE).of(20.0);
+              return null;
+            }
+          },
+          new Function<MutableCount, Void>() {
+            @Override
+            public Void apply(MutableCount arg) {
+              assertThat(arg.getCount()).isEqualTo(5);
+              return null;
+            }
+          },
+          new Function<MutableHistogram, Void>() {
+            @Override
+            public Void apply(MutableHistogram arg) {
+              assertThat(arg.getBucketCounts()).isEqualTo(new long[]{0, 2, 2, 1});
+              return null;
+            }
+          },
+          new Function<MutableRange, Void>() {
+            @Override
+            public Void apply(MutableRange arg) {
+              assertThat(arg.getMin()).isWithin(TOLERANCE).of(-5.0);
+              assertThat(arg.getMax()).isWithin(TOLERANCE).of(20.0);
+              return null;
+            }
+          },
+          new Function<MutableMean, Void>() {
+            @Override
+            public Void apply(MutableMean arg) {
+              assertThat(arg.getMean()).isWithin(TOLERANCE).of(4.0);
+              return null;
+            }
+          },
+          new Function<MutableStdDev, Void>() {
+            @Override
+            public Void apply(MutableStdDev arg) {
+              assertThat(arg.getStdDev()).isWithin(TOLERANCE).of(Math.sqrt(372 / 5.0));
+              return null;
+            }
+          },
+          Functions.<Void>throwIllegalArgumentException());
+    }
+  }
+
+  @Test
+  public void testMatch() {
+    List<MutableAggregation> aggregations = Arrays.asList(
+        MutableSum.create(),
+        MutableCount.create(),
+        MutableHistogram.create(
+            BucketBoundaries.create(Arrays.asList(-10.0, 1.0, 5.0))),
+        MutableRange.create(),
+        MutableMean.create(),
+        MutableStdDev.create());
+
+    List<String> actual = new ArrayList<String>();
+    for (MutableAggregation aggregation : aggregations) {
+      actual.add(aggregation.match(
+          new Function<MutableSum, String>() {
+            @Override
+            public String apply(MutableSum arg) {
+              return "SUM";
+            }
+          },
+          new Function<MutableCount, String>() {
+            @Override
+            public String apply(MutableCount arg) {
+              return "COUNT";
+            }
+          },
+          new Function<MutableHistogram, String>() {
+            @Override
+            public String apply(MutableHistogram arg) {
+              return "HISTOGRAM";
+            }
+          },
+          new Function<MutableRange, String>() {
+            @Override
+            public String apply(MutableRange arg) {
+              return "RANGE";
+            }
+          },
+          new Function<MutableMean, String>() {
+            @Override
+            public String apply(MutableMean arg) {
+              return "MEAN";
+            }
+          },
+          new Function<MutableStdDev, String>() {
+            @Override
+            public String apply(MutableStdDev arg) {
+              return "STDDEV";
+            }
+          },
+          Functions.<String>throwIllegalArgumentException()));
+    }
+
+    assertThat(actual)
+        .isEqualTo(Arrays.asList("SUM", "COUNT", "HISTOGRAM", "RANGE", "MEAN", "STDDEV"));
+  }
+}


### PR DESCRIPTION
This PR is implementation level changes.

MutableAggregation is the implementation class that does the actual recording and updates the corresponding summary stats (count, sum, etc.), similar to [MutableDistribution](https://github.com/census-instrumentation/opencensus-java/blob/master/core/src/main/java/io/opencensus/stats/MutableDistribution.java) in our previous design.