### PR TITLE
Refactor MeasureMap.Builder

### DIFF
--- a/core/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/core/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -54,7 +54,7 @@ public final class MeasureMap {
   public static class Builder {
     /**
      * Associates the {@link MeasureDouble} with the given value. Subsequent updates to the
-     * same {@link MeasureDouble} are ignored.
+     * same {@link MeasureDouble} will overwrite the previous value.
      *
      * @param measure the {@link MeasureDouble}
      * @param value the value to be associated with {@code measure}
@@ -67,7 +67,7 @@ public final class MeasureMap {
 
     /**
      * Associates the {@link MeasureLong} with the given value. Subsequent updates to the
-     * same {@link MeasureLong} are ignored.
+     * same {@link MeasureLong} will overwrite the previous value.
      *
      * @param measure the {@link MeasureLong}
      * @param value the value to be associated with {@code measure}
@@ -85,8 +85,8 @@ public final class MeasureMap {
       // Note: this makes adding measurements quadratic but is fastest for the sizes of
       // MeasureMaps that we should see. We may want to go to a strategy of sort/eliminate
       // for larger MeasureMaps.
-      for (int i = 0; i < measurements.size(); i++) {
-        for (int j = i + 1; j < measurements.size(); j++) {
+      for (int i = measurements.size() - 1; i >= 0; i--) {
+        for (int j = i - 1; j >= 0; j--) {
           if (measurements.get(i).getMeasure() == measurements.get(j).getMeasure()) {
             measurements.remove(j);
             j--;

--- a/core/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/core/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -60,7 +60,7 @@ public final class MeasureMap {
      * @param value the value to be associated with {@code measure}
      * @return this
      */
-    public Builder set(MeasureDouble measure, double value) {
+    public Builder put(MeasureDouble measure, double value) {
       measurements.add(Measurement.MeasurementDouble.create(measure, value));
       return this;
     }
@@ -73,7 +73,7 @@ public final class MeasureMap {
      * @param value the value to be associated with {@code measure}
      * @return this
      */
-    public Builder set(MeasureLong measure, long value) {
+    public Builder put(MeasureLong measure, long value) {
       measurements.add(Measurement.MeasurementLong.create(measure, value));
       return this;
     }

--- a/core/src/test/java/io/opencensus/stats/MeasureMapTest.java
+++ b/core/src/test/java/io/opencensus/stats/MeasureMapTest.java
@@ -21,6 +21,8 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.Lists;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.stats.Measurement.MeasurementDouble;
+import io.opencensus.stats.Measurement.MeasurementLong;
 import java.util.ArrayList;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,15 +35,15 @@ public class MeasureMapTest {
   @Test
   public void testPutDouble() {
     MeasureMap metrics = MeasureMap.builder().put(M1, 44.4).build();
-    assertContains(metrics, Measurement.MeasurementDouble.create(M1, 44.4));
+    assertContains(metrics, MeasurementDouble.create(M1, 44.4));
   }
 
   @Test
   public void testPutLong() {
     MeasureMap metrics = MeasureMap.builder().put(M3, 9999L).put(M4, 8888L).build();
     assertContains(metrics,
-        Measurement.MeasurementLong.create(M3, 9999L),
-        Measurement.MeasurementLong.create(M4, 8888L));
+        MeasurementLong.create(M3, 9999L),
+        MeasurementLong.create(M4, 8888L));
   }
 
   @Test
@@ -49,10 +51,10 @@ public class MeasureMapTest {
     MeasureMap metrics =
         MeasureMap.builder().put(M1, 44.4).put(M2, 66.6).put(M3, 9999L).put(M4, 8888L).build();
     assertContains(metrics,
-        Measurement.MeasurementDouble.create(M1, 44.4),
-        Measurement.MeasurementDouble.create(M2, 66.6),
-        Measurement.MeasurementLong.create(M3, 9999L),
-        Measurement.MeasurementLong.create(M4, 8888L));
+        MeasurementDouble.create(M1, 44.4),
+        MeasurementDouble.create(M2, 66.6),
+        MeasurementLong.create(M3, 9999L),
+        MeasurementLong.create(M4, 8888L));
   }
 
   @Test
@@ -67,7 +69,7 @@ public class MeasureMapTest {
     MeasureMap.Builder builder = MeasureMap.builder();
     for (int i = 1; i <= 10; i++) {
       expected
-          .add(Measurement.MeasurementDouble.create(makeSimpleMeasureDouble("m" + i), i * 11.1));
+          .add(MeasurementDouble.create(makeSimpleMeasureDouble("m" + i), i * 11.1));
       builder.put(makeSimpleMeasureDouble("m" + i), i * 11.1);
       assertContains(builder.build(), expected.toArray(new Measurement[i]));
     }
@@ -75,45 +77,46 @@ public class MeasureMapTest {
 
   @Test
   public void testDuplicateMeasureDoubles() {
-    assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).build(), MEASUREMENT_1);
+    assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).build(),
+        MeasurementDouble.create(M1, 2.0));
     assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).put(M1, 3.0).build(),
-        MEASUREMENT_1);
+        MeasurementDouble.create(M1, 3.0));
     assertContains(MeasureMap.builder().put(M1, 1.0).put(M2, 2.0).put(M1, 3.0).build(),
-        MEASUREMENT_1,
-        MEASUREMENT_2);
+        MeasurementDouble.create(M1, 3.0),
+        MeasurementDouble.create(M2, 2.0));
     assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).put(M2, 2.0).build(),
