### PR TITLE
Rename contrib projects.

### DIFF
--- a/contrib/agent/README.md
+++ b/contrib/agent/README.md
@@ -48,16 +48,16 @@ load-time. Which Java methods we want to intercept/instrument obviously depends 
 ## Installation
 
 To enable the *OpenCensus Agent for Java* for your application, add the option
-`-javaagent:path/to/opencensus-agent.jar` to the invocation of the `java` executable as shown in
-the following example:
+`-javaagent:path/to/opencensus-contrib-agent.jar` to the invocation of the `java` executable as
+shown in the following example:
 
 ```shell
-java -javaagent:path/to/opencensus-agent.jar ...
+java -javaagent:path/to/opencensus-contrib-agent.jar ...
 ```
 
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-java.svg?branch=master
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-java
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/hxthmpkxar4jq4be/branch/master?svg=true
 [appveyor-url]: https://ci.appveyor.com/project/instrumentationjavateam/opencensus-java/branch/master
-[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-agent/badge.svg
-[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-agent
+[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-contrib-agent/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-contrib-agent

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -69,8 +69,7 @@ shadowJar.dependsOn bootstrapJar
 
 // Bundle the agent's classes and dependencies into a single, self-contained JAR file.
 shadowJar {
-  // Output to opencensus-agent-VERSION.jar.
-  baseName = 'opencensus-agent'
+  // Output to opencensus-contrib-agent-VERSION.jar.
   classifier = null
 
   // Include only the following dependencies (excluding transitive dependencies).

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -34,11 +34,11 @@ import net.bytebuddy.agent.builder.AgentBuilder;
  * process to OpenCensus backends such as Stackdriver Trace for analysis and visualization.
  *
  * <p>To enable the *OpenCensus Agent for Java* for your application, add the option
- * <code>-javaagent:path/to/opencensus-agent.jar</code> to the invocation of the
+ * <code>-javaagent:path/to/opencensus-contrib-agent.jar</code> to the invocation of the
  * <code>java</code> executable as shown in the following example:
  *
  * <pre>
- * java -javaagent:path/to/opencensus-agent.jar ...
+ * java -javaagent:path/to/opencensus-contrib-agent.jar ...
  * </pre>
  *
  * @see <a href="https://github.com/census-instrumentation/instrumentation-java/tree/master/agent">https://github.com/census-instrumentation/instrumentation-java/tree/master/agent</a>

--- a/contrib/zpages/README.md
+++ b/contrib/zpages/README.md
@@ -8,5 +8,5 @@ allows library configuration control.
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-java
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/hxthmpkxar4jq4be/branch/master?svg=true
 [appveyor-url]: https://ci.appveyor.com/project/instrumentationjavateam/opencensus-java/branch/master
-[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-zpages/badge.svg
-[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-zpages
+[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-contrib-zpages/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-contrib-zpages

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     compile project(':core'),
             project(':opencensus-api'),
             project(':opencensus-trace-logging-exporter'),
-            project(':opencensus-zpages')
+            project(':opencensus-contrib-zpages')
 
     runtime project(':core_impl_java'),
             project(':opencensus-impl')

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,7 +11,7 @@ include ":core"
 include ":core_impl"
 include ":core_impl_java"
 include ":core_impl_android"
-include ":opencensus-agent"
+include ":opencensus-contrib-agent"
 
 project(':opencensus-api').projectDir = "$rootDir/api" as File
 project(':opencensus-impl-core').projectDir = "$rootDir/impl_core" as File
@@ -19,13 +19,13 @@ project(':opencensus-impl-lite').projectDir = "$rootDir/impl_lite" as File
 project(':opencensus-impl').projectDir = "$rootDir/impl" as File
 project(':opencensus-testing').projectDir = "$rootDir/testing" as File
 project(':opencensus-trace-logging-exporter').projectDir = "$rootDir/exporters/trace_logging" as File
-project(':opencensus-agent').projectDir = "$rootDir/contrib/agent" as File
+project(':opencensus-contrib-agent').projectDir = "$rootDir/contrib/agent" as File
 
 // Java8 projects only
 if (JavaVersion.current().isJava8Compatible()) {
     include ":examples"
     include ":benchmarks"
-    include ":opencensus-zpages"
+    include ":opencensus-contrib-zpages"
 
-    project(':opencensus-zpages').projectDir = "$rootDir/contrib/zpages" as File
+    project(':opencensus-contrib-zpages').projectDir = "$rootDir/contrib/zpages" as File
 }


### PR DESCRIPTION
This change renames the "contrib" projects so that their names (and their Maven artifactIds) consistently start with "opencensus-contrib-". We could have different project names and artifactIds, too, but I think it's not worth the potential confusion.

Fixes https://github.com/census-instrumentation/opencensus-java/issues/549.