### PR TITLE
Fix backwards compatibility between TraceComponentBaseImpl and TraceComponent.

### DIFF
--- a/impl/src/main/java/io/opencensus/impl/trace/TraceComponentImpl.java
+++ b/impl/src/main/java/io/opencensus/impl/trace/TraceComponentImpl.java
@@ -16,20 +16,52 @@
 
 package io.opencensus.impl.trace;
 
+import io.opencensus.common.Clock;
 import io.opencensus.impl.internal.DisruptorEventQueue;
 import io.opencensus.impl.trace.internal.ThreadLocalRandomHandler;
 import io.opencensus.implcore.common.MillisClock;
 import io.opencensus.implcore.trace.TraceComponentImplBase;
 import io.opencensus.trace.TraceComponent;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
 
 /** Java 7 and 8 implementation of the {@link TraceComponent}. */
-public final class TraceComponentImpl extends TraceComponentImplBase {
+public final class TraceComponentImpl extends TraceComponent {
+  private final TraceComponentImplBase traceComponentImplBase;
 
   /** Public constructor to be used with reflection loading. */
   public TraceComponentImpl() {
-    super(
-        MillisClock.getInstance(),
-        new ThreadLocalRandomHandler(),
-        DisruptorEventQueue.getInstance());
+    traceComponentImplBase =
+        new TraceComponentImplBase(
+            MillisClock.getInstance(),
+            new ThreadLocalRandomHandler(),
+            DisruptorEventQueue.getInstance());
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return traceComponentImplBase.getTracer();
+  }
+
+  @Override
+  public PropagationComponent getPropagationComponent() {
+    return traceComponentImplBase.getPropagationComponent();
+  }
+
+  @Override
+  public Clock getClock() {
+    return traceComponentImplBase.getClock();
+  }
+
+  @Override
+  public ExportComponent getExportComponent() {
+    return traceComponentImplBase.getExportComponent();
+  }
+
+  @Override
+  public TraceConfig getTraceConfig() {
+    return traceComponentImplBase.getTraceConfig();
   }
 }

--- a/impl/src/main/java/io/opencensus/trace/TraceComponentImpl.java
+++ b/impl/src/main/java/io/opencensus/trace/TraceComponentImpl.java
@@ -16,22 +16,53 @@
 
 package io.opencensus.trace;
 
+import io.opencensus.common.Clock;
 import io.opencensus.impl.internal.DisruptorEventQueue;
 import io.opencensus.impl.trace.internal.ThreadLocalRandomHandler;
 import io.opencensus.implcore.common.MillisClock;
 import io.opencensus.implcore.trace.TraceComponentImplBase;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
 
 /** Java 7 and 8 implementation of the {@link TraceComponent}. */
 // TraceComponentImpl was moved to io.opencensus.impl.trace. This class exists for backwards
 // compatibility, so that it can be loaded by opencensus-api 0.5.
 @Deprecated
-public final class TraceComponentImpl extends TraceComponentImplBase {
+public final class TraceComponentImpl extends TraceComponent {
+  private final TraceComponentImplBase traceComponentImplBase;
 
   /** Public constructor to be used with reflection loading. */
   public TraceComponentImpl() {
-    super(
-        MillisClock.getInstance(),
-        new ThreadLocalRandomHandler(),
-        DisruptorEventQueue.getInstance());
+    traceComponentImplBase =
+        new TraceComponentImplBase(
+            MillisClock.getInstance(),
+            new ThreadLocalRandomHandler(),
+            DisruptorEventQueue.getInstance());
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return traceComponentImplBase.getTracer();
+  }
+
+  @Override
+  public PropagationComponent getPropagationComponent() {
+    return traceComponentImplBase.getPropagationComponent();
+  }
+
+  @Override
+  public Clock getClock() {
+    return traceComponentImplBase.getClock();
+  }
+
+  @Override
+  public ExportComponent getExportComponent() {
+    return traceComponentImplBase.getExportComponent();
+  }
+
+  @Override
+  public TraceConfig getTraceConfig() {
+    return traceComponentImplBase.getTraceConfig();
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/TraceComponentImplBase.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/TraceComponentImplBase.java
@@ -30,8 +30,14 @@ import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.export.ExportComponent;
 import io.opencensus.trace.propagation.PropagationComponent;
 
-/** Base implementation of the {@link TraceComponent}. */
-public class TraceComponentImplBase extends TraceComponent {
+/**
+ * Helper class to allow sharing the code for all the {@link TraceComponent} implementations. This
+ * class cannot use inheritance because in version 0.5.* the constructor of the {@code
+ * TraceComponent} is package protected.
+ *
+ * <p>This can be changed back to inheritance when version 0.5.* is no longer supported.
+ */
+public final class TraceComponentImplBase {
   private final ExportComponentImpl exportComponent;
   private final PropagationComponent propagationComponent = new PropagationComponentImpl();
   private final Clock clock;
@@ -63,27 +69,22 @@ public class TraceComponentImplBase extends TraceComponent {
     tracer = new TracerImpl(randomHandler, startEndHandler, clock, traceConfig);
   }
 
-  @Override
   public Tracer getTracer() {
     return tracer;
   }
 
-  @Override
   public PropagationComponent getPropagationComponent() {
     return propagationComponent;
   }
 
-  @Override
   public final Clock getClock() {
     return clock;
   }
 
-  @Override
   public ExportComponent getExportComponent() {
     return exportComponent;
   }
 
-  @Override
   public TraceConfig getTraceConfig() {
     return traceConfig;
   }

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/TraceComponentImplBaseTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/TraceComponentImplBaseTest.java
@@ -20,12 +20,9 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.implcore.common.MillisClock;
 import io.opencensus.implcore.internal.SimpleEventQueue;
-import io.opencensus.implcore.trace.TraceComponentImplBase;
-import io.opencensus.implcore.trace.TracerImpl;
 import io.opencensus.implcore.trace.export.ExportComponentImpl;
 import io.opencensus.implcore.trace.internal.RandomHandler.SecureRandomHandler;
 import io.opencensus.implcore.trace.propagation.PropagationComponentImpl;
-import io.opencensus.trace.TraceComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,28 +30,28 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link TraceComponentImplBase}. */
 @RunWith(JUnit4.class)
 public class TraceComponentImplBaseTest {
-  private final TraceComponent traceComponent =
+  private final TraceComponentImplBase traceComponentImplBase =
       new TraceComponentImplBase(
           MillisClock.getInstance(), new SecureRandomHandler(), new SimpleEventQueue());
 
   @Test
   public void implementationOfTracer() {
-    assertThat(traceComponent.getTracer()).isInstanceOf(TracerImpl.class);
+    assertThat(traceComponentImplBase.getTracer()).isInstanceOf(TracerImpl.class);
   }
 
   @Test
   public void implementationOfBinaryPropagationHandler() {
-    assertThat(traceComponent.getPropagationComponent())
+    assertThat(traceComponentImplBase.getPropagationComponent())
         .isInstanceOf(PropagationComponentImpl.class);
   }
 
   @Test
   public void implementationOfClock() {
-    assertThat(traceComponent.getClock()).isInstanceOf(MillisClock.class);
+    assertThat(traceComponentImplBase.getClock()).isInstanceOf(MillisClock.class);
   }
 
   @Test
   public void implementationOfTraceExporter() {
-    assertThat(traceComponent.getExportComponent()).isInstanceOf(ExportComponentImpl.class);
+    assertThat(traceComponentImplBase.getExportComponent()).isInstanceOf(ExportComponentImpl.class);
   }
 }

--- a/impl_lite/src/main/java/io/opencensus/impllite/trace/TraceComponentImplLite.java
+++ b/impl_lite/src/main/java/io/opencensus/impllite/trace/TraceComponentImplLite.java
@@ -16,16 +16,50 @@
 
 package io.opencensus.impllite.trace;
 
+import io.opencensus.common.Clock;
 import io.opencensus.implcore.common.MillisClock;
 import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.implcore.trace.TraceComponentImplBase;
 import io.opencensus.implcore.trace.internal.RandomHandler.SecureRandomHandler;
 import io.opencensus.trace.TraceComponent;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
 
 /** Android-compatible implementation of the {@link TraceComponent}. */
-public final class TraceComponentImplLite extends TraceComponentImplBase {
+public final class TraceComponentImplLite extends TraceComponent {
+  private final TraceComponentImplBase traceComponentImplBase;
 
+  /** Public constructor to be used with reflection loading. */
   public TraceComponentImplLite() {
-    super(MillisClock.getInstance(), new SecureRandomHandler(), new SimpleEventQueue());
+    traceComponentImplBase =
+        new TraceComponentImplBase(
+            MillisClock.getInstance(), new SecureRandomHandler(), new SimpleEventQueue());
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return traceComponentImplBase.getTracer();
+  }
+
+  @Override
+  public PropagationComponent getPropagationComponent() {
+    return traceComponentImplBase.getPropagationComponent();
+  }
+
+  @Override
+  public Clock getClock() {
+    return traceComponentImplBase.getClock();
+  }
+
+  @Override
+  public ExportComponent getExportComponent() {
+    return traceComponentImplBase.getExportComponent();
+  }
+
+  @Override
+  public TraceConfig getTraceConfig() {
+    return traceComponentImplBase.getTraceConfig();
   }
 }

--- a/impl_lite/src/main/java/io/opencensus/trace/TraceComponentImplLite.java
+++ b/impl_lite/src/main/java/io/opencensus/trace/TraceComponentImplLite.java
@@ -16,18 +16,51 @@
 
 package io.opencensus.trace;
 
+import io.opencensus.common.Clock;
 import io.opencensus.implcore.common.MillisClock;
 import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.implcore.trace.TraceComponentImplBase;
 import io.opencensus.implcore.trace.internal.RandomHandler.SecureRandomHandler;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.export.ExportComponent;
+import io.opencensus.trace.propagation.PropagationComponent;
 
 /** Android-compatible implementation of the {@link TraceComponent}. */
 // TraceComponentImplLite was moved to io.opencensus.impllite.trace. This class exists for backwards
 // compatibility, so that it can be loaded by opencensus-api 0.5.
 @Deprecated
-public final class TraceComponentImplLite extends TraceComponentImplBase {
+public final class TraceComponentImplLite extends TraceComponent {
+  private final TraceComponentImplBase traceComponentImplBase;
 
+  /** Public constructor to be used with reflection loading. */
   public TraceComponentImplLite() {
-    super(MillisClock.getInstance(), new SecureRandomHandler(), new SimpleEventQueue());
+    traceComponentImplBase =
+        new TraceComponentImplBase(
+            MillisClock.getInstance(), new SecureRandomHandler(), new SimpleEventQueue());
+  }
+
+  @Override
+  public Tracer getTracer() {
+    return traceComponentImplBase.getTracer();
+  }
+
+  @Override
+  public PropagationComponent getPropagationComponent() {
+    return traceComponentImplBase.getPropagationComponent();
+  }
+
+  @Override
+  public Clock getClock() {
+    return traceComponentImplBase.getClock();
+  }
+
+  @Override
+  public ExportComponent getExportComponent() {
+    return traceComponentImplBase.getExportComponent();
+  }
+
+  @Override
+  public TraceConfig getTraceConfig() {
+    return traceComponentImplBase.getTraceConfig();
   }
 }


### PR DESCRIPTION
The problem is caused by the fact that the constructor of the TraceComponent was package protected in the previous version (0.5.*) and if try to load via the old API the new implementation IllegalAccessError happens:

java.lang.IllegalAccessError: tried to access method io.opencensus.trace.TraceComponent.<init>()V from class io.opencensus.implcore.trace.TraceComponentImplBase
	at io.opencensus.implcore.trace.TraceComponentImplBase.<init>(TraceComponentImplBase.java:49)
	at io.opencensus.trace.TraceComponentImpl.<init>(TraceComponentImpl.java:32)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:422)
	at io.opencensus.internal.Provider.createInstance(Provider.java:67)
	at io.opencensus.trace.Tracing.loadTraceComponent(Tracing.java:81)
	at io.opencensus.trace.Tracing.<clinit>(Tracing.java:29)
	at io.opencensus.exporter.trace.stackdriver.StackdriverExporter.createAndRegister(StackdriverExporter.java:85)
	at com.google.cloud.bigtable.dataflow.WriteToBigtable.initialize(WriteToBigtable.java:74)
	at com.google.cloud.bigtable.dataflow.WriteToBigtable.main(WriteToBigtable.java:125)