### PR TITLE
Make osx build not required and enable fast_finish.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ dist: precise
 language: java
 
 matrix:
+  fast_finish: true
   include:
   - jdk: oraclejdk7
     env: TASK=BUILD
@@ -13,12 +14,17 @@ matrix:
     env: TASK=BUILD
     os: linux
 
+  - env: TASK=CHECK_GIT_HISTORY
+    os: linux
+
   # Work around https://github.com/travis-ci/travis-ci/issues/2317
   - env: TASK=BUILD
     os: osx
 
-  - env: TASK=CHECK_GIT_HISTORY
-    os: linux
+  allow_failures:
+  # Allowing failures because osx builds are very slow.
+  - env: TASK=BUILD
+    os: osx
 
 before_install:
   - git log --oneline --decorate --graph -30


### PR DESCRIPTION
Because osx builds are very slow scheduled mark osx as not required and enable fast_finish which will mark the build as finished when all the required builds are done.