### PR TITLE
Make TagContext implement Iterable<Tag>.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContext.java
+++ b/core/src/main/java/io/opencensus/tags/TagContext.java
@@ -33,12 +33,8 @@ import javax.annotation.concurrent.Immutable;
  */
 // TODO(sebright): Implement equals and hashCode.
 @Immutable
-public abstract class TagContext {
+public abstract class TagContext implements Iterable<Tag> {
   private static final TagContext NOOP_TAG_CONTEXT = new NoopTagContext();
-
-  // TODO(sebright): Consider removing TagContext.unsafeGetIterator() so that we don't need to
-  // support fast access to tags.
-  public abstract Iterator<Tag> unsafeGetIterator();
 
   @Override
   public String toString() {
@@ -59,7 +55,7 @@ public abstract class TagContext {
 
     // TODO(sebright): Is there any way to let the user know that their tags were ignored?
     @Override
-    public Iterator<Tag> unsafeGetIterator() {
+    public Iterator<Tag> iterator() {
       return Collections.<Tag>emptySet().iterator();
     }
   }

--- a/core/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
+++ b/core/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
@@ -45,7 +45,7 @@ public final class ContextUtils {
   private static final class EmptyTagContext extends TagContext {
 
     @Override
-    public Iterator<Tag> unsafeGetIterator() {
+    public Iterator<Tag> iterator() {
       return Collections.<Tag>emptySet().iterator();
     }
   }

--- a/core/src/test/java/io/opencensus/stats/NoopStatsRecorderTest.java
+++ b/core/src/test/java/io/opencensus/stats/NoopStatsRecorderTest.java
@@ -42,7 +42,7 @@ public final class NoopStatsRecorderTest {
       new TagContext() {
 
         @Override
-        public Iterator<Tag> unsafeGetIterator() {
+        public Iterator<Tag> iterator() {
           return Collections.<Tag>singleton(TAG).iterator();
         }
       };

--- a/core/src/test/java/io/opencensus/stats/StatsRecorderTest.java
+++ b/core/src/test/java/io/opencensus/stats/StatsRecorderTest.java
@@ -48,7 +48,7 @@ public final class StatsRecorderTest {
       new TagContext() {
 
         @Override
-        public Iterator<Tag> unsafeGetIterator() {
+        public Iterator<Tag> iterator() {
           return Collections.<Tag>singleton(TAG).iterator();
         }
       };

--- a/core/src/test/java/io/opencensus/tags/CurrentTagContextUtilsTest.java
+++ b/core/src/test/java/io/opencensus/tags/CurrentTagContextUtilsTest.java
@@ -27,7 +27,6 @@ import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.unsafe.ContextUtils;
 import java.util.Iterator;
-import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -42,7 +41,7 @@ public class CurrentTagContextUtilsTest {
       new TagContext() {
 
         @Override
-        public Iterator<Tag> unsafeGetIterator() {
+        public Iterator<Tag> iterator() {
           return ImmutableSet.<Tag>of(TAG).iterator();
         }
       };
@@ -51,7 +50,7 @@ public class CurrentTagContextUtilsTest {
   public void testGetCurrentTagContext_DefaultContext() {
     TagContext tags = CurrentTagContextUtils.getCurrentTagContext();
     assertThat(tags).isNotNull();
-    assertThat(asList(tags)).isEmpty();
+    assertThat(Lists.newArrayList(tags)).isEmpty();
   }
 
   @Test
@@ -60,7 +59,7 @@ public class CurrentTagContextUtilsTest {
     try {
       TagContext tags = CurrentTagContextUtils.getCurrentTagContext();
       assertThat(tags).isNotNull();
-      assertThat(asList(tags)).isEmpty();
+      assertThat(Lists.newArrayList(tags)).isEmpty();
     } finally {
       Context.current().detach(orig);
     }
@@ -68,14 +67,14 @@ public class CurrentTagContextUtilsTest {
 
   @Test
   public void testWithTagContext() {
-    assertThat(asList(CurrentTagContextUtils.getCurrentTagContext())).isEmpty();
+    assertThat(Lists.newArrayList(CurrentTagContextUtils.getCurrentTagContext())).isEmpty();
     Scope scopedTags = CurrentTagContextUtils.withTagContext(tagContext);
     try {
       assertThat(CurrentTagContextUtils.getCurrentTagContext()).isEqualTo(tagContext);
     } finally {
       scopedTags.close();
     }
-    assertThat(asList(CurrentTagContextUtils.getCurrentTagContext())).isEmpty();
+    assertThat(Lists.newArrayList(CurrentTagContextUtils.getCurrentTagContext())).isEmpty();
   }
 
   @Test
@@ -97,12 +96,8 @@ public class CurrentTagContextUtilsTest {
     } finally {
       scopedTags.close();
     }
-    assertThat(asList(CurrentTagContextUtils.getCurrentTagContext())).isEmpty();
+    assertThat(Lists.newArrayList(CurrentTagContextUtils.getCurrentTagContext())).isEmpty();
     // When we run the runnable we will have the TagContext in the current Context.
     runnable.run();
-  }
-
-  private static List<Tag> asList(TagContext tags) {
-    return Lists.newArrayList(tags.unsafeGetIterator());
   }
 }

--- a/core/src/test/java/io/opencensus/tags/ScopedTagContextsTest.java
+++ b/core/src/test/java/io/opencensus/tags/ScopedTagContextsTest.java
@@ -34,7 +34,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
@@ -71,12 +70,12 @@ public class ScopedTagContextsTest {
 
   @Test
   public void defaultTagContext() {
-    assertThat(asList(tagContexts.getCurrentTagContext())).isEmpty();
+    assertThat(Lists.newArrayList(tagContexts.getCurrentTagContext())).isEmpty();
   }
 
   @Test
   public void withTagContext() {
-    assertThat(asList(tagContexts.getCurrentTagContext())).isEmpty();
+    assertThat(Lists.newArrayList(tagContexts.getCurrentTagContext())).isEmpty();
     TagContext scopedTags = new SimpleTagContext(TagString.create(KEY_1, VALUE_1));
     Scope scope = tagContexts.withTagContext(scopedTags);
     try {
@@ -84,7 +83,7 @@ public class ScopedTagContextsTest {
     } finally {
       scope.close();
     }
-    assertThat(asList(tagContexts.getCurrentTagContext())).isEmpty();
+    assertThat(Lists.newArrayList(tagContexts.getCurrentTagContext())).isEmpty();
   }
 
   @Test
@@ -93,7 +92,7 @@ public class ScopedTagContextsTest {
     Scope scope = tagContexts.withTagContext(scopedTags);
     try {
       TagContext newTags = tagContexts.currentBuilder().set(KEY_2, VALUE_2).build();
-      assertThat(asList(newTags))
+      assertThat(Lists.newArrayList(newTags))
           .containsExactly(TagString.create(KEY_1, VALUE_1), TagString.create(KEY_2, VALUE_2));
       assertThat(tagContexts.getCurrentTagContext()).isSameAs(scopedTags);
     } finally {
@@ -103,15 +102,15 @@ public class ScopedTagContextsTest {
 
   @Test
   public void setCurrentTagsWithBuilder() {
-    assertThat(asList(tagContexts.getCurrentTagContext())).isEmpty();
+    assertThat(Lists.newArrayList(tagContexts.getCurrentTagContext())).isEmpty();
     Scope scope = tagContexts.emptyBuilder().set(KEY_1, VALUE_1).buildScoped();
     try {
-      assertThat(asList(tagContexts.getCurrentTagContext()))
+      assertThat(Lists.newArrayList(tagContexts.getCurrentTagContext()))
           .containsExactly(TagString.create(KEY_1, VALUE_1));
     } finally {
       scope.close();
     }
-    assertThat(asList(tagContexts.getCurrentTagContext())).isEmpty();
+    assertThat(Lists.newArrayList(tagContexts.getCurrentTagContext())).isEmpty();
   }
 
   @Test
@@ -121,7 +120,7 @@ public class ScopedTagContextsTest {
     try {
       Scope scope2 = tagContexts.currentBuilder().set(KEY_2, VALUE_2).buildScoped();
       try {
-        assertThat(asList(tagContexts.getCurrentTagContext()))
+        assertThat(Lists.newArrayList(tagContexts.getCurrentTagContext()))
             .containsExactly(TagString.create(KEY_1, VALUE_1), TagString.create(KEY_2, VALUE_2));
       } finally {
         scope2.close();
@@ -130,10 +129,6 @@ public class ScopedTagContextsTest {
     } finally {
       scope1.close();
     }
-  }
-
-  private static List<Tag> asList(TagContext tags) {
-    return Lists.newArrayList(tags.unsafeGetIterator());
   }
 
   private static final class SimpleTagContextBuilder extends TagContextBuilder {
@@ -190,7 +185,7 @@ public class ScopedTagContextsTest {
     }
 
     @Override
-    public Iterator<Tag> unsafeGetIterator() {
+    public Iterator<Tag> iterator() {
       return Iterators.<TagString, Tag>transform(
           tags.iterator(), com.google.common.base.Functions.<TagString>identity());
     }

--- a/core/src/test/java/io/opencensus/tags/TagContextTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagContextTest.java
@@ -51,7 +51,7 @@ public final class TagContextTest {
     }
 
     @Override
-    public Iterator<Tag> unsafeGetIterator() {
+    public Iterator<Tag> iterator() {
       return tags.iterator();
     }
   }

--- a/core/src/test/java/io/opencensus/tags/unsafe/ContextUtilsTest.java
+++ b/core/src/test/java/io/opencensus/tags/unsafe/ContextUtilsTest.java
@@ -20,9 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.Lists;
 import io.grpc.Context;
-import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
-import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -40,7 +38,7 @@ public final class ContextUtilsTest {
   public void testGetCurrentTagContext_DefaultContext() {
     TagContext tags = ContextUtils.TAG_CONTEXT_KEY.get();
     assertThat(tags).isNotNull();
-    assertThat(asList(tags)).isEmpty();
+    assertThat(Lists.newArrayList(tags)).isEmpty();
   }
 
   @Test
@@ -49,13 +47,9 @@ public final class ContextUtilsTest {
     try {
       TagContext tags = ContextUtils.TAG_CONTEXT_KEY.get();
       assertThat(tags).isNotNull();
-      assertThat(asList(tags)).isEmpty();
+      assertThat(Lists.newArrayList(tags)).isEmpty();
     } finally {
       Context.current().detach(orig);
     }
-  }
-
-  private static List<Tag> asList(TagContext tags) {
-    return Lists.newArrayList(tags.unsafeGetIterator());
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -63,7 +63,6 @@ import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import java.util.ArrayList;
-import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -149,8 +148,7 @@ abstract class MutableViewData {
       return ((TagContextImpl) ctx).getTags();
     } else {
       Map<TagKey, TagValue> tags = Maps.newHashMap();
-      for (Iterator<Tag> i = ctx.unsafeGetIterator(); i.hasNext(); ) {
-        Tag tag = i.next();
+      for (Tag tag : ctx) {
         tags.put(
             tag.getKey(),
             tag.match(

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/SerializationUtils.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/SerializationUtils.java
@@ -37,7 +37,6 @@ import java.io.OutputStream;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
-import java.util.Iterator;
 
 /**
  * Methods for serializing and deserializing {@link TagContext}s.
@@ -96,8 +95,7 @@ final class SerializationUtils {
     byteArrayOutputStream.write(VERSION_ID);
 
     // TODO(songya): add support for value types integer and boolean
-    for (Iterator<Tag> i = tags.unsafeGetIterator(); i.hasNext(); ) {
-      Tag tag = i.next();
+    for (Tag tag : tags) {
 
       // TODO(sebright): Is there a better way to handle checked exceptions in function objects?
       IOException ex =

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
@@ -55,7 +55,7 @@ public final class TagContextImpl extends TagContext {
   }
 
   @Override
-  public Iterator<Tag> unsafeGetIterator() {
+  public Iterator<Tag> iterator() {
     return new TagIterator(tags);
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextsImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextsImpl.java
@@ -59,7 +59,7 @@ public final class TagContextsImpl extends TagContexts {
     if (tags instanceof TagContextImpl) {
       return (TagContextImpl) tags;
     } else {
-      Iterator<Tag> i = tags.unsafeGetIterator();
+      Iterator<Tag> i = tags.iterator();
       if (!i.hasNext()) {
         return TagContextImpl.EMPTY;
       }
@@ -80,8 +80,7 @@ public final class TagContextsImpl extends TagContexts {
       return new TagContextBuilderImpl(((TagContextImpl) tags).getTags());
     } else {
       TagContextBuilderImpl builder = new TagContextBuilderImpl();
-      for (Iterator<Tag> i = tags.unsafeGetIterator(); i.hasNext(); ) {
-        Tag tag = i.next();
+      for (Tag tag : tags) {
         if (tag != null) {
           TagContextUtils.addTagToBuilder(tag, builder);
         }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
@@ -221,7 +221,6 @@ public class TagContextDeserializationTest {
   }
 
   private static void assertTagContextsEqual(TagContext actual, TagContext expected) {
-    assertThat(Lists.newArrayList(actual.unsafeGetIterator()))
-        .containsExactlyElementsIn(Lists.newArrayList(expected.unsafeGetIterator()));
+    assertThat(Lists.newArrayList(actual)).containsExactlyElementsIn(Lists.newArrayList(expected));
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
@@ -36,7 +36,6 @@ import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.UnreleasedApiAccessor;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -64,7 +63,7 @@ public class TagContextImplTest {
     TagKeyLong longKey = UnreleasedApiAccessor.createTagKeyLong("key");
     TagKeyBoolean boolKey = UnreleasedApiAccessor.createTagKeyBoolean("key");
     assertThat(
-            asList(
+            Lists.newArrayList(
                 tagContexts
                     .emptyBuilder()
                     .set(stringKey, TagValueString.create("value"))
@@ -80,24 +79,24 @@ public class TagContextImplTest {
   @Test
   public void testSet() {
     TagContext tags = tagContexts.emptyBuilder().set(KS1, V1).build();
-    assertThat(asList(tagContexts.toBuilder(tags).set(KS1, V2).build()))
+    assertThat(Lists.newArrayList(tagContexts.toBuilder(tags).set(KS1, V2).build()))
         .containsExactly(TagString.create(KS1, V2));
-    assertThat(asList(tagContexts.toBuilder(tags).set(KS2, V2).build()))
+    assertThat(Lists.newArrayList(tagContexts.toBuilder(tags).set(KS2, V2).build()))
         .containsExactly(TagString.create(KS1, V1), TagString.create(KS2, V2));
   }
 
   @Test
   public void testClear() {
     TagContext tags = tagContexts.emptyBuilder().set(KS1, V1).build();
-    assertThat(asList(tagContexts.toBuilder(tags).clear(KS1).build())).isEmpty();
-    assertThat(asList(tagContexts.toBuilder(tags).clear(KS2).build()))
+    assertThat(Lists.newArrayList(tagContexts.toBuilder(tags).clear(KS1).build())).isEmpty();
+    assertThat(Lists.newArrayList(tagContexts.toBuilder(tags).clear(KS2).build()))
         .containsExactly(TagString.create(KS1, V1));
   }
 
   @Test
   public void testIterator() {
     TagContext tags = tagContexts.emptyBuilder().set(KS1, V1).set(KS2, V2).build();
-    Iterator<Tag> i = tags.unsafeGetIterator();
+    Iterator<Tag> i = tags.iterator();
     assertTrue(i.hasNext());
     Tag tag1 = i.next();
     assertTrue(i.hasNext());
@@ -112,13 +111,9 @@ public class TagContextImplTest {
   @Test
   public void disallowCallingRemoveOnIterator() {
     TagContext tags = tagContexts.emptyBuilder().set(KS1, V1).set(KS2, V2).build();
-    Iterator<Tag> i = tags.unsafeGetIterator();
+    Iterator<Tag> i = tags.iterator();
     i.next();
     thrown.expect(UnsupportedOperationException.class);
     i.remove();
-  }
-
-  private static List<Tag> asList(TagContext tags) {
-    return Lists.newArrayList(tags.unsafeGetIterator());
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextRoundtripTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextRoundtripTest.java
@@ -63,7 +63,6 @@ public class TagContextRoundtripTest {
     serializer.serialize(expected, output);
     ByteArrayInputStream input = new ByteArrayInputStream(output.toByteArray());
     TagContext actual = serializer.deserialize(input);
-    assertThat(Lists.newArrayList(actual.unsafeGetIterator()))
-        .containsExactlyElementsIn(Lists.newArrayList(expected.unsafeGetIterator()));
+    assertThat(Lists.newArrayList(actual)).containsExactlyElementsIn(Lists.newArrayList(expected));
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextsImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextsImplTest.java
@@ -63,7 +63,7 @@ public class TagContextsImplTest {
 
   @Test
   public void empty() {
-    assertThat(asList(tagContexts.empty())).isEmpty();
+    assertThat(Lists.newArrayList(tagContexts.empty())).isEmpty();
     assertThat(tagContexts.empty()).isInstanceOf(TagContextImpl.class);
   }
 
@@ -71,14 +71,14 @@ public class TagContextsImplTest {
   public void emptyBuilder() {
     TagContextBuilder builder = tagContexts.emptyBuilder();
     assertThat(builder).isInstanceOf(TagContextBuilderImpl.class);
-    assertThat(asList(builder.build())).isEmpty();
+    assertThat(Lists.newArrayList(builder.build())).isEmpty();
   }
 
   @Test
   public void toBuilder_ConvertUnknownTagContextToTagContextImpl() {
     TagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
     TagContext newTagContext = tagContexts.toBuilder(unknownTagContext).build();
-    assertThat(asList(newTagContext)).containsExactly(TAG1, TAG2, TAG3);
+    assertThat(Lists.newArrayList(newTagContext)).containsExactly(TAG1, TAG2, TAG3);
     assertThat(newTagContext).isInstanceOf(TagContextImpl.class);
   }
 
@@ -88,20 +88,20 @@ public class TagContextsImplTest {
     Tag tag2 = TagString.create(KS, VS2);
     TagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
     TagContext newTagContext = tagContexts.toBuilder(tagContextWithDuplicateTags).build();
-    assertThat(asList(newTagContext)).containsExactly(tag2);
+    assertThat(Lists.newArrayList(newTagContext)).containsExactly(tag2);
   }
 
   @Test
   public void toBuilder_SkipNullTag() {
     TagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
     TagContext newTagContext = tagContexts.toBuilder(tagContextWithNullTag).build();
-    assertThat(asList(newTagContext)).containsExactly(TAG1, TAG2);
+    assertThat(Lists.newArrayList(newTagContext)).containsExactly(TAG1, TAG2);
   }
 
   @Test
   public void getCurrentTagContext_DefaultIsEmptyTagContextImpl() {
     TagContext currentTagContext = tagContexts.getCurrentTagContext();
-    assertThat(asList(currentTagContext)).isEmpty();
+    assertThat(Lists.newArrayList(currentTagContext)).isEmpty();
     assertThat(currentTagContext).isInstanceOf(TagContextImpl.class);
   }
 
@@ -110,7 +110,7 @@ public class TagContextsImplTest {
     TagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
     TagContext result = getResultOfGetCurrentTagContext(unknownTagContext);
     assertThat(result).isInstanceOf(TagContextImpl.class);
-    assertThat(asList(result)).containsExactly(TAG1, TAG2, TAG3);
+    assertThat(Lists.newArrayList(result)).containsExactly(TAG1, TAG2, TAG3);
   }
 
   @Test
@@ -119,14 +119,14 @@ public class TagContextsImplTest {
     Tag tag2 = TagString.create(KS, VS2);
     TagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
     TagContext result = getResultOfGetCurrentTagContext(tagContextWithDuplicateTags);
-    assertThat(asList(result)).containsExactly(tag2);
+    assertThat(Lists.newArrayList(result)).containsExactly(tag2);
   }
 
   @Test
   public void getCurrentTagContext_SkipNullTag() {
     TagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
     TagContext result = getResultOfGetCurrentTagContext(tagContextWithNullTag);
-    assertThat(asList(result)).containsExactly(TAG1, TAG2);
+    assertThat(Lists.newArrayList(result)).containsExactly(TAG1, TAG2);
   }
 
   private TagContext getResultOfGetCurrentTagContext(TagContext tagsToSet) {
@@ -143,7 +143,7 @@ public class TagContextsImplTest {
     TagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
     TagContext result = getResultOfWithTagContext(unknownTagContext);
     assertThat(result).isInstanceOf(TagContextImpl.class);
-    assertThat(asList(result)).containsExactly(TAG1, TAG2, TAG3);
+    assertThat(Lists.newArrayList(result)).containsExactly(TAG1, TAG2, TAG3);
   }
 
   @Test
@@ -152,14 +152,14 @@ public class TagContextsImplTest {
     Tag tag2 = TagString.create(KS, VS2);
     TagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
     TagContext result = getResultOfWithTagContext(tagContextWithDuplicateTags);
-    assertThat(asList(result)).containsExactly(tag2);
+    assertThat(Lists.newArrayList(result)).containsExactly(tag2);
   }
 
   @Test
   public void withTagContext_SkipNullTag() {
     TagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
     TagContext result = getResultOfWithTagContext(tagContextWithNullTag);
-    assertThat(asList(result)).containsExactly(TAG1, TAG2);
+    assertThat(Lists.newArrayList(result)).containsExactly(TAG1, TAG2);
   }
 
   private TagContext getResultOfWithTagContext(TagContext tagsToSet) {
@@ -171,10 +171,6 @@ public class TagContextsImplTest {
     }
   }
 
-  private static List<Tag> asList(TagContext tags) {
-    return Lists.newArrayList(tags.unsafeGetIterator());
-  }
-
   private static final class SimpleTagContext extends TagContext {
     private final List<Tag> tags;
 
@@ -183,7 +179,7 @@ public class TagContextsImplTest {
     }
 
     @Override
-    public Iterator<Tag> unsafeGetIterator() {
+    public Iterator<Tag> iterator() {
       return tags.iterator();
     }
   }


### PR DESCRIPTION
This commit also removes TagContext.unsafeGetIterator().  It is one solution
to #584.

/cc @adriancole 