### PR TITLE
Refactor TagContexts to make the current context methods final.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
@@ -78,6 +78,8 @@ public abstract class TagContextBuilder {
    * current context and returns an object that represents that scope. The scope is exited when the
    * returned object is closed.
    *
+   * <p>This implementation calls {@link #build} to create the {@code TagContext}.
+   *
    * @return an object that defines a scope where the {@code TagContext} created from this builder
    *     is set to the current context.
    */

--- a/core/src/test/java/io/opencensus/tags/TagContextsAndTagContextBuilderTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagContextsAndTagContextBuilderTest.java
@@ -43,11 +43,10 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /**
- * Unit tests for the methods in {@link TagContexts} and {@link TagContextBuilder} that interact
- * with the current {@link TagContext}.
+ * Unit tests for {@link TagContexts} and {@link TagContextBuilder}.
  */
 @RunWith(JUnit4.class)
-public class ScopedTagContextsTest {
+public class TagContextsAndTagContextBuilderTest {
   private static final TagKeyString KEY_1 = TagKeyString.create("key 1");
   private static final TagKeyString KEY_2 = TagKeyString.create("key 2");
 
@@ -58,19 +57,36 @@ public class ScopedTagContextsTest {
 
   private final TagContexts tagContexts =
       new TagContexts() {
-        @Override
-        public TagContextBuilder toBuilder(TagContext tags) {
-          return new SimpleTagContextBuilder(((SimpleTagContext) tags).tags);
-        }
 
         @Override
         public TagContext empty() {
           return emptyTagContext;
         }
+
+        @Override
+        public TagContextBuilder emptyBuilder() {
+          return new SimpleTagContextBuilder(Collections.<TagString>emptySet());
+        }
+
+        @Override
+        public TagContextBuilder toBuilder(TagContext tags) {
+          return new SimpleTagContextBuilder(((SimpleTagContext) tags).tags);
+        }
       };
 
   @Test
-  public void defaultTagContext() {
+  public void transformTagContext() {
+    TagContext tags = new SimpleTagContext(TagString.create(KEY_1, VALUE_1));
+    assertThat(tagContexts.transformTagContext(tags)).isSameAs(tags);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void transformTagContext_DisallowNull() {
+    tagContexts.transformTagContext(null);
+  }
+
+  @Test
+  public void defaultCurrentTagContext() {
     assertThat(asList(tagContexts.getCurrentTagContext())).isEmpty();
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextsImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextsImpl.java
@@ -16,7 +16,6 @@
 
 package io.opencensus.implcore.tags;
 
-import io.opencensus.common.Scope;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContexts;
@@ -36,11 +35,6 @@ public final class TagContextsImpl extends TagContexts {
   }
 
   @Override
-  public TagContextImpl getCurrentTagContext() {
-    return toTagContextImpl(super.getCurrentTagContext());
-  }
-
-  @Override
   public TagContextBuilderImpl emptyBuilder() {
     return new TagContextBuilderImpl();
   }
@@ -51,8 +45,8 @@ public final class TagContextsImpl extends TagContexts {
   }
 
   @Override
-  public Scope withTagContext(TagContext tags) {
-    return super.withTagContext(toTagContextImpl(tags));
+  protected TagContext transformTagContext(TagContext tags) {
+    return toTagContextImpl(tags);
   }
 
   private static TagContextImpl toTagContextImpl(TagContext tags) {


### PR DESCRIPTION
In order to make the methods final, this commit adds a non-final protected
method to TagContexts, transformTagContext, which handles any transformation of
the TagContext that must be done by the particular instance of TagContexts.  For
example, if the TagContexts allows tagging to be disabled, then
transformTagContext can return a no-op TagContext.