-        MEASUREMENT_1,
-        MEASUREMENT_2);
+        MeasurementDouble.create(M1, 2.0),
+        MeasurementDouble.create(M2, 2.0));
   }
 
   @Test
   public void testDuplicateMeasureLongs() {
-    assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 100L).build(), MEASUREMENT_3);
+    assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 100L).build(),
+        MeasurementLong.create(M3, 100L));
     assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 200L).put(M3, 300L).build(),
-        MEASUREMENT_3);
+        MeasurementLong.create(M3, 300L));
     assertContains(MeasureMap.builder().put(M3, 100L).put(M4, 200L).put(M3, 300L).build(),
-        MEASUREMENT_3, MEASUREMENT_4);
+        MeasurementLong.create(M3, 300L),
+        MeasurementLong.create(M4, 200L));
     assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 200L).put(M4, 200L).build(),
-        MEASUREMENT_3, MEASUREMENT_4);
+        MeasurementLong.create(M3, 200L),
+        MeasurementLong.create(M4, 200L));
   }
 
   @Test
   public void testDuplicateMeasures() {
     assertContains(MeasureMap.builder().put(M3, 100L).put(M1, 1.0).put(M3, 300L).build(),
-        MEASUREMENT_3, MEASUREMENT_1);
+        MeasurementLong.create(M3, 300L),
+        MeasurementDouble.create(M1, 1.0));
     assertContains(MeasureMap.builder().put(M2, 2.0).put(M3, 100L).put(M2, 3.0).build(),
-        MEASUREMENT_2, MEASUREMENT_3);
+        MeasurementDouble.create(M2, 3.0),
+        MeasurementLong.create(M3, 100L));
   }
 
   private static final MeasureDouble M1 = makeSimpleMeasureDouble("m1");
   private static final MeasureDouble M2 = makeSimpleMeasureDouble("m2");
   private static final MeasureLong M3 = makeSimpleMeasureLong("m3");
   private static final MeasureLong M4 = makeSimpleMeasureLong("m4");
