### PR TITLE
Disallow empty tag keys.

### DIFF
--- a/api/src/main/java/io/opencensus/tags/TagKey.java
+++ b/api/src/main/java/io/opencensus/tags/TagKey.java
@@ -73,6 +73,6 @@ public abstract class TagKey {
    * @return whether the name is valid.
    */
   private static boolean isValid(String name) {
-    return name.length() <= MAX_LENGTH && StringUtil.isPrintableString(name);
+    return !name.isEmpty() && name.length() <= MAX_LENGTH && StringUtil.isPrintableString(name);
   }
 }

--- a/api/src/test/java/io/opencensus/tags/TagKeyTest.java
+++ b/api/src/test/java/io/opencensus/tags/TagKeyTest.java
@@ -59,6 +59,12 @@ public final class TagKeyTest {
   }
 
   @Test
+  public void createString_DisallowEmpty() {
+    thrown.expect(IllegalArgumentException.class);
+    TagKey.create("");
+  }
+
+  @Test
   public void testTagKeyEquals() {
     new EqualsTester()
         .addEqualityGroup(TagKey.create("foo"), TagKey.create("foo"))

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
@@ -33,7 +33,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TagContextRoundtripTest {
 
-  private static final TagKey K_EMPTY = TagKey.create("");
   private static final TagKey K1 = TagKey.create("k1");
   private static final TagKey K2 = TagKey.create("k2");
   private static final TagKey K3 = TagKey.create("k3");
@@ -54,8 +53,6 @@ public class TagContextRoundtripTest {
     testRoundtripSerialization(tagger.emptyBuilder().put(K1, V1).build());
     testRoundtripSerialization(tagger.emptyBuilder().put(K1, V1).put(K2, V2).put(K3, V3).build());
     testRoundtripSerialization(tagger.emptyBuilder().put(K1, V_EMPTY).build());
-    testRoundtripSerialization(tagger.emptyBuilder().put(K_EMPTY, V1).build());
-    testRoundtripSerialization(tagger.emptyBuilder().put(K_EMPTY, V_EMPTY).build());
   }
 
   private void testRoundtripSerialization(TagContext expected) throws Exception {


### PR DESCRIPTION
Do you think we should add this restriction to tag keys?