### PR TITLE
Run the integration tests using different Java versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,11 +51,10 @@ script:
       "CHECK_GIT_HISTORY")
         python check-git-history.py ;;
       "BUILD")
-        export JAVA6_HOME=`jdk_switcher home openjdk6` ;
-        export JAVA7_HOME=`jdk_switcher home openjdk7` ;
         export JAVA8_HOME=`jdk_switcher home oraclejdk8` ;
         case "$TRAVIS_JDK_VERSION" in
           "oraclejdk8")
+            export JAVA_HOMES="`jdk_switcher home openjdk6`/jre:`jdk_switcher home openjdk7`/jre:`jdk_switcher home oraclejdk8`/jre" ;
             ./gradlew clean assemble --stacktrace ;
             ./gradlew check :opencensus-all:jacocoTestReport ;;
           "openjdk7")

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ matrix:
     addons:
       apt:
         packages:
+          # Install the JREs that are used for integration tests in
+          # contrib/agent, but are not installed by default.
           - openjdk-6-jdk
-          - openjdk-7-jdk
 
   - env: TASK=CHECK_GIT_HISTORY
     os: linux
@@ -54,7 +55,7 @@ script:
         export JAVA8_HOME=`jdk_switcher home oraclejdk8` ;
         case "$TRAVIS_JDK_VERSION" in
           "oraclejdk8")
-            export JAVA_HOMES="`jdk_switcher home openjdk6`/jre:`jdk_switcher home openjdk7`/jre:`jdk_switcher home oraclejdk8`/jre" ;
+            export JAVA_HOMES="$(jdk_switcher home openjdk6)/jre:$(jdk_switcher home openjdk7)/jre:$(jdk_switcher home oraclejdk8)/jre" ;
             ./gradlew clean assemble --stacktrace ;
             ./gradlew check :opencensus-all:jacocoTestReport ;;
           "openjdk7")

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,11 @@ matrix:
   - jdk: oraclejdk8
     env: TASK=BUILD
     os: linux
+    addons:
+      apt:
+        packages:
+          - openjdk-6-jdk
+          - openjdk-7-jdk
 
   - env: TASK=CHECK_GIT_HISTORY
     os: linux
@@ -46,6 +51,8 @@ script:
       "CHECK_GIT_HISTORY")
         python check-git-history.py ;;
       "BUILD")
+        export JAVA6_HOME=`jdk_switcher home openjdk6` ;
+        export JAVA7_HOME=`jdk_switcher home openjdk7` ;
         export JAVA8_HOME=`jdk_switcher home oraclejdk8` ;
         case "$TRAVIS_JDK_VERSION" in
           "oraclejdk8")

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,4 +2,8 @@ install:
   - git submodule update --init --recursive
 
 build_script:
+  # The Gradle build script runs the integration tests of contrib/agent using different Java
+  # versions. %JAVA_HOMES% lists the home directories of the JDK installations used for
+  # integration testing. Also see https://www.appveyor.com/docs/build-environment/#java.
+  - set JAVA_HOMES=C:\Program Files\Java\jdk1.6.0\jre;C:\Program Files\Java\jdk1.7.0\jre;C:\Program Files\Java\jdk1.8.0\jre
   - gradlew.bat clean assemble check --stacktrace

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -126,8 +126,9 @@ jar.finalizedBy shadowJar
 
 // TODO(stschmidt): Proguard-shrink the agent JAR.
 
-// Integration tests. The setup is mostly based on
+// Integration tests. The setup was initially based on
 // https://www.petrikainulainen.net/programming/gradle/getting-started-with-gradle-integration-testing/.
