### PR TITLE
Update View and ViewData to have only one Aggregation/Data

### DIFF
--- a/core/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/core/src/main/java/io/opencensus/stats/AggregationData.java
@@ -242,20 +242,20 @@ public abstract class AggregationData {
     /**
      * Creates a {@code MeanData}.
      *
-     * @param sum the aggregated sum.
+     * @param mean the aggregated mean.
      * @param count the aggregated count.
      * @return a {@code MeanData}.
      */
-    public static MeanData create(double sum, long count) {
-      return new AutoValue_AggregationData_MeanData(sum, count);
+    public static MeanData create(double mean, long count) {
+      return new AutoValue_AggregationData_MeanData(mean, count);
     }
 
     /**
-     * Returns the aggregated sum.
+     * Returns the aggregated mean.
      *
-     * @return the aggregated sum.
+     * @return the aggregated mean.
      */
-    public abstract double getSum();
+    public abstract double getMean();
 
     /**
      * Returns the aggregated count.
@@ -263,15 +263,6 @@ public abstract class AggregationData {
      * @return the aggregated count.
      */
     public abstract long getCount();
-
-    /**
-     * Returns the aggregated mean.
-     *
-     * @return the aggregated mean.
-     */
-    public double getMean() {
-      return getCount() == 0 ? 0 : getSum() / getCount();
-    }
 
     @Override
     public final <T> T match(

--- a/core/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/core/src/main/java/io/opencensus/stats/AggregationData.java
@@ -242,19 +242,36 @@ public abstract class AggregationData {
     /**
      * Creates a {@code MeanData}.
      *
-     * @param mean the aggregated mean.
+     * @param sum the aggregated sum.
+     * @param count the aggregated count.
      * @return a {@code MeanData}.
      */
-    public static MeanData create(double mean) {
-      return new AutoValue_AggregationData_MeanData(mean);
+    public static MeanData create(double sum, long count) {
+      return new AutoValue_AggregationData_MeanData(sum, count);
     }
+
+    /**
+     * Returns the aggregated sum.
+     *
+     * @return the aggregated sum.
+     */
+    public abstract double getSum();
+
+    /**
+     * Returns the aggregated count.
+     *
+     * @return the aggregated count.
+     */
+    public abstract long getCount();
 
     /**
      * Returns the aggregated mean.
      *
      * @return the aggregated mean.
      */
-    public abstract double getMean();
+    public double getMean() {
+      return getCount() == 0 ? 0 : getSum() / getCount();
+    }
 
     @Override
     public final <T> T match(

--- a/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
+++ b/core/src/main/java/io/opencensus/stats/RpcViewConstants.java
@@ -43,9 +43,8 @@ import static io.opencensus.stats.RpcMeasureConstants.RPC_SERVER_UNCOMPRESSED_RE
 import static io.opencensus.stats.RpcMeasureConstants.RPC_STATUS;
 
 import io.opencensus.common.Duration;
-import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Histogram;
-import io.opencensus.stats.Aggregation.Sum;
+import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.View.AggregationWindow;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
@@ -74,20 +73,20 @@ public final class RpcViewConstants {
       Arrays.asList(0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0,
           4096.0, 8192.0, 16384.0, 32768.0, 65536.0));
 
-  static final List<Aggregation> AGGREGATION_NO_HISTOGRAM = Collections.unmodifiableList(
-          Arrays.asList(Sum.create(), Count.create()));
+  // Use Aggregation.Mean to record sum and count stats at the same time.
+  static final Aggregation MEAN = Mean.create();
 
-  static final List<Aggregation> AGGREGATION_WITH_BYTES_HISTOGRAM = Collections.unmodifiableList(
-      Arrays.asList(Sum.create(), Count.create(),
-          Histogram.create(BucketBoundaries.create(RPC_BYTES_BUCKET_BOUNDARIES))));
+  static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
+      Histogram.create(BucketBoundaries.create(RPC_BYTES_BUCKET_BOUNDARIES));
+  //    Distribution.create(BucketBoundaries.create(RPC_BYTES_BUCKET_BOUNDARIES));
 
-  static final List<Aggregation> AGGREGATION_WITH_MILLIS_HISTOGRAM = Collections.unmodifiableList(
-      Arrays.asList(Sum.create(), Count.create(),
-          Histogram.create(BucketBoundaries.create(RPC_MILLIS_BUCKET_BOUNDARIES))));
+  static final Aggregation AGGREGATION_WITH_MILLIS_HISTOGRAM =
+      Histogram.create(BucketBoundaries.create(RPC_MILLIS_BUCKET_BOUNDARIES));
+  //    Distribution.create(BucketBoundaries.create(RPC_MILLIS_BUCKET_BOUNDARIES));
 
-  static final List<Aggregation> AGGREGATION_WITH_COUNT_HISTOGRAM = Collections.unmodifiableList(
-      Arrays.asList(Sum.create(), Count.create(),
-          Histogram.create(BucketBoundaries.create(RPC_COUNT_BUCKET_BOUNDARIES))));
+  static final Aggregation AGGREGATION_WITH_COUNT_HISTOGRAM =
+      Histogram.create(BucketBoundaries.create(RPC_COUNT_BUCKET_BOUNDARIES));
+  //    Distribution.create(BucketBoundaries.create(RPC_COUNT_BUCKET_BOUNDARIES));
 
   static final Duration MINUTE = Duration.create(60, 0);
   static final Duration HOUR = Duration.create(60 * 60, 0);
@@ -101,7 +100,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/error_count/distribution_cumulative"),
           "RPC Errors",
           RPC_CLIENT_ERROR_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_STATUS, RPC_CLIENT_METHOD),
           CUMULATIVE);
   public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
@@ -176,7 +175,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/error_count/distribution_cumulative"),
           "RPC Errors",
           RPC_SERVER_ERROR_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_STATUS, RPC_SERVER_METHOD),
           CUMULATIVE);
   public static final View RPC_SERVER_SERVER_LATENCY_VIEW =
@@ -252,7 +251,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/roundtrip_latency/interval"),
           "Minute stats for latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -261,7 +260,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/request_bytes/interval"),
           "Minute stats for request size in bytes",
           RPC_CLIENT_REQUEST_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -270,7 +269,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/response_bytes/interval"),
           "Minute stats for response size in bytes",
           RPC_CLIENT_RESPONSE_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -279,7 +278,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/error_count/interval"),
           "Minute stats for rpc errors",
           RPC_CLIENT_ERROR_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -288,7 +287,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/uncompressed_request_bytes/interval"),
           "Minute stats for uncompressed request size in bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -297,7 +296,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/uncompressed_response_bytes/interval"),
           "Minute stats for uncompressed response size in bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -306,7 +305,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/server_elapsed_time/interval"),
           "Minute stats for server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -315,7 +314,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/started_count/interval"),
           "Minute stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -324,7 +323,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/finished_count/interval"),
           "Minute stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -333,7 +332,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/request_count/interval"),
           "Minute stats on the count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -342,7 +341,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/response_count/interval"),
           "Minute stats on the count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_MINUTE);
 
