### PR TITLE
Specify Ubuntu Precise only for Java 7 Travis build job.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 sudo: false
-dist: precise
 
 language: java
 
@@ -9,6 +8,7 @@ matrix:
   - jdk: oraclejdk7
     env: TASK=BUILD
     os: linux
+    dist: precise
 
   - jdk: oraclejdk8
     env: TASK=BUILD


### PR DESCRIPTION
The other build jobs can upgrade to the new Travis default of Ubuntu Trusty,
because the Java 7 build was the only failure (#475).