### PR TITLE
Move tagging implementation classes into io.opencensus.impl.tags. (part of #379)

### DIFF
--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -42,7 +42,7 @@ public final class Tags {
     try {
       // Call Class.forName with literal string name of the class to help shading tools.
       return Provider.createInstance(
-          Class.forName("io.opencensus.tags.TagsComponentImpl", true, classLoader),
+          Class.forName("io.opencensus.impl.tags.TagsComponentImpl", true, classLoader),
           TagsComponent.class);
     } catch (ClassNotFoundException e) {
       logger.log(
@@ -54,7 +54,7 @@ public final class Tags {
     try {
       // Call Class.forName with literal string name of the class to help shading tools.
       return Provider.createInstance(
-          Class.forName("io.opencensus.tags.TagsComponentImplLite", true, classLoader),
+          Class.forName("io.opencensus.impl.tags.TagsComponentImplLite", true, classLoader),
           TagsComponent.class);
     } catch (ClassNotFoundException e) {
       logger.log(

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -24,7 +24,7 @@ public abstract class TagsComponent {
   private static final TagsComponent NOOP_TAGS_COMPONENT = new NoopTagsComponent();
 
   /** Returns the {@link TagContextFactory} for this implementation. */
-  abstract TagContextFactory getTagContextFactory();
+  public abstract TagContextFactory getTagContextFactory();
 
   /**
    * Returns a {@code TagsComponent} that has a no-op implementation for the {@link
@@ -41,7 +41,7 @@ public abstract class TagsComponent {
   private static final class NoopTagsComponent extends TagsComponent {
 
     @Override
-    TagContextFactory getTagContextFactory() {
+    public TagContextFactory getTagContextFactory() {
       return TagContextFactory.getNoopTagContextFactory();
     }
   }

--- a/core_impl/src/main/java/io/opencensus/impl/tags/TagContextFactoryImpl.java
+++ b/core_impl/src/main/java/io/opencensus/impl/tags/TagContextFactoryImpl.java
@@ -11,14 +11,9 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.impl.tags;
 
-/** Base implementation of {@link TagsComponent}. */
-public abstract class TagsComponentImplBase extends TagsComponent {
-  private final TagContextFactory tagContextFactory = new TagContextFactoryImpl();
+import io.opencensus.tags.TagContextFactory;
 
-  @Override
-  public TagContextFactory getTagContextFactory() {
-    return tagContextFactory;
-  }
+final class TagContextFactoryImpl extends TagContextFactory {
 }

--- a/core_impl/src/main/java/io/opencensus/impl/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/impl/tags/TagsComponentImplBase.java
@@ -11,7 +11,17 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.impl.tags;
 
-/** Java 7 and 8 implementation of {@link TagsComponent}. */
-public final class TagsComponentImpl extends TagsComponentImplBase {}
+import io.opencensus.tags.TagContextFactory;
+import io.opencensus.tags.TagsComponent;
+
+/** Base implementation of {@link TagsComponent}. */
+public abstract class TagsComponentImplBase extends TagsComponent {
+  private final TagContextFactory tagContextFactory = new TagContextFactoryImpl();
+
+  @Override
+  public TagContextFactory getTagContextFactory() {
+    return tagContextFactory;
+  }
+}

--- a/core_impl_android/src/main/java/io/opencensus/impl/tags/TagsComponentImplLite.java
+++ b/core_impl_android/src/main/java/io/opencensus/impl/tags/TagsComponentImplLite.java
@@ -11,7 +11,9 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.impl.tags;
 
-final class TagContextFactoryImpl extends TagContextFactory {
-}
+import io.opencensus.tags.TagsComponent;
+
+/** Android-compatible implementation of {@link TagsComponent}. */
+public final class TagsComponentImplLite extends TagsComponentImplBase {}

--- a/core_impl_android/src/test/java/io/opencensus/impl/tags/TagsTest.java
+++ b/core_impl_android/src/test/java/io/opencensus/impl/tags/TagsTest.java
@@ -11,10 +11,12 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.impl.tags;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opencensus.tags.Tags;
+import io.opencensus.tags.TagsComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/core_impl_java/src/main/java/io/opencensus/impl/tags/TagsComponentImpl.java
+++ b/core_impl_java/src/main/java/io/opencensus/impl/tags/TagsComponentImpl.java
@@ -11,7 +11,9 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.impl.tags;
 
-/** Android-compatible implementation of {@link TagsComponent}. */
-public final class TagsComponentImplLite extends TagsComponentImplBase {}
+import io.opencensus.tags.TagsComponent;
+
+/** Java 7 and 8 implementation of {@link TagsComponent}. */
+public final class TagsComponentImpl extends TagsComponentImplBase {}

--- a/core_impl_java/src/test/java/io/opencensus/impl/tags/TagsTest.java
+++ b/core_impl_java/src/test/java/io/opencensus/impl/tags/TagsTest.java
@@ -11,10 +11,12 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.impl.tags;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opencensus.tags.Tags;
+import io.opencensus.tags.TagsComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;


### PR DESCRIPTION
This change will ensure that the 'tags' implementation only accesses the API
classes through their public API.  That will help us maintain backwards
compatibility.

EDIT: We should probably also put the core, Java 7/8, and Android implementation classes in different packages before the release.