@@ -351,7 +350,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/roundtrip_latency/interval"),
           "Hour stats for latency in msecs",
           RPC_CLIENT_ROUNDTRIP_LATENCY,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -360,7 +359,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/request_bytes/interval"),
           "Hour stats for request size in bytes",
           RPC_CLIENT_REQUEST_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -369,7 +368,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/response_bytes/interval"),
           "Hour stats for response size in bytes",
           RPC_CLIENT_RESPONSE_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -378,7 +377,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/error_count/interval"),
           "Hour stats for rpc errors",
           RPC_CLIENT_ERROR_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -387,7 +386,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/uncompressed_request_bytes/interval"),
           "Hour stats for uncompressed request size in bytes",
           RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -396,7 +395,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/uncompressed_response_bytes/interval"),
           "Hour stats for uncompressed response size in bytes",
           RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -405,7 +404,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/server_elapsed_time/interval"),
           "Hour stats for server elapsed time in msecs",
           RPC_CLIENT_SERVER_ELAPSED_TIME,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -414,7 +413,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/started_count/interval"),
           "Hour stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -423,7 +422,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/finished_count/interval"),
           "Hour stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -432,7 +431,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/request_count/interval"),
           "Hour stats on the count of request messages per client RPC",
           RPC_CLIENT_REQUEST_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -441,7 +440,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/response_count/interval"),
           "Hour stats on the count of response messages per client RPC",
           RPC_CLIENT_RESPONSE_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_CLIENT_METHOD),
           INTERVAL_HOUR);
 
@@ -451,7 +450,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/server_latency/interval"),
           "Minute stats for server latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -460,7 +459,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/request_bytes/interval"),
           "Minute stats for request size in bytes",
           RPC_SERVER_REQUEST_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -469,7 +468,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/response_bytes/interval"),
           "Minute stats for response size in bytes",
           RPC_SERVER_RESPONSE_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -478,7 +477,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/error_count/interval"),
           "Minute stats for rpc errors",
           RPC_SERVER_ERROR_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -487,7 +486,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/uncompressed_request_bytes/interval"),
           "Minute stats for uncompressed request size in bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -496,7 +495,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/uncompressed_response_bytes/interval"),
           "Minute stats for uncompressed response size in bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -505,7 +504,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/server_elapsed_time/interval"),
           "Minute stats for server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -514,7 +513,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/started_count/interval"),
           "Minute stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -523,7 +522,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/finished_count/interval"),
           "Minute stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -532,7 +531,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/request_count/interval"),
           "Minute stats on the count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -541,7 +540,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/response_count/interval"),
           "Minute stats on the count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_MINUTE);
 
