### PR TITLE
Add TagContextParseException to throw from deserialization method.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContextBinarySerializer.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBinarySerializer.java
@@ -16,7 +16,6 @@
 
 package io.opencensus.tags;
 
-import java.io.IOException;
 import javax.annotation.concurrent.Immutable;
 
 /** Object for serializing and deserializing {@link TagContext}s with the binary format. */
@@ -41,10 +40,10 @@ public abstract class TagContextBinarySerializer {
    *
    * @param bytes on-the-wire representation of a {@code TagContext}.
    * @return a {@code TagContext} deserialized from {@code bytes}.
-   * @throws IOException if there is a parse error.
+   * @throws TagContextParseException if there is a parse error.
    */
   // TODO(sebright): Use a more appropriate exception type, since this method doesn't do IO.
-  public abstract TagContext fromByteArray(byte[] bytes) throws IOException;
+  public abstract TagContext fromByteArray(byte[] bytes) throws TagContextParseException;
 
   /**
    * Returns a {@code TagContextBinarySerializer} that serializes all {@code TagContext}s to zero
@@ -64,7 +63,7 @@ public abstract class TagContextBinarySerializer {
     }
 
     @Override
-    public TagContext fromByteArray(byte[] bytes) throws IOException {
+    public TagContext fromByteArray(byte[] bytes) {
       return TagContext.getNoopTagContext();
     }
   }

--- a/core/src/main/java/io/opencensus/tags/TagContextParseException.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextParseException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+/** Exception thrown when a {@link TagContext} cannot be parsed. */
+public final class TagContextParseException extends Exception {
+  private static final long serialVersionUID = 0L;
+
+  /**
+   * Constructs a new {@code TagContextParseException} with the given message.
+   *
+   * @param message a message describing the parse error.
+   */
+  public TagContextParseException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new {@code TagContextParseException} with the given message and cause.
+   *
+   * @param message a message describing the parse error.
+   * @param cause the cause of the parse error.
+   */
+  public TagContextParseException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/core/src/test/java/io/opencensus/tags/TagContextParseExceptionTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagContextParseExceptionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TagContextParseException}. */
+@RunWith(JUnit4.class)
+public final class TagContextParseExceptionTest {
+
+  @Test
+  public void createWithMessage() {
+    assertThat(new TagContextParseException("my message").getMessage()).isEqualTo("my message");
+  }
+
+  @Test
+  public void createWithMessageAndCause() {
+    IOException cause = new IOException();
+    TagContextParseException parseException = new TagContextParseException("my message", cause);
+    assertThat(parseException.getMessage()).isEqualTo("my message");
+    assertThat(parseException.getCause()).isEqualTo(cause);
+  }
+}

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/SerializationUtils.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/SerializationUtils.java
@@ -28,11 +28,11 @@ import io.opencensus.tags.Tag.TagBoolean;
 import io.opencensus.tags.Tag.TagLong;
 import io.opencensus.tags.Tag.TagString;
 import io.opencensus.tags.TagContext;
+import io.opencensus.tags.TagContextParseException;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.TagValue.TagValueString;
-import java.io.IOException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -113,18 +113,18 @@ final class SerializationUtils {
 
   // Deserializes input to TagContext based on the binary format standard.
   // The encoded tags are of the form: <version_id><encoded_tags>
-  static TagContextImpl deserializeBinary(byte[] bytes) throws IOException {
+  static TagContextImpl deserializeBinary(byte[] bytes) throws TagContextParseException {
     try {
       HashMap<TagKey, TagValue> tags = new HashMap<TagKey, TagValue>();
       if (bytes.length == 0) {
         // Does not allow empty byte array.
-        throw new IOException("Input byte[] can not be empty.");
+        throw new TagContextParseException("Input byte[] can not be empty.");
       }
 
       ByteBuffer buffer = ByteBuffer.wrap(bytes).asReadOnlyBuffer();
       int versionId = buffer.get();
       if (versionId != VERSION_ID) {
-        throw new IOException(
+        throw new TagContextParseException(
             "Wrong Version ID: " + versionId + ". Currently supported version is: " + VERSION_ID);
       }
 
@@ -142,12 +142,12 @@ final class SerializationUtils {
           case VALUE_TYPE_FALSE:
           default:
             // TODO(songya): add support for value types integer and boolean
-            throw new IOException("Unsupported tag value type.");
+            throw new TagContextParseException("Unsupported tag value type.");
         }
       }
       return new TagContextImpl(tags);
     } catch (BufferUnderflowException exn) {
-      throw new IOException(exn.toString()); // byte array format error.
+      throw new TagContextParseException(exn.toString()); // byte array format error.
     }
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBinarySerializerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBinarySerializerImpl.java
@@ -18,7 +18,7 @@ package io.opencensus.implcore.tags;
 
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBinarySerializer;
-import java.io.IOException;
+import io.opencensus.tags.TagContextParseException;
 
 final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   @Override
@@ -27,7 +27,7 @@ final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   }
 
   @Override
-  public TagContext fromByteArray(byte[] bytes) throws IOException {
+  public TagContext fromByteArray(byte[] bytes) throws TagContextParseException {
     return SerializationUtils.deserializeBinary(bytes);
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import io.opencensus.implcore.internal.VarInt;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBinarySerializer;
+import io.opencensus.tags.TagContextParseException;
 import io.opencensus.tags.TagContexts;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
@@ -64,7 +65,7 @@ public class TagContextDeserializationTest {
     assertTagContextsEqual(actual, expected);
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = TagContextParseException.class)
   public void testDeserializeEmptyByteArrayThrowException() throws Exception {
     testDeserialize(new byte[0]);
   }
@@ -104,42 +105,42 @@ public class TagContextDeserializationTest {
     assertTagContextsEqual(actual, expected);
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeInteger() throws Exception {
     // TODO(songya): test should pass after we add support for type integer
     testDeserialize(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_INTEGER));
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeTrue() throws Exception {
     // TODO(songya): test should pass after we add support for type boolean
     testDeserialize(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_TRUE));
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeFalse() throws Exception {
     // TODO(songya): test should pass after we add support for type boolean
     testDeserialize(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_FALSE));
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = TagContextParseException.class)
   public void testDeserializeMultipleValueType() throws Exception {
     // TODO(songya): test should pass after we add support for type integer and boolean
     testDeserialize(constructMultiTypeTagInputStream());
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = TagContextParseException.class)
   public void testDeserializeWrongFormat() throws Exception {
     // encoded tags should follow the format <version_id>(<tag_field_id><tag_encoding>)*
     testDeserialize(new byte[3]);
   }
 
-  @Test(expected = IOException.class)
+  @Test(expected = TagContextParseException.class)
   public void testDeserializeWrongVersionId() throws Exception {
     testDeserialize(new byte[] {(byte) (SerializationUtils.VERSION_ID + 1)});
   }
 
-  private TagContext testDeserialize(byte[] bytes) throws IOException {
+  private TagContext testDeserialize(byte[] bytes) throws TagContextParseException {
     return serializer.fromByteArray(bytes);
   }
 


### PR DESCRIPTION
This class will allow us to add fields to the exception if we need to add more information about the error in the future.

____________________________________________________________

The exception isn't used yet, because it depends on updating the deserialization method to not do IO (#213).

/cc @adriancole 