-
-  private static final Measurement MEASUREMENT_1 = Measurement.MeasurementDouble.create(M1, 1.0);
-  private static final Measurement MEASUREMENT_2 = Measurement.MeasurementDouble.create(M2, 2.0);
-  private static final Measurement MEASUREMENT_3 = Measurement.MeasurementLong.create(M3, 100L);
-  private static final Measurement MEASUREMENT_4 = Measurement.MeasurementLong.create(M4, 200L);
 
   private static MeasureDouble makeSimpleMeasureDouble(String measure) {
     return Measure.MeasureDouble.create(measure, measure + " description", "1");

--- a/core/src/test/java/io/opencensus/stats/MeasureMapTest.java
+++ b/core/src/test/java/io/opencensus/stats/MeasureMapTest.java
@@ -32,13 +32,13 @@ public class MeasureMapTest {
 
   @Test
   public void testPutDouble() {
-    MeasureMap metrics = MeasureMap.builder().set(M1, 44.4).build();
+    MeasureMap metrics = MeasureMap.builder().put(M1, 44.4).build();
     assertContains(metrics, Measurement.MeasurementDouble.create(M1, 44.4));
   }
 
   @Test
   public void testPutLong() {
-    MeasureMap metrics = MeasureMap.builder().set(M3, 9999L).set(M4, 8888L).build();
+    MeasureMap metrics = MeasureMap.builder().put(M3, 9999L).put(M4, 8888L).build();
     assertContains(metrics,
         Measurement.MeasurementLong.create(M3, 9999L),
         Measurement.MeasurementLong.create(M4, 8888L));
@@ -47,7 +47,7 @@ public class MeasureMapTest {
   @Test
   public void testCombination() {
     MeasureMap metrics =
-        MeasureMap.builder().set(M1, 44.4).set(M2, 66.6).set(M3, 9999L).set(M4, 8888L).build();
+        MeasureMap.builder().put(M1, 44.4).put(M2, 66.6).put(M3, 9999L).put(M4, 8888L).build();
     assertContains(metrics,
         Measurement.MeasurementDouble.create(M1, 44.4),
         Measurement.MeasurementDouble.create(M2, 66.6),
@@ -68,40 +68,40 @@ public class MeasureMapTest {
     for (int i = 1; i <= 10; i++) {
       expected
           .add(Measurement.MeasurementDouble.create(makeSimpleMeasureDouble("m" + i), i * 11.1));
-      builder.set(makeSimpleMeasureDouble("m" + i), i * 11.1);
+      builder.put(makeSimpleMeasureDouble("m" + i), i * 11.1);
       assertContains(builder.build(), expected.toArray(new Measurement[i]));
     }
   }
 
   @Test
   public void testDuplicateMeasureDoubles() {
-    assertContains(MeasureMap.builder().set(M1, 1.0).set(M1, 2.0).build(), MEASUREMENT_1);
-    assertContains(MeasureMap.builder().set(M1, 1.0).set(M1, 2.0).set(M1, 3.0).build(),
+    assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).build(), MEASUREMENT_1);
+    assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).put(M1, 3.0).build(),
         MEASUREMENT_1);
-    assertContains(MeasureMap.builder().set(M1, 1.0).set(M2, 2.0).set(M1, 3.0).build(),
+    assertContains(MeasureMap.builder().put(M1, 1.0).put(M2, 2.0).put(M1, 3.0).build(),
         MEASUREMENT_1,
         MEASUREMENT_2);
-    assertContains(MeasureMap.builder().set(M1, 1.0).set(M1, 2.0).set(M2, 2.0).build(),
+    assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).put(M2, 2.0).build(),
         MEASUREMENT_1,
         MEASUREMENT_2);
   }
 
   @Test
   public void testDuplicateMeasureLongs() {
-    assertContains(MeasureMap.builder().set(M3, 100L).set(M3, 100L).build(), MEASUREMENT_3);
-    assertContains(MeasureMap.builder().set(M3, 100L).set(M3, 200L).set(M3, 300L).build(),
+    assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 100L).build(), MEASUREMENT_3);
+    assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 200L).put(M3, 300L).build(),
         MEASUREMENT_3);
-    assertContains(MeasureMap.builder().set(M3, 100L).set(M4, 200L).set(M3, 300L).build(),
+    assertContains(MeasureMap.builder().put(M3, 100L).put(M4, 200L).put(M3, 300L).build(),
         MEASUREMENT_3, MEASUREMENT_4);
-    assertContains(MeasureMap.builder().set(M3, 100L).set(M3, 200L).set(M4, 200L).build(),
+    assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 200L).put(M4, 200L).build(),
         MEASUREMENT_3, MEASUREMENT_4);
   }
 
   @Test
   public void testDuplicateMeasures() {
-    assertContains(MeasureMap.builder().set(M3, 100L).set(M1, 1.0).set(M3, 300L).build(),
+    assertContains(MeasureMap.builder().put(M3, 100L).put(M1, 1.0).put(M3, 300L).build(),
         MEASUREMENT_3, MEASUREMENT_1);
-    assertContains(MeasureMap.builder().set(M2, 2.0).set(M3, 100L).set(M2, 3.0).build(),
+    assertContains(MeasureMap.builder().put(M2, 2.0).put(M3, 100L).put(M2, 3.0).build(),
         MEASUREMENT_2, MEASUREMENT_3);
   }
 

--- a/core/src/test/java/io/opencensus/stats/NoopStatsRecorderTest.java
+++ b/core/src/test/java/io/opencensus/stats/NoopStatsRecorderTest.java
@@ -54,19 +54,19 @@ public final class NoopStatsRecorderTest {
   @Test
   public void record() {
     StatsRecorder.getNoopStatsRecorder()
-        .record(tagContext, MeasureMap.builder().set(MEASURE, 5).build());
+        .record(tagContext, MeasureMap.builder().put(MEASURE, 5).build());
   }
 
   // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
   // exception.
   @Test
   public void recordWithCurrentContext() {
-    StatsRecorder.getNoopStatsRecorder().record(MeasureMap.builder().set(MEASURE, 6).build());
+    StatsRecorder.getNoopStatsRecorder().record(MeasureMap.builder().put(MEASURE, 6).build());
   }
 
   @Test
   public void record_DisallowNullTagContext() {
-    MeasureMap measures = MeasureMap.builder().set(MEASURE, 7).build();
+    MeasureMap measures = MeasureMap.builder().put(MEASURE, 7).build();
     thrown.expect(NullPointerException.class);
     StatsRecorder.getNoopStatsRecorder().record(null, measures);
   }

--- a/core/src/test/java/io/opencensus/stats/StatsRecorderTest.java
+++ b/core/src/test/java/io/opencensus/stats/StatsRecorderTest.java
@@ -62,7 +62,7 @@ public final class StatsRecorderTest {
 
   @Test
   public void record_CurrentContextNotSet() {
-    MeasureMap measures = MeasureMap.builder().set(MEASURE, 1.0).build();
+    MeasureMap measures = MeasureMap.builder().put(MEASURE, 1.0).build();
     statsRecorder.record(measures);
     verify(statsRecorder).record(same(ContextUtils.TAG_CONTEXT_KEY.get()), same(measures));
   }
@@ -71,7 +71,7 @@ public final class StatsRecorderTest {
   public void record_CurrentContextSet() {
     Context orig = Context.current().withValue(ContextUtils.TAG_CONTEXT_KEY, tagContext).attach();
     try {
-      MeasureMap measures = MeasureMap.builder().set(MEASURE, 2.0).build();
+      MeasureMap measures = MeasureMap.builder().put(MEASURE, 2.0).build();
       statsRecorder.record(measures);
       verify(statsRecorder).record(same(tagContext), same(measures));
     } finally {

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -181,7 +181,7 @@ public class ViewManagerImplTest {
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
     double[] values = {10.0, 20.0, 30.0, 40.0};
     for (double val : values) {
-      statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, val).build());
+      statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, val).build());
     }
     clock.setTime(Timestamp.create(3, 4));
     ViewData viewData = viewManager.getView(VIEW_NAME);
@@ -217,7 +217,7 @@ public class ViewManagerImplTest {
        * 5.0 should fall into the third bucket [35.0, 37.5).
        */
       clock.setTime(Timestamp.fromMillis(startTimeMillis + i * MILLIS_PER_SECOND));
-      statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, values[i - 1]).build());
+      statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, values[i - 1]).build());
     }
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 8 * MILLIS_PER_SECOND));
@@ -240,7 +240,7 @@ public class ViewManagerImplTest {
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 12 * MILLIS_PER_SECOND));
     // 42s, add a new value 9.0, should fall into bucket [40.0, 42.5)
