### PR TITLE
Add missing task dependency on shadowJar.

### DIFF
--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -173,6 +173,7 @@ task integrationTest(type: Test) {
 }
 
 check.dependsOn integrationTest
+integrationTest.dependsOn shadowJar
 integrationTest.mustRunAfter test
 integrationTest.enabled = false
 


### PR DESCRIPTION
The permanent failure from https://github.com/census-instrumentation/opencensus-java/issues/557 is likely caused by this missing task dependency. 

After:
```none
     +--- :opencensus-contrib-agent:integrationTest
     |    +--- :opencensus-contrib-agent:classes *
     |    +--- :opencensus-contrib-agent:integrationTestClasses *
     |    +--- :opencensus-contrib-agent:shadowJar
     |    |    +--- :opencensus-contrib-agent:bootstrapJar
     |    |    |    \--- :opencensus-contrib-agent:classes *
     |    |    \--- :opencensus-contrib-agent:classes *
     |    \--- :opencensus-contrib-agent:testClasses *
     \--- :opencensus-contrib-agent:test
          +--- :opencensus-contrib-agent:classes *
          \--- :opencensus-contrib-agent:testClasses *
```

Before:
```none
     +--- :opencensus-contrib-agent:integrationTest
     |    +--- :opencensus-contrib-agent:classes *
     |    +--- :opencensus-contrib-agent:integrationTestClasses *
     |    \--- :opencensus-contrib-agent:testClasses *
     \--- :opencensus-contrib-agent:test
          +--- :opencensus-contrib-agent:classes *
          \--- :opencensus-contrib-agent:testClasses *
```