### PR TITLE
Add the Gradle Versions plugin.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,10 @@ buildscript {
     }
 }
 
+// Display the version report using: ./gradlew dependencyUpdates
+// Also see https://github.com/ben-manes/gradle-versions-plugin.
+apply plugin: 'com.github.ben-manes.versions'
+
 subprojects {
     apply plugin: "checkstyle"
     apply plugin: 'maven'
@@ -25,7 +29,6 @@ subprojects {
     apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'findbugs'
     apply plugin: "net.ltgt.apt"
-    apply plugin: 'com.github.ben-manes.versions'
     // Plugins that require java8
     if (JavaVersion.current().isJava8Compatible()) {
         // TODO(bdrutu): enable all checks.

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ buildscript {
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.0'
         classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.11'
         classpath "net.ltgt.gradle:gradle-apt-plugin:0.10"
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
     }
 }
 
@@ -24,6 +25,7 @@ subprojects {
     apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'findbugs'
     apply plugin: "net.ltgt.apt"
+    apply plugin: 'com.github.ben-manes.versions'
     // Plugins that require java8
     if (JavaVersion.current().isJava8Compatible()) {
         // TODO(bdrutu): enable all checks.


### PR DESCRIPTION
Website: https://github.com/ben-manes/gradle-versions-plugin

Example run:
```
./gradlew dependencyUpdates

> Configure project :opencensus-agent
Gradle now uses separate output directories for each JVM language, but this build assumes a single directory for all classes from a source set. This behaviour has been deprecated and is scheduled to be removed in Gradle 5.0
        at build_yybdm0czmtrzmvw9xebzxag0.run(/usr/local/google/home/stschmidt/instrumentation-java/all/build.gradle:29)

> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - net.sf.androidscents.signature:android-api-level-14:4.0_r4
 - com.google.code.findbugs:annotations:3.0.1
 - com.google.auto.service:auto-service:1.0-rc3
 - com.lmax:disruptor:3.3.6
 - com.github.ben-manes:gradle-versions-plugin:0.15.0
 - org.codehaus.mojo.signature:java16:1.1
 - org.codehaus.mojo.signature:java17:1.0
 - org.codehaus.mojo.signature:java18:1.0
 - com.github.jengelman.gradle.plugins:shadow:2.0.1

The following dependencies exceed the version found at the milestone revision level:
 - net.ltgt.gradle:gradle-errorprone-plugin [0.0.11 <- 0.0.6]
 - me.champeau.gradle:jmh-gradle-plugin [0.4.4 <- 0.2.0]

The following dependencies have later milestone versions:
 - com.google.auto.value:auto-value [1.4 -> 1.5]
 - net.bytebuddy:byte-buddy [1.7.1 -> 1.7.3]
 - org.kt3k.gradle.plugin:coveralls-gradle-plugin [2.0.1 -> 2.8.1]
 - com.google.errorprone:error_prone_annotations [2.0.19 -> 2.0.21]
 - com.google.errorprone:error_prone_core [2.0.19 -> 2.0.21]
 - ru.vyarus:gradle-animalsniffer-plugin [1.4.0 -> 1.4.1]
 - io.grpc:grpc-context [1.4.0 -> 1.5.0]
 - com.google.guava:guava [19.0 -> 23.0]
 - com.google.guava:guava-testlib [19.0 -> 23.0]
 - com.google.code.findbugs:jsr305 [3.0.1 -> 3.0.2]
 - junit:junit [4.11 -> 4.12]
 - org.mockito:mockito-core [1.9.5 -> 2.8.47]
 - com.google.truth:truth [0.30 -> 0.34]

Failed to determine the latest version for the following dependencies (use --info for details):
 - net.ltgt.gradle:gradle-apt-plugin
 - gradle.plugin.io.morethan.jmhreport:gradle-jmh-report
 - gradle.plugin.me.tatarka:gradle-retrolambda

Generated report file build/dependencyUpdates/report.txt


BUILD SUCCESSFUL in 7s
1 actionable task: 1 executed
```