-    statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 9.0).build());
+    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, 9.0).build());
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 17 * MILLIS_PER_SECOND));
     // 47s, values in the first and second bucket should have expired, and 80% of values in the
@@ -254,7 +254,7 @@ public class ViewManagerImplTest {
 
     clock.setTime(Timestamp.fromMillis(60 * MILLIS_PER_SECOND));
     // 60s, all previous values should have expired, add a new value 30.0
-    statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 30.0).build());
+    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, 30.0).build());
     StatsTestUtil.assertAggregationMapEquals(
         viewManager.getView(VIEW_NAME).getAggregationMap(),
         ImmutableMap.of(
@@ -273,7 +273,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(10, 0));
     viewManager.registerView(view);
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
-    statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 0.1).build());
+    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, 0.1).build());
     clock.setTime(Timestamp.create(11, 0));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
     assertThat(viewData1.getWindowData())
@@ -284,7 +284,7 @@ public class ViewManagerImplTest {
             Arrays.asList(VALUE), StatsTestUtil.createAggregationData(MEAN, 0.1)),
         EPSILON);
 
-    statsRecorder.record(tags, MeasureMap.builder().set(MEASURE, 0.2).build());
+    statsRecorder.record(tags, MeasureMap.builder().put(MEASURE, 0.2).build());
     clock.setTime(Timestamp.create(12, 0));
     ViewData viewData2 = viewManager.getView(VIEW_NAME);
 
