### PR TITLE
Rename classes to make room for tracing-related methods.

### DIFF
--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
-import io.opencensus.contrib.agent.bootstrap.ContextManager;
-import io.opencensus.contrib.agent.bootstrap.ContextStrategy;
+import io.opencensus.contrib.agent.bootstrap.TraceStrategy;
+import io.opencensus.contrib.agent.bootstrap.TraceTrampoline;
 import io.opencensus.contrib.agent.instrumentation.Instrumenter;
 import java.lang.instrument.Instrumentation;
 import java.util.ServiceLoader;
@@ -65,14 +65,14 @@ public final class AgentMain {
 
     logger.info("Initializing.");
 
-    // The classes in bootstrap.jar, such as ContextManger and ContextStrategy, will be referenced
+    // The classes in bootstrap.jar, such as TraceTrampoline and TraceStrategy, will be referenced
     // from classes loaded by the bootstrap classloader. Thus, these classes have to be loaded by
     // the bootstrap classloader, too.
     instrumentation.appendToBootstrapClassLoaderSearch(
             new JarFile(Resources.getResourceAsTempFile("bootstrap.jar")));
 
-    checkLoadedByBootstrapClassloader(ContextManager.class);
-    checkLoadedByBootstrapClassloader(ContextStrategy.class);
+    checkLoadedByBootstrapClassloader(TraceTrampoline.class);
+    checkLoadedByBootstrapClassloader(TraceStrategy.class);
 
     AgentBuilder agentBuilder = new AgentBuilder.Default()
             .disableClassFormatChanges()

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/TraceStrategy.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/TraceStrategy.java
@@ -19,7 +19,7 @@ package io.opencensus.contrib.agent.bootstrap;
 /**
  * Strategy interface for accessing and manipulating the context.
  */
-public interface ContextStrategy {
+public interface TraceStrategy {
 
   /**
    * Wraps a {@link Runnable} so that it executes with the context that is associated with the

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/TraceStrategy.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/TraceStrategy.java
@@ -17,7 +17,7 @@
 package io.opencensus.contrib.agent.bootstrap;
 
 /**
- * Strategy interface for accessing and manipulating the context.
+ * Strategy interface for tracing-related methods.
  */
 public interface TraceStrategy {
 

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/TraceTrampoline.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/TraceTrampoline.java
@@ -17,48 +17,48 @@
 package io.opencensus.contrib.agent.bootstrap;
 
 /**
- * {@code ContextManager} provides methods for accessing and manipulating the context from
- * instrumented bytecode.
+ * {@code TraceTrampoline} provides access to tracing-related methods of classes which are otherwise
+ * inaccessible from classes loaded by the bootstrap classloader.
  *
- * <p>{@code ContextManager} avoids tight coupling with the concrete implementation of the context
- * by accessing and manipulating the context through the {@link ContextStrategy} interface.
+ * <p>{@code TraceTrampoline} avoids tight coupling with the concrete implementation of the
+ * tracing-related methods via the {@link TraceStrategy} interface.
  *
- * <p>Both {@link ContextManager} and {@link ContextStrategy} are loaded by the bootstrap
+ * <p>Both {@link TraceTrampoline} and {@link TraceStrategy} are loaded by the bootstrap
  * classloader so that they can be used from classes loaded by the bootstrap classloader.
- * A concrete implementation of {@link ContextStrategy} will be loaded by the system classloader.
- * This allows for using the same context implementation as the instrumented application.
+ * A concrete implementation of {@link TraceStrategy} will be loaded by the system classloader.
+ * This allows for using the same implementation as the instrumented application.
  *
- * <p>{@code ContextManager} is implemented as a static class to allow for easy and fast use from
+ * <p>{@code TraceTrampoline} is implemented as a static class to allow for easy and fast use from
  * instrumented bytecode. We cannot use dependency injection for the instrumented bytecode.
  */
-public final class ContextManager {
+public final class TraceTrampoline {
 
   // Not synchronized to avoid any synchronization costs after initialization.
-  // The agent is responsible for initializing this once (through #setContextStrategy) before any
+  // The agent is responsible for initializing this once (through #setTraceStrategy) before any
   // other method of this class is called.
-  private static ContextStrategy contextStrategy;
+  private static TraceStrategy traceStrategy;
 
-  private ContextManager() {
+  private TraceTrampoline() {
   }
 
   /**
-   * Sets the concrete strategy for accessing and manipulating the context.
+   * Sets the concrete strategy for tracing-related methods.
    *
-   * <p>NB: The agent is responsible for setting the context strategy once before any other method
-   * of this class is called.
+   * <p>NB: The agent is responsible for setting the {@link TraceStrategy} once before any other
+   * method of this class is called.
    *
-   * @param contextStrategy the concrete strategy for accessing and manipulating the context
+   * @param traceStrategy the concrete strategy for for tracing-related methods
    */
-  public static void setContextStrategy(ContextStrategy contextStrategy) {
-    if (ContextManager.contextStrategy != null) {
-      throw new IllegalStateException("contextStrategy was already set");
+  public static void setTraceStrategy(TraceStrategy traceStrategy) {
+    if (TraceTrampoline.traceStrategy != null) {
+      throw new IllegalStateException("traceStrategy was already set");
     }
 
-    if (contextStrategy == null) {
-      throw new NullPointerException("contextStrategy");
+    if (traceStrategy == null) {
+      throw new NullPointerException("traceStrategy");
     }
 
-    ContextManager.contextStrategy = contextStrategy;
+    TraceTrampoline.traceStrategy = traceStrategy;
   }
 
   /**
@@ -68,10 +68,10 @@ public final class ContextManager {
    * @param runnable a {@link Runnable} object
    * @return the wrapped {@link Runnable} object
    *
-   * @see ContextStrategy#wrapInCurrentContext
+   * @see TraceStrategy#wrapInCurrentContext
    */
   public static Runnable wrapInCurrentContext(Runnable runnable) {
-    return contextStrategy.wrapInCurrentContext(runnable);
+    return traceStrategy.wrapInCurrentContext(runnable);
   }
 
   /**
@@ -83,7 +83,7 @@ public final class ContextManager {
    * @param thread a {@link Thread} object
    */
   public static void saveContextForThread(Thread thread) {
-    contextStrategy.saveContextForThread(thread);
+    traceStrategy.saveContextForThread(thread);
   }
 
   /**
@@ -92,6 +92,6 @@ public final class ContextManager {
    * @param thread a {@link Thread} object
    */
   public static void attachContextForThread(Thread thread) {
-    contextStrategy.attachContextForThread(thread);
+    traceStrategy.attachContextForThread(thread);
   }
 }

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentation.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentation.java
@@ -26,7 +26,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.opencensus.contrib.agent.bootstrap.ContextManager;
+import io.opencensus.contrib.agent.bootstrap.TraceTrampoline;
 import java.util.concurrent.Executor;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
@@ -49,8 +49,8 @@ public final class ExecutorInstrumentation implements Instrumenter {
 
     // TODO(stschmidt): Gracefully handle the case of missing io.grpc.Context at runtime.
 
-    // Initialize the ContextManager with the concrete ContextStrategy.
-    ContextManager.setContextStrategy(new ContextStrategyImpl());
+    // Initialize the TraceTrampoline with the concrete TraceStrategy.
+    TraceTrampoline.setTraceStrategy(new TraceStrategyImpl());
 
     return agentBuilder
             .type(createMatcher())
@@ -95,7 +95,7 @@ public final class ExecutorInstrumentation implements Instrumenter {
     @SuppressWarnings(value = "UnusedAssignment")
     @SuppressFBWarnings(value = {"DLS_DEAD_LOCAL_STORE", "UPM_UNCALLED_PRIVATE_METHOD",})
     private static void enter(@Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
-      runnable = ContextManager.wrapInCurrentContext(runnable);
+      runnable = TraceTrampoline.wrapInCurrentContext(runnable);
     }
   }
 }

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentation.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentation.java
@@ -22,7 +22,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.opencensus.contrib.agent.bootstrap.ContextManager;
+import io.opencensus.contrib.agent.bootstrap.TraceTrampoline;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -76,7 +76,7 @@ public final class ThreadInstrumentation implements Instrumenter {
     @Advice.OnMethodEnter
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private static void enter(@Advice.This Thread thread) {
-      ContextManager.saveContextForThread(thread);
+      TraceTrampoline.saveContextForThread(thread);
     }
   }
 
@@ -93,7 +93,7 @@ public final class ThreadInstrumentation implements Instrumenter {
     @Advice.OnMethodEnter
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private static void enter(@Advice.This Thread thread) {
-      ContextManager.attachContextForThread(thread);
+      TraceTrampoline.attachContextForThread(thread);
     }
   }
 }

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/TraceStrategyImpl.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/TraceStrategyImpl.java
@@ -19,14 +19,14 @@ package io.opencensus.contrib.agent.instrumentation;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import io.grpc.Context;
-import io.opencensus.contrib.agent.bootstrap.ContextStrategy;
+import io.opencensus.contrib.agent.bootstrap.TraceStrategy;
 import java.lang.ref.WeakReference;
 
 /**
- * Implementation of {@link ContextStrategy} for accessing and manipulating the
+ * Implementation of {@link TraceStrategy} for accessing and manipulating the
  * {@link io.grpc.Context}.
  */
-final class ContextStrategyImpl implements ContextStrategy {
+final class TraceStrategyImpl implements TraceStrategy {
 
   /**
    * Thread-safe mapping of {@link Thread}s to {@link Context}s, used for tunneling the caller's

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/TraceStrategyImpl.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/TraceStrategyImpl.java
@@ -23,8 +23,7 @@ import io.opencensus.contrib.agent.bootstrap.TraceStrategy;
 import java.lang.ref.WeakReference;
 
 /**
- * Implementation of {@link TraceStrategy} for accessing and manipulating the
- * {@link io.grpc.Context}.
+ * Implementation of {@link TraceStrategy} for tracing-related methods.
  */
 final class TraceStrategyImpl implements TraceStrategy {
 

--- a/contrib/agent/src/test/java/io/opencensus/contrib/agent/bootstrap/TraceTrampolineTest.java
+++ b/contrib/agent/src/test/java/io/opencensus/contrib/agent/bootstrap/TraceTrampolineTest.java
@@ -27,16 +27,16 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 /**
- * Unit tests for {@link ContextManager}.
+ * Unit tests for {@link TraceTrampoline}.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class ContextManagerTest {
+public class TraceTrampolineTest {
 
-  private static final ContextStrategy mockContextStrategy;
+  private static final TraceStrategy mockTraceStrategy;
 
   static {
-    mockContextStrategy = mock(ContextStrategy.class);
-    ContextManager.setContextStrategy(mockContextStrategy);
+    mockTraceStrategy = mock(TraceStrategy.class);
+    TraceTrampoline.setTraceStrategy(mockTraceStrategy);
   }
 
   @Rule
@@ -49,30 +49,30 @@ public class ContextManagerTest {
   private Thread thread;
 
   @Test
-  public void setContextStrategy_already_initialized() {
+  public void setTraceStrategy_already_initialized() {
     exception.expect(IllegalStateException.class);
 
-    ContextManager.setContextStrategy(mockContextStrategy);
+    TraceTrampoline.setTraceStrategy(mockTraceStrategy);
   }
 
   @Test
   public void wrapInCurrentContext() {
-    ContextManager.wrapInCurrentContext(runnable);
+    TraceTrampoline.wrapInCurrentContext(runnable);
 
-    Mockito.verify(mockContextStrategy).wrapInCurrentContext(runnable);
+    Mockito.verify(mockTraceStrategy).wrapInCurrentContext(runnable);
   }
 
   @Test
   public void saveContextForThread() {
-    ContextManager.saveContextForThread(thread);
+    TraceTrampoline.saveContextForThread(thread);
 
-    Mockito.verify(mockContextStrategy).saveContextForThread(thread);
+    Mockito.verify(mockTraceStrategy).saveContextForThread(thread);
   }
 
   @Test
   public void attachContextForThread() {
-    ContextManager.attachContextForThread(thread);
+    TraceTrampoline.attachContextForThread(thread);
 
-    Mockito.verify(mockContextStrategy).attachContextForThread(thread);
+    Mockito.verify(mockTraceStrategy).attachContextForThread(thread);
   }
 }


### PR DESCRIPTION
I want to add tracing-related methods, which are going to be called from classes loaded by the bootstrap classloader, using the exact same mechanism as in ContextManager, ContextStrategy, ContextStrategyImpl. It doesn't make much sense to introduce additional classes for this purpose, but instead I'm going to rename the existing classes to something more meaningful, which covers the extended use case:

*  ContextManager => TraceTrampoline
    (it was a trampoline between classes loaded by different classloaders from the beginning)
*  ContextStrategy => TraceStrategy
*  ContextStrategyImp => TraceStrategyImpl

Otherwise, this change is a no-op. I'll add tracing-related methods in subsequent changes.