### PR TITLE
Wrap long to double internally.

### DIFF
--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -136,7 +136,10 @@ abstract class MutableViewData {
   /**
    * Record long stats with the given tags.
    */
-  abstract void record(TagContext tags, long value, Timestamp timestamp);
+  void record(TagContext tags, long value, Timestamp timestamp) {
+    // TODO(songya): shall we check for precision loss here?
+    record(tags, (double) value, timestamp);
+  }
 
   /**
    * Convert this {@link MutableViewData} to {@link ViewData}.
@@ -254,12 +257,6 @@ abstract class MutableViewData {
     }
 
     @Override
-    void record(TagContext tags, long value, Timestamp timestamp) {
-      // TODO(songya): implement this.
-      throw new UnsupportedOperationException("Not implemented.");
-    }
-
-    @Override
     ViewData toViewData(Clock clock) {
       return ViewData.create(
           super.view, createAggregationMap(tagValueAggregationMap),
@@ -326,12 +323,6 @@ abstract class MutableViewData {
       refreshBucketList(timestamp);
       // It is always the last bucket that does the recording.
       buckets.peekLast().record(tagValues, value);
-    }
-
-    @Override
-    void record(TagContext tags, long value, Timestamp timestamp) {
-      // TODO(songya): implement this.
-      throw new UnsupportedOperationException("Not implemented.");
     }
 
     @Override

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -27,10 +27,12 @@ import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.implcore.tags.TaggerImpl;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Aggregation.Mean;
+import io.opencensus.stats.AggregationData;
 import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.BucketBoundaries;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.stats.MeasureMap;
 import io.opencensus.stats.UnreleasedApiAccessor;
 import io.opencensus.stats.View;
@@ -72,8 +74,11 @@ public class ViewManagerImplTest {
 
   private static final String MEASURE_DESCRIPTION = "measure description";
 
-  private static final MeasureDouble MEASURE =
-      Measure.MeasureDouble.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT);
+  private static final MeasureDouble MEASURE_DOUBLE =
+      MeasureDouble.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT);
+
+  private static final MeasureLong MEASURE_LONG =
+      MeasureLong.create(MEASURE_NAME_2, MEASURE_DESCRIPTION, MEASURE_UNIT);
 
   private static final Name VIEW_NAME = Name.create("my view");
   private static final Name VIEW_NAME_2 = Name.create("my view 2");
@@ -103,7 +108,7 @@ public class ViewManagerImplTest {
   private final StatsRecorderImpl statsRecorder = statsComponent.getStatsRecorder();
 
   private static View createCumulativeView() {
-    return createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY));
+    return createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY));
   }
 
   private static View createCumulativeView(
@@ -126,7 +131,7 @@ public class ViewManagerImplTest {
         View.create(
             VIEW_NAME,
             VIEW_DESCRIPTION,
-            MEASURE,
+            MEASURE_DOUBLE,
             MEAN,
             Arrays.asList(KEY),
             Interval.create(Duration.create(60, 0)));
@@ -148,19 +153,37 @@ public class ViewManagerImplTest {
   public void preventRegisteringDifferentViewWithSameName() {
     View view1 =
         View.create(
-            VIEW_NAME, "View description.", MEASURE, MEAN, Arrays.asList(KEY), CUMULATIVE);
-    viewManager.registerView(view1);
+            VIEW_NAME, "View description.", MEASURE_DOUBLE, MEAN, Arrays.asList(KEY),
+            CUMULATIVE);
     View view2 =
         View.create(
             VIEW_NAME,
             "This is a different description.",
-            MEASURE,
+            MEASURE_DOUBLE,
             MEAN,
             Arrays.asList(KEY),
             CUMULATIVE);
+    testFailedToRegisterView(view1, view2,
+        "A different view with the same name is already registered");
+  }
+
+  @Test
+  public void preventRegisteringDifferentMeasureWithSameName() {
+    MeasureDouble measure1 = MeasureDouble.create("measure", "description", "1");
+    MeasureLong measure2 = MeasureLong.create("measure", "description", "1");
+    View view1 = View.create(
+        VIEW_NAME, VIEW_DESCRIPTION, measure1, MEAN, Arrays.asList(KEY), CUMULATIVE);
+    View view2 = View.create(
+        VIEW_NAME_2, VIEW_DESCRIPTION, measure2, MEAN, Arrays.asList(KEY), CUMULATIVE);
+    testFailedToRegisterView(view1, view2,
+        "A different measure with the same name is already registered");
+  }
+
+  private void testFailedToRegisterView(View view1, View view2, String message) {
+    viewManager.registerView(view1);
     try {
       thrown.expect(IllegalArgumentException.class);
-      thrown.expectMessage("A different view with the same name is already registered");
+      thrown.expectMessage(message);
       viewManager.registerView(view2);
     } finally {
       assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view1);
@@ -174,14 +197,22 @@ public class ViewManagerImplTest {
   }
 
   @Test
-  public void testRecordCumulative() {
-    View view = createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY));
+  public void testRecordDouble_cumulative() {
+    testRecordCumulative(MEASURE_DOUBLE, 10.0, 20.0, 30.0, 40.0);
+  }
+
+  @Test
+  public void testRecordLong_cumulative() {
+    testRecordCumulative(MEASURE_LONG, 1000, 2000, 3000, 4000);
+  }
+
+  private void testRecordCumulative(Measure measure, double... values) {
+    View view = createCumulativeView(VIEW_NAME, measure, MEAN, Arrays.asList(KEY));
     clock.setTime(Timestamp.create(1, 2));
     viewManager.registerView(view);
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
-    double[] values = {10.0, 20.0, 30.0, 40.0};
     for (double val : values) {
-      statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, val).build());
+      statsRecorder.record(tags, buildMeasureMap(measure, val));
     }
     clock.setTime(Timestamp.create(3, 4));
     ViewData viewData = viewManager.getView(VIEW_NAME);
@@ -196,11 +227,41 @@ public class ViewManagerImplTest {
   }
 
   @Test
-  public void testRecordInterval() {
+  public void testRecordDouble_interval() {
+    testRecordInterval(
+        MEASURE_DOUBLE,
+        new double[]{20.0, -1.0, 1.0, -5.0, 5.0},
+        9.0,
+        30.0,
+        MeanData.create((19 * 0.6 + 1) / 4, 4),
+        MeanData.create(0.2 * 5 + 9, 1),
+        MeanData.create(30.0, 1));
+  }
+
+  @Test
+  public void testRecordLong_interval() {
+    testRecordInterval(
+        MEASURE_LONG,
+        new double[]{1000, 2000, 3000, 4000, 5000},
+        -5000,
+        30,
+        MeanData.create((3000 * 0.6 + 12000) / 4, 4),
+        MeanData.create(-4000, 1),
+        MeanData.create(30, 1));
+  }
+
+  private void testRecordInterval(
+      Measure measure,
+      double[] initialValues, /* There are 5 initial values recorded before we call getView(). */
+      double value6,
+      double value7,
+      AggregationData expectedValues1,
+      AggregationData expectedValues2,
+      AggregationData expectedValues3) {
     // The interval is 10 seconds, i.e. values should expire after 10 seconds.
     // Each bucket has a duration of 2.5 seconds.
     View view = View.create(
-        VIEW_NAME, VIEW_DESCRIPTION, MEASURE, MEAN, Arrays.asList(KEY),
+        VIEW_NAME, VIEW_DESCRIPTION, measure, MEAN, Arrays.asList(KEY),
         Interval.create(TEN_SECONDS));
     long startTimeMillis = 30 * MILLIS_PER_SECOND; // start at 30s
     clock.setTime(Timestamp.fromMillis(startTimeMillis));
@@ -208,16 +269,15 @@ public class ViewManagerImplTest {
 
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
 
-    double[] values = {20.0, -1.0, 1.0, -5.0, 5.0};
     for (int i = 1; i <= 5; i++) {
       /*
        * Add each value in sequence, at 31s, 32s, 33s, etc.
-       * 20.0 and -1.0 should fall into the first bucket [30.0, 32.5),
-       * 1.0 and -5.0 should fall into the second bucket [32.5, 35.0),
-       * 5.0 should fall into the third bucket [35.0, 37.5).
+       * 1st and 2nd values should fall into the first bucket [30.0, 32.5),
+       * 3rd and 4th values should fall into the second bucket [32.5, 35.0),
+       * 5th value should fall into the third bucket [35.0, 37.5).
        */
       clock.setTime(Timestamp.fromMillis(startTimeMillis + i * MILLIS_PER_SECOND));
-      statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, values[i - 1]).build());
+      statsRecorder.record(tags, buildMeasureMap(measure, initialValues[i - 1]));
     }
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 8 * MILLIS_PER_SECOND));
@@ -226,40 +286,34 @@ public class ViewManagerImplTest {
         viewManager.getView(VIEW_NAME).getAggregationMap(),
         ImmutableMap.of(
             Arrays.asList(VALUE),
-            StatsTestUtil.createAggregationData(MEAN, values)),
+            StatsTestUtil.createAggregationData(MEAN, initialValues)),
         EPSILON);
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 11 * MILLIS_PER_SECOND));
     // 41s, 40% of the values in the first bucket should have expired (1 / 2.5 = 0.4).
     StatsTestUtil.assertAggregationMapEquals(
         viewManager.getView(VIEW_NAME).getAggregationMap(),
-        ImmutableMap.of(
-            Arrays.asList(VALUE),
-            MeanData.create((19 * 0.6 + 1) / 4, 4)),
+        ImmutableMap.of(Arrays.asList(VALUE), expectedValues1),
         EPSILON);
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 12 * MILLIS_PER_SECOND));
-    // 42s, add a new value 9.0, should fall into bucket [40.0, 42.5)
-    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, 9.0).build());
+    // 42s, add a new value value1, should fall into bucket [40.0, 42.5)
+    statsRecorder.record(tags, buildMeasureMap(measure, value6));
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 17 * MILLIS_PER_SECOND));
     // 47s, values in the first and second bucket should have expired, and 80% of values in the
     // third bucket should have expired. The new value should persist.
     StatsTestUtil.assertAggregationMapEquals(
         viewManager.getView(VIEW_NAME).getAggregationMap(),
-        ImmutableMap.of(
-            Arrays.asList(VALUE),
-            MeanData.create(0.2 * 5 + 9, 1)),
+        ImmutableMap.of(Arrays.asList(VALUE), expectedValues2),
         EPSILON);
 
     clock.setTime(Timestamp.fromMillis(60 * MILLIS_PER_SECOND));