@@ -305,13 +305,13 @@ public class ViewManagerImplTest {
         createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY)));
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().set(MEASURE, 10.0).build());
+        MeasureMap.builder().put(MEASURE, 10.0).build());
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE_2).build(),
-        MeasureMap.builder().set(MEASURE, 30.0).build());
+        MeasureMap.builder().put(MEASURE, 30.0).build());
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE_2).build(),
-        MeasureMap.builder().set(MEASURE, 50.0).build());
+        MeasureMap.builder().put(MEASURE, 50.0).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
         viewData.getAggregationMap(),
@@ -336,16 +336,16 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.fromMillis(11 * MILLIS_PER_SECOND));
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().set(MEASURE, 10.0).build());
+        MeasureMap.builder().put(MEASURE, 10.0).build());
 
     // record for TagValue2 at 15s
     clock.setTime(Timestamp.fromMillis(15 * MILLIS_PER_SECOND));
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE_2).build(),
-        MeasureMap.builder().set(MEASURE, 30.0).build());
+        MeasureMap.builder().put(MEASURE, 30.0).build());
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE_2).build(),
-        MeasureMap.builder().set(MEASURE, 50.0).build());
+        MeasureMap.builder().put(MEASURE, 50.0).build());
 
     // get ViewData at 19s, no stats should have expired.
     clock.setTime(Timestamp.fromMillis(19 * MILLIS_PER_SECOND));
@@ -381,7 +381,7 @@ public class ViewManagerImplTest {
   public void allowRecordingWithoutRegisteringMatchingViewData() {
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().set(MEASURE, 10).build());
+        MeasureMap.builder().put(MEASURE, 10).build());
   }
 
   @Test
@@ -389,7 +389,7 @@ public class ViewManagerImplTest {
     viewManager.registerView(
         createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY)));
     // DEFAULT doesn't have tags, but the view has tag key "KEY".
-    statsRecorder.record(tagger.empty(), MeasureMap.builder().set(MEASURE, 10.0).build());
+    statsRecorder.record(tagger.empty(), MeasureMap.builder().put(MEASURE, 10.0).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
         viewData.getAggregationMap(),
@@ -413,7 +413,7 @@ public class ViewManagerImplTest {
     MeasureDouble measure2 = Measure.MeasureDouble.create(MEASURE_NAME_2, "measure", MEASURE_UNIT);
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().set(measure2, 10.0).build());
+        MeasureMap.builder().put(measure2, 10.0).build());
     ViewData view = viewManager.getView(VIEW_NAME);
     assertThat(view.getAggregationMap()).isEmpty();
   }
