### PR TITLE
Add methods for interacting with the current TagContext.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
@@ -13,6 +13,7 @@
 
 package io.opencensus.tags;
 
+import io.opencensus.common.Scope;
 import io.opencensus.tags.TagKey.TagKeyBoolean;
 import io.opencensus.tags.TagKey.TagKeyLong;
 import io.opencensus.tags.TagKey.TagKeyString;
@@ -65,6 +66,18 @@ public abstract class TagContextBuilder {
    * @return a {@code TagContext} with the same tags as this builder.
    */
   public abstract TagContext build();
+
+  /**
+   * Enters the scope of code where the {@link TagContext} created from this builder is in the
+   * current context and returns an object that represents that scope. The scope is exited when the
+   * returned object is closed.
+   *
+   * @return an object that defines a scope where the {@code TagContext} created from this builder
+   *     is set to the current context.
+   */
+  public final Scope buildScoped() {
+    return CurrentTagContextUtils.withTagContext(build());
+  }
 
   /**
    * Returns a {@code TagContextBuilder} that ignores all calls to {@link #set}.

--- a/core/src/main/java/io/opencensus/tags/TagContexts.java
+++ b/core/src/main/java/io/opencensus/tags/TagContexts.java
@@ -13,10 +13,11 @@
 
 package io.opencensus.tags;
 
+import io.opencensus.common.Scope;
 import javax.annotation.concurrent.Immutable;
 
 /**
- * Object for creating new {@link TagContext}s.
+ * Object for creating new {@link TagContext}s and {@code TagContext}s based on the current context.
  *
  * <p>This class returns {@link TagContextBuilder builders} that can be used to create the
  * implementation-dependent {@link TagContext}s.
@@ -30,6 +31,17 @@ public abstract class TagContexts {
    * @return an empty {@code TagContext}.
    */
   public abstract TagContext empty();
+
+  /**
+   * Returns the current {@code TagContext}.
+   *
+   * @return the current {@code TagContext}.
+   */
+  // TODO(sebright): Should we let the implementation override this method?
+  public final TagContext getCurrentTagContext() {
+    TagContext tags = CurrentTagContextUtils.getCurrentTagContext();
+    return tags == null ? empty() : tags;
+  }
 
   /**
    * Returns a new empty {@code Builder}.
@@ -46,6 +58,28 @@ public abstract class TagContexts {
    * @return a builder based on this {@code TagContext}.
    */
   public abstract TagContextBuilder toBuilder(TagContext tags);
+
+  /**
+   * Returns a new builder created from the current {@code TagContext}.
+   *
+   * @return a new builder created from the current {@code TagContext}.
+   */
+  public final TagContextBuilder currentBuilder() {
+    return toBuilder(getCurrentTagContext());
+  }
+
+  /**
+   * Enters the scope of code where the given {@code TagContext} is in the current context and
+   * returns an object that represents that scope. The scope is exited when the returned object is
+   * closed.
+   *
+   * @param tags the {@code TagContext} to be set to the current context.
+   * @return an object that defines a scope where the given {@code TagContext} is set to the current
+   *     context.
+   */
+  public final Scope withTagContext(TagContext tags) {
+    return CurrentTagContextUtils.withTagContext(tags);
+  }
 
   /**
    * Returns a {@code TagContexts} that only produces {@link TagContext}s with no tags.

--- a/core/src/test/java/io/opencensus/tags/ScopedTagContextsTest.java
+++ b/core/src/test/java/io/opencensus/tags/ScopedTagContextsTest.java
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import io.opencensus.common.Scope;
+import io.opencensus.tags.Tag.TagString;
+import io.opencensus.tags.TagKey.TagKeyBoolean;
+import io.opencensus.tags.TagKey.TagKeyLong;
+import io.opencensus.tags.TagKey.TagKeyString;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for the methods in {@link TagContexts} and {@link TagContextBuilder} that interact
+ * with the current {@link TagContext}.
+ */
+@RunWith(JUnit4.class)
+public class ScopedTagContextsTest {
+  private static final TagKeyString KEY_1 = TagKeyString.create("key 1");
+  private static final TagKeyString KEY_2 = TagKeyString.create("key 2");
+
+  private static final TagValueString VALUE_1 = TagValueString.create("value 1");
+  private static final TagValueString VALUE_2 = TagValueString.create("value 2");
+
+  private final TagContext emptyTagContext = new SimpleTagContext();
+
+  private final TagContexts tagContexts =
+      new TagContexts() {
+        @Override
+        public TagContextBuilder toBuilder(TagContext tags) {
+          return new SimpleTagContextBuilder(((SimpleTagContext) tags).tags);
+        }
+
+        @Override
+        public TagContext empty() {
+          return emptyTagContext;
+        }
+      };
+
+  @Test
+  public void defaultTagContext() {
+    assertThat(tagContexts.getCurrentTagContext()).isSameAs(emptyTagContext);
+  }
+
+  @Test
+  public void withTagContext() {
+    assertThat(tagContexts.getCurrentTagContext()).isSameAs(emptyTagContext);
+    TagContext scopedTags = new SimpleTagContext(TagString.create(KEY_1, VALUE_1));
+    Scope scope = tagContexts.withTagContext(scopedTags);
+    try {
+      assertThat(tagContexts.getCurrentTagContext()).isSameAs(scopedTags);
+    } finally {
+      scope.close();
+    }
+    assertThat(tagContexts.getCurrentTagContext()).isSameAs(emptyTagContext);
+  }
+
+  @Test
+  public void createBuilderFromCurrentTags() {
+    TagContext scopedTags = new SimpleTagContext(TagString.create(KEY_1, VALUE_1));
+    Scope scope = tagContexts.withTagContext(scopedTags);
+    try {
+      TagContext newTags = tagContexts.currentBuilder().set(KEY_2, VALUE_2).build();
+      assertThat(asList(newTags))
+          .containsExactly(TagString.create(KEY_1, VALUE_1), TagString.create(KEY_2, VALUE_2));
+      assertThat(tagContexts.getCurrentTagContext()).isSameAs(scopedTags);
+    } finally {
+      scope.close();
+    }
+  }
+
+  @Test
+  public void setCurrentTagsWithBuilder() {
+    assertThat(tagContexts.getCurrentTagContext()).isSameAs(emptyTagContext);
+    Scope scope = tagContexts.emptyBuilder().set(KEY_1, VALUE_1).buildScoped();
+    try {
+      assertThat(asList(tagContexts.getCurrentTagContext()))
+          .containsExactly(TagString.create(KEY_1, VALUE_1));
+    } finally {
+      scope.close();
+    }
+    assertThat(tagContexts.getCurrentTagContext()).isSameAs(emptyTagContext);
+  }
+
+  @Test
+  public void addToCurrentTagsWithBuilder() {
+    TagContext scopedTags = new SimpleTagContext(TagString.create(KEY_1, VALUE_1));
+    Scope scope1 = tagContexts.withTagContext(scopedTags);
+    try {
+      Scope scope2 = tagContexts.currentBuilder().set(KEY_2, VALUE_2).buildScoped();
+      try {
+        assertThat(asList(tagContexts.getCurrentTagContext()))
+            .containsExactly(TagString.create(KEY_1, VALUE_1), TagString.create(KEY_2, VALUE_2));
+      } finally {
+        scope2.close();
+      }
+      assertThat(tagContexts.getCurrentTagContext()).isSameAs(scopedTags);
+    } finally {
+      scope1.close();
+    }
+  }
+
+  private static List<Tag> asList(TagContext tags) {
+    return Lists.newArrayList(tags.unsafeGetIterator());
+  }
+
+  private static final class SimpleTagContextBuilder extends TagContextBuilder {
+    private final Map<TagKeyString, TagValueString> tagMap;
+
+    SimpleTagContextBuilder(Set<TagString> tags) {
+      Map<TagKeyString, TagValueString> tagMap = Maps.newHashMap();
+      for (TagString tag : tags) {
+        tagMap.put(tag.getKey(), tag.getValue());
+      }
+      this.tagMap = Maps.newHashMap(tagMap);
+    }
+
+    @Override
+    public TagContextBuilder set(TagKeyString key, TagValueString value) {
+      tagMap.put(key, value);
+      return this;
+    }
+
+    @Override
+    public TagContextBuilder set(TagKeyLong key, long value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TagContextBuilder set(TagKeyBoolean key, boolean value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TagContextBuilder clear(TagKey key) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public TagContext build() {
+      Set<TagString> tags = new HashSet<TagString>();
+      for (Entry<TagKeyString, TagValueString> entry : tagMap.entrySet()) {
+        tags.add(TagString.create(entry.getKey(), entry.getValue()));
+      }
+      return new SimpleTagContext(tags);
+    }
+  }
+
+  private static final class SimpleTagContext extends TagContext {
+    private final Set<TagString> tags;
+
+    public SimpleTagContext(TagString... tags) {
+      this(Arrays.asList(tags));
+    }
+
+    public SimpleTagContext(Collection<TagString> tags) {
+      this.tags = Collections.unmodifiableSet(new HashSet<TagString>(tags));
+    }
+
+    @Override
+    public Iterator<Tag> unsafeGetIterator() {
+      return Iterators.<TagString, Tag>transform(
+          tags.iterator(), com.google.common.base.Functions.<TagString>identity());
+    }
+  }
+}


### PR DESCRIPTION
This PR adds methods for getting the current TagContext and setting the TagContext in a scope.  It also adds convenience methods for creating a builder from the current tags and setting the scoped tags with a builder.

The new methods correspond to methods for working with the current span.  (There are some differences, because the TagContext doesn't need to be started, and it doesn't have a parent-child relationship.)

Tagging                                                                    | Tracing
-------------------------------------------------------------------|------------------------------------------------------
`TagContexts.getCurrentTagContext()`                   | `Tracer.getCurrentSpan()`
`TagContexts.withTagContext(TagContext tags)`    | `Tracer.withSpan(Span span)`
`TagContexts.currentBuilder()`                                | `Tracer.spanBuilder(String spanName)`
`TagContextBuilder.buildScoped()`                          | `SpanBuilder.startScopedSpan()`

Existing methods that don't use the current context:

Tagging                                                      | Tracing
--------------------------------------------------------|------------------------------------------------------
`TagContexts.emptyBuilder()` and `TagContexts.toBuilder(TagContext tags)` | `Tracer.spanBuilderWithExplicitParent(String spanName, @Nullable Span parent)`
`TagContextBuilder.build()`                        | `SpanBuilder.startSpan()`

/cc @adriancole