### PR TITLE
Change TagContext serialization methods to use byte[] (closes #213).

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContextBinarySerializer.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBinarySerializer.java
@@ -17,8 +17,6 @@
 package io.opencensus.tags;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 import javax.annotation.concurrent.Immutable;
 
 /** Object for serializing and deserializing {@link TagContext}s with the binary format. */
@@ -29,25 +27,24 @@ public abstract class TagContextBinarySerializer {
   /**
    * Serializes the {@code TagContext} into the on-the-wire representation.
    *
-   * <p>This method should be the inverse of {@link #deserialize}.
+   * <p>This method should be the inverse of {@link #fromByteArray}.
    *
    * @param tags the {@code TagContext} to serialize.
-   * @param output the {@link OutputStream} to write the serialized tags to.
-   * @throws IOException if there is an {@code IOException} while writing to {@code output}.
+   * @return the on-the-wire representation of a {@code TagContext}.
    */
-  public abstract void serialize(TagContext tags, OutputStream output) throws IOException;
+  public abstract byte[] toByteArray(TagContext tags);
 
   /**
    * Creates a {@code TagContext} from the given on-the-wire encoded representation.
    *
-   * <p>This method should be the inverse of {@link #serialize}.
+   * <p>This method should be the inverse of {@link #toByteArray}.
    *
-   * @param input on-the-wire representation of a {@code TagContext}.
-   * @return a {@code TagContext} deserialized from {@code input}.
-   * @throws IOException if there is a parse error or an {@code IOException} while reading from
-   *     {@code input}.
+   * @param bytes on-the-wire representation of a {@code TagContext}.
+   * @return a {@code TagContext} deserialized from {@code bytes}.
+   * @throws IOException if there is a parse error.
    */
-  public abstract TagContext deserialize(InputStream input) throws IOException;
+  // TODO(sebright): Use a more appropriate exception type, since this method doesn't do IO.
+  public abstract TagContext fromByteArray(byte[] bytes) throws IOException;
 
   /**
    * Returns a {@code TagContextBinarySerializer} that serializes all {@code TagContext}s to zero
@@ -59,12 +56,15 @@ public abstract class TagContextBinarySerializer {
 
   @Immutable
   private static final class NoopTagContextBinarySerializer extends TagContextBinarySerializer {
+    private static final byte[] EMPTY_BYTE_ARRAY = {};
 
     @Override
-    public void serialize(TagContext tags, OutputStream output) throws IOException {}
+    public byte[] toByteArray(TagContext tags) {
+      return EMPTY_BYTE_ARRAY;
+    }
 
     @Override
-    public TagContext deserialize(InputStream input) throws IOException {
+    public TagContext fromByteArray(byte[] bytes) throws IOException {
       return TagContext.getNoopTagContext();
     }
   }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBinarySerializerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBinarySerializerImpl.java
@@ -19,17 +19,15 @@ package io.opencensus.implcore.tags;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBinarySerializer;
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
 
 final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   @Override
-  public void serialize(TagContext tags, OutputStream output) throws IOException {
-    SerializationUtils.serializeBinary(tags, output);
+  public byte[] toByteArray(TagContext tags) {
+    return SerializationUtils.serializeBinary(tags);
   }
 
   @Override
-  public TagContext deserialize(InputStream input) throws IOException {
-    return SerializationUtils.deserializeBinary(input);
+  public TagContext fromByteArray(byte[] bytes) throws IOException {
+    return SerializationUtils.deserializeBinary(bytes);
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
@@ -25,10 +25,8 @@ import io.opencensus.tags.TagContextBinarySerializer;
 import io.opencensus.tags.TagContexts;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
-import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -62,16 +60,13 @@ public class TagContextDeserializationTest {
     TagContext expected = tagContexts.empty();
     TagContext actual =
         testDeserialize(
-            new ByteArrayInputStream(
-                new byte[] {
-                  SerializationUtils.VERSION_ID
-                })); // One byte that represents Version ID.
+            new byte[] {SerializationUtils.VERSION_ID}); // One byte that represents Version ID.
     assertTagContextsEqual(actual, expected);
   }
 
   @Test(expected = IOException.class)
   public void testDeserializeEmptyByteArrayThrowException() throws Exception {
-    testDeserialize(new ByteArrayInputStream(new byte[0]));
+    testDeserialize(new byte[0]);
   }
 
   @Test
@@ -97,7 +92,7 @@ public class TagContextDeserializationTest {
     encodeString("Key2", byteArrayOutputStream);
     encodeString("String2", byteArrayOutputStream);
     TagContext actual =
-        testDeserialize(new ByteArrayInputStream(byteArrayOutputStream.toByteArray()));
+        testDeserialize(byteArrayOutputStream.toByteArray());
     TagContext expected =
         tagContexts
             .emptyBuilder()
@@ -136,17 +131,16 @@ public class TagContextDeserializationTest {
   @Test(expected = IOException.class)
   public void testDeserializeWrongFormat() throws Exception {
     // encoded tags should follow the format <version_id>(<tag_field_id><tag_encoding>)*
-    testDeserialize(new ByteArrayInputStream(new byte[3]));
+    testDeserialize(new byte[3]);
   }
 
   @Test(expected = IOException.class)
   public void testDeserializeWrongVersionId() throws Exception {
-    testDeserialize(
-        new ByteArrayInputStream(new byte[] {(byte) (SerializationUtils.VERSION_ID + 1)}));
+    testDeserialize(new byte[] {(byte) (SerializationUtils.VERSION_ID + 1)});
   }
 
-  private TagContext testDeserialize(InputStream inputStream) throws IOException {
-    return serializer.deserialize(inputStream);
+  private TagContext testDeserialize(byte[] bytes) throws IOException {
+    return serializer.fromByteArray(bytes);
   }
 
   /*
@@ -157,22 +151,22 @@ public class TagContextDeserializationTest {
    * remove this method and use StatsContext.serialize() instead.
    * Currently StatsContext.serialize() can only serialize strings.
    */
-  private static InputStream constructSingleTypeTagInputStream(int valueType) throws IOException {
+  private static byte[] constructSingleTypeTagInputStream(int valueType) throws IOException {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     byteArrayOutputStream.write(SerializationUtils.VERSION_ID);
     encodeSingleTypeTagToOutputStream(valueType, byteArrayOutputStream);
-    return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+    return byteArrayOutputStream.toByteArray();
   }
 
   // Construct an InputStream with all 4 types of tags.
-  private static InputStream constructMultiTypeTagInputStream() throws IOException {
+  private static byte[] constructMultiTypeTagInputStream() throws IOException {
     ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
     byteArrayOutputStream.write(SerializationUtils.VERSION_ID);
     encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_STRING, byteArrayOutputStream);
     encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_INTEGER, byteArrayOutputStream);
     encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_TRUE, byteArrayOutputStream);
     encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_FALSE, byteArrayOutputStream);
-    return new ByteArrayInputStream(byteArrayOutputStream.toByteArray());
+    return byteArrayOutputStream.toByteArray();
   }
 
   private static void encodeSingleTypeTagToOutputStream(

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextRoundtripTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextRoundtripTest.java
@@ -24,8 +24,6 @@ import io.opencensus.tags.TagContextBinarySerializer;
 import io.opencensus.tags.TagContexts;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -59,10 +57,8 @@ public class TagContextRoundtripTest {
   }
 
   private void testRoundtripSerialization(TagContext expected) throws Exception {
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    serializer.serialize(expected, output);
-    ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
-    TagContext actual = serializer.deserialize(input);
+    byte[] bytes = serializer.toByteArray(expected);
+    TagContext actual = serializer.fromByteArray(bytes);
     assertThat(Lists.newArrayList(actual.unsafeGetIterator()))
         .containsExactlyElementsIn(Lists.newArrayList(expected.unsafeGetIterator()));
   }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextSerializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextSerializationTest.java
@@ -18,6 +18,7 @@ package io.opencensus.implcore.tags;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Collections2;
 import io.opencensus.implcore.internal.VarInt;
 import io.opencensus.tags.Tag.TagString;
@@ -86,8 +87,7 @@ public class TagContextSerializationTest {
       builder.set(tag.getKey(), tag.getValue());
     }
 
-    ByteArrayOutputStream actual = new ByteArrayOutputStream();
-    serializer.serialize(builder.build(), actual);
+    byte[] actual = serializer.toByteArray(builder.build());
 
     Collection<List<TagString>> tagPermutation = Collections2.permutations(Arrays.asList(tags));
     Set<String> possibleOutputs = new HashSet<String>();
@@ -102,7 +102,7 @@ public class TagContextSerializationTest {
       possibleOutputs.add(expected.toString());
     }
 
-    assertThat(possibleOutputs).contains(actual.toString());
+    assertThat(possibleOutputs).contains(new String(actual, Charsets.UTF_8));
   }
 
   private static void encodeString(String input, ByteArrayOutputStream byteArrayOutputStream)


### PR DESCRIPTION
The signatures changed from

```java
    void serialize(TagContext tags, OutputStream output) throws IOException
    TagContext deserialize(InputStream input) throws IOException
```

to

```java
    byte[] toByteArray(TagContext tags)
    TagContext fromByteArray(byte[] bytes) throws IOException
```

fromByteArray can only fail if there is a parse error, so we should probably
change it to use a more appropriate exception type later.

This commit also refactors the toByteArray implementation to remove the
possibility of ~~an unchecked~~ a checked exception, since it is no longer doing IO.

/cc @bogdandrutu 