@@ -424,10 +424,10 @@ public class ViewManagerImplTest {
         createCumulativeView(VIEW_NAME, MEASURE, MEAN, Arrays.asList(KEY)));
     statsRecorder.record(
         tagger.emptyBuilder().put(TagKeyString.create("wrong key"), VALUE).build(),
-        MeasureMap.builder().set(MEASURE, 10.0).build());
+        MeasureMap.builder().put(MEASURE, 10.0).build());
     statsRecorder.record(
         tagger.emptyBuilder().put(TagKeyString.create("another wrong key"), VALUE).build(),
-        MeasureMap.builder().set(MEASURE, 50.0).build());
+        MeasureMap.builder().put(MEASURE, 50.0).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
         viewData.getAggregationMap(),
@@ -452,28 +452,28 @@ public class ViewManagerImplTest {
             .put(key1, TagValueString.create("v1"))
             .put(key2, TagValueString.create("v10"))
             .build(),
-        MeasureMap.builder().set(MEASURE, 1.1).build());
+        MeasureMap.builder().put(MEASURE, 1.1).build());
     statsRecorder.record(
         tagger
             .emptyBuilder()
             .put(key1, TagValueString.create("v1"))
             .put(key2, TagValueString.create("v20"))
             .build(),
-        MeasureMap.builder().set(MEASURE, 2.2).build());
+        MeasureMap.builder().put(MEASURE, 2.2).build());
     statsRecorder.record(
         tagger
             .emptyBuilder()
             .put(key1, TagValueString.create("v2"))
             .put(key2, TagValueString.create("v10"))
             .build(),
-        MeasureMap.builder().set(MEASURE, 3.3).build());
+        MeasureMap.builder().put(MEASURE, 3.3).build());
     statsRecorder.record(
         tagger
             .emptyBuilder()
             .put(key1, TagValueString.create("v1"))
             .put(key2, TagValueString.create("v10"))
             .build(),
-        MeasureMap.builder().set(MEASURE, 4.4).build());
+        MeasureMap.builder().put(MEASURE, 4.4).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertAggregationMapEquals(
         viewData.getAggregationMap(),
@@ -497,7 +497,7 @@ public class ViewManagerImplTest {
     viewManager.registerView(view2);
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().set(MEASURE, 5.0).build());
+        MeasureMap.builder().put(MEASURE, 5.0).build());
     clock.setTime(Timestamp.create(3, 3));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
     clock.setTime(Timestamp.create(4, 4));
@@ -533,7 +533,7 @@ public class ViewManagerImplTest {
     viewManager.registerView(view2);
     statsRecorder.record(
         tagger.emptyBuilder().put(KEY, VALUE).build(),
-        MeasureMap.builder().set(measure1, 1.1).set(measure2, 2.2).build());
+        MeasureMap.builder().put(measure1, 1.1).put(measure2, 2.2).build());
     clock.setTime(Timestamp.create(3, 0));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
     clock.setTime(Timestamp.create(4, 0));

--- a/examples/src/main/java/io/opencensus/examples/stats/StatsRunner.java
+++ b/examples/src/main/java/io/opencensus/examples/stats/StatsRunner.java
@@ -67,7 +67,7 @@ public class StatsRunner {
         System.out.println(
             "    Current == Default + tags1 + tags2: "
                 + tagger.getCurrentTagContext().equals(tags2));
-        statsRecorder.record(MeasureMap.builder().set(M1, 0.2).set(M2, 0.4).build());
+        statsRecorder.record(MeasureMap.builder().put(M1, 0.2).put(M2, 0.4).build());
       }
     }
     System.out.println(


### PR DESCRIPTION
1. Rename MeasureMap.Builder.set() to put(). Consistent with TagContextBuilder #627 
2. Overwrite existing Measure values, if there are subsequent updates to a Measure that is already put.