@@ -550,7 +549,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/server_latency/interval"),
           "Hour stats for server latency in msecs",
           RPC_SERVER_SERVER_LATENCY,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -559,7 +558,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/request_bytes/interval"),
           "Hour stats for request size in bytes",
           RPC_SERVER_REQUEST_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -568,7 +567,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/response_bytes/interval"),
           "Hour stats for response size in bytes",
           RPC_SERVER_RESPONSE_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -577,7 +576,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/error_count/interval"),
           "Hour stats for rpc errors",
           RPC_SERVER_ERROR_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -586,7 +585,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/uncompressed_request_bytes/interval"),
           "Hour stats for uncompressed request size in bytes",
           RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -595,7 +594,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/uncompressed_response_bytes/interval"),
           "Hour stats for uncompressed response size in bytes",
           RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -604,7 +603,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/server_elapsed_time/interval"),
           "Hour stats for server elapsed time in msecs",
           RPC_SERVER_SERVER_ELAPSED_TIME,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -613,7 +612,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/started_count/interval"),
           "Hour stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -622,7 +621,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/finished_count/interval"),
           "Hour stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -631,7 +630,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/request_count/interval"),
           "Hour stats on the count of request messages per server RPC",
           RPC_SERVER_REQUEST_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 
@@ -640,7 +639,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/response_count/interval"),
           "Hour stats on the count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
-          AGGREGATION_NO_HISTOGRAM,
+          MEAN,
           Arrays.asList(RPC_SERVER_METHOD),
           INTERVAL_HOUR);
 

--- a/core/src/main/java/io/opencensus/stats/View.java
+++ b/core/src/main/java/io/opencensus/stats/View.java
@@ -59,10 +59,9 @@ public abstract class View {
   public abstract Measure getMeasure();
 
   /**
-   * The {@link Aggregation}s associated with this {@link View}. {@link Aggregation}s should be
-   * unique within one view.
+   * The {@link Aggregation} associated with this {@link View}.
    */
-  public abstract List<Aggregation> getAggregations();
+  public abstract Aggregation getAggregation();
 
   /**
    * Columns (a.k.a Tag Keys) to match with the associated {@link Measure}.
@@ -85,8 +84,7 @@ public abstract class View {
    * @param name the {@link Name} of view. Must be unique.
    * @param description the description of view.
    * @param measure the {@link Measure} to be aggregated by this view.
-   * @param aggregations basic {@link Aggregation}s that this view will support. The aggregation
-   *     list should not contain duplicates.
+   * @param aggregation the basic {@link Aggregation} that this view will support.
    * @param columns the {@link TagKey}s that this view will aggregate on. Columns should not contain
    *     duplicates.
    * @param window the {@link AggregationWindow} of view.
@@ -96,11 +94,9 @@ public abstract class View {
       Name name,
       String description,
       Measure measure,
-      List<Aggregation> aggregations,
+      Aggregation aggregation,
       List<? extends TagKey> columns,
       AggregationWindow window) {
-    checkArgument(new HashSet<Aggregation>(aggregations).size() == aggregations.size(),
-        "Aggregations have duplicate.");
     checkArgument(new HashSet<TagKey>(columns).size() == columns.size(),
         "Columns have duplicate.");
 
@@ -108,7 +104,7 @@ public abstract class View {
         name,
         description,
         measure,
-        Collections.unmodifiableList(new ArrayList<Aggregation>(aggregations)),
+        aggregation,
         Collections.unmodifiableList(new ArrayList<TagKey>(columns)),
         window);
   }

--- a/core/src/main/java/io/opencensus/stats/ViewData.java
+++ b/core/src/main/java/io/opencensus/stats/ViewData.java
@@ -17,18 +17,17 @@
 package io.opencensus.stats;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.Maps;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
 import io.opencensus.tags.TagValue;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import javax.annotation.concurrent.Immutable;
-
 
 /** The aggregated data for a particular {@link View}. */
 @Immutable
@@ -42,10 +41,10 @@ public abstract class ViewData {
   public abstract View getView();
 
   /**
-   * The {@link AggregationData}s grouped by combination of tag values, associated with this
+   * The {@link AggregationData} grouped by combination of tag values, associated with this
    * {@link ViewData}.
    */
-  public abstract Map<List<TagValue>, List<AggregationData>> getAggregationMap();
+  public abstract Map<List<TagValue>, AggregationData> getAggregationMap();
 
   /**
    * Returns the {@link AggregationWindowData} associated with this {@link ViewData}.
@@ -57,7 +56,7 @@ public abstract class ViewData {
   /** Constructs a new {@link ViewData}. */
   public static ViewData create(
       View view,
-      Map<? extends List<? extends TagValue>, List<AggregationData>> map,
+      Map<? extends List<? extends TagValue>, ? extends AggregationData> map,
       final AggregationWindowData windowData) {
     view.getWindow()
         .match(
@@ -91,12 +90,12 @@ public abstract class ViewData {
             },
             Functions.<Void>throwIllegalArgumentException());
 
-    Map<List<TagValue>, List<AggregationData>> deepCopy =
-        new HashMap<List<TagValue>, List<AggregationData>>();
-    for (Entry<? extends List<? extends TagValue>, List<AggregationData>> entry : map.entrySet()) {
+    Map<List<TagValue>, AggregationData> deepCopy = Maps.newHashMap();
+    for (Entry<? extends List<? extends TagValue>, ? extends AggregationData> entry : map
+        .entrySet()) {
       deepCopy.put(
           Collections.unmodifiableList(new ArrayList<TagValue>(entry.getKey())),
-          Collections.unmodifiableList(new ArrayList<AggregationData>(entry.getValue())));
+          entry.getValue());
     }
 
     return new AutoValue_ViewData(view, Collections.unmodifiableMap(deepCopy), windowData);

--- a/core/src/test/java/io/opencensus/stats/AggregationDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/AggregationDataTest.java
@@ -91,11 +91,11 @@ public class AggregationDataTest {
             RangeData.create(-5.0, 1.0),
             RangeData.create(-5.0, 1.0))
         .addEqualityGroup(
-            MeanData.create(5.0),
-            MeanData.create(5.0))
+            MeanData.create(5.0, 1),
+            MeanData.create(5.0, 1))
         .addEqualityGroup(
-            MeanData.create(-5.0),
-            MeanData.create(-5.0))
+            MeanData.create(-5.0, 1),
+            MeanData.create(-5.0, 1))
         .addEqualityGroup(
             StdDevData.create(23.3),
             StdDevData.create(23.3))
@@ -112,7 +112,7 @@ public class AggregationDataTest {
         CountData.create(40),
         HistogramData.create(new long[]{0, 10, 0}),
         RangeData.create(-1.0, 1.0),
-        MeanData.create(5.0),
+        MeanData.create(5.0, 1),
         StdDevData.create(23.3));
 
     final List<Object> actual = new ArrayList<Object>();

--- a/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
+++ b/core/src/test/java/io/opencensus/stats/RpcViewConstantsTest.java
@@ -19,9 +19,6 @@ package io.opencensus.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Duration;
-import io.opencensus.stats.Aggregation.Count;
-import io.opencensus.stats.Aggregation.Histogram;
-import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
 import org.junit.Test;
@@ -46,30 +43,6 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.RPC_COUNT_BUCKET_BOUNDARIES).containsExactly(
         0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0,
         4096.0, 8192.0, 16384.0, 32768.0, 65536.0).inOrder();