-    // 60s, all previous values should have expired, add a new value 30.0
-    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, 30.0).build());
+    // 60s, all previous values should have expired, add another value value2
+    statsRecorder.record(tags, buildMeasureMap(measure, value7));
     StatsTestUtil.assertAggregationMapEquals(
         viewManager.getView(VIEW_NAME).getAggregationMap(),
-        ImmutableMap.of(
-            Arrays.asList(VALUE),
-            MeanData.create(30.0, 1)),
+        ImmutableMap.of(Arrays.asList(VALUE), expectedValues3),
         EPSILON);
 
     clock.setTime(Timestamp.fromMillis(100 * MILLIS_PER_SECOND));
@@ -269,11 +323,11 @@ public class ViewManagerImplTest {
 
   @Test
   public void getViewDoesNotClearStats() {
-    View view = createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY));
+    View view = createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY));
     clock.setTime(Timestamp.create(10, 0));
     viewManager.registerView(view);
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
-    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, 0.1).build());
+    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE_DOUBLE, 0.1).build());
     clock.setTime(Timestamp.create(11, 0));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
     assertThat(viewData1.getWindowData())
@@ -284,7 +338,7 @@ public class ViewManagerImplTest {
             Arrays.asList(VALUE), StatsTestUtil.createAggregationData(MEAN, 0.1)),
         EPSILON);
 
