### PR TITLE
Add a new SpanContextParseException and use it in BinaryFormat.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -32,7 +32,7 @@ import java.text.ParseException;
  *     Tracing.getPropagationComponent().getBinaryFormat();
  * void onSendRequest() {
  *   try (Scope ss = tracer.spanBuilder("Sent.MyRequest").startScopedSpan()) {
- *     byte[] binaryValue = binaryFormat.toBinaryValue(tracer.getCurrentContext().context());
+ *     byte[] binaryValue = binaryFormat.toByteArray(tracer.getCurrentContext().context());
  *     // Send the request including the binaryValue and wait for the response.
  *   }
  * }
@@ -49,9 +49,9 @@ import java.text.ParseException;
  *   SpanContext spanContext = SpanContext.INVALID;
  *   try {
  *     if (binaryValue != null) {
- *       spanContext = binaryFormat.fromBinaryValue(binaryValue);
+ *       spanContext = binaryFormat.fromByteArray(binaryValue);
  *     }
- *   } catch (ParseException e) {
+ *   } catch (SpanContextParseException e) {
  *     // Maybe log the exception.
  *   }
  *   try (Scope ss =
@@ -65,23 +65,58 @@ public abstract class BinaryFormat {
   static final NoopBinaryFormat NOOP_BINARY_FORMAT = new NoopBinaryFormat();
 
   /**
-   * Serializes a {@link SpanContext} using the binary format.
+   * @deprecated use {@link #toByteArray(SpanContext)}.
+   * @param spanContext the {@code SpanContext} to serialize.
+   * @return the serialized binary value.
+   * @throws NullPointerException if the {@code spanContext} is {@code null}.
+   */
+  @Deprecated
+  public byte[] toBinaryValue(SpanContext spanContext) {
+    return toByteArray(spanContext);
+  }
+
+  /**
+   * Serializes a {@link SpanContext} using the binary format into a byte array.
    *
    * @param spanContext the {@code SpanContext} to serialize.
    * @return the serialized binary value.
    * @throws NullPointerException if the {@code spanContext} is {@code null}.
    */
-  public abstract byte[] toBinaryValue(SpanContext spanContext);
+  public byte[] toByteArray(SpanContext spanContext) {
+    return toBinaryValue(spanContext);
+  }
 
   /**
-   * Parses the {@link SpanContext} from the binary format.
-   *
+   * @deprecated use {@link #fromByteArray(byte[])}.
    * @param bytes a binary encoded buffer from which the {@code SpanContext} will be parsed.
    * @return the parsed {@code SpanContext}.
    * @throws NullPointerException if the {@code input} is {@code null}.
    * @throws ParseException if the version is not supported or the input is invalid
    */
-  public abstract SpanContext fromBinaryValue(byte[] bytes) throws ParseException;
+  @Deprecated
+  public SpanContext fromBinaryValue(byte[] bytes) throws ParseException {
+    try {
+      return fromByteArray(bytes);
+    } catch (SpanContextParseException e) {
+      throw new ParseException(e.toString(), 0);
+    }
+  }
+
+  /**
+   * Parses the {@link SpanContext} using the binary format from a byte array.
+   *
+   * @param bytes a binary encoded buffer from which the {@code SpanContext} will be parsed.
+   * @return the parsed {@code SpanContext}.
+   * @throws NullPointerException if the {@code input} is {@code null}.
+   * @throws SpanContextParseException if the version is not supported or the input is invalid
+   */
+  public SpanContext fromByteArray(byte[] bytes) throws SpanContextParseException {
+    try {
+      return fromBinaryValue(bytes);
+    } catch (ParseException e) {
+      throw new SpanContextParseException("Error while parsing.", e);
+    }
+  }
 
   /**
    * Returns the no-op implementation of the {@code BinaryFormat}.
@@ -94,13 +129,13 @@ public abstract class BinaryFormat {
 
   private static final class NoopBinaryFormat extends BinaryFormat {
     @Override
-    public byte[] toBinaryValue(SpanContext spanContext) {
+    public byte[] toByteArray(SpanContext spanContext) {
       checkNotNull(spanContext, "spanContext");
       return new byte[0];
     }
 
     @Override
-    public SpanContext fromBinaryValue(byte[] bytes) throws ParseException {
+    public SpanContext fromByteArray(byte[] bytes) throws SpanContextParseException {
       checkNotNull(bytes, "bytes");
       return SpanContext.INVALID;
     }

--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -76,13 +76,14 @@ public abstract class BinaryFormat {
   }
 
   /**
-   * Serializes a {@link SpanContext} using the binary format into a byte array.
+   * Serializes a {@link SpanContext} into a byte array using the binary format.
    *
    * @param spanContext the {@code SpanContext} to serialize.
    * @return the serialized binary value.
    * @throws NullPointerException if the {@code spanContext} is {@code null}.
    */
   public byte[] toByteArray(SpanContext spanContext) {
+    // Implementation must override this method.
     return toBinaryValue(spanContext);
   }
 
@@ -103,7 +104,7 @@ public abstract class BinaryFormat {
   }
 
   /**
-   * Parses the {@link SpanContext} using the binary format from a byte array.
+   * Parses the {@link SpanContext} from a byte array using the binary format.
    *
    * @param bytes a binary encoded buffer from which the {@code SpanContext} will be parsed.
    * @return the parsed {@code SpanContext}.
@@ -111,6 +112,7 @@ public abstract class BinaryFormat {
    * @throws SpanContextParseException if the version is not supported or the input is invalid
    */
   public SpanContext fromByteArray(byte[] bytes) throws SpanContextParseException {
+    // Implementation must override this method.
     try {
       return fromBinaryValue(bytes);
     } catch (ParseException e) {
@@ -135,7 +137,7 @@ public abstract class BinaryFormat {
     }
 
     @Override
-    public SpanContext fromByteArray(byte[] bytes) throws SpanContextParseException {
+    public SpanContext fromByteArray(byte[] bytes) {
       checkNotNull(bytes, "bytes");
       return SpanContext.INVALID;
     }

--- a/api/src/main/java/io/opencensus/trace/propagation/SpanContextParseException.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/SpanContextParseException.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.propagation;
+
+/** Exception thrown when a {@link io.opencensus.trace.SpanContext} cannot be parsed. */
+public class SpanContextParseException extends Exception {
+  private static final long serialVersionUID = 0L;
+
+  /**
+   * Constructs a new {@code SpanContextParseException} with the given message.
+   *
+   * @param message a message describing the parse error.
+   */
+  public SpanContextParseException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new {@code SpanContextParseException} with the given message and cause.
+   *
+   * @param message a message describing the parse error.
+   * @param cause the cause of the parse error.
+   */
+  public SpanContextParseException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/api/src/main/java/io/opencensus/trace/propagation/SpanContextParseException.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/SpanContextParseException.java
@@ -17,7 +17,7 @@
 package io.opencensus.trace.propagation;
 
 /** Exception thrown when a {@link io.opencensus.trace.SpanContext} cannot be parsed. */
-public class SpanContextParseException extends Exception {
+public final class SpanContextParseException extends Exception {
   private static final long serialVersionUID = 0L;
 
   /**

--- a/api/src/test/java/io/opencensus/trace/propagation/BinaryFormatTest.java
+++ b/api/src/test/java/io/opencensus/trace/propagation/BinaryFormatTest.java
@@ -27,8 +27,7 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link BinaryFormat}. */
 @RunWith(JUnit4.class)
 public class BinaryFormatTest {
-  private static final BinaryFormat binaryFormat =
-      BinaryFormat.getNoopBinaryFormat();
+  private static final BinaryFormat binaryFormat = BinaryFormat.getNoopBinaryFormat();
 
   @Test(expected = NullPointerException.class)
   public void toBinaryValue_NullSpanContext() {
@@ -41,6 +40,16 @@ public class BinaryFormatTest {
   }
 
   @Test(expected = NullPointerException.class)
+  public void toByteArray_NullSpanContext() {
+    binaryFormat.toByteArray(null);
+  }
+
+  @Test
+  public void toByteArray_NotNullSpanContext() {
+    assertThat(binaryFormat.toByteArray(SpanContext.INVALID)).isEqualTo(new byte[0]);
+  }
+
+  @Test(expected = NullPointerException.class)
   public void fromBinaryValue_NullInput() throws ParseException {
     binaryFormat.fromBinaryValue(null);
   }
@@ -48,5 +57,15 @@ public class BinaryFormatTest {
   @Test
   public void fromBinaryValue_NotNullInput() throws ParseException {
     assertThat(binaryFormat.fromBinaryValue(new byte[0])).isEqualTo(SpanContext.INVALID);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void fromByteArray_NullInput() throws SpanContextParseException {
+    binaryFormat.fromByteArray(null);
+  }
+
+  @Test
+  public void fromByteArray_NotNullInput() throws SpanContextParseException {
+    assertThat(binaryFormat.fromByteArray(new byte[0])).isEqualTo(SpanContext.INVALID);
   }
 }

--- a/api/src/test/java/io/opencensus/trace/propagation/SpanContextParseExceptionTest.java
+++ b/api/src/test/java/io/opencensus/trace/propagation/SpanContextParseExceptionTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.propagation;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link SpanContextParseException}. */
+@RunWith(JUnit4.class)
+public class SpanContextParseExceptionTest {
+
+  @Test
+  public void createWithMessage() {
+    assertThat(new SpanContextParseException("my message").getMessage()).isEqualTo("my message");
+  }
+
+  @Test
+  public void createWithMessageAndCause() {
+    IOException cause = new IOException();
+    SpanContextParseException parseException = new SpanContextParseException("my message", cause);
+    assertThat(parseException.getMessage()).isEqualTo("my message");
+    assertThat(parseException.getCause()).isEqualTo(cause);
+  }
+}

--- a/benchmarks/src/jmh/java/io/opencensus/trace/propagation/BinaryPropagationImplBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/propagation/BinaryPropagationImplBenchmark.java
@@ -21,7 +21,6 @@ import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.TraceId;
 import io.opencensus.trace.TraceOptions;
-import java.text.ParseException;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
@@ -42,7 +41,7 @@ public class BinaryPropagationImplBenchmark {
   private static final TraceOptions traceOptions = TraceOptions.fromBytes(traceOptionsBytes);
   private static final SpanContext spanContext = SpanContext.create(traceId, spanId, traceOptions);
   private static final BinaryFormat BINARY_PROPAGATION = new BinaryFormatImpl();
-  private static final byte[] spanContextBinary = BINARY_PROPAGATION.toBinaryValue(spanContext);
+  private static final byte[] spanContextBinary = BINARY_PROPAGATION.toByteArray(spanContext);
 
   /**
    * This benchmark attempts to measure performance of {@link
@@ -52,7 +51,7 @@ public class BinaryPropagationImplBenchmark {
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
   public byte[] toBinaryValueSpanContext() {
-    return BINARY_PROPAGATION.toBinaryValue(spanContext);
+    return BINARY_PROPAGATION.toByteArray(spanContext);
   }
 
   /**
@@ -62,8 +61,8 @@ public class BinaryPropagationImplBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
-  public SpanContext fromBinaryValueSpanContext() throws ParseException {
-    return BINARY_PROPAGATION.fromBinaryValue(spanContextBinary);
+  public SpanContext fromBinaryValueSpanContext() throws SpanContextParseException {
+    return BINARY_PROPAGATION.fromByteArray(spanContextBinary);
   }
 
   /**
@@ -74,7 +73,7 @@ public class BinaryPropagationImplBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
-  public SpanContext toFromBinarySpanContext() throws ParseException {
-    return BINARY_PROPAGATION.fromBinaryValue(BINARY_PROPAGATION.toBinaryValue(spanContext));
+  public SpanContext toFromBinarySpanContext() throws SpanContextParseException {
+    return BINARY_PROPAGATION.fromByteArray(BINARY_PROPAGATION.toByteArray(spanContext));
   }
 }

--- a/benchmarks/src/jmh/java/io/opencensus/trace/propagation/BinaryPropagationImplBenchmark.java
+++ b/benchmarks/src/jmh/java/io/opencensus/trace/propagation/BinaryPropagationImplBenchmark.java
@@ -50,7 +50,7 @@ public class BinaryPropagationImplBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
-  public byte[] toBinaryValueSpanContext() {
+  public byte[] toBinarySpanContext() {
     return BINARY_PROPAGATION.toByteArray(spanContext);
   }
 
@@ -61,7 +61,7 @@ public class BinaryPropagationImplBenchmark {
   @Benchmark
   @BenchmarkMode(Mode.SampleTime)
   @OutputTimeUnit(TimeUnit.NANOSECONDS)
-  public SpanContext fromBinaryValueSpanContext() throws SpanContextParseException {
+  public SpanContext fromBinarySpanContext() throws SpanContextParseException {
     return BINARY_PROPAGATION.fromByteArray(spanContextBinary);
   }
 

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/BinaryFormatImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/BinaryFormatImpl.java
@@ -23,7 +23,7 @@ import io.opencensus.trace.SpanId;
 import io.opencensus.trace.TraceId;
 import io.opencensus.trace.TraceOptions;
 import io.opencensus.trace.propagation.BinaryFormat;
-import java.text.ParseException;
+import io.opencensus.trace.propagation.SpanContextParseException;
 
 /**
  * Implementation of the {@link BinaryFormat}.
@@ -77,7 +77,7 @@ public final class BinaryFormatImpl extends BinaryFormat {
       4 * ID_SIZE + TraceId.SIZE + SpanId.SIZE + TraceOptions.SIZE;
 
   @Override
-  public byte[] toBinaryValue(SpanContext spanContext) {
+  public byte[] toByteArray(SpanContext spanContext) {
     checkNotNull(spanContext, "spanContext");
     byte[] bytes = new byte[FORMAT_LENGTH];
     bytes[VERSION_ID_OFFSET] = VERSION_ID;
@@ -91,10 +91,10 @@ public final class BinaryFormatImpl extends BinaryFormat {
   }
 
   @Override
-  public SpanContext fromBinaryValue(byte[] bytes) throws ParseException {
+  public SpanContext fromByteArray(byte[] bytes) throws SpanContextParseException {
     checkNotNull(bytes, "bytes");
     if (bytes.length == 0 || bytes[0] != VERSION_ID) {
-      throw new ParseException("Unsupported version.", 0);
+      throw new SpanContextParseException("Unsupported version.");
     }
     TraceId traceId = TraceId.INVALID;
     SpanId spanId = SpanId.INVALID;
@@ -114,7 +114,7 @@ public final class BinaryFormatImpl extends BinaryFormat {
       }
       return SpanContext.create(traceId, spanId, traceOptions);
     } catch (IndexOutOfBoundsException e) {
-      throw new ParseException("Invalid input: " + e.toString(), pos);
+      throw new SpanContextParseException("Invalid input.", e);
     }
   }
 }


### PR DESCRIPTION
Add new methods in BinaryFormat which throw the new exception and deprecate the old methods.