-
-    // Test Aggregations
-    assertThat(RpcViewConstants.AGGREGATION_NO_HISTOGRAM)
-        .containsExactly(Sum.create(), Count.create())
-        .inOrder();
-    assertThat(RpcViewConstants.AGGREGATION_WITH_BYTES_HISTOGRAM)
-        .containsExactly(
-            Sum.create(),
-            Count.create(),
-            Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_BYTES_BUCKET_BOUNDARIES)))
-        .inOrder();
-    assertThat(RpcViewConstants.AGGREGATION_WITH_COUNT_HISTOGRAM)
-        .containsExactly(
-            Sum.create(),
-            Count.create(),
-            Histogram.create(BucketBoundaries.create(RpcViewConstants.RPC_COUNT_BUCKET_BOUNDARIES)))
-        .inOrder();
-    assertThat(RpcViewConstants.AGGREGATION_WITH_MILLIS_HISTOGRAM)
-        .containsExactly(
-            Sum.create(),
-            Count.create(),
-            Histogram.create(
-                BucketBoundaries.create(RpcViewConstants.RPC_MILLIS_BUCKET_BOUNDARIES)))
-        .inOrder();
 
     // Test Duration and Window
     assertThat(RpcViewConstants.MINUTE).isEqualTo(Duration.create(60, 0));

--- a/core/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -25,18 +25,8 @@ import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
-import io.opencensus.stats.Aggregation.Count;
-import io.opencensus.stats.Aggregation.Histogram;
 import io.opencensus.stats.Aggregation.Mean;
-import io.opencensus.stats.Aggregation.Range;
-import io.opencensus.stats.Aggregation.StdDev;
-import io.opencensus.stats.Aggregation.Sum;
-import io.opencensus.stats.AggregationData.CountData;
-import io.opencensus.stats.AggregationData.HistogramData;
 import io.opencensus.stats.AggregationData.MeanData;
-import io.opencensus.stats.AggregationData.RangeData;
-import io.opencensus.stats.AggregationData.StdDevData;
-import io.opencensus.stats.AggregationData.SumData;
 import io.opencensus.stats.View.AggregationWindow;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
