### PR TITLE
Increase test timeouts.

### DIFF
--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentationIT.java
@@ -56,7 +56,7 @@ public class ExecutorInstrumentationIT {
     executor.shutdown();
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void execute() throws Exception {
     final Thread callerThread = Thread.currentThread();
     final Context context = Context.current().withValue(KEY, "myvalue");
@@ -85,7 +85,7 @@ public class ExecutorInstrumentationIT {
     assertThat(tested.get()).isTrue();
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void submit_Callable() throws Exception {
     final Thread callerThread = Thread.currentThread();
     final Context context = Context.current().withValue(KEY, "myvalue");
@@ -108,7 +108,7 @@ public class ExecutorInstrumentationIT {
     assertThat(tested.get()).isTrue();
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void submit_Runnable() throws Exception {
     final Thread callerThread = Thread.currentThread();
     final Context context = Context.current().withValue(KEY, "myvalue");
@@ -129,7 +129,7 @@ public class ExecutorInstrumentationIT {
     assertThat(tested.get()).isTrue();
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void submit_RunnableWithResult() throws Exception {
     final Thread callerThread = Thread.currentThread();
     final Context context = Context.current().withValue(KEY, "myvalue");
@@ -153,7 +153,7 @@ public class ExecutorInstrumentationIT {
     assertThat(tested.get()).isTrue();
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void currentContextExecutor() throws Exception {
     final Thread callerThread = Thread.currentThread();
     final Context context = Context.current().withValue(KEY, "myvalue");

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
@@ -45,7 +45,7 @@ public class ThreadInstrumentationIT {
     Context.current().detach(previousContext);
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void start_Runnable() throws Exception {
     final Context context = Context.current().withValue(KEY, "myvalue");
     previousContext = context.attach();
@@ -67,7 +67,7 @@ public class ThreadInstrumentationIT {
     assertThat(tested.get()).isTrue();
   }
 
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void start_Subclass() throws Exception {
     final Context context = Context.current().withValue(KEY, "myvalue");
     previousContext = context.attach();
@@ -96,7 +96,7 @@ public class ThreadInstrumentationIT {
    * Tests that the automatic context propagation added by {@link ThreadInstrumentation} does not
    * interfere with the automatically propagated context from Executor#execute.
    */
-  @Test(timeout = 5000)
+  @Test(timeout = 60000)
   public void start_automaticallyWrappedRunnable() throws Exception {
     final Context context = Context.current().withValue(KEY, "myvalue");
     previousContext = context.attach();


### PR DESCRIPTION
This should fix the occasional build failures seen on Travis, https://github.com/census-instrumentation/opencensus-java/issues/540. There could be other causes which I've not seen or thought of yet, though.