### PR TITLE
Implement equals and hashCode for TagContext.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContext.java
+++ b/core/src/main/java/io/opencensus/tags/TagContext.java
@@ -62,12 +62,8 @@ public abstract class TagContext {
     return tags1.equals(tags2);
   }
 
-  /**
-   * Returns the sum of the hash codes of all tags in this {@code TagContext}, ignoring nulls.
-   * Implementations are free to override this method to provide better performance.
-   */
   @Override
-  public int hashCode() {
+  public final int hashCode() {
     int hashCode = 0;
     for (Iterator<Tag> i = unsafeGetIterator(); i.hasNext(); ) {
       Tag tag = i.next();

--- a/core/src/test/java/io/opencensus/tags/CurrentTagContextUtilsTest.java
+++ b/core/src/test/java/io/opencensus/tags/CurrentTagContextUtilsTest.java
@@ -71,7 +71,7 @@ public class CurrentTagContextUtilsTest {
     assertThat(asList(CurrentTagContextUtils.getCurrentTagContext())).isEmpty();
     Scope scopedTags = CurrentTagContextUtils.withTagContext(tagContext);
     try {
-      assertThat(CurrentTagContextUtils.getCurrentTagContext()).isEqualTo(tagContext);
+      assertThat(CurrentTagContextUtils.getCurrentTagContext()).isSameAs(tagContext);
     } finally {
       scopedTags.close();
     }
@@ -83,7 +83,7 @@ public class CurrentTagContextUtilsTest {
     Runnable runnable;
     Scope scopedTags = CurrentTagContextUtils.withTagContext(tagContext);
     try {
-      assertThat(CurrentTagContextUtils.getCurrentTagContext()).isEqualTo(tagContext);
+      assertThat(CurrentTagContextUtils.getCurrentTagContext()).isSameAs(tagContext);
       runnable =
           Context.current()
               .wrap(
@@ -91,7 +91,7 @@ public class CurrentTagContextUtilsTest {
                     @Override
                     public void run() {
                       assertThat(CurrentTagContextUtils.getCurrentTagContext())
-                          .isEqualTo(tagContext);
+                          .isSameAs(tagContext);
                     }
                   });
     } finally {

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
@@ -68,12 +68,6 @@ public final class TagContextImpl extends TagContext {
     return super.equals(other);
   }
 
-  @Override
-  public int hashCode() {
-    // implemented in TagContext
-    return super.hashCode();
-  }
-
   private static final class TagIterator implements Iterator<Tag> {
     Iterator<Map.Entry<TagKey, TagValue>> iterator;
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
@@ -59,6 +59,21 @@ public final class TagContextImpl extends TagContext {
     return new TagIterator(tags);
   }
 
+  @Override
+  public boolean equals(Object other) {
+    // Directly compare the tags when both objects are TagContextImpls, for efficiency.
+    if (other instanceof TagContextImpl) {
+      return getTags().equals(((TagContextImpl) other).getTags());
+    }
+    return super.equals(other);
+  }
+
+  @Override
+  public int hashCode() {
+    // implemented in TagContext
+    return super.hashCode();
+  }
+
   private static final class TagIterator implements Iterator<Tag> {
     Iterator<Map.Entry<TagKey, TagValue>> iterator;
 

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import com.google.common.collect.Lists;
+import com.google.common.testing.EqualsTester;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.Tag.TagBoolean;
 import io.opencensus.tags.Tag.TagLong;
@@ -116,6 +117,25 @@ public class TagContextImplTest {
     i.next();
     thrown.expect(UnsupportedOperationException.class);
     i.remove();
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            tagContexts.emptyBuilder().set(KS1, V1).set(KS2, V2).build(),
+            tagContexts.emptyBuilder().set(KS1, V1).set(KS2, V2).build(),
+            tagContexts.emptyBuilder().set(KS2, V2).set(KS1, V1).build(),
+            new TagContext() {
+              @Override
+              public Iterator<Tag> unsafeGetIterator() {
+                return Lists.<Tag>newArrayList(TagString.create(KS1, V1), TagString.create(KS2, V2))
+                    .iterator();
+              }
+            })
+        .addEqualityGroup(tagContexts.emptyBuilder().set(KS1, V1).set(KS2, V1).build())
+        .addEqualityGroup(tagContexts.emptyBuilder().set(KS1, V2).set(KS2, V1).build())
+        .testEquals();
   }
 
   private static List<Tag> asList(TagContext tags) {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextRoundtripTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextRoundtripTest.java
@@ -18,7 +18,6 @@ package io.opencensus.implcore.tags;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.Lists;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBinarySerializer;
 import io.opencensus.tags.TagContexts;
@@ -59,7 +58,6 @@ public class TagContextRoundtripTest {
   private void testRoundtripSerialization(TagContext expected) throws Exception {
     byte[] bytes = serializer.toByteArray(expected);
     TagContext actual = serializer.fromByteArray(bytes);
-    assertThat(Lists.newArrayList(actual.unsafeGetIterator()))
-        .containsExactlyElementsIn(Lists.newArrayList(expected.unsafeGetIterator()));
+    assertThat(actual).isEqualTo(expected);
   }
 }


### PR DESCRIPTION
Both methods are non-final so that subclasses can provide more efficient
implementations.  For example, TagContextImpl can compare the tag maps directly
when it is compared with another TagContextImpl.

/cc @bogdandrutu 