@@ -65,7 +55,7 @@ public final class ViewDataTest {
   @Test
   public void testDistributionViewData() {
     View view =
-        View.create(name, description, measure, AGGREGATIONS, tagKeys, CUMULATIVE);
+        View.create(name, description, measure, MEAN, tagKeys, CUMULATIVE);
     Timestamp start = Timestamp.fromMillis(1000);
     Timestamp end = Timestamp.fromMillis(2000);
     AggregationWindowData windowData = CumulativeData.create(start, end);
@@ -78,7 +68,7 @@ public final class ViewDataTest {
   @Test
   public void testIntervalViewData() {
     View view = View.create(
-        name, description, measure, AGGREGATIONS, tagKeys, INTERVAL_HOUR);
+        name, description, measure, MEAN, tagKeys, INTERVAL_HOUR);
     Timestamp end = Timestamp.fromMillis(2000);
     AggregationWindowData windowData = IntervalData.create(end);
     ViewData viewData = ViewData.create(view, ENTRIES, windowData);
@@ -90,9 +80,9 @@ public final class ViewDataTest {
   @Test
   public void testViewDataEquals() {
     View cumulativeView =
-        View.create(name, description, measure, AGGREGATIONS, tagKeys, CUMULATIVE);
+        View.create(name, description, measure, MEAN, tagKeys, CUMULATIVE);
     View intervalView =
-        View.create(name, description, measure, AGGREGATIONS, tagKeys, INTERVAL_HOUR);
+        View.create(name, description, measure, MEAN, tagKeys, INTERVAL_HOUR);
 
     new EqualsTester()
         .addEqualityGroup(
@@ -120,7 +110,7 @@ public final class ViewDataTest {
                 IntervalData.create(Timestamp.fromMillis(2000))))
         .addEqualityGroup(
             ViewData.create(
-                intervalView, Collections.<List<TagValue>, List<AggregationData>>emptyMap(),
+                intervalView, Collections.<List<TagValue>, AggregationData>emptyMap(),
                 IntervalData.create(Timestamp.fromMillis(2000))))
         .testEquals();
   }
@@ -170,7 +160,7 @@ public final class ViewDataTest {
   public void preventWindowAndAggregationWindowDataMismatch() {
     thrown.expect(IllegalArgumentException.class);
     ViewData.create(
-        View.create(name, description, measure, AGGREGATIONS, tagKeys, INTERVAL_HOUR),
+        View.create(name, description, measure, MEAN, tagKeys, INTERVAL_HOUR),
         ENTRIES,
         CumulativeData.create(
             Timestamp.fromMillis(1000), Timestamp.fromMillis(2000)));
@@ -180,7 +170,7 @@ public final class ViewDataTest {
   public void preventWindowAndAggregationWindowDataMismatch2() {
     thrown.expect(IllegalArgumentException.class);
     ViewData.create(
-        View.create(name, description, measure, AGGREGATIONS, tagKeys, CUMULATIVE),
+        View.create(name, description, measure, MEAN, tagKeys, CUMULATIVE),
         ENTRIES,
         IntervalData.create(Timestamp.fromMillis(1000)));
   }
@@ -208,28 +198,14 @@ public final class ViewDataTest {
   private static final BucketBoundaries BUCKET_BOUNDARIES = BucketBoundaries.create(
       Arrays.asList(10.0, 20.0, 30.0, 40.0));
   
-  private static final List<Aggregation> AGGREGATIONS = Collections.unmodifiableList(Arrays.asList(
-      Sum.create(), Count.create(), Range.create(), Histogram.create(BUCKET_BOUNDARIES),
-      Mean.create(), StdDev.create()));
+  private static final Mean MEAN = Mean.create();
 
-  private static final ImmutableMap<List<TagValueString>, List<AggregationData>> ENTRIES =
+  private static final ImmutableMap<List<TagValueString>, ? extends AggregationData> ENTRIES =
       ImmutableMap.of(
           Arrays.asList(V1, V2),
-          Arrays.asList(
-              SumData.create(0),
-              CountData.create(1),
-              HistogramData.create(1, 0, 0, 0, 0),
-              RangeData.create(0, 0),
-              MeanData.create(0),
-              StdDevData.create(0)),
+          MeanData.create(0, 1),
           Arrays.asList(V10, V20),
-          Arrays.asList(
-              SumData.create(50),
-              CountData.create(2),
-              HistogramData.create(0, 0, 2, 0, 0),
-              RangeData.create(25, 25),
-              MeanData.create(25),
-              StdDevData.create(0)));
+          MeanData.create(50, 2));
 
   // name
   private final View.Name name = View.Name.create("test-view");

--- a/core/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/core/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -200,7 +200,7 @@ public final class ViewDataTest {
   
   private static final Mean MEAN = Mean.create();
 
-  private static final ImmutableMap<List<TagValueString>, ? extends AggregationData> ENTRIES =
+  private static final ImmutableMap<List<TagValueString>, MeanData> ENTRIES =
       ImmutableMap.of(
           Arrays.asList(V1, V2),
           MeanData.create(0, 1),

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/IntervalBucket.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/IntervalBucket.java
@@ -35,21 +35,21 @@ final class IntervalBucket {
 
   private final Timestamp start;
   private final Duration duration;
-  private final List<Aggregation> aggregations;
-  private final Map<List<TagValue>, List<MutableAggregation>> tagValueAggregationMap =
+  private final Aggregation aggregation;
+  private final Map<List<TagValue>, MutableAggregation> tagValueAggregationMap =
       Maps.newHashMap();
 
-  IntervalBucket(Timestamp start, Duration duration, List<Aggregation> aggregations) {
+  IntervalBucket(Timestamp start, Duration duration, Aggregation aggregation) {
     checkNotNull(start, "Start");
     checkNotNull(duration, "Duration");
     checkArgument(duration.compareTo(ZERO) > 0, "Duration must be positive");
-    checkNotNull(aggregations, "Aggregations");
+    checkNotNull(aggregation, "Aggregation");
     this.start = start;
     this.duration = duration;
-    this.aggregations = aggregations;
+    this.aggregation = aggregation;
   }
 
-  Map<List<TagValue>, List<MutableAggregation>> getTagValueAggregationMap() {
+  Map<List<TagValue>, MutableAggregation> getTagValueAggregationMap() {
     return tagValueAggregationMap;
   }
 
@@ -61,11 +61,9 @@ final class IntervalBucket {
   void record(List<TagValue> tagValues, double value) {
     if (!tagValueAggregationMap.containsKey(tagValues)) {
       tagValueAggregationMap.put(
-          tagValues, MutableViewData.createMutableAggregations(aggregations));
+          tagValues, MutableViewData.createMutableAggregation(aggregation));
     }
-    for (MutableAggregation aggregation : tagValueAggregationMap.get(tagValues)) {
-      aggregation.add(value);
-    }
+    tagValueAggregationMap.get(tagValues).add(value);
   }
   
   /*

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableAggregation.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableAggregation.java
@@ -295,7 +295,7 @@ abstract class MutableAggregation {
   /** Calculate mean on aggregated {@code MeasureValue}s. */
   static final class MutableMean extends MutableAggregation {
 
-    private double mean = 0.0;
+    private double sum = 0.0;
     private long count = 0;
 
     private MutableMean() {
@@ -313,13 +313,15 @@ abstract class MutableAggregation {
     @Override
     void add(double value) {
       count++;
-      double deltaFromMean = value - mean;
-      mean += deltaFromMean / count;
+      sum += value;
     }
 
     @Override
     void combine(MutableAggregation other, double fraction) {
-      throw new UnsupportedOperationException("Not supported in v0.1.");
+      checkArgument(other instanceof MutableMean, "MutableMean expected.");
+      MutableMean mutableMean = (MutableMean) other;
+      this.count += Math.round(mutableMean.count * fraction);
+      this.sum += mutableMean.sum * fraction;
     }
 
     /**
@@ -328,7 +330,25 @@ abstract class MutableAggregation {
      * @return the aggregated mean.
      */
     double getMean() {
-      return mean;
+      return getCount() == 0 ? 0 : getSum() / getCount();
+    }
+
+    /**
+     * Returns the aggregated count.
+     *
+     * @return the aggregated count.
+     */
+    long getCount() {
+      return count;
+    }
+
+    /**
+     * Returns the aggregated sum.
+     *
+     * @return the aggregated sum.
+     */
+    double getSum() {
+      return sum;
     }
 
     @Override

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -568,7 +568,7 @@ abstract class MutableViewData {
   private static final class CreateMeanData implements Function<MutableMean, AggregationData> {
     @Override
     public AggregationData apply(MutableMean arg) {
-      return MeanData.create(arg.getSum(), arg.getCount());
+      return MeanData.create(arg.getMean(), arg.getCount());
     }
 
     private static final CreateMeanData INSTANCE = new CreateMeanData();

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/IntervalBucketTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/IntervalBucketTest.java
@@ -20,18 +20,12 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Duration;
 import io.opencensus.common.Timestamp;
-import io.opencensus.implcore.stats.MutableAggregation.MutableCount;
-import io.opencensus.implcore.stats.MutableAggregation.MutableHistogram;
-import io.opencensus.implcore.stats.MutableAggregation.MutableSum;
-import io.opencensus.stats.Aggregation;
-import io.opencensus.stats.Aggregation.Count;
-import io.opencensus.stats.Aggregation.Histogram;
-import io.opencensus.stats.Aggregation.Sum;
-import io.opencensus.stats.BucketBoundaries;
+import io.opencensus.implcore.stats.MutableAggregation.MutableMean;
+import io.opencensus.stats.Aggregation.Mean;
+import io.opencensus.stats.UnreleasedApiAccessor;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.TagValue.TagValueString;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
@@ -49,28 +43,24 @@ public class IntervalBucketTest {
   private static final Duration MINUTE = Duration.create(60, 0);
   private static final Duration NEGATIVE_TEN_SEC = Duration.create(-10, 0);
   private static final Timestamp START = Timestamp.create(60, 0);
-  private static final BucketBoundaries BUCKET_BOUNDARIES =
-      BucketBoundaries.create(Arrays.asList(-10.0, 0.0, 10.0));
-  private static final List<Aggregation> AGGREGATIONS_V1 =
-      Collections.unmodifiableList(Arrays.asList(
-          Sum.create(), Count.create(), Histogram.create(BUCKET_BOUNDARIES)));
+  private static final Mean MEAN = UnreleasedApiAccessor.createMean();
 
   @Test
   public void preventNullStartTime() {
     thrown.expect(NullPointerException.class);
-    new IntervalBucket(null, MINUTE, AGGREGATIONS_V1);
+    new IntervalBucket(null, MINUTE, MEAN);
   }
 
   @Test
   public void preventNullDuration() {
     thrown.expect(NullPointerException.class);
-    new IntervalBucket(START, null, AGGREGATIONS_V1);
+    new IntervalBucket(START, null, MEAN);
   }
 
   @Test
   public void preventNegativeDuration() {
     thrown.expect(IllegalArgumentException.class);
-    new IntervalBucket(START, NEGATIVE_TEN_SEC, AGGREGATIONS_V1);
+    new IntervalBucket(START, NEGATIVE_TEN_SEC, MEAN);
   }
 
   @Test
@@ -81,54 +71,43 @@ public class IntervalBucketTest {
   
   @Test
   public void testGetTagValueAggregationMap_empty() {
-    assertThat(new IntervalBucket(START, MINUTE, AGGREGATIONS_V1).getTagValueAggregationMap())
+    assertThat(new IntervalBucket(START, MINUTE, MEAN).getTagValueAggregationMap())
         .isEmpty();
   }
 
   @Test
   public void testGetStart() {
-    assertThat(new IntervalBucket(START, MINUTE, AGGREGATIONS_V1).getStart()).isEqualTo(START);
+    assertThat(new IntervalBucket(START, MINUTE, MEAN).getStart()).isEqualTo(START);
   }
 
   @Test
   public void testRecord() {
-    IntervalBucket bucket = new IntervalBucket(START, MINUTE, AGGREGATIONS_V1);
+    IntervalBucket bucket = new IntervalBucket(START, MINUTE, MEAN);
     List<TagValue> tagValues1 = Arrays.<TagValue>asList(TagValueString.create("VALUE1"));
     List<TagValue> tagValues2 = Arrays.<TagValue>asList(TagValueString.create("VALUE2"));
     bucket.record(tagValues1, 5.0);
     bucket.record(tagValues1, 15.0);
     bucket.record(tagValues2, 10.0);
-    assertThat(bucket.getTagValueAggregationMap()).containsKey(tagValues1);
-    verifyMutableAggregations(bucket.getTagValueAggregationMap().get(tagValues1),
-        20.0, 2, new long[]{0, 0, 1, 1}, TOLERANCE);
-    assertThat(bucket.getTagValueAggregationMap()).containsKey(tagValues2);
-    verifyMutableAggregations(bucket.getTagValueAggregationMap().get(tagValues2),
-        10.0, 1, new long[]{0, 0, 0, 1}, TOLERANCE);
-  }
-
-  private static void verifyMutableAggregations(
-      List<MutableAggregation> aggregations, double sum, long count, long[] bucketCounts,
-      double tolerance) {
-    assertThat(aggregations).hasSize(3);
-    assertThat(aggregations.get(0)).isInstanceOf(MutableSum.class);
-    assertThat(((MutableSum) aggregations.get(0)).getSum()).isWithin(tolerance).of(sum);
-    assertThat(aggregations.get(1)).isInstanceOf(MutableCount.class);
-    assertThat(((MutableCount) aggregations.get(1)).getCount()).isEqualTo(count);
-    assertThat(aggregations.get(2)).isInstanceOf(MutableHistogram.class);
-    assertThat(((MutableHistogram) aggregations.get(2)).getBucketCounts()).isEqualTo(bucketCounts);
+    assertThat(bucket.getTagValueAggregationMap().keySet()).containsExactly(tagValues1, tagValues2);
+    MutableMean mutableMean1 = (MutableMean) bucket.getTagValueAggregationMap().get(tagValues1);
+    MutableMean mutableMean2 = (MutableMean) bucket.getTagValueAggregationMap().get(tagValues2);
+    assertThat(mutableMean1.getSum()).isWithin(TOLERANCE).of(20);
+    assertThat(mutableMean2.getSum()).isWithin(TOLERANCE).of(10);
+    assertThat(mutableMean1.getCount()).isEqualTo(2);
+    assertThat(mutableMean2.getCount()).isEqualTo(1);
   }
 
   @Test
   public void testGetFraction() {
     Timestamp thirtySecondsAfterStart = Timestamp.create(90, 0);
     assertThat(
-        new IntervalBucket(START, MINUTE, AGGREGATIONS_V1).getFraction(thirtySecondsAfterStart))
+        new IntervalBucket(START, MINUTE, MEAN).getFraction(thirtySecondsAfterStart))
         .isWithin(TOLERANCE).of(0.5);
   }
 
   @Test
   public void preventCallingGetFractionOnPastBuckets() {
-    IntervalBucket bucket = new IntervalBucket(START, MINUTE, AGGREGATIONS_V1);
+    IntervalBucket bucket = new IntervalBucket(START, MINUTE, MEAN);
     Timestamp twoMinutesAfterStart = Timestamp.create(180, 0);
     thrown.expect(IllegalArgumentException.class);
     bucket.getFraction(twoMinutesAfterStart);
@@ -136,7 +115,7 @@ public class IntervalBucketTest {
 
   @Test
   public void preventCallingGetFractionOnFutureBuckets() {
-    IntervalBucket bucket = new IntervalBucket(START, MINUTE, AGGREGATIONS_V1);
+    IntervalBucket bucket = new IntervalBucket(START, MINUTE, MEAN);
     Timestamp thirtySecondsBeforeStart = Timestamp.create(30, 0);
     thrown.expect(IllegalArgumentException.class);
     bucket.getFraction(thirtySecondsBeforeStart);

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MeasureToViewMapTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MeasureToViewMapTest.java
@@ -19,7 +19,6 @@ package io.opencensus.implcore.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Timestamp;
-import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.UnreleasedApiAccessor;
 import io.opencensus.stats.View;
@@ -30,7 +29,6 @@ import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.testing.common.TestClock;
 import java.util.Arrays;
-import java.util.List;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -47,14 +45,10 @@ public class MeasureToViewMapTest {
 
   private static final Name VIEW_NAME = View.Name.create("my view");
 
-  private static final List<Aggregation> AGGREGATIONS_NO_HISTOGRAM = Arrays.asList(
-      Aggregation.Sum.create(), Aggregation.Count.create(), UnreleasedApiAccessor.createRange(),
-      UnreleasedApiAccessor.createMean(), UnreleasedApiAccessor.createStdDev());
-
   private static final Cumulative CUMULATIVE = Cumulative.create();
 
   private static final View VIEW =
-      View.create(VIEW_NAME, "view description", MEASURE, AGGREGATIONS_NO_HISTOGRAM,
+      View.create(VIEW_NAME, "view description", MEASURE, UnreleasedApiAccessor.createMean(),
           Arrays.asList(TagKeyString.create("my key")), CUMULATIVE);
 
   @Test

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MutableViewDataTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MutableViewDataTest.java
@@ -128,7 +128,7 @@ public class MutableViewDataTest {
         CountData.create(0),
         HistogramData.create(0, 0, 0, 0),
         RangeData.create(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY),
-        MeanData.create(0),
+        MeanData.create(0, 0),
         StdDevData.create(0))
         .inOrder();
   }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -553,4 +553,26 @@ public class ViewManagerImplTest {
             Arrays.asList(VALUE), StatsTestUtil.createAggregationData(MEAN, 2.2)),
         EPSILON);
   }
+
+  //  @Test
+  //  public void testGetCumulativeViewDataWithoutBucketBoundaries() {
+  //    Aggregation noHistogram = Distribution.create(null);
+  //    View view =
+  //        createCumulativeView(VIEW_NAME, MEASURE, noHistogram, Arrays.asList(KEY));
+  //    clock.setTime(Timestamp.create(1, 0));
+  //    viewManager.registerView(view);
+  //    statsRecorder.record(
+  //        tagContexts.emptyBuilder().put(KEY, VALUE).build(),
+  //        MeasureMap.builder().set(MEASURE, 1.1).build());
+  //    clock.setTime(Timestamp.create(3, 0));
+  //    ViewData viewData = viewManager.getView(VIEW_NAME);
+  //    assertThat(viewData.getWindowData())
+  //        .isEqualTo(CumulativeData.create(Timestamp.create(1, 0), Timestamp.create(3, 0)));
+  //    StatsTestUtil.assertAggregationMapEquals(
+  //        viewData.getAggregationMap(),
+  //        ImmutableMap.of(
+  //            Arrays.asList(VALUE),
+  //            createAggregationData(noHistogram, 1.1)),
+  //        EPSILON);
+  //  }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -235,7 +235,7 @@ public class ViewManagerImplTest {
         viewManager.getView(VIEW_NAME).getAggregationMap(),
         ImmutableMap.of(
             Arrays.asList(VALUE),
-            MeanData.create(19 * 0.6 + 1, 4)),
+            MeanData.create((19 * 0.6 + 1) / 4, 4)),
         EPSILON);
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 12 * MILLIS_PER_SECOND));


### PR DESCRIPTION
Per our discussion, now each `View` will have one `Aggregation` and each `ViewData` will have one type of `AggregationData`. Also update `MeanData` so that users can get count from it.

Might be easier to review by each commit.

`Distribution` Aggregation will be added in PR #630 .