-    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, 0.2).build());
+    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE_DOUBLE, 0.2).build());
     clock.setTime(Timestamp.create(12, 0));
     ViewData viewData2 = viewManager.getView(VIEW_NAME);
 
@@ -302,16 +356,16 @@ public class ViewManagerImplTest {
   @Test
   public void testRecordCumulativeMultipleTagValues() {
     viewManager.registerView(
-        createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY)));
+        createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY)));
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().put(MEASURE, 10.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 10.0).build());
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE_2).build(),
-        MeasureMap.builder().put(MEASURE, 30.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 30.0).build());
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE_2).build(),
-        MeasureMap.builder().put(MEASURE, 50.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 50.0).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
         viewData.getAggregationMap(),
@@ -327,7 +381,7 @@ public class ViewManagerImplTest {
   public void testRecordIntervalMultipleTagValues() {
     // The interval is 10 seconds, i.e. values should expire after 10 seconds.
     View view = View.create(
-        VIEW_NAME, VIEW_DESCRIPTION, MEASURE, MEAN, Arrays.asList(KEY),
+        VIEW_NAME, VIEW_DESCRIPTION, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY),
         Interval.create(TEN_SECONDS));
     clock.setTime(Timestamp.create(10, 0)); // Start at 10s
     viewManager.registerView(view);
@@ -336,16 +390,16 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.fromMillis(11 * MILLIS_PER_SECOND));
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().put(MEASURE, 10.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 10.0).build());
 
     // record for TagValue2 at 15s
     clock.setTime(Timestamp.fromMillis(15 * MILLIS_PER_SECOND));
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE_2).build(),
-        MeasureMap.builder().put(MEASURE, 30.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 30.0).build());
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE_2).build(),
-        MeasureMap.builder().put(MEASURE, 50.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 50.0).build());
 
     // get ViewData at 19s, no stats should have expired.
     clock.setTime(Timestamp.fromMillis(19 * MILLIS_PER_SECOND));
