### PR TITLE
Add TODOs on whether we want to change StdDev.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/Aggregation.java
+++ b/core/src/main/java/io/opencensus/stats/Aggregation.java
@@ -212,6 +212,8 @@ public abstract class Aggregation {
   /** Calculate standard deviation on aggregated {@code MeasureValue}s. */
   @Immutable
   @AutoValue
+  // TODO(songya): StackDriver uses sumOfSquaredDeviation instead of standard deviation, do we want
+  // to change this aggregation to sumOfSquaredDeviation instead?
   public abstract static class StdDev extends Aggregation {
 
     StdDev() {

--- a/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
+++ b/core_impl/src/main/java/io/opencensus/stats/MutableAggregation.java
@@ -335,6 +335,7 @@ abstract class MutableAggregation {
      *
      * @return the aggregated standard deviations.
      */
+    // TODO(songya): decide if we want to return sumOfSquaredDeviations directly.
     double getStdDev() {
       return count == 0 ? 0 : Math.sqrt(sumOfSquaredDeviations / count);
     }


### PR DESCRIPTION
Using `SumOfSquaredDeviation` will be more align with StackDriver APIs: https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TypedValue, but users might also want to get standard deviation directly.