### PR TITLE
Clarifies the contract around scoping a trace context

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContexts.java
+++ b/core/src/main/java/io/opencensus/tags/TagContexts.java
@@ -25,10 +25,9 @@ import javax.annotation.concurrent.Immutable;
  * <p>This class returns {@link TagContextBuilder builders} that can be used to create the
  * implementation-dependent {@link TagContext}s.
  *
- * <p>Implementations may have different constraints and are free to require their own subtypes of
- * {@linkplain TagContext}. This means callers cannot assume the {@link #getCurrentTagContext()
- * current context} is the same instance as the one {@link #withTagContext(TagContext) placed into
- * scope}
+ * <p>Implementations may have different constraints and are free to convert tag contexts to their
+ * own subtypes. This means callers cannot assume the {@link #getCurrentTagContext() current
+ * context} is the same instance as the one {@link #withTagContext(TagContext) placed into scope}.
  */
 public abstract class TagContexts {
   private static final TagContexts NOOP_TAG_CONTEXTS = new NoopTagContexts();

--- a/core/src/main/java/io/opencensus/tags/TagContexts.java
+++ b/core/src/main/java/io/opencensus/tags/TagContexts.java
@@ -24,6 +24,11 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>This class returns {@link TagContextBuilder builders} that can be used to create the
  * implementation-dependent {@link TagContext}s.
+ *
+ * <p>Implementations may have different constraints and are free to require their own subtypes of
+ * {@linkplain TagContext}. This means callers cannot assume the {@link #getCurrentTagContext()
+ * current context} is the same instance as the one {@link #withTagContext(TagContext) placed into
+ * scope}
  */
 public abstract class TagContexts {
   private static final TagContexts NOOP_TAG_CONTEXTS = new NoopTagContexts();


### PR DESCRIPTION
Users may assume that the current trace context is the same as what they
placed into scope. For example, they might wrap a trace context and be
suprised that whatever they decorated it with is lost. This clarifies
the type-level javadoc on `TagContexts` to clarify this isn't supported.

See https://github.com/census-instrumentation/opencensus-java/pull/569#discussion_r136727376