@@ -381,15 +435,16 @@ public class ViewManagerImplTest {
   public void allowRecordingWithoutRegisteringMatchingViewData() {
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().put(MEASURE, 10).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 10).build());
   }
 
   @Test
   public void testRecordWithEmptyStatsContext() {
     viewManager.registerView(
-        createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY)));
+        createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY)));
     // DEFAULT doesn't have tags, but the view has tag key "KEY".
-    statsRecorder.record(tagger.empty(), MeasureMap.builder().put(MEASURE, 10.0).build());
+    statsRecorder
+        .record(tagger.empty(), MeasureMap.builder().put(MEASURE_DOUBLE, 10.0).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
         viewData.getAggregationMap(),
@@ -403,17 +458,31 @@ public class ViewManagerImplTest {
   }
 
   @Test
-  public void testRecordWithNonExistentMeasurement() {
+  public void testRecord_MeasureNameNotMatch() {
+    testRecord_MeasureNotMatch(
+        MeasureDouble.create(MEASURE_NAME, "measure", MEASURE_UNIT),
+        MeasureDouble.create(MEASURE_NAME_2, "measure", MEASURE_UNIT),
+        10.0);
+  }
+
+  @Test
+  public void testRecord_MeasureTypeNotMatch() {
+    testRecord_MeasureNotMatch(
+        MeasureLong.create(MEASURE_NAME, "measure", MEASURE_UNIT),
+        MeasureDouble.create(MEASURE_NAME, "measure", MEASURE_UNIT),
+        10.0);
+  }
+
+  private void testRecord_MeasureNotMatch(Measure measure1, Measure measure2, double value) {
     viewManager.registerView(
         createCumulativeView(
             VIEW_NAME,
-            Measure.MeasureDouble.create(MEASURE_NAME, "measure", MEASURE_UNIT),
+            measure1,
             MEAN,
             Arrays.asList(KEY)));
-    MeasureDouble measure2 = Measure.MeasureDouble.create(MEASURE_NAME_2, "measure", MEASURE_UNIT);
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().put(measure2, 10.0).build());
+        buildMeasureMap(measure2, value));
     ViewData view = viewManager.getView(VIEW_NAME);
     assertThat(view.getAggregationMap()).isEmpty();
   }
@@ -421,13 +490,13 @@ public class ViewManagerImplTest {
   @Test
   public void testRecordWithTagsThatDoNotMatchViewData() {
     viewManager.registerView(
-        createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY)));
+        createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY)));
     statsRecorder.record(
         tagger.emptyBuilder().put(TagKeyString.create("wrong key"), VALUE).build(),
-        MeasureMap.builder().put(MEASURE, 10.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 10.0).build());
     statsRecorder.record(
         tagger.emptyBuilder().put(TagKeyString.create("another wrong key"), VALUE).build(),
-        MeasureMap.builder().put(MEASURE, 50.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 50.0).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
         viewData.getAggregationMap(),
@@ -445,35 +514,35 @@ public class ViewManagerImplTest {
     TagKeyString key1 = TagKeyString.create("Key-1");
     TagKeyString key2 = TagKeyString.create("Key-2");
     viewManager.registerView(
-        createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(key1, key2)));
+        createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(key1, key2)));
     statsRecorder.record(
         tagger
             .emptyBuilder()
             .put(key1, TagValueString.create("v1"))
             .put(key2, TagValueString.create("v10"))
             .build(),
-        MeasureMap.builder().put(MEASURE, 1.1).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 1.1).build());
     statsRecorder.record(
         tagger
             .emptyBuilder()
             .put(key1, TagValueString.create("v1"))
             .put(key2, TagValueString.create("v20"))
             .build(),
-        MeasureMap.builder().put(MEASURE, 2.2).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 2.2).build());
     statsRecorder.record(
         tagger
             .emptyBuilder()
             .put(key1, TagValueString.create("v2"))
             .put(key2, TagValueString.create("v10"))
             .build(),
-        MeasureMap.builder().put(MEASURE, 3.3).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 3.3).build());
     statsRecorder.record(
         tagger
             .emptyBuilder()
             .put(key1, TagValueString.create("v1"))
             .put(key2, TagValueString.create("v10"))
             .build(),
-        MeasureMap.builder().put(MEASURE, 4.4).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 4.4).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
         viewData.getAggregationMap(),
