### PR TITLE
Add Duration.toMillis() method and tests.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -206,6 +206,9 @@ public abstract class View {
       /**
        * Constructs an interval {@code Window} that has a finite explicit {@code Duration}.
        *
+       * <p>The {@code Duration} should be able to round to milliseconds. Currently interval window
+       * cannot have smaller {@code Duration} such as microseconds or nanoseconds.
+       *
        * @return an interval {@code Window}.
        */
       public static Interval create(Duration duration) {

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -228,12 +228,7 @@ final class MutableViewData {
     return tagValues;
   }
 
-  /**
-   * Returns the milliseconds representation of this {@code Duration}.
-   *
-   * @param duration {@code Duration}.
-   * @return the milliseconds representation of a {@code Duration}.
-   */
+  // Returns the milliseconds representation of a Duration.
   static long toMillis(Duration duration) {
     return duration.getSeconds() * MILLIS_PER_SECOND + duration.getNanos() / NANOS_PER_MILLI;
   }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -20,6 +20,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import io.opencensus.common.Clock;
+import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
@@ -67,6 +68,9 @@ import javax.annotation.Nullable;
  * A mutable version of {@link ViewData}, used for recording stats and start/end time.
  */
 final class MutableViewData {
+
+  private static final long MILLIS_PER_SECOND = 1000L;
+  private static final long NANOS_PER_MILLI = 1000 * 1000;
 
   private static final Function<TagString, TagValue> GET_STRING_TAG_VALUE =
       new Function<TagString, TagValue>() {
@@ -222,6 +226,16 @@ final class MutableViewData {
       }
     }
     return tagValues;
+  }
+
+  /**
+   * Returns the milliseconds representation of this {@code Duration}.
+   *
+   * @param duration {@code Duration}.
+   * @return the milliseconds representation of a {@code Duration}.
+   */
+  static long toMillis(Duration duration) {
+    return duration.getSeconds() * MILLIS_PER_SECOND + duration.getNanos() / NANOS_PER_MILLI;
   }
 
   /**

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MutableViewDataTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MutableViewDataTest.java
@@ -17,8 +17,10 @@
 package io.opencensus.implcore.stats;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.implcore.stats.MutableViewData.toMillis;
 
 import com.google.common.collect.ImmutableMap;
+import io.opencensus.common.Duration;
 import io.opencensus.implcore.stats.MutableAggregation.MutableCount;
 import io.opencensus.implcore.stats.MutableAggregation.MutableHistogram;
 import io.opencensus.implcore.stats.MutableAggregation.MutableMean;
@@ -129,5 +131,15 @@ public class MutableViewDataTest {
         MeanData.create(0),
         StdDevData.create(0))
         .inOrder();
+  }
+
+  @Test
+  public void testDurationToMillis() {
+    assertThat(toMillis(Duration.create(0, 0))).isEqualTo(0);
+    assertThat(toMillis(Duration.create(0, 987000000))).isEqualTo(987);
+    assertThat(toMillis(Duration.create(3, 456000000))).isEqualTo(3456);
+    assertThat(toMillis(Duration.create(0, -1000000))).isEqualTo(-1);
+    assertThat(toMillis(Duration.create(-1, 0))).isEqualTo(-1000);
+    assertThat(toMillis(Duration.create(-3, -456000000))).isEqualTo(-3456);
   }
 }


### PR DESCRIPTION
This method is needed to calculate interval stats based on time buckets, because buckets may be incomplete and we need to calculate the ratio of passed time / bucket duration. E.g, a time bucket starts at timestamp 0 and has a duration of 20 seconds, and now is 14th seconds, the aggregated data of this bucket should be weighted as `toMillis(14 - 0) / toMillis(20)` = 0.7. 

/cc @dinooliva 