### PR TITLE
Add initial implementation of the tracez page.

### DIFF
--- a/contrib/zpages/README.md
+++ b/contrib/zpages/README.md
@@ -1,0 +1,12 @@
+# OpenCensus Z-Pages
+[![Build Status][travis-image]][travis-url] [![Build status][appveyor-image]][appveyor-url] [![Maven Central][maven-image]][maven-url]
+
+The *OpenCensus ZPages for Java* is a collection of HTML pages to display stats and trace data and
+allows library configuration control.
+
+[travis-image]: https://travis-ci.org/census-instrumentation/opencensus-java.svg?branch=master
+[travis-url]: https://travis-ci.org/census-instrumentation/opencensus-java
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/hxthmpkxar4jq4be/branch/master?svg=true
+[appveyor-url]: https://ci.appveyor.com/project/instrumentationjavateam/opencensus-java/branch/master
+[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-zpages/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-zpages

--- a/contrib/zpages/README.md
+++ b/contrib/zpages/README.md
@@ -1,7 +1,7 @@
 # OpenCensus Z-Pages
 [![Build Status][travis-image]][travis-url] [![Build status][appveyor-image]][appveyor-url] [![Maven Central][maven-image]][maven-url]
 
-The *OpenCensus ZPages for Java* is a collection of HTML pages to display stats and trace data and
+The *OpenCensus Z-Pages for Java* is a collection of HTML pages to display stats and trace data and
 allows library configuration control.
 
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-java.svg?branch=master

--- a/contrib/zpages/build.gradle
+++ b/contrib/zpages/build.gradle
@@ -1,0 +1,14 @@
+description = 'OpenCensus Z-Pages'
+
+apply plugin: 'java'
+
+[compileJava, compileTestJava].each() {
+    it.sourceCompatibility = 1.8
+    it.targetCompatibility = 1.8
+}
+
+dependencies {
+    compile project(':opencensus-api')
+
+    signature "org.codehaus.mojo.signature:java18:+@signature"
+}

--- a/contrib/zpages/src/main/java/io/opencensus/zpages/TracezHttpHandler.java
+++ b/contrib/zpages/src/main/java/io/opencensus/zpages/TracezHttpHandler.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.zpages;
+
+import com.google.common.collect.ImmutableMap;
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import com.sun.net.httpserver.HttpServer;
+import io.opencensus.common.Scope;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.export.ExportComponent;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * An {@code HttpHandler} that displays information about active and sampled spans recorded using
+ * the OpenCensus library.
+ *
+ * <p>Example usage with automatic context propagation:
+ *
+ * <pre>{@code
+ * public class Main {
+ *   public static void main(String[] args) throws Exception {
+ *     HttpServer server = HttpServer.create(new InetSocketAddress(8000), 10);
+ *     TracezHttpHandler.register(server);
+ *     server.start();
+ *   }
+ * }
+ * }</pre>
+ */
+public final class TracezHttpHandler implements HttpHandler {
+  private static final Tracer tracer = Tracing.getTracer();
+  private static final String TRACEZ_URL = "/tracez";
+  private static final String HTTP_SERVER_SPAN_NAME = "HttpServer/tracez";
+  private final TracezPageFormatter pageFormatter;
+
+  /** Constructs a new {@code TracezHttpHandler}. */
+  private TracezHttpHandler() {
+    ExportComponent exportComponent = Tracing.getExportComponent();
+    this.pageFormatter =
+        TracezPageFormatter.create(
+            exportComponent.getRunningSpanStore(), exportComponent.getSampledSpanStore());
+    Tracing.getExportComponent()
+        .getSampledSpanStore()
+        .registerSpanNamesForCollection(Arrays.asList(HTTP_SERVER_SPAN_NAME));
+  }
+
+  /**
+   * Registers the tracez {@code HttpHandler} to the given {@code HttpServer}.
+   *
+   * @param server the server that exports the tracez page.
+   */
+  public static void register(HttpServer server) {
+    server.createContext(TRACEZ_URL, new TracezHttpHandler());
+  }
+
+  @Override
+  public final void handle(HttpExchange httpExchange) throws IOException {
+    try (Scope ss =
+        tracer
+            .spanBuilderWithExplicitParent(HTTP_SERVER_SPAN_NAME, null)
+            .setRecordEvents(true)
+            .startScopedSpan()) {
+      tracer
+          .getCurrentSpan()
+          .addAttributes(
+              ImmutableMap.<String, AttributeValue>builder()
+                  .put(
+                      "RequestMethod",
+                      AttributeValue.stringAttributeValue(httpExchange.getRequestMethod()))
+                  .build());
+      httpExchange.sendResponseHeaders(200, 0);
+      pageFormatter.emitHtml(queryToMap(httpExchange), httpExchange.getResponseBody());
+      httpExchange.close();
+    }
+  }
+
+  private static Map<String, String> queryToMap(HttpExchange httpExchange) {
+    String query = httpExchange.getRequestURI().getQuery();
+    if (query == null) {
+      return Collections.emptyMap();
+    }
+    Map<String, String> result = new HashMap<String, String>();
+    for (String param : query.split("&")) {
+      String[] pair = param.split("=");
+      if (pair.length > 1) {
+        result.put(pair[0], pair[1]);
+      } else {
+        result.put(pair[0], "");
+      }
+    }
+    tracer.getCurrentSpan().addAnnotation("Finish to parse query components.");
+    return result;
+  }
+}

--- a/contrib/zpages/src/main/java/io/opencensus/zpages/TracezHttpHandler.java
+++ b/contrib/zpages/src/main/java/io/opencensus/zpages/TracezHttpHandler.java
@@ -90,7 +90,7 @@ public final class TracezHttpHandler implements HttpHandler {
       httpExchange.sendResponseHeaders(200, 0);
       pageFormatter.emitHtml(
           uriQueryToMap(httpExchange.getRequestURI()), httpExchange.getResponseBody());
-    } finally{
+    } finally {
       httpExchange.close();
     }
   }

