### PR TITLE
Clean up TagContext equals and hashCode

### DIFF
--- a/core/src/main/java/io/opencensus/tags/TagContext.java
+++ b/core/src/main/java/io/opencensus/tags/TagContext.java
@@ -17,7 +17,9 @@
 package io.opencensus.tags;
 
 import com.google.common.collect.HashMultiset;
+import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Multiset;
 import io.opencensus.tags.TagValue.TagValueString;
 import java.util.Collections;
 import java.util.Iterator;
@@ -56,16 +58,28 @@ public abstract class TagContext {
     if (!(other instanceof TagContext)) {
       return false;
     }
-    HashMultiset<Tag> tags1 = HashMultiset.create(Lists.newArrayList(unsafeGetIterator()));
-    HashMultiset<Tag> tags2 =
-        HashMultiset.create(Lists.newArrayList(((TagContext) other).unsafeGetIterator()));
+    TagContext otherTags = (TagContext) other;
+    Iterator<Tag> iter1 = unsafeGetIterator();
+    Iterator<Tag> iter2 = otherTags.unsafeGetIterator();
+    Multiset<Tag> tags1 =
+        iter1 == null
+            ? ImmutableMultiset.<Tag>of()
+            : HashMultiset.create(Lists.newArrayList(iter1));
+    Multiset<Tag> tags2 =
+        iter2 == null
+            ? ImmutableMultiset.<Tag>of()
+            : HashMultiset.create(Lists.newArrayList(iter2));
     return tags1.equals(tags2);
   }
 
   @Override
   public final int hashCode() {
     int hashCode = 0;
-    for (Iterator<Tag> i = unsafeGetIterator(); i.hasNext(); ) {
+    Iterator<Tag> i = unsafeGetIterator();
+    if (i == null) {
+      return hashCode;
+    }
+    while (i.hasNext()) {
       Tag tag = i.next();
       if (tag != null) {
         hashCode += tag.hashCode();

--- a/core/src/test/java/io/opencensus/tags/TagContextTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagContextTest.java
@@ -55,6 +55,16 @@ public final class TagContextTest {
   }
 
   @Test
+  public void equals_HandlesNullIterator() {
+    new EqualsTester()
+        .addEqualityGroup(
+            new SimpleTagContext((List<Tag>) null),
+            new SimpleTagContext((List<Tag>) null),
+            new SimpleTagContext())
+        .testEquals();
+  }
+
+  @Test
   public void equals_DoesNotIgnoreNullTags() {
     new EqualsTester()
         .addEqualityGroup(new SimpleTagContext(TAG1))
@@ -81,12 +91,16 @@ public final class TagContextTest {
     private final List<Tag> tags;
 
     SimpleTagContext(Tag... tags) {
-      this.tags = Collections.unmodifiableList(Lists.newArrayList(tags));
+      this(Lists.newArrayList(tags));
+    }
+
+    SimpleTagContext(List<Tag> tags) {
+      this.tags = tags == null ? null : Collections.unmodifiableList(Lists.newArrayList(tags));
     }
 
     @Override
     public Iterator<Tag> unsafeGetIterator() {
-      return tags.iterator();
+      return tags == null ? null : tags.iterator();
     }
   }
 }

--- a/core/src/test/java/io/opencensus/tags/TagContextTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagContextTest.java
@@ -72,21 +72,6 @@ public final class TagContextTest {
   }
 
   @Test
-  public void hashCode_SumsTagHashCodes() {
-    assertThat(new SimpleTagContext().hashCode()).isEqualTo(0);
-    assertThat(new SimpleTagContext(TAG1, TAG2).hashCode())
-        .isEqualTo(TAG1.hashCode() + TAG2.hashCode());
-    assertThat(new SimpleTagContext(TAG1, TAG2, TAG2).hashCode())
-        .isEqualTo(TAG1.hashCode() + 2 * TAG2.hashCode());
-  }
-
-  @Test
-  public void hashCode_IgnoresNullTags() {
-    assertThat(new SimpleTagContext(TAG1, TAG1, TAG2, null).hashCode())
-        .isEqualTo(2 * TAG1.hashCode() + TAG2.hashCode());
-  }
-
-  @Test
   public void testToString() {
     assertThat(new SimpleTagContext().toString()).isEqualTo("TagContext");
     assertThat(new SimpleTagContext(TAG1, TAG2).toString()).isEqualTo("TagContext");


### PR DESCRIPTION
#### Check for null in TagContext equals and hashCode.

This isn't a good place to throw a NullPointerException if the subclass
incorrectly returns a null Iterator.

#### Remove obsolete TagContext.hashCode() tests.

These tests aren't needed, because we don't specify the behavior of TagContext.hashCode().