### PR TITLE
Implement StatsRecorder.record(MeasureMap).

### DIFF
--- a/core/src/main/java/io/opencensus/stats/StatsRecorder.java
+++ b/core/src/main/java/io/opencensus/stats/StatsRecorder.java
@@ -15,25 +15,30 @@ package io.opencensus.stats;
 
 import com.google.common.base.Preconditions;
 import io.opencensus.tags.TagContext;
+import io.opencensus.tags.unsafe.ContextUtils;
 import javax.annotation.concurrent.Immutable;
 
 /** Provides methods to record stats against tags. */
 public abstract class StatsRecorder {
   private static final StatsRecorder NOOP_STATS_RECORDER = new NoopStatsRecorder();
 
-  //  // TODO(sebright): Add a "record" method for implicit propagation:
-  //
-  //  public void record(MeasurementMap measurementValues) {
-  //    record(getCurrentTagContext(), measurementValues);
-  //  }
+  /**
+   * Records a set of measurements with the tags in the current context.
+   *
+   * @param measureValues the measurements to record.
+   */
+  public final void record(MeasureMap measureValues) {
+    // Use the context key directly, to avoid depending on the tags implementation.
+    record(ContextUtils.TAG_CONTEXT_KEY.get(), measureValues);
+  }
 
   /**
    * Records a set of measurements with a set of tags.
    *
    * @param tags the tags associated with the measurements.
-   * @param measurementValues the measurements to record.
+   * @param measureValues the measurements to record.
    */
-  public abstract void record(TagContext tags, MeasureMap measurementValues);
+  public abstract void record(TagContext tags, MeasureMap measureValues);
 
   /**
    * Returns a {@code StatsRecorder} that does not record any data.
@@ -48,9 +53,9 @@ public abstract class StatsRecorder {
   private static final class NoopStatsRecorder extends StatsRecorder {
 
     @Override
-    public void record(TagContext tags, MeasureMap measurementValues) {
+    public void record(TagContext tags, MeasureMap measureValues) {
       Preconditions.checkNotNull(tags);
-      Preconditions.checkNotNull(measurementValues);
+      Preconditions.checkNotNull(measureValues);
     }
   }
 }

--- a/core/src/test/java/io/opencensus/stats/NoopStatsRecorderTest.java
+++ b/core/src/test/java/io/opencensus/stats/NoopStatsRecorderTest.java
@@ -46,12 +46,16 @@ public final class NoopStatsRecorderTest {
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
+  // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
+  // exception.
   @Test
   public void record() {
     StatsRecorder.getNoopStatsRecorder()
         .record(tagContext, MeasureMap.builder().set(MEASURE, 5).build());
   }
 
+  // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
+  // exception.
   @Test
   public void recordWithCurrentContext() {
     StatsRecorder.getNoopStatsRecorder().record(MeasureMap.builder().set(MEASURE, 6).build());

--- a/core/src/test/java/io/opencensus/stats/NoopStatsRecorderTest.java
+++ b/core/src/test/java/io/opencensus/stats/NoopStatsRecorderTest.java
@@ -47,21 +47,32 @@ public final class NoopStatsRecorderTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void defaultRecord() {
+  public void record() {
     StatsRecorder.getNoopStatsRecorder()
         .record(tagContext, MeasureMap.builder().set(MEASURE, 5).build());
   }
 
   @Test
-  public void defaultRecord_DisallowNullTagContext() {
-    MeasureMap measures = MeasureMap.builder().set(MEASURE, 6).build();
+  public void recordWithCurrentContext() {
+    StatsRecorder.getNoopStatsRecorder().record(MeasureMap.builder().set(MEASURE, 6).build());
+  }
+
+  @Test
+  public void record_DisallowNullTagContext() {
+    MeasureMap measures = MeasureMap.builder().set(MEASURE, 7).build();
     thrown.expect(NullPointerException.class);
     StatsRecorder.getNoopStatsRecorder().record(null, measures);
   }
 
   @Test
-  public void defaultRecord_DisallowNullMeasureMap() {
+  public void record_DisallowNullMeasureMap() {
     thrown.expect(NullPointerException.class);
     StatsRecorder.getNoopStatsRecorder().record(tagContext, null);
+  }
+
+  @Test
+  public void recordWithCurrentContext_DisallowNullMeasureMap() {
+    thrown.expect(NullPointerException.class);
+    StatsRecorder.getNoopStatsRecorder().record(null);
   }
 }


### PR DESCRIPTION
~~Two commits:~~

~~#### Give TAG_CONTEXT_KEY a default value (an empty TagContext).~~

#### Implement StatsRecorder.record(MeasureMap).

This `record` overload uses the current TagContext.  I also split StatsRecorderTest into StatsRecorderTest and NoopStatsRecorderTest.