### PR TITLE
Implementation for IntervalView

### DIFF
--- a/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MeasureToViewMap.java
@@ -84,14 +84,15 @@ final class MeasureToViewMap {
   }
 
   // Records stats with a set of tags.
-  synchronized void record(StatsContextImpl tags, MeasureMap stats) {
+  synchronized void record(StatsContextImpl tags, MeasureMap stats, Clock clock) {
     Iterator<Measurement> iterator = stats.iterator();
     while (iterator.hasNext()) {
       Measurement measurement = iterator.next();
       Collection<MutableViewData> views = mutableMap.get(measurement.getMeasure().getName());
       for (MutableViewData view : views) {
         measurement.match(
-            new RecordDoubleValueFunc(tags, view), new RecordLongValueFunc(tags, view));
+            new RecordDoubleValueFunc(tags, view, clock),
+            new RecordLongValueFunc(tags, view, clock));
       }
     }
   }
@@ -99,32 +100,36 @@ final class MeasureToViewMap {
   private static final class RecordDoubleValueFunc implements Function<MeasurementDouble, Void> {
     @Override
     public Void apply(MeasurementDouble arg) {
-      view.record(tags, arg.getValue());
+      view.record(tags, arg.getValue(), clock);
       return null;
     }
 
     private final StatsContextImpl tags;
     private final MutableViewData view;
+    private final Clock clock;
 
-    private RecordDoubleValueFunc(StatsContextImpl tags, MutableViewData view) {
+    private RecordDoubleValueFunc(StatsContextImpl tags, MutableViewData view, Clock clock) {
       this.tags = tags;
       this.view = view;
+      this.clock = clock;
     }
   }
 
   private static final class RecordLongValueFunc implements Function<MeasurementLong, Void> {
     @Override
     public Void apply(MeasurementLong arg) {
-      view.record(tags, arg.getValue());
+      view.record(tags, arg.getValue(), clock);
       return null;
     }
 
     private final StatsContextImpl tags;
     private final MutableViewData view;
+    private final Clock clock;
 
-    private RecordLongValueFunc(StatsContextImpl tags, MutableViewData view) {
+    private RecordLongValueFunc(StatsContextImpl tags, MutableViewData view, Clock clock) {
       this.tags = tags;
       this.view = view;
+      this.clock = clock;
     }
   }
 }

--- a/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
@@ -23,7 +23,6 @@ import java.util.Queue;
 import java.util.logging.Logger;
 
 /** Mutable version of {@link Aggregation} that supports adding values. */
-// TODO(songya): synchronization
 abstract class MutableAggregation {
 
   private static final Logger logger = Logger.getLogger(MutableAggregation.class.getName());

--- a/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
@@ -13,14 +13,20 @@
 
 package io.opencensus.stats;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.opencensus.common.Function;
-
 import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.logging.Logger;
 
 /** Mutable version of {@link Aggregation} that supports adding values. */
+// TODO(songya): synchronization
 abstract class MutableAggregation {
+
+  private static final Logger logger = Logger.getLogger(MutableAggregation.class.getName());
 
   private MutableAggregation() {
   }
@@ -31,6 +37,20 @@ abstract class MutableAggregation {
    * @param value new value to be added to population
    */
   abstract void add(double value);
+
+  /**
+   * Update the summary stats by removing an expired value.
+   *
+   * @param value the expired value to be removed from population.
+   */
+  abstract void remove(double value);
+
+  private static final double EPSILON = 1e-7;
+
+  // Compare two double values to see if their difference is within Epsilon.
+  private static boolean isEqualWithinEpsilon(double v1, double v2) {
+    return Math.abs(v1 - v2) <= EPSILON;
+  }
 
   /**
    * Applies the given match function to the underlying data type.
@@ -63,6 +83,11 @@ abstract class MutableAggregation {
     @Override
     void add(double value) {
       sum += value;
+    }
+
+    @Override
+    void remove(double value) {
+      sum -= value;
     }
 
     /**
@@ -106,6 +131,11 @@ abstract class MutableAggregation {
     @Override
     void add(double value) {
       count++;
+    }
+
+    @Override
+    void remove(double value) {
+      count--;
     }
 
     /**
@@ -161,6 +191,17 @@ abstract class MutableAggregation {
       bucketCounts[bucketCounts.length - 1]++;
     }
 
+    @Override
+    void remove(double value) {
+      for (int i = 0; i < bucketBoundaries.getBoundaries().size(); i++) {
+        if (value < bucketBoundaries.getBoundaries().get(i)) {
+          bucketCounts[i]--;
+          return;
+        }
+      }
+      bucketCounts[bucketCounts.length - 1]--;
+    }
+
     /**
      * Returns the aggregated bucket count.
      *
@@ -188,6 +229,8 @@ abstract class MutableAggregation {
     // Initial "impossible" values, that will get reset as soon as first value is added.
     private double min = Double.POSITIVE_INFINITY;
     private double max = Double.NEGATIVE_INFINITY;
+
+    private Queue<Double> values = new LinkedList<Double>();
 
     private MutableRange() {
     }
@@ -232,6 +275,41 @@ abstract class MutableAggregation {
       if (value > max) {
         max = value;
       }
+
+      boolean added = values.offer(value);
+      if (!added) {
+        logger.severe("Failed to enqueue value " + value + " for MutableRange.");
+      }
+    }
+
+    // TODO(songya): shall we use a more efficient but complicated algorithm to calculate this?
+    // e.g. sliding window max/min?
+    @Override
+    void remove(double value) {
+      checkArgument(isEqualWithinEpsilon(value, values.poll()),
+          "The value queues between MutableViewData and MutableRange don't match.");
+      if (!isEqualWithinEpsilon(value, min) && !isEqualWithinEpsilon(value, max)) {
+        return; // the passed-in value is neither min nor max.
+      }
+
+      double minOfRestValues = Double.POSITIVE_INFINITY;
+      double maxOfRestValues = Double.NEGATIVE_INFINITY;
+      for (double v : values) {
+        // The passed-in value has already been dequeued.
+        if (v < minOfRestValues) {
+          minOfRestValues = v;
+        }
+        if (v > maxOfRestValues) {
+          maxOfRestValues = v;
+        }
+      }
+
+      if (isEqualWithinEpsilon(value, min)) {
+        min = minOfRestValues;
+      }
+      if (isEqualWithinEpsilon(value, max)) {
+        max = maxOfRestValues;
+      }
     }
 
     @Override
@@ -269,6 +347,17 @@ abstract class MutableAggregation {
       count++;
       double deltaFromMean = value - mean;
       mean += deltaFromMean / count;
+    }
+
+    @Override
+    void remove(double value) {
+      count--;
+      if (count == 0) {
+        mean = 0;
+      } else {
+        double deltaFromMean = value - mean;
+        mean -= deltaFromMean / count;
+      }
     }
 
     /**
@@ -326,6 +415,20 @@ abstract class MutableAggregation {
       mean += deltaFromMean / count;
       double deltaFromMean2 = value - mean;
       sumOfSquaredDeviations += deltaFromMean * deltaFromMean2;
+    }
+
+    @Override
+    void remove(double value) {
+      count--;
+      if (count == 0) {
+        mean = 0;
+        sumOfSquaredDeviations = 0;
+      } else {
+        double deltaFromMean = value - mean;
+        mean -= deltaFromMean / count;
+        double deltaFromMean2 = value - mean;
+        sumOfSquaredDeviations -= deltaFromMean * deltaFromMean2;
+      }
     }
 
     /**

--- a/core_impl/src/main/java/io/opencensus/stats/StatsManager.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsManager.java
@@ -13,6 +13,8 @@
 
 package io.opencensus.stats;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.opencensus.common.Clock;
 import io.opencensus.internal.EventQueue;
 
@@ -27,14 +29,13 @@ final class StatsManager {
   private final MeasureToViewMap measureToViewMap = new MeasureToViewMap();
 
   StatsManager(EventQueue queue, Clock clock) {
+    checkNotNull(queue, "EventQueue");
+    checkNotNull(clock, "Clock");
     this.queue = queue;
     this.clock = clock;
   }
 
   void registerView(View view) {
-    if (view.getWindow() instanceof View.Window.Interval) {
-      throw new UnsupportedOperationException("IntervalView not supported yet.");
-    }
     measureToViewMap.registerView(view, clock);
   }
 
@@ -56,17 +57,17 @@ final class StatsManager {
   private static final class StatsEvent implements EventQueue.Entry {
     private final StatsContextImpl tags;
     private final MeasureMap stats;
-    private final StatsManager viewManager;
+    private final StatsManager statsManager;
 
-    StatsEvent(StatsManager viewManager, StatsContextImpl tags, MeasureMap stats) {
-      this.viewManager = viewManager;
+    StatsEvent(StatsManager statsManager, StatsContextImpl tags, MeasureMap stats) {
+      this.statsManager = statsManager;
       this.tags = tags;
       this.stats = stats;
     }
 
     @Override
     public void process() {
-      viewManager.measureToViewMap.record(tags, stats);
+      statsManager.measureToViewMap.record(tags, stats, statsManager.clock);
     }
   }
 }

--- a/core_impl/src/main/java/io/opencensus/stats/StatsRecorderImpl.java
+++ b/core_impl/src/main/java/io/opencensus/stats/StatsRecorderImpl.java
@@ -13,11 +13,14 @@
 
 package io.opencensus.stats;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 /** Implementation of {@link StatsRecorder}. */
 final class StatsRecorderImpl extends StatsRecorder {
   private final StatsManager statsManager;
 
   StatsRecorderImpl(StatsManager statsManager) {
+    checkNotNull(statsManager, "statsManager");
     this.statsManager = statsManager;
   }
 

--- a/core_impl/src/test/java/io/opencensus/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/ViewManagerImplTest.java
@@ -17,7 +17,6 @@ import static com.google.common.truth.Truth.assertThat;
 import static io.opencensus.stats.StatsTestUtil.createContext;
 
 import com.google.common.collect.ImmutableMap;
-import io.opencensus.common.Duration;
 import io.opencensus.common.Timestamp;
 import io.opencensus.internal.SimpleEventQueue;
 import io.opencensus.stats.Aggregation.Count;
@@ -28,7 +27,6 @@ import io.opencensus.stats.Aggregation.StdDev;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View.Window.Cumulative;
-import io.opencensus.stats.View.Window.Interval;
 import io.opencensus.stats.ViewData.WindowData.CumulativeData;
 import io.opencensus.testing.common.TestClock;
 import java.util.Arrays;
@@ -111,20 +109,6 @@ public class ViewManagerImplTest {
     View view = createCumulativeView();
     viewManager.registerView(view);
     assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view);
-  }
-
-  @Test
-  public void preventRegisteringIntervalView() {
-    View intervalView =
-        View.create(
-            VIEW_NAME,
-            VIEW_DESCRIPTION,
-            MEASURE,
-            AGGREGATIONS,
-            Arrays.asList(KEY),
-            Interval.create(Duration.create(60, 0)));
-    thrown.expect(UnsupportedOperationException.class);
-    viewManager.registerView(intervalView);
   }
 
   @Test


### PR DESCRIPTION
Implementation to support `IntervalView`. Tests are in PR #495.

The basic idea is, for IntervalView we will store a queue of values associated with the timestamp when they get processed (after going through the async `DisruptorQueue`). Every time when getView() is called, we dequeue those values that have expired (i.e. the time when they are processed + specified duration of interval view < current time), and update the summary stats by eliminating expired values.