--- a/contrib/zpages/src/main/java/io/opencensus/zpages/TracezPageFormatter.java
+++ b/contrib/zpages/src/main/java/io/opencensus/zpages/TracezPageFormatter.java
@@ -43,6 +43,8 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.io.Serializable;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -138,7 +140,8 @@ public final class TracezPageFormatter {
     out.close();
   }
 
-  private void emitHtmlBody(Map<String, String> queryMap, PrintWriter out) {
+  private void emitHtmlBody(Map<String, String> queryMap, PrintWriter out)
+      throws UnsupportedEncodingException {
     if (runningSpanStore == null || sampledSpanStore == null) {
       out.write("OpenCensus implementation not available.");
       return;
@@ -342,7 +345,8 @@ public final class TracezPageFormatter {
   }
 
   // Emits the summary table with links to all samples.
-  private void emitSummaryTable(PrintWriter out, Formatter formatter) {
+  private void emitSummaryTable(PrintWriter out, Formatter formatter)
+      throws UnsupportedEncodingException {
     RunningSpanStore.Summary runningSpanStoreSummary = runningSpanStore.getSummary();
     SampledSpanStore.Summary sampledSpanStoreSummary = sampledSpanStore.getSummary();
 
@@ -460,12 +464,12 @@ public final class TracezPageFormatter {
       String spanName,
       int numSamples,
       int type,
-      int subtype) {
+      int subtype) throws UnsupportedEncodingException {
     if (numSamples > 0) {
       formatter.format(
           "<td align=\"center\"><a href='?%s=%s&%s=%d&%s=%d'>%d</a></td>%n",
           HEADER_SPAN_NAME,
-          spanName,
+          URLEncoder.encode(spanName, "UTF-8"),
           HEADER_SAMPLES_TYPE,
           type,
           HEADER_SAMPLES_SUB_TYPE,

--- a/contrib/zpages/src/main/java/io/opencensus/zpages/TracezPageFormatter.java
+++ b/contrib/zpages/src/main/java/io/opencensus/zpages/TracezPageFormatter.java
@@ -1,0 +1,615 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.zpages;
+
+import static com.google.common.html.HtmlEscapers.htmlEscaper;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.io.BaseEncoding;
+import io.opencensus.common.Duration;
+import io.opencensus.common.Function;
+import io.opencensus.common.Functions;
+import io.opencensus.common.Timestamp;
+import io.opencensus.trace.Annotation;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.NetworkEvent;
+import io.opencensus.trace.NetworkEvent.Type;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.Status;
+import io.opencensus.trace.Status.CanonicalCode;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.export.RunningSpanStore;
+import io.opencensus.trace.export.SampledSpanStore;
+import io.opencensus.trace.export.SampledSpanStore.ErrorFilter;
+import io.opencensus.trace.export.SampledSpanStore.LatencyBucketBoundaries;
+import io.opencensus.trace.export.SampledSpanStore.LatencyFilter;
+import io.opencensus.trace.export.SpanData;
+import io.opencensus.trace.export.SpanData.TimedEvent;
+import io.opencensus.trace.export.SpanData.TimedEvents;
+import java.io.BufferedWriter;
+import java.io.OutputStream;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Calendar;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Formatter;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/**
+ * HTML page formatter for tracing debug. The page displays information about all active spans and
+ * all sampled spans based on latency and errors.
+ *
+ * <p>It prints a summary table which contains one row for each span name and data about number of
+ * active and sampled spans.
+ */
+public final class TracezPageFormatter {
+
+  private static final Tracer tracer = Tracing.getTracer();
+  private static final Logger logger = Logger.getLogger(TracezPageFormatter.class.getName());
+
+  // Color to use for zebra-striping.
+  private static final String ZEBRA_STRIPE_COLOR = "#eee";
+  // The header for span name.
+  private static final String HEADER_SPAN_NAME = "zspanname";
+  // The header for type (running = 0, latency = 1, error = 2) to display.
+  private static final String HEADER_SAMPLES_TYPE = "ztype";
+  private static final int TYPE_RUNNING = 0;
+  private static final int TYPE_LATENCY = 1;
+  private static final int TYPE_ERROR = 2;
+  // The header for sub-type:
+  // * for latency based samples [0, 8] representing the latency buckets, where 0 is the first one;
+  // * for error based samples [0, 15], 0 - means all, otherwise the error code;
+  private static final String HEADER_SAMPLES_SUB_TYPE = "zsubtype";
+
+  // Map from LatencyBucketBoundaries to the human string displayed on the UI for each bucket.
+  private static final Map<LatencyBucketBoundaries, String> LATENCY_BUCKET_BOUNDARIES_STRING_MAP =
+      buildLatencyBucketBoundariesStringMap();
+
+  private final RunningSpanStore runningSpanStore;
+  private final SampledSpanStore sampledSpanStore;
+
+  private TracezPageFormatter(
+      @Nullable RunningSpanStore runningSpanStore, @Nullable SampledSpanStore sampledSpanStore) {
+    this.runningSpanStore = runningSpanStore;
+    this.sampledSpanStore = sampledSpanStore;
+  }
+
+  /**
+   * Constructs a new {@code TracezPageFormatter}.
+   *
+   * @param runningSpanStore the instance of the {@code RunningSpanStore} to be used.
+   * @param sampledSpanStore the instance of the {@code SampledSpanStore} to be used.
+   * @return a new {@code TracezPageFormatter}.
+   */
+  public static TracezPageFormatter create(
+      @Nullable RunningSpanStore runningSpanStore, @Nullable SampledSpanStore sampledSpanStore) {
+    return new TracezPageFormatter(runningSpanStore, sampledSpanStore);
+  }
+
+  /**
+   * Emits the HTML generated page to the {@code outputStream}.
+   *
+   * @param queryMap the query components map.
+   * @param outputStream the output {@code OutputStream}.
+   */
+  public void emitHtml(Map<String, String> queryMap, OutputStream outputStream) {
+    PrintWriter out =
+        new PrintWriter(
+            new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("US-ASCII"))));
+    out.write("<html><head><title>Tracez</title>");
+    out.write("<link rel=\"shortcut icon\" href=\"//www.opencensus.io/favicon.ico\"/>");
+    out.write("</head>\n");
+    if (runningSpanStore == null || sampledSpanStore == null) {
+      out.write("OpenCensus implementation not available.");
+      out.close();
+      return;
+    }
+    Formatter formatter = new Formatter(out, Locale.US);
+    emitSummaryTable(out, formatter);
+    String spanName = queryMap.get(HEADER_SPAN_NAME);
+    if (spanName != null) {
+      tracer
+          .getCurrentSpan()
+          .addAnnotation(
+              "Render spans.",
+              ImmutableMap.<String, AttributeValue>builder()
+                  .put("SpanName", AttributeValue.stringAttributeValue(spanName))
+                  .build());
+      String typeStr = queryMap.get(HEADER_SAMPLES_TYPE);
+      if (typeStr != null) {
+        List<SpanData> spans = null;
+        int type = Integer.parseInt(typeStr);
+        if (type < 0 || type > TYPE_ERROR) {
+          return;
+        }
+        if (type == TYPE_RUNNING) {
+          // Display running.
+          spans =
+              new ArrayList<>(
+                  runningSpanStore.getRunningSpans(RunningSpanStore.Filter.create(spanName, 0)));
+          // Sort active spans incremental.
+          Collections.sort(spans, new SpanDataComparator(true));
+        } else {
+          String subtypeStr = queryMap.get(HEADER_SAMPLES_SUB_TYPE);
+          if (subtypeStr != null) {
+            int subtype = Integer.parseInt(subtypeStr);
+            if (type == TYPE_ERROR) {
+              if (subtype < 0 || subtype >= CanonicalCode.values().length) {
+                return;
+              }
+              // Display errors. subtype 0 means all.
+              CanonicalCode code = subtype == 0 ? null : CanonicalCode.values()[subtype];
+              spans =
+                  new ArrayList<>(
+                      sampledSpanStore.getErrorSampledSpans(ErrorFilter.create(spanName, code, 0)));
+            } else {
+              if (subtype < 0 || subtype >= LatencyBucketBoundaries.values().length) {
+                return;
+              }
+              // Display latency.
+              LatencyBucketBoundaries latencyBucketBoundaries =
+                  LatencyBucketBoundaries.values()[subtype];
+              spans =
+                  new ArrayList<>(
+                      sampledSpanStore.getLatencySampledSpans(
+                          LatencyFilter.create(
+                              spanName,
+                              latencyBucketBoundaries.getLatencyLowerNs(),
+                              latencyBucketBoundaries.getLatencyUpperNs(),
+                              0)));
+              // Sort sampled spans decremental.
+              Collections.sort(spans, new SpanDataComparator(false));
+            }
+          }
+        }
+        emitSpanNameAndCountPages(formatter, spanName, spans == null ? 0 : spans.size(), type);
+
+        if (spans != null) {
+          emitSpans(out, formatter, spans);
+        }
+      }
+    }
+    out.write("</body>\n");
+    out.write("</html>\n");
+    tracer.getCurrentSpan().addAnnotation("Finish rendering.");
+    out.close();
+  }
+
+  private static void emitSpanNameAndCountPages(
+      Formatter formatter, String spanName, int returnedNum, int type) {
+    formatter.format("<p><b>Span Name: %s </b></p>%n", htmlEscaper().escape(spanName));
+    formatter.format(
+        "%s Requests %d</b></p>%n",
+        type == 0 ? "Running" : type == 1 ? "Finished" : "Failed", returnedNum);
+  }
+
+  /** Emits the list of SampledRequets with a header. */
+  private static void emitSpans(PrintWriter out, Formatter formatter, Collection<SpanData> spans) {
+    out.write("<pre>\n");
+    formatter.format("%-23s %18s%n", "When", "Elapsed(s)");
+    out.write("-------------------------------------------\n");
+    for (SpanData span : spans) {
+      tracer
+          .getCurrentSpan()
+          .addAnnotation(
+              "Render span.",
+              ImmutableMap.<String, AttributeValue>builder()
+                  .put(
+                      "SpanId",
+                      AttributeValue.stringAttributeValue(
+                          BaseEncoding.base16()
+                              .lowerCase()
+                              .encode(span.getContext().getSpanId().getBytes())))
+                  .build());
+
+      emitSingleSpan(out, formatter, span);
+    }
+    out.write("</pre>\n");
+  }
+
+  // Emits the internal html for a single {@link SpanData}.
+  private static void emitSingleSpan(PrintWriter out, Formatter formatter, SpanData span) {
+    Calendar calendar = Calendar.getInstance();
+    calendar.setTimeInMillis(TimeUnit.SECONDS.toMillis(span.getStartTimestamp().getSeconds()));
+    long microsField = TimeUnit.NANOSECONDS.toMicros(span.getStartTimestamp().getNanos());
+    double elapsedSeconds =
+        (span.getEndTimestamp() == null
+                ? 0
+                : durationToNanos(
+                    span.getEndTimestamp().subtractTimestamp(span.getStartTimestamp())))
+            * 1.0e-9;
+
+    formatter.format(
+        "<b>%04d/%02d/%02d-%02d:%02d:%02d.%06d %13.6f     TraceId: %s SpanId: %s "
+            + "ParentSpanId: %s</b>%n",
+        calendar.get(Calendar.YEAR),
+        calendar.get(Calendar.MONTH) + 1,
+        calendar.get(Calendar.DAY_OF_MONTH),
+        calendar.get(Calendar.HOUR_OF_DAY),
+        calendar.get(Calendar.MINUTE),
+        calendar.get(Calendar.SECOND),
+        microsField,
+        elapsedSeconds,
+        BaseEncoding.base16().lowerCase().encode(span.getContext().getTraceId().getBytes()),
+        BaseEncoding.base16().lowerCase().encode(span.getContext().getSpanId().getBytes()),
+        BaseEncoding.base16()
+            .lowerCase()
+            .encode(
+                span.getParentSpanId() == null
+                    ? SpanId.INVALID.getBytes()
+                    : span.getParentSpanId().getBytes()));
+
+    int lastEntryDayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
+
+    Timestamp lastTimestampNanos = span.getStartTimestamp();
+    TimedEvents<Annotation> annotations = span.getAnnotations();
+    TimedEvents<NetworkEvent> networkEvents = span.getNetworkEvents();
+    List<TimedEvent<?>> timedEvents = new ArrayList<TimedEvent<?>>(annotations.getEvents());
+    timedEvents.addAll(networkEvents.getEvents());
+    Collections.sort(timedEvents, new TimedEventComparator());
+    for (TimedEvent<?> event : timedEvents) {
+      // Special printing so that durations smaller than one second
+      // are left padded with blanks instead of '0' characters.
+      // E.g.,
+      //        Number                  Printout
+      //        ---------------------------------
+      //        0.000534                  .   534
+      //        1.000534                 1.000534
+      long deltaMicros =
+          TimeUnit.NANOSECONDS.toMicros(
+              durationToNanos(event.getTimestamp().subtractTimestamp(lastTimestampNanos)));
+      String deltaString;
+      if (deltaMicros >= 1000000) {
+        deltaString = String.format("%.6f", (deltaMicros / 1000000.0));
+      } else {
+        deltaString = String.format(".%6d", deltaMicros);
+      }
+
+      calendar.setTimeInMillis(
+          TimeUnit.SECONDS.toMillis(event.getTimestamp().getSeconds())
+              + TimeUnit.NANOSECONDS.toMillis(event.getTimestamp().getNanos()));
+      microsField = TimeUnit.NANOSECONDS.toMicros(event.getTimestamp().getNanos());
+
+      int dayOfYear = calendar.get(Calendar.DAY_OF_YEAR);
+      if (dayOfYear == lastEntryDayOfYear) {
+        formatter.format("%11s", "");
+      } else {
+        formatter.format(
+            "%04d/%02d/%02d-",
+            calendar.get(Calendar.YEAR),
+            calendar.get(Calendar.MONTH) + 1,
+            calendar.get(Calendar.DAY_OF_MONTH));
+        lastEntryDayOfYear = dayOfYear;
+      }
+
+      formatter.format(
+          "%02d:%02d:%02d.%06d %13s ... %s%n",
+          calendar.get(Calendar.HOUR_OF_DAY),
+          calendar.get(Calendar.MINUTE),
+          calendar.get(Calendar.SECOND),
+          microsField,
+          deltaString,
+          htmlEscaper()
+              .escape(
+                  event.getEvent() instanceof Annotation
+                      ? renderAnnotation((Annotation) event.getEvent())
+                      : renderNetworkEvents((NetworkEvent) event.getEvent())));
+
+      lastTimestampNanos = event.getTimestamp();
+    }
+    if (span.getStatus() != null) {
+      formatter.format("%44s %s%n", "", htmlEscaper().escape(renderStatus(span.getStatus())));
+    }
+    formatter.format(
+        "%44s %s%n",
+        "", htmlEscaper().escape(renderAttributes(span.getAttributes().getAttributeMap())));
+  }
+
+  // Emits the summary table with links to all samples.
+  private void emitSummaryTable(PrintWriter out, Formatter formatter) {
+    RunningSpanStore.Summary runningSpanStoreSummary = runningSpanStore.getSummary();
+    SampledSpanStore.Summary sampledSpanStoreSummary = sampledSpanStore.getSummary();
+
+    out.write("<table style='border-spacing: 0'>\n");
+    emitSummaryTableHeader(out, formatter);
+
+    Set<String> spanNames = new TreeSet<>(runningSpanStoreSummary.getPerSpanNameSummary().keySet());
+    spanNames.addAll(sampledSpanStoreSummary.getPerSpanNameSummary().keySet());
+    boolean zebraColor = true;
+    for (String spanName : spanNames) {
+      out.write("<tr>\n");
+      if (!zebraColor) {
+        out.write("<tr>\n");
+      } else {
+        formatter.format("<tr style=\"background: %s\">%n", ZEBRA_STRIPE_COLOR);
+      }
+      zebraColor = !zebraColor;
+      formatter.format("<td>%s</td>%n", htmlEscaper().escape(spanName));
+
+      // Running
+      out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+      RunningSpanStore.PerSpanNameSummary runningSpanStorePerSpanNameSummary =
+          runningSpanStoreSummary.getPerSpanNameSummary().get(spanName);
+
+      // subtype ignored for running requests.
+      emitSingleCell(
+          out,
+          formatter,
+          spanName,
+          runningSpanStorePerSpanNameSummary == null
+              ? 0
+              : runningSpanStorePerSpanNameSummary.getNumRunningSpans(),
+          TYPE_RUNNING,
+          0);
+
+      SampledSpanStore.PerSpanNameSummary sampledSpanStorePerSpanNameSummary =
+          sampledSpanStoreSummary.getPerSpanNameSummary().get(spanName);
+
+      // Latency based samples
+      out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+      Map<LatencyBucketBoundaries, Integer> latencyBucketsSummaries =
+          sampledSpanStorePerSpanNameSummary != null
+              ? sampledSpanStorePerSpanNameSummary.getNumbersOfLatencySampledSpans()
+              : null;
+      int subtype = 0;
+      for (LatencyBucketBoundaries latencyBucketsBoundaries : LatencyBucketBoundaries.values()) {
+        if (latencyBucketsSummaries != null) {
+          int numSamples =
+              latencyBucketsSummaries.containsKey(latencyBucketsBoundaries)
+                  ? latencyBucketsSummaries.get(latencyBucketsBoundaries)
+                  : 0;
+          emitSingleCell(out, formatter, spanName, numSamples, TYPE_LATENCY, subtype++);
+        } else {
+          // numSamples < -1 means "Not Available".
+          emitSingleCell(out, formatter, spanName, -1, TYPE_LATENCY, subtype++);
+        }
+      }
+
+      // Error based samples.
+      out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+      if (sampledSpanStorePerSpanNameSummary != null) {
+        Map<CanonicalCode, Integer> errorBucketsSummaries =
+            sampledSpanStorePerSpanNameSummary.getNumbersOfErrorSampledSpans();
+        int numErrorSamples = 0;
+        for (Map.Entry<CanonicalCode, Integer> it : errorBucketsSummaries.entrySet()) {
+          numErrorSamples += it.getValue();
+        }
+        // subtype 0 means all;
+        emitSingleCell(out, formatter, spanName, numErrorSamples, TYPE_ERROR, 0);
+      } else {
+        // numSamples < -1 means "Not Available".
+        emitSingleCell(out, formatter, spanName, -1, TYPE_ERROR, 0);
+      }
+
+      out.write("</tr>\n");
+    }
+    out.write("</table>");
+  }
+
+  private static void emitSummaryTableHeader(PrintWriter out, Formatter formatter) {
+    out.write(
+        "<tr><td colspan=25 align=\"center\"><font size=\"5\"><b>Tracez "
+            + "Summary</b></font></td></tr>\n");
+    // First line.
+    out.write("<tr>\n");
+    out.write("<td colspan=1 align=\"center\"><b>Span Name</b></td>\n");
+    out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+    out.write("<td colspan=1 align=\"center\"><b>Running</b></td>\n");
+    out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+    out.write("<td colspan=9 align=\"center\"><b>Latency Samples</b></td>\n");
+    out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+    out.write("<td colspan=1 align=\"center\"><b>Error Samples</b></td>\n");
+    out.write("</tr>\n");
+    // Second line.
+    out.write("<tr>\n");
+    out.write("<td colspan=1></td>\n");
+    out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+    out.write("<td colspan=1></td>\n");
+    out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+    for (LatencyBucketBoundaries latencyBucketsBoundaries : LatencyBucketBoundaries.values()) {
+      formatter.format(
+          "<td colspan=1 align=\"center\"><b>[%s]</b></td>%n",
+          LATENCY_BUCKET_BOUNDARIES_STRING_MAP.get(latencyBucketsBoundaries));
+    }
+    out.write("<td>&nbsp;&nbsp;|&nbsp;&nbsp;</td>");
+    out.write("<td colspan=1></td>\n");
+    out.write("</tr>\n");
+  }
+
+  // If numSamples is greater than 0 then emit a link to see span data, if the numSamples is
+  // negative then print "N/A", otherwise print the text "0".
+  private static void emitSingleCell(
+      PrintWriter out,
+      Formatter formatter,
+      String spanName,
+      int numSamples,
+      int type,
+      int subtype) {
+    if (numSamples > 0) {
+      formatter.format(
+          "<td align=\"center\"><a href='?%s=%s&%s=%d&%s=%d'>%d</a></td>%n",
+          HEADER_SPAN_NAME,
+          spanName,
+          HEADER_SAMPLES_TYPE,
+          type,
+          HEADER_SAMPLES_SUB_TYPE,
+          subtype,
+          numSamples);
+    } else if (numSamples < 0) {
+      out.write("<td align=\"center\">N/A</td>\n");
+    } else {
+      out.write("<td align=\"center\">0</td>\n");
+    }
+  }
+
+  private static Map<LatencyBucketBoundaries, String> buildLatencyBucketBoundariesStringMap() {
+    Map<LatencyBucketBoundaries, String> ret = new HashMap<>();
+    for (LatencyBucketBoundaries latencyBucketBoundaries : LatencyBucketBoundaries.values()) {
+      ret.put(latencyBucketBoundaries, latencyBucketBoundariesToString(latencyBucketBoundaries));
+    }
+    return Collections.unmodifiableMap(ret);
+  }
+
+  private static long durationToNanos(Duration duration) {
+    return TimeUnit.SECONDS.toNanos(duration.getSeconds()) + duration.getNanos();
+  }
+
+  private static String latencyBucketBoundariesToString(
+      LatencyBucketBoundaries latencyBucketBoundaries) {
+    switch (latencyBucketBoundaries) {
+      case ZERO_MICROSx10:
+        return ">0us";
+      case MICROSx10_MICROSx100:
+        return ">10us";
+      case MICROSx100_MILLIx1:
+        return ">100us";
+      case MILLIx1_MILLIx10:
+        return ">1ms";
+      case MILLIx10_MILLIx100:
+        return ">10ms";
+      case MILLIx100_SECONDx1:
+        return ">100ms";
+      case SECONDx1_SECONDx10:
+        return ">1s";
+      case SECONDx10_SECONDx100:
+        return ">10s";
+      case SECONDx100_MAX:
+        return ">100s";
+    }
+    throw new IllegalArgumentException("No value string available for: " + latencyBucketBoundaries);
+  }
+
+  private static String renderNetworkEvents(NetworkEvent networkEvent) {
+    StringBuilder stringBuilder = new StringBuilder();
+    if (networkEvent.getType() == Type.RECV) {
+      stringBuilder.append("Received");
+    } else if (networkEvent.getType() == Type.SENT) {
+      stringBuilder.append("Sent");
+    } else {
+      stringBuilder.append("Unknown");
+    }
+    stringBuilder.append(" message_id=");
+    stringBuilder.append(networkEvent.getMessageId());
+    stringBuilder.append(" message_size=");
+    stringBuilder.append(networkEvent.getMessageSize());
+    if (networkEvent.getKernelTimestamp() != null) {
+      stringBuilder.append(" kernel_timestamp=");
+      stringBuilder.append(networkEvent.getKernelTimestamp().toString());
+    }
+    return stringBuilder.toString();
+  }
+
+  private static String renderAnnotation(Annotation annotation) {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append(annotation.getDescription());
+    if (!annotation.getAttributes().isEmpty()) {
+      stringBuilder.append(" ");
+      stringBuilder.append(renderAttributes(annotation.getAttributes()));
+    }
+    return stringBuilder.toString();
+  }
+
+  private static String renderStatus(Status status) {
+    return status.toString();
+  }
+
+  private static String renderAttributes(Map<String, AttributeValue> attributes) {
+    StringBuilder stringBuilder = new StringBuilder();
+    stringBuilder.append("Attributes:{");
+    boolean first = true;
+    for (Map.Entry<String, AttributeValue> entry : attributes.entrySet()) {
+      if (first) {
+        first = false;
+        stringBuilder.append(entry.getKey());
+        stringBuilder.append("=");
+        stringBuilder.append(attributeValueToString(entry.getValue()));
+      } else {
+        stringBuilder.append(", ");
+        stringBuilder.append(entry.getKey());
+        stringBuilder.append("=");
+        stringBuilder.append(attributeValueToString(entry.getValue()));
+      }
+    }
+    stringBuilder.append("}");
+    return stringBuilder.toString();
+  }
+
+  private static String attributeValueToString(AttributeValue attributeValue) {
+    return attributeValue.match(
+        new Function<String, String>() {
+          @Override
+          public String apply(String stringValue) {
+            return stringValue;
+          }
+        },
+        new Function<Boolean, String>() {
+          @Override
+          public String apply(Boolean booleanValue) {
+            return booleanValue.toString();
+          }
+        },
+        new Function<Long, String>() {
+          @Override
+          public String apply(Long longValue) {
+            return longValue.toString();
+          }
+        },
+        Functions.<String>returnNull());
+  }
+
+  private static final class TimedEventComparator
+      implements Comparator<TimedEvent<?>>, Serializable {
+    private static final long serialVersionUID = 0;
+
+    @Override
+    public int compare(TimedEvent<?> o1, TimedEvent<?> o2) {
+      return o1.getTimestamp().compareTo(o2.getTimestamp());
+    }
+  }
+
+  private static final class SpanDataComparator implements Comparator<SpanData>, Serializable {
+    private static final long serialVersionUID = 0;
+    private final boolean incremental;
+
+    /**
+     * Returns a new {@code SpanDataComparator}.
+     *
+     * @param incremental {@code true} if sorted incremental.
+     */
+    private SpanDataComparator(boolean incremental) {
+      this.incremental = incremental;
+    }
+
+    @Override
+    public int compare(SpanData o1, SpanData o2) {
+      return incremental
+          ? o1.getStartTimestamp().compareTo(o2.getStartTimestamp())
+          : o2.getStartTimestamp().compareTo(o1.getStartTimestamp());
+    }
+  }
+}

--- a/contrib/zpages/src/main/java/io/opencensus/zpages/TracezPageFormatter.java
+++ b/contrib/zpages/src/main/java/io/opencensus/zpages/TracezPageFormatter.java
@@ -121,12 +121,26 @@ public final class TracezPageFormatter {
     PrintWriter out =
         new PrintWriter(
             new BufferedWriter(new OutputStreamWriter(outputStream, Charset.forName("US-ASCII"))));
-    out.write("<html><head><title>Tracez</title>");
-    out.write("<link rel=\"shortcut icon\" href=\"//www.opencensus.io/favicon.ico\"/>");
+    out.write("<!DOCTYPE html>\n");
+    out.write("<html lang=\"en\"><head>\n");
+    out.write("<meta charset=\"utf-8\">\n");
+    out.write("<title>Tracez</title>\n");
+    out.write("<link rel=\"shortcut icon\" href=\"//www.opencensus.io/favicon.ico\"/>\n");
     out.write("</head>\n");
+    out.write("<body>\n");
+    try {
+      emitHtmlBody(queryMap, out);
+    } catch (Throwable t) {
+      out.write("Errors while generate the HTML page " + t);
+    }
+    out.write("</body>\n");
+    out.write("</html>\n");
+    out.close();
+  }
+
+  private void emitHtmlBody(Map<String, String> queryMap, PrintWriter out) {
     if (runningSpanStore == null || sampledSpanStore == null) {
       out.write("OpenCensus implementation not available.");
-      out.close();
       return;
     }
     Formatter formatter = new Formatter(out, Locale.US);
@@ -194,10 +208,7 @@ public final class TracezPageFormatter {
         }
       }
     }
-    out.write("</body>\n");
-    out.write("</html>\n");
     tracer.getCurrentSpan().addAnnotation("Finish rendering.");
-    out.close();
   }
 
   private static void emitSpanNameAndCountPages(

--- a/contrib/zpages/src/test/java/io/opencensus/zpages/TracezHttpHandlerTest.java
+++ b/contrib/zpages/src/test/java/io/opencensus/zpages/TracezHttpHandlerTest.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.zpages;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TracezHttpHandler}. */
+@RunWith(JUnit4.class)
+public class TracezHttpHandlerTest {
+  @Test
+  public void parseUndefinedQuery() throws URISyntaxException {
+    URI uri = new URI("http://localhost:8000/tracez");
+    assertThat(TracezHttpHandler.uriQueryToMap(uri)).isEmpty();
+  }
+
+  @Test
+  public void parseQuery() throws URISyntaxException {
+    URI uri = new URI("http://localhost:8000/tracez?ztype=1&zsubtype&zname=Test");
+    assertThat(TracezHttpHandler.uriQueryToMap(uri))
+        .containsExactly("ztype", "1", "zsubtype", "", "zname", "Test");
+  }
+}

--- a/contrib/zpages/src/test/java/io/opencensus/zpages/TracezPageFormatterTest.java
+++ b/contrib/zpages/src/test/java/io/opencensus/zpages/TracezPageFormatterTest.java
@@ -1,0 +1,141 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.zpages;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.when;
+
+import io.opencensus.trace.Status.CanonicalCode;
+import io.opencensus.trace.export.RunningSpanStore;
+import io.opencensus.trace.export.SampledSpanStore;
+import io.opencensus.trace.export.SampledSpanStore.LatencyBucketBoundaries;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link TracezPageFormatter}. */
+@RunWith(JUnit4.class)
+public class TracezPageFormatterTest {
+  private static final String ACTIVE_SPAN_NAME = "TestActiveSpan";
+  private static final String SAMPLED_SPAN_NAME = "TestSampledSpan";
+  private static final String ACTIVE_SAMPLED_SPAN_NAME = "TestActiveAndSampledSpan";
+  @Mock private RunningSpanStore runningSpanStore;
+  @Mock private SampledSpanStore sampledSpanStore;
+  RunningSpanStore.Summary runningSpanStoreSummary;
+  SampledSpanStore.Summary sampledSpanStoreSummary;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    Map<String, RunningSpanStore.PerSpanNameSummary> runningSummaryMap = new HashMap<>();
+    runningSummaryMap.put(ACTIVE_SPAN_NAME, RunningSpanStore.PerSpanNameSummary.create(3));
+    runningSummaryMap.put(ACTIVE_SAMPLED_SPAN_NAME, RunningSpanStore.PerSpanNameSummary.create(5));
+    runningSpanStoreSummary = RunningSpanStore.Summary.create(runningSummaryMap);
+    Map<LatencyBucketBoundaries, Integer> numbersOfLatencySampledSpans = new HashMap<>();
+    numbersOfLatencySampledSpans.put(LatencyBucketBoundaries.MILLIx1_MILLIx10, 3);
+    numbersOfLatencySampledSpans.put(LatencyBucketBoundaries.MICROSx10_MICROSx100, 7);
+    Map<CanonicalCode, Integer> numbersOfErrorSampledSpans = new HashMap<>();
+    numbersOfErrorSampledSpans.put(CanonicalCode.CANCELLED, 2);
+    numbersOfErrorSampledSpans.put(CanonicalCode.DEADLINE_EXCEEDED, 5);
+    Map<String, SampledSpanStore.PerSpanNameSummary> sampledSummaryMap = new HashMap<>();
+    sampledSummaryMap.put(
+        SAMPLED_SPAN_NAME,
+        SampledSpanStore.PerSpanNameSummary.create(
+            numbersOfLatencySampledSpans, numbersOfErrorSampledSpans));
+    sampledSummaryMap.put(
+        ACTIVE_SAMPLED_SPAN_NAME,
+        SampledSpanStore.PerSpanNameSummary.create(
+            numbersOfLatencySampledSpans, numbersOfErrorSampledSpans));
+    sampledSpanStoreSummary = SampledSpanStore.Summary.create(sampledSummaryMap);
+  }
+
+  @Test
+  public void emitSummaryTableForEachSpan() {
+    OutputStream output = new ByteArrayOutputStream();
+    TracezPageFormatter tracezPageFormatter =
+        TracezPageFormatter.create(runningSpanStore, sampledSpanStore);
+    when(runningSpanStore.getSummary()).thenReturn(runningSpanStoreSummary);
+    when(sampledSpanStore.getSummary()).thenReturn(sampledSpanStoreSummary);
+    tracezPageFormatter.emitHtml(Collections.emptyMap(), output);
+    assertThat(output.toString()).contains(ACTIVE_SPAN_NAME);
+    assertThat(output.toString()).contains(SAMPLED_SPAN_NAME);
+    assertThat(output.toString()).contains(ACTIVE_SAMPLED_SPAN_NAME);
+  }
+
+  @Test
+  public void linksForActiveRequests_InSummaryTable() {
+    OutputStream output = new ByteArrayOutputStream();
+    TracezPageFormatter tracezPageFormatter =
+        TracezPageFormatter.create(runningSpanStore, sampledSpanStore);
+    when(runningSpanStore.getSummary()).thenReturn(runningSpanStoreSummary);
+    when(sampledSpanStore.getSummary()).thenReturn(sampledSpanStoreSummary);
+    tracezPageFormatter.emitHtml(Collections.emptyMap(), output);
+    // 3 active requests
+    assertThat(output.toString()).contains("href='?zspanname=TestActiveSpan&ztype=0&zsubtype=0'>3");
+    // No active links
+    assertThat(output.toString())
+        .doesNotContain("href='?zspanname=TestSampledSpan&ztype=0&zsubtype=0'");
+    // 5 active requests
+    assertThat(output.toString())
+        .contains("href='?zspanname=TestActiveAndSampledSpan&ztype=0&zsubtype=0'>5");
+  }
+
+  @Test
+  public void linksForSampledRequests_InSummaryTable() {
+    OutputStream output = new ByteArrayOutputStream();
+    TracezPageFormatter tracezPageFormatter =
+        TracezPageFormatter.create(runningSpanStore, sampledSpanStore);
+    when(runningSpanStore.getSummary()).thenReturn(runningSpanStoreSummary);
+    when(sampledSpanStore.getSummary()).thenReturn(sampledSpanStoreSummary);
+    tracezPageFormatter.emitHtml(Collections.emptyMap(), output);
+    // No sampled links (ztype=1);
+    assertThat(output.toString()).doesNotContain("href=\"?zspanname=TestActiveSpan&ztype=1");
+    // Links for 7 samples [10us, 100us) and 3 samples [1ms, 10ms);
+    assertThat(output.toString())
+        .contains("href='?zspanname=TestSampledSpan&ztype=1&zsubtype=1'>7");
+    assertThat(output.toString())
+        .contains("href='?zspanname=TestSampledSpan&ztype=1&zsubtype=3'>3");
+    // Links for 7 samples [10us, 100us) and 3 samples [1ms, 10ms);
+    assertThat(output.toString())
+        .contains("href='?zspanname=TestActiveAndSampledSpan&ztype=1&zsubtype=1'>7");
+    assertThat(output.toString())
+        .contains("href='?zspanname=TestActiveAndSampledSpan&ztype=1&zsubtype=3'>3");
+  }
+
+  @Test
+  public void linksForFailedRequests_InSummaryTable() {
+    OutputStream output = new ByteArrayOutputStream();
+    TracezPageFormatter tracezPageFormatter =
+        TracezPageFormatter.create(runningSpanStore, sampledSpanStore);
+    when(runningSpanStore.getSummary()).thenReturn(runningSpanStoreSummary);
+    when(sampledSpanStore.getSummary()).thenReturn(sampledSpanStoreSummary);
+    tracezPageFormatter.emitHtml(Collections.emptyMap(), output);
+    // No sampled links (ztype=1);
+    assertThat(output.toString()).doesNotContain("href=\"?zspanname=TestActiveSpan&ztype=2");
+    // Links for 7 errors 2 CANCELLED + 5 DEADLINE_EXCEEDED;
+    assertThat(output.toString())
+        .contains("href='?zspanname=TestSampledSpan&ztype=2&zsubtype=0'>7");
+    // Links for 7 errors 2 CANCELLED + 5 DEADLINE_EXCEEDED;
+    assertThat(output.toString())
+        .contains("href='?zspanname=TestActiveAndSampledSpan&ztype=2&zsubtype=0'>7");
+  }
+}

--- a/contrib/zpages/src/test/java/io/opencensus/zpages/TracezPageFormatterTest.java
+++ b/contrib/zpages/src/test/java/io/opencensus/zpages/TracezPageFormatterTest.java
@@ -138,4 +138,7 @@ public class TracezPageFormatterTest {
     assertThat(output.toString())
         .contains("href='?zspanname=TestActiveAndSampledSpan&ztype=2&zsubtype=0'>7");
   }
+
+  // TODO(bdrutu): Add tests for latency.
+  // TODO(bdrutu): Add tests for samples/running/errors.
 }

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -49,7 +49,7 @@ task multiSpansContextTracing(type: CreateStartScripts) {
 }
 
 task zPagesTester(type: CreateStartScripts) {
-    mainClassName = 'io.opencensus.examples.zpages.Tester'
+    mainClassName = 'io.opencensus.examples.zpages.ZPagesTester'
     applicationName = 'ZPagesTester'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -8,7 +8,8 @@ tasks.withType(JavaCompile) {
 dependencies {
     compile project(':core'),
             project(':opencensus-api'),
-            project(':opencensus-trace-logging-exporter')
+            project(':opencensus-trace-logging-exporter'),
+            project(':opencensus-zpages')
 
     runtime project(':core_impl_java'),
             project(':opencensus-impl')
@@ -47,10 +48,18 @@ task multiSpansContextTracing(type: CreateStartScripts) {
     classpath = jar.outputs.files + project.configurations.runtime
 }
 
+task zPagesTester(type: CreateStartScripts) {
+    mainClassName = 'io.opencensus.examples.zpages.Tester'
+    applicationName = 'ZPagesTester'
+    outputDir = new File(project.buildDir, 'tmp')
+    classpath = jar.outputs.files + project.configurations.runtime
+}
+
 applicationDistribution.into('bin') {
     from(multiSpansTracing)
     from(multiSpansScopedTracing)
     from(multiSpansContextTracing)
     from(statsRunner)
+    from(zPagesTester)
     fileMode = 0755
 }

--- a/examples/src/main/java/io/opencensus/examples/zpages/Tester.java
+++ b/examples/src/main/java/io/opencensus/examples/zpages/Tester.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2017, Google Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.examples.zpages;
+
+import com.sun.net.httpserver.HttpServer;
+import io.opencensus.zpages.TracezHttpHandler;
+import java.net.InetSocketAddress;
+import java.util.logging.Logger;
+
+/**
+ * Testing only class for the UI.
+ */
+public class Tester {
+  private static final Logger logger = Logger.getLogger(Tester.class.getName());
+
+  /** Main method. */
+  public static void main(String[] args) throws Exception {
+    HttpServer server = HttpServer.create(new InetSocketAddress(8000), 10);
+    TracezHttpHandler.register(server);
+    server.start();
+    logger.info(server.getAddress().toString());
+  }
+
+}

--- a/examples/src/main/java/io/opencensus/examples/zpages/ZPagesTester.java
+++ b/examples/src/main/java/io/opencensus/examples/zpages/ZPagesTester.java
@@ -21,8 +21,8 @@ import java.util.logging.Logger;
 /**
  * Testing only class for the UI.
  */
-public class Tester {
-  private static final Logger logger = Logger.getLogger(Tester.class.getName());
+public class ZPagesTester {
+  private static final Logger logger = Logger.getLogger(ZPagesTester.class.getName());
 
   /** Main method. */
   public static void main(String[] args) throws Exception {

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,6 +1,5 @@
 rootProject.name = "opencensus-java"
 
-include ":opencensus-agent"
 include ":opencensus-api"
 include ":opencensus-impl-core"
 include ":opencensus-impl-lite"
@@ -12,20 +11,20 @@ include ":core"
 include ":core_impl"
 include ":core_impl_java"
 include ":core_impl_android"
+include ":opencensus-agent"
+include ":opencensus-zpages"
 
-project(':opencensus-agent').projectDir = "$rootDir/contrib/agent" as File
 project(':opencensus-api').projectDir = "$rootDir/api" as File
 project(':opencensus-impl-core').projectDir = "$rootDir/impl_core" as File
 project(':opencensus-impl-lite').projectDir = "$rootDir/impl_lite" as File
 project(':opencensus-impl').projectDir = "$rootDir/impl" as File
 project(':opencensus-testing').projectDir = "$rootDir/testing" as File
 project(':opencensus-trace-logging-exporter').projectDir = "$rootDir/exporters/trace_logging" as File
+project(':opencensus-agent').projectDir = "$rootDir/contrib/agent" as File
+project(':opencensus-zpages').projectDir = "$rootDir/contrib/zpages" as File
 
 // Java8 projects only
 if (JavaVersion.current().isJava8Compatible()) {
     include ":examples"
     include ":benchmarks"
-
-    project(':examples').projectDir = "$rootDir/examples" as File
-    project(':benchmarks').projectDir = "$rootDir/benchmarks" as File
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,6 @@ include ":core_impl"
 include ":core_impl_java"
 include ":core_impl_android"
 include ":opencensus-agent"
-include ":opencensus-zpages"
 
 project(':opencensus-api').projectDir = "$rootDir/api" as File
 project(':opencensus-impl-core').projectDir = "$rootDir/impl_core" as File
@@ -21,10 +20,12 @@ project(':opencensus-impl').projectDir = "$rootDir/impl" as File
 project(':opencensus-testing').projectDir = "$rootDir/testing" as File
 project(':opencensus-trace-logging-exporter').projectDir = "$rootDir/exporters/trace_logging" as File
 project(':opencensus-agent').projectDir = "$rootDir/contrib/agent" as File
-project(':opencensus-zpages').projectDir = "$rootDir/contrib/zpages" as File
 
 // Java8 projects only
 if (JavaVersion.current().isJava8Compatible()) {
     include ":examples"
     include ":benchmarks"
+    include ":opencensus-zpages"
+
+    project(':opencensus-zpages').projectDir = "$rootDir/contrib/zpages" as File
 }


### PR DESCRIPTION
Debugging page that displays data about all the active Spans and samples based on latency and errors. Used to debug real-time problems.

![tracez](https://user-images.githubusercontent.com/1373887/29381240-5cf633cc-827d-11e7-9ab9-8363cc18ecb0.png)

