### PR TITLE
Add combine() method to MutableAggregation.

### DIFF
--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableAggregation.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableAggregation.java
@@ -39,16 +39,16 @@ abstract class MutableAggregation {
   abstract void add(double value);
 
   /**
-   * Creates a new {@code MutableAggregation} by combining the internal values of this {@code 
-   * MutableAggregation} and the given {@code MutableAggregation}, with the given fraction.
+   * Combine the internal values of this MutableAggregation and value of the given
+   * MutableAggregation, with the given fraction. Then set the internal value of this
+   * MutableAggregation to the combined value.
    * 
    * @param other the other {@code MutableAggregation}. The type of this and other {@code
    *     MutableAggregation} must match.
    * @param fraction the fraction that the value in other {@code MutableAggregation} should
    *     contribute. Must be within [0.0, 1.0].
-   * @return a new {@code MutableAggregation} with the combined value.
    */
-  abstract MutableAggregation combine(MutableAggregation other, double fraction);
+  abstract void combine(MutableAggregation other, double fraction);
 
   /**
    * Applies the given match function to the underlying data type.
@@ -69,10 +69,6 @@ abstract class MutableAggregation {
     private MutableSum() {
     }
 
-    private MutableSum(double sum) {
-      this.sum = sum;
-    }
-
     /**
      * Construct a {@code MutableSum}.
      *
@@ -88,9 +84,9 @@ abstract class MutableAggregation {
     }
 
     @Override
-    MutableAggregation combine(MutableAggregation other, double fraction) {
+    void combine(MutableAggregation other, double fraction) {
       checkArgument(other instanceof MutableSum, "MutableSum expected.");
-      return new MutableSum(this.sum + fraction * ((MutableSum) other).getSum());
+      this.sum += fraction * ((MutableSum) other).getSum();
     }
 
     /**
@@ -122,10 +118,6 @@ abstract class MutableAggregation {
     private MutableCount() {
     }
 
-    private MutableCount(long count) {
-      this.count = count;
-    }
-
     /**
      * Construct a {@code MutableCount}.
      *
@@ -141,9 +133,9 @@ abstract class MutableAggregation {
     }
 
     @Override
-    MutableAggregation combine(MutableAggregation other, double fraction) {
+    void combine(MutableAggregation other, double fraction) {
       checkArgument(other instanceof MutableCount, "MutableCount expected.");
-      return new MutableCount(this.count + (long) (fraction * ((MutableCount) other).getCount()));
+      this.count += (long) (fraction * ((MutableCount) other).getCount());
     }
 
     /**
@@ -178,11 +170,6 @@ abstract class MutableAggregation {
       this.bucketCounts = new long[bucketBoundaries.getBoundaries().size() + 1];
     }
 
-    private MutableHistogram(BucketBoundaries bucketBoundaries, long[] bucketCounts) {
-      this.bucketBoundaries = bucketBoundaries;
-      this.bucketCounts = bucketCounts;
-    }
-
     /**
      * Construct a {@code MutableHistogram}.
      *
@@ -205,16 +192,14 @@ abstract class MutableAggregation {
     }
 
     @Override
-    MutableAggregation combine(MutableAggregation other, double fraction) {
+    void combine(MutableAggregation other, double fraction) {
       checkArgument(other instanceof MutableHistogram, "MutableHistogram expected.");
       checkArgument(((MutableHistogram) other).bucketBoundaries.equals(this.bucketBoundaries),
           "Bucket boundaries should match.");
       long[] bucketCounts = ((MutableHistogram) other).getBucketCounts();
-      long[] combined = new long[bucketCounts.length];
       for (int i = 0; i < bucketCounts.length; i++) {
-        combined[i] = this.bucketCounts[i] + (long) (bucketCounts[i] * fraction);
+        this.bucketCounts[i] += (long) (bucketCounts[i] * fraction);
       }
-      return new MutableHistogram(this.bucketBoundaries, combined);
     }
 
     /**
@@ -291,7 +276,7 @@ abstract class MutableAggregation {
     }
 
     @Override
-    MutableAggregation combine(MutableAggregation other, double fraction) {
+    void combine(MutableAggregation other, double fraction) {
       throw new UnsupportedOperationException("Not supported in v0.1.");
     }
 
@@ -333,7 +318,7 @@ abstract class MutableAggregation {
     }
 
     @Override
-    MutableAggregation combine(MutableAggregation other, double fraction) {
+    void combine(MutableAggregation other, double fraction) {
       throw new UnsupportedOperationException("Not supported in v0.1.");
     }
 
@@ -395,7 +380,7 @@ abstract class MutableAggregation {
     }
 
     @Override
-    MutableAggregation combine(MutableAggregation other, double fraction) {
+    void combine(MutableAggregation other, double fraction) {
       throw new UnsupportedOperationException("Not supported in v0.1.");
     }
 

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MutableAggregationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MutableAggregationTest.java
@@ -18,7 +18,6 @@ package io.opencensus.implcore.stats;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.Lists;
 import io.opencensus.common.Function;
 import io.opencensus.implcore.stats.MutableAggregation.MutableCount;
 import io.opencensus.implcore.stats.MutableAggregation.MutableHistogram;

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MutableAggregationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MutableAggregationTest.java
@@ -212,19 +212,26 @@ public class MutableAggregationTest {
     List<Double> valueList1 = Arrays.asList(-1.0, -5.0);
     List<Double> valueList2 = Arrays.asList(10.0, 50.0);
 
-    for (int i = 0; i < valueList1.size(); i++) {
+    for (double val : valueList1) {
       for (MutableAggregation aggregation : aggregations1) {
-        aggregation.add(valueList1.get(i));
+        aggregation.add(val);
       }
+    }
+    for (double val : valueList2) {
       for (MutableAggregation aggregation : aggregations2) {
-        aggregation.add(valueList2.get(i));
+        aggregation.add(val);
       }
     }
 
-    List<MutableAggregation> combined = Lists.newArrayList();
-    double fraction = 0.6;
-    for (int i = 0; i < aggregations1.size(); i++) {
-      combined.add(aggregations1.get(i).combine(aggregations2.get(i), fraction));
+    List<MutableAggregation> combined = Arrays.asList(
+        MutableSum.create(),
+        MutableCount.create(),
+        MutableHistogram.create(BucketBoundaries.create(Arrays.asList(-10.0, 0.0, 10.0))));
+    double fraction1 = 1.0;
+    double fraction2 = 0.6;
+    for (int i = 0; i < combined.size(); i++) {
+      combined.get(i).combine(aggregations1.get(i), fraction1);
+      combined.get(i).combine(aggregations2.get(i), fraction2);
     }
 
     assertThat(((MutableSum) combined.get(0)).getSum()).isWithin(TOLERANCE).of(30);


### PR DESCRIPTION
Add `MutableAggregation.combine()` so that we can combine `MutableAggregation`s from different `IntervalBucket`s.