### PR TITLE
Refactor tag validation code.

### DIFF
--- a/api/src/main/java/io/opencensus/internal/StringUtil.java
+++ b/api/src/main/java/io/opencensus/internal/StringUtil.java
@@ -44,17 +44,12 @@ public final class StringUtil {
   }
 
   /**
-   * Determines whether the {@code String} is a valid tag key, tag value, or metric name.
+   * Determines whether the {@code String} contains only printable characters.
    *
-   * @param string the {@code String} to be validated.
-   * @return whether the {@code String} is valid.
-   * @see #sanitize(String)
+   * @param str the {@code String} to be validated.
+   * @return whether the {@code String} contains only printable characters.
    */
-  public static boolean isValid(String string) {
-    return string.length() <= MAX_LENGTH && isPrintableString(string);
-  }
-
-  private static boolean isPrintableString(String str) {
+  public static boolean isPrintableString(String str) {
     for (int i = 0; i < str.length(); i++) {
       if (!isPrintableChar(str.charAt(i))) {
         return false;

--- a/core/src/main/java/io/opencensus/tags/TagKey.java
+++ b/core/src/main/java/io/opencensus/tags/TagKey.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public abstract class TagKey {
   /** The maximum length for a tag key name. The value is {@value #MAX_LENGTH}. */
-  public static final int MAX_LENGTH = StringUtil.MAX_LENGTH;
+  public static final int MAX_LENGTH = 255;
 
   TagKey() {}
 
@@ -113,6 +113,16 @@ public abstract class TagKey {
       Function<? super TagKeyBoolean, T> booleanFunction,
       Function<? super TagKey, T> defaultFunction);
 
+  /**
+   * Determines whether the given {@code String} is a valid tag key.
+   *
+   * @param name the tag key name to be validated.
+   * @return whether the name is valid.
+   */
+  private static boolean isValid(String name) {
+    return name.length() <= MAX_LENGTH && StringUtil.isPrintableString(name);
+  }
+
   /** A {@code TagKey} for values of type {@code String}. */
   @Immutable
   @AutoValue
@@ -133,7 +143,7 @@ public abstract class TagKey {
      * @throws IllegalArgumentException if the name is not valid.
      */
     public static TagKeyString create(String name) {
-      checkArgument(StringUtil.isValid(name));
+      checkArgument(isValid(name));
       return new AutoValue_TagKey_TagKeyString(name);
     }
 
@@ -173,7 +183,7 @@ public abstract class TagKey {
      */
     // TODO(sebright): Make this public once we support types other than String.
     static TagKeyLong create(String name) {
-      checkArgument(StringUtil.isValid(name));
+      checkArgument(isValid(name));
       return new AutoValue_TagKey_TagKeyLong(name);
     }
 
@@ -213,7 +223,7 @@ public abstract class TagKey {
      */
     // TODO(sebright): Make this public once we support types other than String.
     static TagKeyBoolean create(String name) {
-      checkArgument(StringUtil.isValid(name));
+      checkArgument(isValid(name));
       return new AutoValue_TagKey_TagKeyBoolean(name);
     }
 

--- a/core/src/main/java/io/opencensus/tags/TagValueString.java
+++ b/core/src/main/java/io/opencensus/tags/TagValueString.java
@@ -29,7 +29,7 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 public abstract class TagValueString {
   /** The maximum length for a {@code String} tag value. The value is {@value #MAX_LENGTH}. */
-  public static final int MAX_LENGTH = StringUtil.MAX_LENGTH;
+  public static final int MAX_LENGTH = 255;
 
   TagValueString() {}
 
@@ -46,7 +46,7 @@ public abstract class TagValueString {
    * @throws IllegalArgumentException if the {@code String} is not valid.
    */
   public static TagValueString create(String value) {
-    Preconditions.checkArgument(StringUtil.isValid(value));
+    Preconditions.checkArgument(isValid(value));
     return new AutoValue_TagValueString(value);
   }
 
@@ -56,4 +56,14 @@ public abstract class TagValueString {
    * @return the tag value as a {@code String}.
    */
   public abstract String asString();
+
+  /**
+   * Determines whether the given {@code String} is a valid tag value.
+   *
+   * @param name the tag value to be validated.
+   * @return whether the value is valid.
+   */
+  private static boolean isValid(String name) {
+    return name.length() <= MAX_LENGTH && StringUtil.isPrintableString(name);
+  }
 }


### PR DESCRIPTION
This commit splits tag validation into separate methods for handling tag keys
and values, since keys and values may need different restrictions on their input
Strings.  There should be no change in behavior.

/cc @dinooliva 