+// The same suite of integration tests are run on different Java versions with the agent enabled.
 
 sourceSets {
   integrationTest {
@@ -155,21 +156,41 @@ checkstyleIntegrationTest.enabled = JavaVersion.current().isJava8Compatible()
 // Disable findbugs for integration tests, too.
 findbugsIntegrationTest.enabled = false
 
-// Run integration tests with the agent enabled.
-task integrationTest(type: Test) {
-  testLogging {
-    // Let Gradle output the stdout and stderr from tests, too. This is useful for investigating
-    // test failures on Travis, where we can't view Gradle's test reports.
-    showStandardStreams = true
+def javaExecutables = [ 'JAVA6_HOME', 'JAVA7_HOME', 'JAVA8_HOME' ]
+    .collect { System.getenv(it) }
+    .findAll { it != null }
+    .plus(System.getProperty('java.home'))
+    .collect { org.apache.tools.ant.taskdefs.condition.Os.isFamily(
+                   org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)
+                   ? "${it}/bin/java.exe"
+                   : "${it}/bin/java" }
+    .findAll { new File(it).canExecute() }
+    .unique()
 
-    // Include the exception message and full stacktrace for failed tests.
-    exceptionFormat 'full'
+assert javaExecutables.size > 0 :
+       'No Java executables found for running integration tests'
+
+task integrationTest
+
+javaExecutables.eachWithIndex { javaExecutable, index ->
+  def perVersionIntegrationTest = task("integrationTest_${index}", type: Test) {
+    testLogging {
+      // Let Gradle output the stdout and stderr from tests, too. This is useful for investigating
+      // test failures on Travis, where we can't view Gradle's test reports.
+      showStandardStreams = true
+
+      // Include the exception message and full stacktrace for failed tests.
+      exceptionFormat 'full'
+    }
+
+    testClassesDirs = sourceSets.integrationTest.output.classesDirs
+    classpath = sourceSets.integrationTest.runtimeClasspath
+
+    executable = javaExecutable
+    jvmArgs "-javaagent:${shadowJar.archivePath}"
   }
 
-  testClassesDirs = sourceSets.integrationTest.output.classesDirs
-  classpath = sourceSets.integrationTest.runtimeClasspath
-
-  jvmArgs "-javaagent:${shadowJar.archivePath}"
+  integrationTest.dependsOn perVersionIntegrationTest
 }
 
 check.dependsOn integrationTest

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -128,7 +128,9 @@ jar.finalizedBy shadowJar
 
 // Integration tests. The setup was initially based on
 // https://www.petrikainulainen.net/programming/gradle/getting-started-with-gradle-integration-testing/.
-// The same suite of integration tests are run on different Java versions with the agent enabled.
+// We run the same suite of integration tests on different Java versions with the agent enabled.
+// The JAVA_HOMES environment variable lists the home directories of the Java installations used
+// for integration testing.
 
 sourceSets {
   integrationTest {
@@ -156,15 +158,15 @@ checkstyleIntegrationTest.enabled = JavaVersion.current().isJava8Compatible()
 // Disable findbugs for integration tests, too.
 findbugsIntegrationTest.enabled = false
 
-def javaExecutables = [ 'JAVA6_HOME', 'JAVA7_HOME', 'JAVA8_HOME' ]
-    .collect { System.getenv(it) }
-    .findAll { it != null }
+def javaExecutables = (System.getenv('JAVA_HOMES') ?: '')
+    .tokenize(File.pathSeparator)
     .plus(System.getProperty('java.home'))
+    .findAll { new File(it).exists() }
     .collect { org.apache.tools.ant.taskdefs.condition.Os.isFamily(
                    org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)
                    ? "${it}/bin/java.exe"
                    : "${it}/bin/java" }
-    .findAll { new File(it).canExecute() }
+    .collect { new File(it).getCanonicalPath() }
     .unique()
 
 assert javaExecutables.size > 0 :
@@ -188,6 +190,8 @@ javaExecutables.eachWithIndex { javaExecutable, index ->
 
     executable = javaExecutable
     jvmArgs "-javaagent:${shadowJar.archivePath}"
+
+    doFirst { logger.lifecycle("Running integrations tests using ${javaExecutable}.") }
   }
 
   integrationTest.dependsOn perVersionIntegrationTest

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -161,7 +161,6 @@ findbugsIntegrationTest.enabled = false
 def javaExecutables = (System.getenv('JAVA_HOMES') ?: '')
     .tokenize(File.pathSeparator)
     .plus(System.getProperty('java.home'))
-    .findAll { new File(it).exists() }
     .collect { org.apache.tools.ant.taskdefs.condition.Os.isFamily(
                    org.apache.tools.ant.taskdefs.condition.Os.FAMILY_WINDOWS)
                    ? "${it}/bin/java.exe"
@@ -191,7 +190,7 @@ javaExecutables.eachWithIndex { javaExecutable, index ->
     executable = javaExecutable
     jvmArgs "-javaagent:${shadowJar.archivePath}"
 
-    doFirst { logger.lifecycle("Running integrations tests using ${javaExecutable}.") }
+    doFirst { logger.lifecycle("Running integration tests using ${javaExecutable}.") }
   }
 
   integrationTest.dependsOn perVersionIntegrationTest


### PR DESCRIPTION
This change let's Gradle execute the integration tests using different JRE versions. This makes it easy to test the agent on arbitrary JRE versions by just setting JAVA_HOMES appropriately. On Travis and AppVeyor, we test the Java 8-built agent on Java 6, 7, and 8 to increase our confidence in compatiblity with different Java versions. Also see #616, #619.