@@ -489,15 +558,15 @@ public class ViewManagerImplTest {
 
   @Test
   public void testMultipleViewSameMeasure() {
-    final View view1 = createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY));
-    final View view2 = createCumulativeView(VIEW_NAME_2, MEASURE, MEAN, Arrays.asList(KEY));
+    final View view1 = createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY));
+    final View view2 = createCumulativeView(VIEW_NAME_2, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY));
     clock.setTime(Timestamp.create(1, 1));
     viewManager.registerView(view1);
     clock.setTime(Timestamp.create(2, 2));
     viewManager.registerView(view2);
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().put(MEASURE, 5.0).build());
+        MeasureMap.builder().put(MEASURE_DOUBLE, 5.0).build());
     clock.setTime(Timestamp.create(3, 3));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
     clock.setTime(Timestamp.create(4, 4));
@@ -519,21 +588,36 @@ public class ViewManagerImplTest {
   }
 
   @Test
-  public void testMultipleViewsDifferentMeasures() {
-    MeasureDouble measure1 =
-        Measure.MeasureDouble.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT);
-    MeasureDouble measure2 =
-        Measure.MeasureDouble.create(MEASURE_NAME_2, MEASURE_DESCRIPTION, MEASURE_UNIT);
-    final View view1 = createCumulativeView(VIEW_NAME, measure1, MEAN, Arrays.asList(KEY));
+  public void testMultipleViews_DifferentMeasureNames() {
+    testMultipleViews_DifferentMeasures(
+        MeasureDouble.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT),
+        MeasureDouble.create(MEASURE_NAME_2, MEASURE_DESCRIPTION, MEASURE_UNIT),
+        1.1,
+        2.2);
+  }
+
+  @Test
+  public void testMultipleViews_DifferentMeasureTypes() {
+    testMultipleViews_DifferentMeasures(
+        MeasureDouble.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT),
+        MeasureLong.create(MEASURE_NAME_2, MEASURE_DESCRIPTION, MEASURE_UNIT),
+        1.1,
+        5000);
+  }
+
+  private void testMultipleViews_DifferentMeasures(
+      Measure measure1, Measure measure2, double value1, double value2) {
+    final View view1 =
+        createCumulativeView(VIEW_NAME, measure1, MEAN, Arrays.asList(KEY));
     final View view2 =
         createCumulativeView(VIEW_NAME_2, measure2, MEAN, Arrays.asList(KEY));
     clock.setTime(Timestamp.create(1, 0));
     viewManager.registerView(view1);
     clock.setTime(Timestamp.create(2, 0));
     viewManager.registerView(view2);
-    statsRecorder.record(
-        tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().put(measure1, 1.1).put(measure2, 2.2).build());
+    TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
+    statsRecorder.record(tags, buildMeasureMap(measure1, value1));
+    statsRecorder.record(tags, buildMeasureMap(measure2, value2));
     clock.setTime(Timestamp.create(3, 0));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
     clock.setTime(Timestamp.create(4, 0));
@@ -543,14 +627,14 @@ public class ViewManagerImplTest {
     StatsTestUtil.assertAggregationMapEquals(
         viewData1.getAggregationMap(),
         ImmutableMap.of(
-            Arrays.asList(VALUE), StatsTestUtil.createAggregationData(MEAN, 1.1)),
+            Arrays.asList(VALUE), StatsTestUtil.createAggregationData(MEAN, value1)),
         EPSILON);
     assertThat(viewData2.getWindowData())
         .isEqualTo(CumulativeData.create(Timestamp.create(2, 0), Timestamp.create(4, 0)));
     StatsTestUtil.assertAggregationMapEquals(
         viewData2.getAggregationMap(),
         ImmutableMap.of(
-            Arrays.asList(VALUE), StatsTestUtil.createAggregationData(MEAN, 2.2)),
+            Arrays.asList(VALUE), StatsTestUtil.createAggregationData(MEAN, value2)),
         EPSILON);
   }
 
@@ -575,4 +659,15 @@ public class ViewManagerImplTest {
   //            createAggregationData(noHistogram, 1.1)),
   //        EPSILON);
   //  }
+
+  private static MeasureMap buildMeasureMap(Measure measure, double value) {
+    if (measure instanceof MeasureDouble) {
+      return MeasureMap.builder().put((MeasureDouble) measure, value).build();
+    } else if (measure instanceof MeasureLong) {
+      return MeasureMap.builder().put((MeasureLong) measure, Math.round(value)).build();
+    } else {
+      // Future measures.
+      throw new AssertionError();
+    }
+  }
 }


### PR DESCRIPTION
For supporting long measure values. The output `AggregationData` will all be double, even if the input values are long.