### PR TITLE
Rename TagContextBuilder methods to be more consistent with Map and Collection

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
@@ -61,10 +61,10 @@ public abstract class TagContextBuilder {
   /**
    * Removes the key if it exists.
    *
-   * @param key the {@code TagKey} which will be cleared.
+   * @param key the {@code TagKey} which will be removed.
    * @return this
    */
-  public abstract TagContextBuilder clear(TagKey key);
+  public abstract TagContextBuilder remove(TagKey key);
 
   /**
    * Creates a {@code TagContext} from this builder.
@@ -113,7 +113,7 @@ public abstract class TagContextBuilder {
     }
 
     @Override
-    public TagContextBuilder clear(TagKey key) {
+    public TagContextBuilder remove(TagKey key) {
       return this;
     }
 

--- a/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
@@ -26,7 +26,7 @@ import io.opencensus.tags.TagValue.TagValueString;
 import javax.annotation.concurrent.Immutable;
 
 /** Builder for the {@link TagContext} class. */
-// TODO(sebright): Decide what to do when 'set' is called with a key that has the same name as an
+// TODO(sebright): Decide what to do when 'put' is called with a key that has the same name as an
 // existing key, but a different type.  We currently keep both keys.
 public abstract class TagContextBuilder {
   private static final TagContextBuilder NOOP_TAG_CONTEXT_BUILDER = new NoopTagContextBuilder();
@@ -38,7 +38,7 @@ public abstract class TagContextBuilder {
    * @param value the value to set for the given key.
    * @return this
    */
-  public abstract TagContextBuilder set(TagKeyString key, TagValueString value);
+  public abstract TagContextBuilder put(TagKeyString key, TagValueString value);
 
   /**
    * Adds the key/value pair regardless of whether the key is present.
@@ -47,7 +47,7 @@ public abstract class TagContextBuilder {
    * @param value the value to set for the given key.
    * @return this
    */
-  public abstract TagContextBuilder set(TagKeyLong key, TagValueLong value);
+  public abstract TagContextBuilder put(TagKeyLong key, TagValueLong value);
 
   /**
    * Adds the key/value pair regardless of whether the key is present.
@@ -56,7 +56,7 @@ public abstract class TagContextBuilder {
    * @param value the value to set for the given key.
    * @return this
    */
-  public abstract TagContextBuilder set(TagKeyBoolean key, TagValueBoolean value);
+  public abstract TagContextBuilder put(TagKeyBoolean key, TagValueBoolean value);
 
   /**
    * Removes the key if it exists.
@@ -86,9 +86,9 @@ public abstract class TagContextBuilder {
   }
 
   /**
-   * Returns a {@code TagContextBuilder} that ignores all calls to {@link #set}.
+   * Returns a {@code TagContextBuilder} that ignores all calls to {@link #put}.
    *
-   * @return a {@code TagContextBuilder} that ignores all calls to {@link #set}.
+   * @return a {@code TagContextBuilder} that ignores all calls to {@link #put}.
    */
   static TagContextBuilder getNoopTagContextBuilder() {
     return NOOP_TAG_CONTEXT_BUILDER;
@@ -98,17 +98,17 @@ public abstract class TagContextBuilder {
   private static final class NoopTagContextBuilder extends TagContextBuilder {
 
     @Override
-    public TagContextBuilder set(TagKeyString key, TagValueString value) {
+    public TagContextBuilder put(TagKeyString key, TagValueString value) {
       return this;
     }
 
     @Override
-    public TagContextBuilder set(TagKeyLong key, TagValueLong value) {
+    public TagContextBuilder put(TagKeyLong key, TagValueLong value) {
       return this;
     }
 
     @Override
-    public TagContextBuilder set(TagKeyBoolean key, TagValueBoolean value) {
+    public TagContextBuilder put(TagKeyBoolean key, TagValueBoolean value) {
       return this;
     }
 

--- a/core/src/test/java/io/opencensus/tags/ScopedTagContextsTest.java
+++ b/core/src/test/java/io/opencensus/tags/ScopedTagContextsTest.java
@@ -164,7 +164,7 @@ public class ScopedTagContextsTest {
     }
 
     @Override
-    public TagContextBuilder clear(TagKey key) {
+    public TagContextBuilder remove(TagKey key) {
       throw new UnsupportedOperationException();
     }
 

--- a/core/src/test/java/io/opencensus/tags/ScopedTagContextsTest.java
+++ b/core/src/test/java/io/opencensus/tags/ScopedTagContextsTest.java
@@ -92,7 +92,7 @@ public class ScopedTagContextsTest {
     TagContext scopedTags = new SimpleTagContext(TagString.create(KEY_1, VALUE_1));
     Scope scope = tagContexts.withTagContext(scopedTags);
     try {
-      TagContext newTags = tagContexts.currentBuilder().set(KEY_2, VALUE_2).build();
+      TagContext newTags = tagContexts.currentBuilder().put(KEY_2, VALUE_2).build();
       assertThat(asList(newTags))
           .containsExactly(TagString.create(KEY_1, VALUE_1), TagString.create(KEY_2, VALUE_2));
       assertThat(tagContexts.getCurrentTagContext()).isSameAs(scopedTags);
@@ -104,7 +104,7 @@ public class ScopedTagContextsTest {
   @Test
   public void setCurrentTagsWithBuilder() {
     assertThat(asList(tagContexts.getCurrentTagContext())).isEmpty();
-    Scope scope = tagContexts.emptyBuilder().set(KEY_1, VALUE_1).buildScoped();
+    Scope scope = tagContexts.emptyBuilder().put(KEY_1, VALUE_1).buildScoped();
     try {
       assertThat(asList(tagContexts.getCurrentTagContext()))
           .containsExactly(TagString.create(KEY_1, VALUE_1));
@@ -119,7 +119,7 @@ public class ScopedTagContextsTest {
     TagContext scopedTags = new SimpleTagContext(TagString.create(KEY_1, VALUE_1));
     Scope scope1 = tagContexts.withTagContext(scopedTags);
     try {
-      Scope scope2 = tagContexts.currentBuilder().set(KEY_2, VALUE_2).buildScoped();
+      Scope scope2 = tagContexts.currentBuilder().put(KEY_2, VALUE_2).buildScoped();
       try {
         assertThat(asList(tagContexts.getCurrentTagContext()))
             .containsExactly(TagString.create(KEY_1, VALUE_1), TagString.create(KEY_2, VALUE_2));
@@ -148,18 +148,18 @@ public class ScopedTagContextsTest {
     }
 
     @Override
-    public TagContextBuilder set(TagKeyString key, TagValueString value) {
+    public TagContextBuilder put(TagKeyString key, TagValueString value) {
       tagMap.put(key, value);
       return this;
     }
 
     @Override
-    public TagContextBuilder set(TagKeyLong key, TagValueLong value) {
+    public TagContextBuilder put(TagKeyLong key, TagValueLong value) {
       throw new UnsupportedOperationException();
     }
 
     @Override
-    public TagContextBuilder set(TagKeyBoolean key, TagValueBoolean value) {
+    public TagContextBuilder put(TagKeyBoolean key, TagValueBoolean value) {
       throw new UnsupportedOperationException();
     }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBuilderImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBuilderImpl.java
@@ -62,7 +62,7 @@ final class TagContextBuilderImpl extends TagContextBuilder {
   }
 
   @Override
-  public TagContextBuilderImpl clear(TagKey key) {
+  public TagContextBuilderImpl remove(TagKey key) {
     tags.remove(key);
     return this;
   }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBuilderImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBuilderImpl.java
@@ -42,17 +42,17 @@ final class TagContextBuilderImpl extends TagContextBuilder {
   }
 
   @Override
-  public TagContextBuilderImpl set(TagKeyString key, TagValueString value) {
+  public TagContextBuilderImpl put(TagKeyString key, TagValueString value) {
     return setInternal(key, checkNotNull(value, "value"));
   }
 
   @Override
-  public TagContextBuilderImpl set(TagKeyLong key, TagValueLong value) {
+  public TagContextBuilderImpl put(TagKeyLong key, TagValueLong value) {
     return setInternal(key, value);
   }
 
   @Override
-  public TagContextBuilderImpl set(TagKeyBoolean key, TagValueBoolean value) {
+  public TagContextBuilderImpl put(TagKeyBoolean key, TagValueBoolean value) {
     return setInternal(key, value);
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextUtils.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextUtils.java
@@ -49,7 +49,7 @@ final class TagContextUtils {
 
     @Override
     public Void apply(TagString tag) {
-      builder.set(tag.getKey(), tag.getValue());
+      builder.put(tag.getKey(), tag.getValue());
       return null;
     }
   }
@@ -63,7 +63,7 @@ final class TagContextUtils {
 
     @Override
     public Void apply(TagLong tag) {
-      builder.set(tag.getKey(), tag.getValue());
+      builder.put(tag.getKey(), tag.getValue());
       return null;
     }
   }
@@ -77,7 +77,7 @@ final class TagContextUtils {
 
     @Override
     public Void apply(TagBoolean tag) {
-      builder.set(tag.getKey(), tag.getValue());
+      builder.put(tag.getKey(), tag.getValue());
       return null;
     }
   }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -195,7 +195,7 @@ public class ViewManagerImplTest {
     View view = createCumulativeView(VIEW_NAME, MEASURE, AGGREGATIONS, Arrays.asList(KEY));
     clock.setTime(Timestamp.create(1, 2));
     viewManager.registerView(view);
-    TagContext tags = tagContexts.emptyBuilder().set(KEY, VALUE).build();
+    TagContext tags = tagContexts.emptyBuilder().put(KEY, VALUE).build();
     double[] values = {10.0, 20.0, 30.0, 40.0};
     for (double val : values) {
       statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, val).build());
@@ -223,7 +223,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.fromMillis(startTimeMillis));
     viewManager.registerView(view);
 
-    TagContext tags = tagContexts.emptyBuilder().set(KEY, VALUE).build();
+    TagContext tags = tagContexts.emptyBuilder().put(KEY, VALUE).build();
 
     double[] values = {20.0, -1.0, 1.0, -5.0, 5.0};
     for (int i = 1; i <= 5; i++) {
@@ -298,7 +298,7 @@ public class ViewManagerImplTest {
     View view = createCumulativeView(VIEW_NAME, MEASURE, AGGREGATIONS, Arrays.asList(KEY));
     clock.setTime(Timestamp.create(10, 0));
     viewManager.registerView(view);
-    TagContext tags = tagContexts.emptyBuilder().set(KEY, VALUE).build();
+    TagContext tags = tagContexts.emptyBuilder().put(KEY, VALUE).build();
     statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 0.1).build());
     clock.setTime(Timestamp.create(11, 0));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
@@ -330,13 +330,13 @@ public class ViewManagerImplTest {
     viewManager.registerView(
         createCumulativeView(VIEW_NAME, MEASURE, AGGREGATIONS, Arrays.asList(KEY)));
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE).build(),
         MeasureMap.builder().set(MEASURE, 10.0).build());
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE_2).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE_2).build(),
         MeasureMap.builder().set(MEASURE, 30.0).build());
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE_2).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE_2).build(),
         MeasureMap.builder().set(MEASURE, 50.0).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
@@ -361,16 +361,16 @@ public class ViewManagerImplTest {
     // record for TagValue1 at 11s
     clock.setTime(Timestamp.fromMillis(11 * MILLIS_PER_SECOND));
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE).build(),
         MeasureMap.builder().set(MEASURE, 10.0).build());
 
     // record for TagValue2 at 15s
     clock.setTime(Timestamp.fromMillis(15 * MILLIS_PER_SECOND));
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE_2).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE_2).build(),
         MeasureMap.builder().set(MEASURE, 30.0).build());
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE_2).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE_2).build(),
         MeasureMap.builder().set(MEASURE, 50.0).build());
 
     // get ViewData at 19s, no stats should have expired.
@@ -406,7 +406,7 @@ public class ViewManagerImplTest {
   @Test
   public void allowRecordingWithoutRegisteringMatchingViewData() {
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE).build(),
         MeasureMap.builder().set(MEASURE, 10).build());
   }
 
@@ -438,7 +438,7 @@ public class ViewManagerImplTest {
             Arrays.asList(KEY)));
     MeasureDouble measure2 = Measure.MeasureDouble.create(MEASURE_NAME_2, "measure", MEASURE_UNIT);
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE).build(),
         MeasureMap.builder().set(measure2, 10.0).build());
     ViewData view = viewManager.getView(VIEW_NAME);
     assertThat(view.getAggregationMap()).isEmpty();
@@ -449,10 +449,10 @@ public class ViewManagerImplTest {
     viewManager.registerView(
         createCumulativeView(VIEW_NAME, MEASURE, AGGREGATIONS, Arrays.asList(KEY)));
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(TagKeyString.create("wrong key"), VALUE).build(),
+        tagContexts.emptyBuilder().put(TagKeyString.create("wrong key"), VALUE).build(),
         MeasureMap.builder().set(MEASURE, 10.0).build());
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(TagKeyString.create("another wrong key"), VALUE).build(),
+        tagContexts.emptyBuilder().put(TagKeyString.create("another wrong key"), VALUE).build(),
         MeasureMap.builder().set(MEASURE, 50.0).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
@@ -475,29 +475,29 @@ public class ViewManagerImplTest {
     statsRecorder.record(
         tagContexts
             .emptyBuilder()
-            .set(key1, TagValueString.create("v1"))
-            .set(key2, TagValueString.create("v10"))
+            .put(key1, TagValueString.create("v1"))
+            .put(key2, TagValueString.create("v10"))
             .build(),
         MeasureMap.builder().set(MEASURE, 1.1).build());
     statsRecorder.record(
         tagContexts
             .emptyBuilder()
-            .set(key1, TagValueString.create("v1"))
-            .set(key2, TagValueString.create("v20"))
+            .put(key1, TagValueString.create("v1"))
+            .put(key2, TagValueString.create("v20"))
             .build(),
         MeasureMap.builder().set(MEASURE, 2.2).build());
     statsRecorder.record(
         tagContexts
             .emptyBuilder()
-            .set(key1, TagValueString.create("v2"))
-            .set(key2, TagValueString.create("v10"))
+            .put(key1, TagValueString.create("v2"))
+            .put(key2, TagValueString.create("v10"))
             .build(),
         MeasureMap.builder().set(MEASURE, 3.3).build());
     statsRecorder.record(
         tagContexts
             .emptyBuilder()
-            .set(key1, TagValueString.create("v1"))
-            .set(key2, TagValueString.create("v10"))
+            .put(key1, TagValueString.create("v1"))
+            .put(key2, TagValueString.create("v10"))
             .build(),
         MeasureMap.builder().set(MEASURE, 4.4).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
@@ -522,7 +522,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(2, 2));
     viewManager.registerView(view2);
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE).build(),
         MeasureMap.builder().set(MEASURE, 5.0).build());
     clock.setTime(Timestamp.create(3, 3));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
@@ -558,7 +558,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(2, 0));
     viewManager.registerView(view2);
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE).build(),
         MeasureMap.builder().set(measure1, 1.1).set(measure2, 2.2).build());
     clock.setTime(Timestamp.create(3, 0));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
@@ -590,7 +590,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(1, 0));
     viewManager.registerView(view);
     statsRecorder.record(
-        tagContexts.emptyBuilder().set(KEY, VALUE).build(),
+        tagContexts.emptyBuilder().put(KEY, VALUE).build(),
         MeasureMap.builder().set(MEASURE, 1.1).build());
     clock.setTime(Timestamp.create(3, 0));
     ViewData viewData = viewManager.getView(VIEW_NAME);

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
@@ -76,7 +76,7 @@ public class TagContextDeserializationTest {
     TagContext expected =
         tagContexts
             .emptyBuilder()
-            .set(
+            .put(
                 TagKeyString.create(KEY + SerializationUtils.VALUE_TYPE_STRING),
                 TagValueString.create(VALUE_STRING))
             .build();
@@ -96,10 +96,10 @@ public class TagContextDeserializationTest {
     TagContext expected =
         tagContexts
             .emptyBuilder()
-            .set(
+            .put(
                 TagKeyString.create(KEY + SerializationUtils.VALUE_TYPE_STRING),
                 TagValueString.create(VALUE_STRING))
-            .set(TagKeyString.create("Key2"), TagValueString.create("String2"))
+            .put(TagKeyString.create("Key2"), TagValueString.create("String2"))
             .build();
     assertTagContextsEqual(actual, expected);
   }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
@@ -67,9 +67,9 @@ public class TagContextImplTest {
             asList(
                 tagContexts
                     .emptyBuilder()
-                    .set(stringKey, TagValueString.create("value"))
-                    .set(longKey, TagValueLong.create(123))
-                    .set(boolKey, TagValueBoolean.create(true))
+                    .put(stringKey, TagValueString.create("value"))
+                    .put(longKey, TagValueLong.create(123))
+                    .put(boolKey, TagValueBoolean.create(true))
                     .build()))
         .containsExactly(
             TagString.create(stringKey, TagValueString.create("value")),
@@ -79,16 +79,16 @@ public class TagContextImplTest {
 
   @Test
   public void testSet() {
-    TagContext tags = tagContexts.emptyBuilder().set(KS1, V1).build();
-    assertThat(asList(tagContexts.toBuilder(tags).set(KS1, V2).build()))
+    TagContext tags = tagContexts.emptyBuilder().put(KS1, V1).build();
+    assertThat(asList(tagContexts.toBuilder(tags).put(KS1, V2).build()))
         .containsExactly(TagString.create(KS1, V2));
-    assertThat(asList(tagContexts.toBuilder(tags).set(KS2, V2).build()))
+    assertThat(asList(tagContexts.toBuilder(tags).put(KS2, V2).build()))
         .containsExactly(TagString.create(KS1, V1), TagString.create(KS2, V2));
   }
 
   @Test
   public void testClear() {
-    TagContext tags = tagContexts.emptyBuilder().set(KS1, V1).build();
+    TagContext tags = tagContexts.emptyBuilder().put(KS1, V1).build();
     assertThat(asList(tagContexts.toBuilder(tags).clear(KS1).build())).isEmpty();
     assertThat(asList(tagContexts.toBuilder(tags).clear(KS2).build()))
         .containsExactly(TagString.create(KS1, V1));
@@ -96,7 +96,7 @@ public class TagContextImplTest {
 
   @Test
   public void testIterator() {
-    TagContext tags = tagContexts.emptyBuilder().set(KS1, V1).set(KS2, V2).build();
+    TagContext tags = tagContexts.emptyBuilder().put(KS1, V1).put(KS2, V2).build();
     Iterator<Tag> i = tags.unsafeGetIterator();
     assertTrue(i.hasNext());
     Tag tag1 = i.next();
@@ -111,7 +111,7 @@ public class TagContextImplTest {
 
   @Test
   public void disallowCallingRemoveOnIterator() {
-    TagContext tags = tagContexts.emptyBuilder().set(KS1, V1).set(KS2, V2).build();
+    TagContext tags = tagContexts.emptyBuilder().put(KS1, V1).put(KS2, V2).build();
     Iterator<Tag> i = tags.unsafeGetIterator();
     i.next();
     thrown.expect(UnsupportedOperationException.class);

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
@@ -89,8 +89,8 @@ public class TagContextImplTest {
   @Test
   public void testClear() {
     TagContext tags = tagContexts.emptyBuilder().put(KS1, V1).build();
-    assertThat(asList(tagContexts.toBuilder(tags).clear(KS1).build())).isEmpty();
-    assertThat(asList(tagContexts.toBuilder(tags).clear(KS2).build()))
+    assertThat(asList(tagContexts.toBuilder(tags).remove(KS1).build())).isEmpty();
+    assertThat(asList(tagContexts.toBuilder(tags).remove(KS2).build()))
         .containsExactly(TagString.create(KS1, V1));
   }
 

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextRoundtripTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextRoundtripTest.java
@@ -48,12 +48,12 @@ public class TagContextRoundtripTest {
   @Test
   public void testRoundtripSerialization() throws Exception {
     testRoundtripSerialization(tagContexts.empty());
-    testRoundtripSerialization(tagContexts.emptyBuilder().set(K1, V1).build());
+    testRoundtripSerialization(tagContexts.emptyBuilder().put(K1, V1).build());
     testRoundtripSerialization(
-        tagContexts.emptyBuilder().set(K1, V1).set(K2, V2).set(K3, V3).build());
-    testRoundtripSerialization(tagContexts.emptyBuilder().set(K1, V_EMPTY).build());
-    testRoundtripSerialization(tagContexts.emptyBuilder().set(K_EMPTY, V1).build());
-    testRoundtripSerialization(tagContexts.emptyBuilder().set(K_EMPTY, V_EMPTY).build());
+        tagContexts.emptyBuilder().put(K1, V1).put(K2, V2).put(K3, V3).build());
+    testRoundtripSerialization(tagContexts.emptyBuilder().put(K1, V_EMPTY).build());
+    testRoundtripSerialization(tagContexts.emptyBuilder().put(K_EMPTY, V1).build());
+    testRoundtripSerialization(tagContexts.emptyBuilder().put(K_EMPTY, V_EMPTY).build());
   }
 
   private void testRoundtripSerialization(TagContext expected) throws Exception {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextSerializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextSerializationTest.java
@@ -84,7 +84,7 @@ public class TagContextSerializationTest {
   private void testSerialize(TagString... tags) throws IOException {
     TagContextBuilder builder = tagContexts.emptyBuilder();
     for (TagString tag : tags) {
-      builder.set(tag.getKey(), tag.getValue());
+      builder.put(tag.getKey(), tag.getValue());
     }
 
     byte[] actual = serializer.toByteArray(builder.build());

--- a/examples/src/main/java/io/opencensus/examples/stats/StatsRunner.java
+++ b/examples/src/main/java/io/opencensus/examples/stats/StatsRunner.java
@@ -56,12 +56,12 @@ public class StatsRunner {
     System.out.println("Hello Stats World");
     System.out.println("Default Tags: " + tagContexts.empty());
     System.out.println("Current Tags: " + tagContexts.getCurrentTagContext());
-    TagContext tags1 = tagContexts.emptyBuilder().set(K1, V1).set(K2, V2).build();
+    TagContext tags1 = tagContexts.emptyBuilder().put(K1, V1).put(K2, V2).build();
     try (Scope scopedTagCtx1 = tagContexts.withTagContext(tags1)) {
       System.out.println("  Current Tags: " + tagContexts.getCurrentTagContext());
       System.out.println(
           "  Current == Default + tags1: " + tagContexts.getCurrentTagContext().equals(tags1));
-      TagContext tags2 = tagContexts.toBuilder(tags1).set(K3, V3).set(K4, V4).build();
+      TagContext tags2 = tagContexts.toBuilder(tags1).put(K3, V3).put(K4, V4).build();
       try (Scope scopedTagCtx2 = tagContexts.withTagContext(tags2)) {
         System.out.println("    Current Tags: " + tagContexts.getCurrentTagContext());
         System.out.println(


### PR DESCRIPTION
#### Rename TagContextBuilder.set methods to "put".

"put" is a more descriptive name, since these methods behave like Map.put.  The name is also more consistent with Span.putAttribute.

#### Rename TagContextBuilder.clear to "remove".
    
This method removes a specific key from the builder.  The corresponding methods
in Map and Collection are named "remove".  "clear" was slightly misleading,
because Map and Collection also have "clear" methods, but they remove all
values.
