### PR TITLE
Rename integration test classes to *IT.

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -225,6 +225,8 @@
         </module>
         <module name="CommentsIndentation"/>
         <module name="FileContentsHolder"/>
+        <module name="SuppressWarningsHolder"/>
     </module>
     <module name="SuppressionCommentFilter"/>
+    <module name="SuppressWarningsFilter"/>
 </module>

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentationIT.java
@@ -37,7 +37,8 @@ import org.junit.runners.JUnit4;
  * via the {@code -javaagent} command line option.
  */
 @RunWith(JUnit4.class)
-public class ExecutorInstrumentationTest {
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+public class ExecutorInstrumentationIT {
 
   private static final Context.Key<String> KEY = Context.key("mykey");
 

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
@@ -33,7 +33,8 @@ import org.junit.runners.JUnit4;
  * via the {@code -javaagent} command line option.
  */
 @RunWith(JUnit4.class)
-public class ThreadInstrumentationTest {
+@SuppressWarnings("checkstyle:AbbreviationAsWordInName")
+public class ThreadInstrumentationIT {
 
   private static final Context.Key<String> KEY = Context.key("mykey");
 


### PR DESCRIPTION
I'd like to rename integration test classes to `*IT` to avoid potential naming collisions with unit test classes. The `*IT` naming convention is somewhat widely used as it is the default in Maven's Failsafe plugin.

Now, `IT` triggers a checkstyle violation (module AbbreviationAsWordInName) given the current checkstyle rules. It seems to me that adding a `@SuppressWarnings("checkstyle:AbbreviationAsWordInName")` annotation would be a nice, uninstrusive solution. Thus enabling the support for `@SuppressWarnings` in `checkstyle.xml`, too.