### PR TITLE
Minimal API changes to support MeasureLong.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/core/src/main/java/io/opencensus/stats/AggregationData.java
@@ -27,12 +27,14 @@ import javax.annotation.concurrent.Immutable;
  * {@link AggregationData} is the result of applying a given {@link Aggregation} to a set of
  * {@code MeasureValue}s.
  *
- * <p>{@link AggregationData} currently supports 6 types of basic aggregation values:
+ * <p>{@link AggregationData} currently supports 8 types of basic aggregation values:
  * <ul>
- *   <li>SumData
+ *   <li>SumDataDouble
+ *   <li>SumDataLong
  *   <li>CountData
  *   <li>HistogramData
- *   <li>RangeData
+ *   <li>RangeDataDouble
+ *   <li>RangeDataLong
  *   <li>MeanData
  *   <li>StdDevData (standard deviation)
  * </ul>
@@ -50,93 +52,82 @@ public abstract class AggregationData {
    * Applies the given match function to the underlying data type.
    */
   public abstract <T> T match(
-      Function<? super SumData, T> p0,
-      Function<? super CountData, T> p1,
-      Function<? super HistogramData, T> p2,
-      Function<? super RangeData, T> p3,
-      Function<? super MeanData, T> p4,
-      Function<? super StdDevData, T> p5,
+      Function<? super SumDataDouble, T> p0,
+      Function<? super SumDataLong, T> p1,
+      Function<? super CountData, T> p2,
+      Function<? super HistogramData, T> p3,
+      Function<? super RangeDataDouble, T> p4,
+      Function<? super RangeDataLong, T> p5,
+      Function<? super MeanData, T> p6,
+      Function<? super StdDevData, T> p7,
       Function<? super AggregationData, T> defaultFunction);
 
-  /** The sum value of aggregated {@code MeasureValue}s. */
-  @Immutable
-  public abstract static class SumData extends AggregationData {
 
-    private SumData() {
+  /** The double sum value on aggregated values of type {@code MeasureDouble}. */
+  @Immutable
+  @AutoValue
+  public abstract static class SumDataDouble extends AggregationData {
+
+    SumDataDouble() {
     }
+
+    static SumDataDouble create(double sum) {
+      return new AutoValue_AggregationData_SumDataDouble(sum);
+    }
+
+    /**
+     * Returns the aggregated sum.
+     *
+     * @return the aggregated sum.
+     */
+    public abstract double getSum();
 
     @Override
     public final <T> T match(
-        Function<? super SumData, T> p0,
-        Function<? super CountData, T> p1,
-        Function<? super HistogramData, T> p2,
-        Function<? super RangeData, T> p3,
-        Function<? super MeanData, T> p4,
-        Function<? super StdDevData, T> p5,
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super HistogramData, T> p3,
+        Function<? super RangeDataDouble, T> p4,
+        Function<? super RangeDataLong, T> p5,
+        Function<? super MeanData, T> p6,
+        Function<? super StdDevData, T> p7,
         Function<? super AggregationData, T> defaultFunction) {
       return p0.apply(this);
     }
+  }
 
-    /** Applies the given match function to the underlying data type. */
-    public abstract <T> T match(
-        Function<? super SumDataDouble, T> p0,
-        Function<? super SumDataLong, T> p1,
-        Function<? super SumData, T> defaultFunction);
+  /** The long sum value on aggregated values of type {@code MeasureLong}. */
+  @Immutable
+  @AutoValue
+  public abstract static class SumDataLong extends AggregationData {
 
-    /** The double sum value on aggregated values of type {@code MeasureDouble}. */
-    @Immutable
-    @AutoValue
-    public abstract static class SumDataDouble extends SumData {
-
-      SumDataDouble() {
-      }
-
-      static SumDataDouble create(double sum) {
-        return new AutoValue_AggregationData_SumData_SumDataDouble(sum);
-      }
-
-      /**
-       * Returns the aggregated sum.
-       *
-       * @return the aggregated sum.
-       */
-      public abstract double getSum();
-
-      @Override
-      public final <T> T match(
-          Function<? super SumDataDouble, T> p0,
-          Function<? super SumDataLong, T> p1,
-          Function<? super SumData, T> defaultFunction) {
-        return p0.apply(this);
-      }
+    SumDataLong() {
     }
 
-    /** The long sum value on aggregated values of type {@code MeasureLong}. */
-    @Immutable
-    @AutoValue
-    public abstract static class SumDataLong extends SumData {
+    static SumDataLong create(long sum) {
+      return new AutoValue_AggregationData_SumDataLong(sum);
+    }
 
-      SumDataLong() {
-      }
+    /**
+     * Returns the aggregated sum.
+     *
+     * @return the aggregated sum.
+     */
+    public abstract long getSum();
 
-      static SumDataLong create(long sum) {
-        return new AutoValue_AggregationData_SumData_SumDataLong(sum);
-      }
-
-      /**
-       * Returns the aggregated sum.
-       *
-       * @return the aggregated sum.
-       */
-      public abstract long getSum();
-
-      @Override
-      public final <T> T match(
-          Function<? super SumDataDouble, T> p0,
-          Function<? super SumDataLong, T> p1,
-          Function<? super SumData, T> defaultFunction) {
-        return p1.apply(this);
-      }
+    @Override
+    public final <T> T match(
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super HistogramData, T> p3,
+        Function<? super RangeDataDouble, T> p4,
+        Function<? super RangeDataLong, T> p5,
+        Function<? super MeanData, T> p6,
+        Function<? super StdDevData, T> p7,
+        Function<? super AggregationData, T> defaultFunction) {
+      return p1.apply(this);
     }
   }
 
@@ -161,14 +152,16 @@ public abstract class AggregationData {
 
     @Override
     public final <T> T match(
-        Function<? super SumData, T> p0,
-        Function<? super CountData, T> p1,
-        Function<? super HistogramData, T> p2,
-        Function<? super RangeData, T> p3,
-        Function<? super MeanData, T> p4,
-        Function<? super StdDevData, T> p5,
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super HistogramData, T> p3,
+        Function<? super RangeDataDouble, T> p4,
+        Function<? super RangeDataLong, T> p5,
+        Function<? super MeanData, T> p6,
+        Function<? super StdDevData, T> p7,
         Function<? super AggregationData, T> defaultFunction) {
-      return p1.apply(this);
+      return p2.apply(this);
     }
   }
 
@@ -200,116 +193,104 @@ public abstract class AggregationData {
 
     @Override
     public final <T> T match(
-        Function<? super SumData, T> p0,
-        Function<? super CountData, T> p1,
-        Function<? super HistogramData, T> p2,
-        Function<? super RangeData, T> p3,
-        Function<? super MeanData, T> p4,
-        Function<? super StdDevData, T> p5,
-        Function<? super AggregationData, T> defaultFunction) {
-      return p2.apply(this);
-    }
-  }
-
-  /** The range of aggregated {@code MeasureValue}s. */
-  @Immutable
-  public abstract static class RangeData extends AggregationData {
-
-    private RangeData() {
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super SumData, T> p0,
-        Function<? super CountData, T> p1,
-        Function<? super HistogramData, T> p2,
-        Function<? super RangeData, T> p3,
-        Function<? super MeanData, T> p4,
-        Function<? super StdDevData, T> p5,
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super HistogramData, T> p3,
+        Function<? super RangeDataDouble, T> p4,
+        Function<? super RangeDataLong, T> p5,
+        Function<? super MeanData, T> p6,
+        Function<? super StdDevData, T> p7,
         Function<? super AggregationData, T> defaultFunction) {
       return p3.apply(this);
     }
+  }
 
-    /** Applies the given match function to the underlying data type. */
-    public abstract <T> T match(
-        Function<? super RangeDataDouble, T> p0,
-        Function<? super RangeDataLong, T> p1,
-        Function<? super RangeData, T> defaultFunction);
+  /** The range on aggregated values of type {@code MeasureDouble}. */
+  @Immutable
+  @AutoValue
+  public abstract static class RangeDataDouble extends AggregationData {
 
-    /** The range on aggregated values of type {@code MeasureDouble}. */
-    @Immutable
-    @AutoValue
-    public abstract static class RangeDataDouble extends RangeData {
-
-      RangeDataDouble() {
-      }
-
-      static RangeDataDouble create(double min, double max) {
-        if (min != Double.POSITIVE_INFINITY || max != Double.NEGATIVE_INFINITY) {
-          checkArgument(min <= max, "max should be greater or equal to min.");
-        }
-        return new AutoValue_AggregationData_RangeData_RangeDataDouble(min, max);
-      }
-
-      /**
-       * Returns the minimum of the population values.
-       *
-       * @return the minimum of the population values.
-       */
-      public abstract double getMin();
-
-      /**
-       * Returns the maximum of the population values.
-       *
-       * @return the maximum of the population values.
-       */
-      public abstract double getMax();
-
-      @Override
-      public final <T> T match(
-          Function<? super RangeDataDouble, T> p0,
-          Function<? super RangeDataLong, T> p1,
-          Function<? super RangeData, T> defaultFunction) {
-        return p0.apply(this);
-      }
+    RangeDataDouble() {
     }
 
-    /** The range on aggregated values of type {@code MeasureLong}. */
-    @Immutable
-    @AutoValue
-    public abstract static class RangeDataLong extends RangeData {
-
-      RangeDataLong() {
+    static RangeDataDouble create(double min, double max) {
+      if (min != Double.POSITIVE_INFINITY || max != Double.NEGATIVE_INFINITY) {
+        checkArgument(min <= max, "max should be greater or equal to min.");
       }
+      return new AutoValue_AggregationData_RangeDataDouble(min, max);
+    }
 
-      static RangeDataLong create(long min, long max) {
-        if (min != Long.MAX_VALUE || max != Long.MIN_VALUE) {
-          checkArgument(min <= max, "max should be greater or equal to min.");
-        }
-        return new AutoValue_AggregationData_RangeData_RangeDataLong(min, max);
+    /**
+     * Returns the minimum of the population values.
+     *
+     * @return the minimum of the population values.
+     */
+    public abstract double getMin();
+
+    /**
+     * Returns the maximum of the population values.
+     *
+     * @return the maximum of the population values.
+     */
+    public abstract double getMax();
+
+    @Override
+    public final <T> T match(
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super HistogramData, T> p3,
+        Function<? super RangeDataDouble, T> p4,
+        Function<? super RangeDataLong, T> p5,
+        Function<? super MeanData, T> p6,
+        Function<? super StdDevData, T> p7,
+        Function<? super AggregationData, T> defaultFunction) {
+      return p4.apply(this);
+    }
+  }
+
+  /** The range on aggregated values of type {@code MeasureLong}. */
+  @Immutable
+  @AutoValue
+  public abstract static class RangeDataLong extends AggregationData {
+
+    RangeDataLong() {
+    }
+
+    static RangeDataLong create(long min, long max) {
+      if (min != Long.MAX_VALUE || max != Long.MIN_VALUE) {
+        checkArgument(min <= max, "max should be greater or equal to min.");
       }
+      return new AutoValue_AggregationData_RangeDataLong(min, max);
+    }
 
-      /**
-       * Returns the minimum of the population values.
-       *
-       * @return the minimum of the population values.
-       */
-      public abstract long getMin();
+    /**
+     * Returns the minimum of the population values.
+     *
+     * @return the minimum of the population values.
+     */
+    public abstract long getMin();
 
-      /**
-       * Returns the maximum of the population values.
-       *
-       * @return the maximum of the population values.
-       */
-      public abstract long getMax();
+    /**
+     * Returns the maximum of the population values.
+     *
+     * @return the maximum of the population values.
+     */
+    public abstract long getMax();
 
-      @Override
-      public final <T> T match(
-          Function<? super RangeDataDouble, T> p0,
-          Function<? super RangeDataLong, T> p1,
-          Function<? super RangeData, T> defaultFunction) {
-        return p1.apply(this);
-      }
+    @Override
+    public final <T> T match(
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super HistogramData, T> p3,
+        Function<? super RangeDataDouble, T> p4,
+        Function<? super RangeDataLong, T> p5,
+        Function<? super MeanData, T> p6,
+        Function<? super StdDevData, T> p7,
+        Function<? super AggregationData, T> defaultFunction) {
+      return p5.apply(this);
     }
   }
 
@@ -334,14 +315,16 @@ public abstract class AggregationData {
 
     @Override
     public final <T> T match(
-        Function<? super SumData, T> p0,
-        Function<? super CountData, T> p1,
-        Function<? super HistogramData, T> p2,
-        Function<? super RangeData, T> p3,
-        Function<? super MeanData, T> p4,
-        Function<? super StdDevData, T> p5,
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super HistogramData, T> p3,
+        Function<? super RangeDataDouble, T> p4,
+        Function<? super RangeDataLong, T> p5,
+        Function<? super MeanData, T> p6,
+        Function<? super StdDevData, T> p7,
         Function<? super AggregationData, T> defaultFunction) {
-      return p4.apply(this);
+      return p6.apply(this);
     }
   }
 
@@ -366,14 +349,16 @@ public abstract class AggregationData {
 
     @Override
     public final <T> T match(
-        Function<? super SumData, T> p0,
-        Function<? super CountData, T> p1,
-        Function<? super HistogramData, T> p2,
-        Function<? super RangeData, T> p3,
-        Function<? super MeanData, T> p4,
-        Function<? super StdDevData, T> p5,
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super HistogramData, T> p3,
+        Function<? super RangeDataDouble, T> p4,
+        Function<? super RangeDataLong, T> p5,
+        Function<? super MeanData, T> p6,
+        Function<? super StdDevData, T> p7,
         Function<? super AggregationData, T> defaultFunction) {
-      return p5.apply(this);
+      return p7.apply(this);
     }
   }
 }

--- a/core/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/core/src/main/java/io/opencensus/stats/AggregationData.java
@@ -60,22 +60,10 @@ public abstract class AggregationData {
 
   /** The sum value of aggregated {@code MeasureValue}s. */
   @Immutable
-  @AutoValue
   public abstract static class SumData extends AggregationData {
 
-    SumData() {
+    private SumData() {
     }
-
-    static SumData create(double sum) {
-      return new AutoValue_AggregationData_SumData(sum);
-    }
-
-    /**
-     * Returns the aggregated sum.
-     *
-     * @return the aggregated sum.
-     */
-    public abstract double getSum();
 
     @Override
     public final <T> T match(
@@ -87,6 +75,68 @@ public abstract class AggregationData {
         Function<? super StdDevData, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
       return p0.apply(this);
+    }
+
+    /** Applies the given match function to the underlying data type. */
+    public abstract <T> T match(
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super SumData, T> defaultFunction);
+
+    /** The double sum value on aggregated values of type {@code MeasureDouble}. */
+    @Immutable
+    @AutoValue
+    public abstract static class SumDataDouble extends SumData {
+
+      SumDataDouble() {
+      }
+
+      static SumDataDouble create(double sum) {
+        return new AutoValue_AggregationData_SumData_SumDataDouble(sum);
+      }
+
+      /**
+       * Returns the aggregated sum.
+       *
+       * @return the aggregated sum.
+       */
+      public abstract double getSum();
+
+      @Override
+      public final <T> T match(
+          Function<? super SumDataDouble, T> p0,
+          Function<? super SumDataLong, T> p1,
+          Function<? super SumData, T> defaultFunction) {
+        return p0.apply(this);
+      }
+    }
+
+    /** The long sum value on aggregated values of type {@code MeasureLong}. */
+    @Immutable
+    @AutoValue
+    public abstract static class SumDataLong extends SumData {
+
+      SumDataLong() {
+      }
+
+      static SumDataLong create(long sum) {
+        return new AutoValue_AggregationData_SumData_SumDataLong(sum);
+      }
+
+      /**
+       * Returns the aggregated sum.
+       *
+       * @return the aggregated sum.
+       */
+      public abstract long getSum();
+
+      @Override
+      public final <T> T match(
+          Function<? super SumDataDouble, T> p0,
+          Function<? super SumDataLong, T> p1,
+          Function<? super SumData, T> defaultFunction) {
+        return p1.apply(this);
+      }
     }
   }
 
@@ -163,32 +213,10 @@ public abstract class AggregationData {
 
   /** The range of aggregated {@code MeasureValue}s. */
   @Immutable
-  @AutoValue
   public abstract static class RangeData extends AggregationData {
 
-    RangeData() {
+    private RangeData() {
     }
-
-    static RangeData create(double min, double max) {
-      if (min != Double.POSITIVE_INFINITY || max != Double.NEGATIVE_INFINITY) {
-        checkArgument(min <= max, "max should be greater or equal to min.");
-      }
-      return new AutoValue_AggregationData_RangeData(min, max);
-    }
-
-    /**
-     * Returns the minimum of the population values.
-     *
-     * @return the minimum of the population values.
-     */
-    public abstract double getMin();
-
-    /**
-     * Returns the maximum of the population values.
-     *
-     * @return the maximum of the population values.
-     */
-    public abstract double getMax();
 
     @Override
     public final <T> T match(
@@ -200,6 +228,88 @@ public abstract class AggregationData {
         Function<? super StdDevData, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
       return p3.apply(this);
+    }
+
+    /** Applies the given match function to the underlying data type. */
+    public abstract <T> T match(
+        Function<? super RangeDataDouble, T> p0,
+        Function<? super RangeDataLong, T> p1,
+        Function<? super RangeData, T> defaultFunction);
+
+    /** The range on aggregated values of type {@code MeasureDouble}. */
+    @Immutable
+    @AutoValue
+    public abstract static class RangeDataDouble extends RangeData {
+
+      RangeDataDouble() {
+      }
+
+      static RangeDataDouble create(double min, double max) {
+        if (min != Double.POSITIVE_INFINITY || max != Double.NEGATIVE_INFINITY) {
+          checkArgument(min <= max, "max should be greater or equal to min.");
+        }
+        return new AutoValue_AggregationData_RangeData_RangeDataDouble(min, max);
+      }
+
+      /**
+       * Returns the minimum of the population values.
+       *
+       * @return the minimum of the population values.
+       */
+      public abstract double getMin();
+
+      /**
+       * Returns the maximum of the population values.
+       *
+       * @return the maximum of the population values.
+       */
+      public abstract double getMax();
+
+      @Override
+      public final <T> T match(
+          Function<? super RangeDataDouble, T> p0,
+          Function<? super RangeDataLong, T> p1,
+          Function<? super RangeData, T> defaultFunction) {
+        return p0.apply(this);
+      }
+    }
+
+    /** The range on aggregated values of type {@code MeasureLong}. */
+    @Immutable
+    @AutoValue
+    public abstract static class RangeDataLong extends RangeData {
+
+      RangeDataLong() {
+      }
+
+      static RangeDataLong create(long min, long max) {
+        if (min != Long.MAX_VALUE || max != Long.MIN_VALUE) {
+          checkArgument(min <= max, "max should be greater or equal to min.");
+        }
+        return new AutoValue_AggregationData_RangeData_RangeDataLong(min, max);
+      }
+
+      /**
+       * Returns the minimum of the population values.
+       *
+       * @return the minimum of the population values.
+       */
+      public abstract long getMin();
+
+      /**
+       * Returns the maximum of the population values.
+       *
+       * @return the maximum of the population values.
+       */
+      public abstract long getMax();
+
+      @Override
+      public final <T> T match(
+          Function<? super RangeDataDouble, T> p0,
+          Function<? super RangeDataLong, T> p1,
+          Function<? super RangeData, T> defaultFunction) {
+        return p1.apply(this);
+      }
     }
   }
 

--- a/core/src/test/java/io/opencensus/stats/AggregationDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/AggregationDataTest.java
@@ -22,8 +22,12 @@ import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.HistogramData;
 import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.RangeData;
+import io.opencensus.stats.AggregationData.RangeData.RangeDataDouble;
+import io.opencensus.stats.AggregationData.RangeData.RangeDataLong;
 import io.opencensus.stats.AggregationData.StdDevData;
 import io.opencensus.stats.AggregationData.SumData;
+import io.opencensus.stats.AggregationData.SumData.SumDataDouble;
+import io.opencensus.stats.AggregationData.SumData.SumDataLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -57,18 +61,21 @@ public class AggregationDataTest {
   public void testRangeDataMinIsGreaterThanMax() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("max should be greater or equal to min.");
-    RangeData.create(10.0, 0.0);
+    RangeDataDouble.create(10.0, 0.0);
   }
 
   @Test
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            SumData.create(10.0),
-            SumData.create(10.0))
+            SumDataDouble.create(10.0),
+            SumDataDouble.create(10.0))
         .addEqualityGroup(
-            SumData.create(20.0),
-            SumData.create(20.0))
+            SumDataDouble.create(20.0),
+            SumDataDouble.create(20.0))
+        .addEqualityGroup(
+            SumDataLong.create(10),
+            SumDataLong.create(10))
         .addEqualityGroup(
             CountData.create(40),
             CountData.create(40))
@@ -82,11 +89,14 @@ public class AggregationDataTest {
             HistogramData.create(new long[]{0, 10, 100}),
             HistogramData.create(new long[]{0, 10, 100}))
         .addEqualityGroup(
-            RangeData.create(-1.0, 1.0),
-            RangeData.create(-1.0, 1.0))
+            RangeDataDouble.create(-1.0, 1.0),
+            RangeDataDouble.create(-1.0, 1.0))
         .addEqualityGroup(
-            RangeData.create(-5.0, 1.0),
-            RangeData.create(-5.0, 1.0))
+            RangeDataDouble.create(-5.0, 1.0),
+            RangeDataDouble.create(-5.0, 1.0))
+        .addEqualityGroup(
+            RangeDataLong.create(-1, 1),
+            RangeDataLong.create(-1, 1))
         .addEqualityGroup(
             MeanData.create(5.0),
             MeanData.create(5.0))
@@ -105,10 +115,10 @@ public class AggregationDataTest {
   @Test
   public void testMatchAndGet() {
     List<AggregationData> aggregations = Arrays.asList(
-        SumData.create(10.0),
+        SumDataDouble.create(10.0),
         CountData.create(40),
         HistogramData.create(new long[]{0, 10, 0}),
-        RangeData.create(-1.0, 1.0),
+        RangeDataDouble.create(-1.0, 1.0),
         MeanData.create(5.0),
         StdDevData.create(23.3));
 
@@ -118,7 +128,7 @@ public class AggregationDataTest {
           new Function<SumData, Void>() {
             @Override
             public Void apply(SumData arg) {
-              actual.add(arg.getSum());
+              actual.add(((SumDataDouble) arg).getSum());
               return null;
             }
           },
@@ -139,8 +149,8 @@ public class AggregationDataTest {
           new Function<RangeData, Void>() {
             @Override
             public Void apply(RangeData arg) {
-              actual.add(arg.getMin());
-              actual.add(arg.getMax());
+              actual.add(((RangeDataDouble) arg).getMin());
+              actual.add(((RangeDataDouble) arg).getMax());
               return null;
             }
           },

--- a/core/src/test/java/io/opencensus/stats/AggregationDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/AggregationDataTest.java
@@ -21,13 +21,11 @@ import io.opencensus.common.Functions;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.HistogramData;
 import io.opencensus.stats.AggregationData.MeanData;
-import io.opencensus.stats.AggregationData.RangeData;
-import io.opencensus.stats.AggregationData.RangeData.RangeDataDouble;
-import io.opencensus.stats.AggregationData.RangeData.RangeDataLong;
+import io.opencensus.stats.AggregationData.RangeDataDouble;
+import io.opencensus.stats.AggregationData.RangeDataLong;
 import io.opencensus.stats.AggregationData.StdDevData;
-import io.opencensus.stats.AggregationData.SumData;
-import io.opencensus.stats.AggregationData.SumData.SumDataDouble;
-import io.opencensus.stats.AggregationData.SumData.SumDataLong;
+import io.opencensus.stats.AggregationData.SumDataDouble;
+import io.opencensus.stats.AggregationData.SumDataLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -116,19 +114,28 @@ public class AggregationDataTest {
   public void testMatchAndGet() {
     List<AggregationData> aggregations = Arrays.asList(
         SumDataDouble.create(10.0),
+        SumDataLong.create(100),
         CountData.create(40),
         HistogramData.create(new long[]{0, 10, 0}),
         RangeDataDouble.create(-1.0, 1.0),
+        RangeDataLong.create(10000, 500000),
         MeanData.create(5.0),
         StdDevData.create(23.3));
 
     final List<Object> actual = new ArrayList<Object>();
     for (AggregationData aggregation : aggregations) {
       aggregation.match(
-          new Function<SumData, Void>() {
+          new Function<SumDataDouble, Void>() {
             @Override
-            public Void apply(SumData arg) {
-              actual.add(((SumDataDouble) arg).getSum());
+            public Void apply(SumDataDouble arg) {
+              actual.add(arg.getSum());
+              return null;
+            }
+          },
+          new Function<SumDataLong, Void>() {
+            @Override
+            public Void apply(SumDataLong arg) {
+              actual.add(arg.getSum());
               return null;
             }
           },
@@ -146,11 +153,19 @@ public class AggregationDataTest {
               return null;
             }
           },
-          new Function<RangeData, Void>() {
+          new Function<RangeDataDouble, Void>() {
             @Override
-            public Void apply(RangeData arg) {
-              actual.add(((RangeDataDouble) arg).getMin());
-              actual.add(((RangeDataDouble) arg).getMax());
+            public Void apply(RangeDataDouble arg) {
+              actual.add(arg.getMin());
+              actual.add(arg.getMax());
+              return null;
+            }
+          },
+          new Function<RangeDataLong, Void>() {
+            @Override
+            public Void apply(RangeDataLong arg) {
+              actual.add(arg.getMin());
+              actual.add(arg.getMax());
               return null;
             }
           },
@@ -171,7 +186,7 @@ public class AggregationDataTest {
           Functions.<Void>throwIllegalArgumentException());
     }
 
-    assertThat(actual).isEqualTo(
-        Arrays.asList(10.0, 40L, Arrays.asList(0L, 10L, 0L), -1.0, 1.0, 5.0, 23.3));
+    assertThat(actual).isEqualTo(Arrays.asList(
+        10.0, 100L, 40L, Arrays.asList(0L, 10L, 0L), -1.0, 1.0, 10000L, 500000L, 5.0, 23.3));
   }
 }

--- a/core/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -31,9 +31,11 @@ import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.HistogramData;
 import io.opencensus.stats.AggregationData.MeanData;
-import io.opencensus.stats.AggregationData.RangeData;
+import io.opencensus.stats.AggregationData.RangeDataDouble;
+import io.opencensus.stats.AggregationData.RangeDataLong;
 import io.opencensus.stats.AggregationData.StdDevData;
-import io.opencensus.stats.AggregationData.SumData;
+import io.opencensus.stats.AggregationData.SumDataDouble;
+import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.View.Window;
 import io.opencensus.stats.View.Window.Cumulative;
 import io.opencensus.stats.View.Window.Interval;
@@ -210,18 +212,22 @@ public final class ViewDataTest {
       ImmutableMap.of(
           Arrays.asList(V1, V2),
           Arrays.asList(
-              SumData.SumDataDouble.create(0),
+              SumDataDouble.create(0),
+              SumDataLong.create(0),
               CountData.create(1),
               HistogramData.create(1, 0, 0, 0, 0),
-              RangeData.RangeDataDouble.create(0, 0),
+              RangeDataDouble.create(0, 0),
+              RangeDataLong.create(0, 0),
               MeanData.create(0),
               StdDevData.create(0)),
           Arrays.asList(V10, V20),
           Arrays.asList(
-              SumData.SumDataDouble.create(50),
+              SumDataDouble.create(50),
+              SumDataLong.create(10000000),
               CountData.create(2),
               HistogramData.create(0, 0, 2, 0, 0),
-              RangeData.RangeDataDouble.create(25, 25),
+              RangeDataDouble.create(25, 25),
+              RangeDataLong.create(25000, 250000),
               MeanData.create(25),
               StdDevData.create(0)));
 

--- a/core/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -210,18 +210,18 @@ public final class ViewDataTest {
       ImmutableMap.of(
           Arrays.asList(V1, V2),
           Arrays.asList(
-              SumData.create(0),
+              SumData.SumDataDouble.create(0),
               CountData.create(1),
               HistogramData.create(1, 0, 0, 0, 0),
-              RangeData.create(0, 0),
+              RangeData.RangeDataDouble.create(0, 0),
               MeanData.create(0),
               StdDevData.create(0)),
           Arrays.asList(V10, V20),
           Arrays.asList(
-              SumData.create(50),
+              SumData.SumDataDouble.create(50),
               CountData.create(2),
               HistogramData.create(0, 0, 2, 0, 0),
-              RangeData.create(25, 25),
+              RangeData.RangeDataDouble.create(25, 25),
               MeanData.create(25),
               StdDevData.create(0)));
 

--- a/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
@@ -20,6 +20,7 @@ import io.opencensus.common.Function;
 import java.util.Arrays;
 
 /** Mutable version of {@link Aggregation} that supports adding values. */
+// TODO(songya): Add MutableSumLong and MutableRangeLong
 abstract class MutableAggregation {
 
   private MutableAggregation() {

--- a/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
@@ -260,7 +260,7 @@ final class MutableViewData {
   private static final class CreateSumData implements Function<MutableSum, AggregationData> {
     @Override
     public AggregationData apply(MutableSum arg) {
-      return SumData.create(arg.getSum());
+      return SumData.SumDataDouble.create(arg.getSum());
     }
 
     private static final CreateSumData INSTANCE = new CreateSumData();
@@ -288,7 +288,7 @@ final class MutableViewData {
   private static final class CreateRangeData implements Function<MutableRange, AggregationData> {
     @Override
     public AggregationData apply(MutableRange arg) {
-      return RangeData.create(arg.getMin(), arg.getMax());
+      return RangeData.RangeDataDouble.create(arg.getMin(), arg.getMax());
     }
 
     private static final CreateRangeData INSTANCE = new CreateRangeData();

--- a/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableViewData.java
@@ -29,9 +29,9 @@ import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.HistogramData;
 import io.opencensus.stats.AggregationData.MeanData;
-import io.opencensus.stats.AggregationData.RangeData;
+import io.opencensus.stats.AggregationData.RangeDataDouble;
 import io.opencensus.stats.AggregationData.StdDevData;
-import io.opencensus.stats.AggregationData.SumData;
+import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.MutableAggregation.MutableCount;
 import io.opencensus.stats.MutableAggregation.MutableHistogram;
 import io.opencensus.stats.MutableAggregation.MutableMean;
@@ -171,6 +171,7 @@ final class MutableViewData {
    * @return an empty {@code MutableAggregation}.
    */
   @VisibleForTesting
+  // TODO(songya): support SumLong and RangeLong
   static MutableAggregation createMutableAggregation(Aggregation aggregation) {
     return aggregation.match(
         CreateMutableSum.INSTANCE,
@@ -189,12 +190,13 @@ final class MutableViewData {
    * @return an {@code AggregationData} which is the snapshot of current summary statistics.
    */
   @VisibleForTesting
+  // TODO(songya): support SumLong and RangeLong
   static AggregationData createAggregationData(MutableAggregation aggregation) {
     return aggregation.match(
-        CreateSumData.INSTANCE,
+        CreateSumDataDouble.INSTANCE,
         CreateCountData.INSTANCE,
         CreateHistogramData.INSTANCE,
-        CreateRangeData.INSTANCE,
+        CreateRangeDataDouble.INSTANCE,
         CreateMeanData.INSTANCE,
         CreateStdDevData.INSTANCE);
   }
@@ -257,13 +259,23 @@ final class MutableViewData {
   }
 
 
-  private static final class CreateSumData implements Function<MutableSum, AggregationData> {
+  private static final class CreateSumDataDouble implements Function<MutableSum, AggregationData> {
     @Override
     public AggregationData apply(MutableSum arg) {
-      return SumData.SumDataDouble.create(arg.getSum());
+      return SumDataDouble.create(arg.getSum());
     }
 
-    private static final CreateSumData INSTANCE = new CreateSumData();
+    private static final CreateSumDataDouble INSTANCE = new CreateSumDataDouble();
+  }
+
+  private static final class CreateSumDataLong implements Function<MutableSum, AggregationData> {
+    @Override
+    public AggregationData apply(MutableSum arg) {
+      // TODO(songya): implement this
+      throw new UnsupportedOperationException();
+    }
+
+    private static final MutableViewData.CreateSumDataLong INSTANCE = new CreateSumDataLong();
   }
 
   private static final class CreateCountData implements Function<MutableCount, AggregationData> {
@@ -285,13 +297,25 @@ final class MutableViewData {
     private static final CreateHistogramData INSTANCE = new CreateHistogramData();
   }
 
-  private static final class CreateRangeData implements Function<MutableRange, AggregationData> {
+  private static final class CreateRangeDataDouble
+      implements Function<MutableRange, AggregationData> {
     @Override
     public AggregationData apply(MutableRange arg) {
-      return RangeData.RangeDataDouble.create(arg.getMin(), arg.getMax());
+      return RangeDataDouble.create(arg.getMin(), arg.getMax());
     }
 
-    private static final CreateRangeData INSTANCE = new CreateRangeData();
+    private static final CreateRangeDataDouble INSTANCE = new CreateRangeDataDouble();
+  }
+
+  private static final class CreateRangeDataLong
+      implements Function<MutableRange, AggregationData> {
+    @Override
+    public AggregationData apply(MutableRange arg) {
+      // TODO(songya): implement this
+      throw new UnsupportedOperationException();
+    }
+
+    private static final CreateRangeDataLong INSTANCE = new CreateRangeDataLong();
   }
 
   private static final class CreateMeanData implements Function<MutableMean, AggregationData> {

--- a/core_impl/src/test/java/io/opencensus/stats/MutableViewDataTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/MutableViewDataTest.java
@@ -112,10 +112,10 @@ public class MutableViewDataTest {
       aggregates.add(MutableViewData.createAggregationData(mutableAggregation));
     }
     assertThat(aggregates).containsExactly(
-        SumData.create(0),
+        SumData.SumDataDouble.create(0),
         CountData.create(0),
         HistogramData.create(0, 0, 0, 0),
-        RangeData.create(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY),
+        RangeData.RangeDataDouble.create(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY),
         MeanData.create(0),
         StdDevData.create(0))
         .inOrder();

--- a/core_impl/src/test/java/io/opencensus/stats/MutableViewDataTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/MutableViewDataTest.java
@@ -25,9 +25,9 @@ import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.HistogramData;
 import io.opencensus.stats.AggregationData.MeanData;
-import io.opencensus.stats.AggregationData.RangeData;
+import io.opencensus.stats.AggregationData.RangeDataDouble;
 import io.opencensus.stats.AggregationData.StdDevData;
-import io.opencensus.stats.AggregationData.SumData;
+import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.MutableAggregation.MutableCount;
 import io.opencensus.stats.MutableAggregation.MutableHistogram;
 import io.opencensus.stats.MutableAggregation.MutableMean;
@@ -112,10 +112,10 @@ public class MutableViewDataTest {
       aggregates.add(MutableViewData.createAggregationData(mutableAggregation));
     }
     assertThat(aggregates).containsExactly(
-        SumData.SumDataDouble.create(0),
+        SumDataDouble.create(0),
         CountData.create(0),
         HistogramData.create(0, 0, 0, 0),
-        RangeData.RangeDataDouble.create(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY),
+        RangeDataDouble.create(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY),
         MeanData.create(0),
         StdDevData.create(0))
         .inOrder();

--- a/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
@@ -141,7 +141,7 @@ public class StatsContextTest {
       assertThat(entry.getValue()).hasSize(3);
       StatsTestUtil.assertAggregationDataListEquals(
           Arrays.asList(
-              AggregationData.SumData.create(5.1),
+              AggregationData.SumData.SumDataDouble.create(5.1),
               AggregationData.CountData.create(1),
               AggregationData.HistogramData.create(0, 0, 0, 0, 0, 0, 1)),
           entry.getValue(),

--- a/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsContextTest.java
@@ -141,7 +141,7 @@ public class StatsContextTest {
       assertThat(entry.getValue()).hasSize(3);
       StatsTestUtil.assertAggregationDataListEquals(
           Arrays.asList(
-              AggregationData.SumData.SumDataDouble.create(5.1),
+              AggregationData.SumDataDouble.create(5.1),
               AggregationData.CountData.create(1),
               AggregationData.HistogramData.create(0, 0, 0, 0, 0, 0, 1)),
           entry.getValue(),

--- a/core_impl/src/test/java/io/opencensus/stats/StatsTestUtil.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsTestUtil.java
@@ -21,11 +21,11 @@ import io.opencensus.common.Functions;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.HistogramData;
 import io.opencensus.stats.AggregationData.MeanData;
-import io.opencensus.stats.AggregationData.RangeData;
-import io.opencensus.stats.AggregationData.RangeData.RangeDataDouble;
+import io.opencensus.stats.AggregationData.RangeDataDouble;
+import io.opencensus.stats.AggregationData.RangeDataLong;
 import io.opencensus.stats.AggregationData.StdDevData;
-import io.opencensus.stats.AggregationData.SumData;
-import io.opencensus.stats.AggregationData.SumData.SumDataDouble;
+import io.opencensus.stats.AggregationData.SumDataDouble;
+import io.opencensus.stats.AggregationData.SumDataLong;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -115,12 +115,19 @@ final class StatsTestUtil {
       final AggregationData actual = actualValue.get(i);
       AggregationData expected = expectedValue.get(i);
       expected.match(
-          new Function<SumData, Void>() {
+          new Function<SumDataDouble, Void>() {
             @Override
-            public Void apply(SumData arg) {
+            public Void apply(SumDataDouble arg) {
               assertThat(actual).isInstanceOf(SumDataDouble.class);
-              assertThat(((SumDataDouble) actual).getSum()).isWithin(tolerance).of(
-                  ((SumDataDouble) arg).getSum());
+              assertThat(((SumDataDouble) actual).getSum()).isWithin(tolerance).of((arg.getSum()));
+              return null;
+            }
+          },
+          new Function<SumDataLong, Void>() {
+            @Override
+            public Void apply(SumDataLong arg) {
+              assertThat(actual).isInstanceOf(SumDataLong.class);
+              assertThat(((SumDataLong) actual).getSum()).isEqualTo(arg.getSum());
               return null;
             }
           },
@@ -141,11 +148,20 @@ final class StatsTestUtil {
               return null;
             }
           },
-          new Function<RangeData, Void>() {
+          new Function<RangeDataDouble, Void>() {
             @Override
-            public Void apply(RangeData arg) {
+            public Void apply(RangeDataDouble arg) {
               assertThat(actual).isInstanceOf(RangeDataDouble.class);
-              assertRangeDataEquals((RangeDataDouble) actual, (RangeDataDouble) arg, tolerance);
+              assertRangeDataDoubleEquals((RangeDataDouble) actual, arg, tolerance);
+              return null;
+            }
+          },
+          new Function<RangeDataLong, Void>() {
+            @Override
+            public Void apply(RangeDataLong arg) {
+              assertThat(actual).isInstanceOf(RangeDataLong.class);
+              assertThat(((RangeDataLong) actual).getMax()).isEqualTo(arg.getMax());
+              assertThat(((RangeDataLong) actual).getMin()).isEqualTo(arg.getMin());
               return null;
             }
           },
@@ -169,8 +185,8 @@ final class StatsTestUtil {
     }
   }
 
-  // Compare the expected and actual RangeData within the given tolerance.
-  private static void assertRangeDataEquals(
+  // Compare the expected and actual RangeDataDouble within the given tolerance.
+  private static void assertRangeDataDoubleEquals(
       RangeDataDouble actual, RangeDataDouble expected, double tolerance) {
     if (expected.getMax() == Double.NEGATIVE_INFINITY
         && expected.getMin() == Double.POSITIVE_INFINITY) {

--- a/core_impl/src/test/java/io/opencensus/stats/StatsTestUtil.java
+++ b/core_impl/src/test/java/io/opencensus/stats/StatsTestUtil.java
@@ -22,8 +22,10 @@ import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.HistogramData;
 import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.RangeData;
+import io.opencensus.stats.AggregationData.RangeData.RangeDataDouble;
 import io.opencensus.stats.AggregationData.StdDevData;
 import io.opencensus.stats.AggregationData.SumData;
+import io.opencensus.stats.AggregationData.SumData.SumDataDouble;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -116,8 +118,9 @@ final class StatsTestUtil {
           new Function<SumData, Void>() {
             @Override
             public Void apply(SumData arg) {
-              assertThat(actual).isInstanceOf(SumData.class);
-              assertThat(((SumData) actual).getSum()).isWithin(tolerance).of(arg.getSum());
+              assertThat(actual).isInstanceOf(SumDataDouble.class);
+              assertThat(((SumDataDouble) actual).getSum()).isWithin(tolerance).of(
+                  ((SumDataDouble) arg).getSum());
               return null;
             }
           },
@@ -141,8 +144,8 @@ final class StatsTestUtil {
           new Function<RangeData, Void>() {
             @Override
             public Void apply(RangeData arg) {
-              assertThat(actual).isInstanceOf(RangeData.class);
-              assertRangeDataEquals((RangeData) actual, arg, tolerance);
+              assertThat(actual).isInstanceOf(RangeDataDouble.class);
+              assertRangeDataEquals((RangeDataDouble) actual, (RangeDataDouble) arg, tolerance);
               return null;
             }
           },
@@ -168,7 +171,7 @@ final class StatsTestUtil {
 
   // Compare the expected and actual RangeData within the given tolerance.
   private static void assertRangeDataEquals(
-      RangeData actual, RangeData expected, double tolerance) {
+      RangeDataDouble actual, RangeDataDouble expected, double tolerance) {
     if (expected.getMax() == Double.NEGATIVE_INFINITY
         && expected.getMin() == Double.POSITIVE_INFINITY) {
       assertThat(actual.getMax()).isNegativeInfinity();


### PR DESCRIPTION
From the conversation with @dinooliva, we have summarized the correspondence between different types of `Measure` and `Aggregation`:

                       Sum           Count      Histogram         Range               Mean       StandardDeviation
    MeasureDouble    double          long       List<Long>     (double, double)     double            double
    MeasureLong       long           long       List<Long>      (long, long)        double            double

Only `Sum` and `Range` need to have different output types for different `Measure`s. In order to support `MeasureLong` in v0.1, I think the minimal API changes to make is to add subclasses of `Sum` and `Range` that hold double and long values respectively. I don't think it's necessary for other `Aggregation`s (Count, Mean, etc.) to have such hierarchy on API level, since their output types on double or long are the same.

Update: we decide to have `SumDataDouble`, `SumDataLong`, `RangeDataDouble` and `RangeDataLong` at top level, inline with other `Aggregation` types.