### PR TITLE
Move current TagContext logic from the API to the implementation (closes #632).

### DIFF
--- a/api/src/main/java/io/opencensus/internal/NoopScope.java
+++ b/api/src/main/java/io/opencensus/internal/NoopScope.java
@@ -19,7 +19,7 @@ package io.opencensus.internal;
 import io.opencensus.common.Scope;
 
 /**
- * A {@link Scope} that does nothing when it is closed.
+ * A {@link Scope} that does nothing when it is created or closed.
  */
 public final class NoopScope implements Scope {
   private static final Scope INSTANCE = new NoopScope();

--- a/api/src/main/java/io/opencensus/internal/NoopScope.java
+++ b/api/src/main/java/io/opencensus/internal/NoopScope.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.internal;
+
+import io.opencensus.common.Scope;
+
+public final class NoopScope implements Scope {
+  private static final Scope INSTANCE = new NoopScope();
+
+  private NoopScope() {}
+
+  /**
+   * Returns a {@code NoopScope}.
+   *
+   * @return a {@code NoopScope}.
+   */
+  public static Scope getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void close() {}
+}

--- a/api/src/main/java/io/opencensus/internal/NoopScope.java
+++ b/api/src/main/java/io/opencensus/internal/NoopScope.java
@@ -18,6 +18,9 @@ package io.opencensus.internal;
 
 import io.opencensus.common.Scope;
 
+/**
+ * A {@link Scope} that does nothing when it is closed.
+ */
 public final class NoopScope implements Scope {
   private static final Scope INSTANCE = new NoopScope();
 

--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -16,6 +16,8 @@
 
 package io.opencensus.tags;
 
+import io.opencensus.common.Scope;
+import io.opencensus.internal.NoopScope;
 import io.opencensus.tags.TagKey.TagKeyBoolean;
 import io.opencensus.tags.TagKey.TagKeyLong;
 import io.opencensus.tags.TagKey.TagKeyString;
@@ -105,8 +107,28 @@ final class NoopTags {
     }
 
     @Override
+    public TagContext getCurrentTagContext() {
+      return getNoopTagContext();
+    }
+
+    @Override
+    public TagContextBuilder emptyBuilder() {
+      return getNoopTagContextBuilder();
+    }
+
+    @Override
     public TagContextBuilder toBuilder(TagContext tags) {
       return getNoopTagContextBuilder();
+    }
+
+    @Override
+    public TagContextBuilder currentBuilder() {
+      return getNoopTagContextBuilder();
+    }
+
+    @Override
+    public Scope withTagContext(TagContext tags) {
+      return NoopScope.getInstance();
     }
   }
 
@@ -137,6 +159,11 @@ final class NoopTags {
     @Override
     public TagContext build() {
       return getNoopTagContext();
+    }
+
+    @Override
+    public Scope buildScoped() {
+      return NoopScope.getInstance();
     }
   }
 

--- a/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
@@ -79,7 +79,5 @@ public abstract class TagContextBuilder {
    * @return an object that defines a scope where the {@code TagContext} created from this builder
    *     is set to the current context.
    */
-  public final Scope buildScoped() {
-    return CurrentTagContextUtils.withTagContext(build());
-  }
+  public abstract Scope buildScoped();
 }

--- a/core/src/main/java/io/opencensus/tags/Tagger.java
+++ b/core/src/main/java/io/opencensus/tags/Tagger.java
@@ -42,18 +42,14 @@ public abstract class Tagger {
    *
    * @return the current {@code TagContext}.
    */
-  public TagContext getCurrentTagContext() {
-    return CurrentTagContextUtils.getCurrentTagContext();
-  }
+  public abstract TagContext getCurrentTagContext();
 
   /**
    * Returns a new empty {@code Builder}.
    *
    * @return a new empty {@code Builder}.
    */
-  public TagContextBuilder emptyBuilder() {
-    return toBuilder(empty());
-  }
+  public abstract TagContextBuilder emptyBuilder();
 
   /**
    * Returns a builder based on this {@code TagContext}.
@@ -67,9 +63,7 @@ public abstract class Tagger {
    *
    * @return a new builder created from the current {@code TagContext}.
    */
-  public final TagContextBuilder currentBuilder() {
-    return toBuilder(CurrentTagContextUtils.getCurrentTagContext());
-  }
+  public abstract TagContextBuilder currentBuilder();
 
   /**
    * Enters the scope of code where the given {@code TagContext} is in the current context and
@@ -80,7 +74,5 @@ public abstract class Tagger {
    * @return an object that defines a scope where the given {@code TagContext} is set to the current
    *     context.
    */
-  public Scope withTagContext(TagContext tags) {
-    return CurrentTagContextUtils.withTagContext(tags);
-  }
+  public abstract Scope withTagContext(TagContext tags);
 }

--- a/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -19,6 +19,7 @@ package io.opencensus.tags;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.Lists;
+import io.opencensus.internal.NoopScope;
 import io.opencensus.tags.Tag.TagString;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
@@ -51,9 +52,13 @@ public final class NoopTagsTest {
 
   @Test
   public void noopTagger() {
-    assertThat(NoopTags.getNoopTagger().empty()).isSameAs(NoopTags.getNoopTagContext());
-    assertThat(NoopTags.getNoopTagger().toBuilder(TAG_CONTEXT))
-        .isSameAs(NoopTags.getNoopTagContextBuilder());
+    Tagger noopTagger = NoopTags.getNoopTagger();
+    assertThat(noopTagger.empty()).isSameAs(NoopTags.getNoopTagContext());
+    assertThat(noopTagger.getCurrentTagContext()).isSameAs(NoopTags.getNoopTagContext());
+    assertThat(noopTagger.emptyBuilder()).isSameAs(NoopTags.getNoopTagContextBuilder());
+    assertThat(noopTagger.toBuilder(TAG_CONTEXT)).isSameAs(NoopTags.getNoopTagContextBuilder());
+    assertThat(noopTagger.currentBuilder()).isSameAs(NoopTags.getNoopTagContextBuilder());
+    assertThat(noopTagger.withTagContext(TAG_CONTEXT)).isSameAs(NoopScope.getInstance());
   }
 
   @Test
@@ -64,6 +69,12 @@ public final class NoopTagsTest {
                 .put(TagKeyString.create("key"), TagValueString.create("value"))
                 .build())
         .isSameAs(NoopTags.getNoopTagContext());
+    assertThat(NoopTags.getNoopTagContextBuilder().buildScoped()).isSameAs(NoopScope.getInstance());
+    assertThat(
+            NoopTags.getNoopTagContextBuilder()
+                .put(TagKeyString.create("key"), TagValueString.create("value"))
+                .buildScoped())
+        .isSameAs(NoopScope.getInstance());
   }
 
   @Test

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/CurrentTagContextUtils.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/CurrentTagContextUtils.java
@@ -14,10 +14,11 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.implcore.tags;
 
 import io.grpc.Context;
 import io.opencensus.common.Scope;
+import io.opencensus.tags.TagContext;
 import io.opencensus.tags.unsafe.ContextUtils;
 import javax.annotation.Nullable;
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBuilderImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextBuilderImpl.java
@@ -18,6 +18,7 @@ package io.opencensus.implcore.tags;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import io.opencensus.common.Scope;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagKey.TagKeyBoolean;
@@ -70,5 +71,10 @@ final class TagContextBuilderImpl extends TagContextBuilder {
   @Override
   public TagContextImpl build() {
     return new TagContextImpl(tags);
+  }
+
+  @Override
+  public Scope buildScoped() {
+    return CurrentTagContextUtils.withTagContext(build());
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
@@ -19,6 +19,7 @@ package io.opencensus.implcore.tags;
 import io.opencensus.common.Scope;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
+import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.Tagger;
 import java.util.Iterator;
 
@@ -37,12 +38,17 @@ public final class TaggerImpl extends Tagger {
 
   @Override
   public TagContextImpl getCurrentTagContext() {
-    return toTagContextImpl(super.getCurrentTagContext());
+    return toTagContextImpl(CurrentTagContextUtils.getCurrentTagContext());
   }
 
   @Override
   public TagContextBuilderImpl emptyBuilder() {
     return new TagContextBuilderImpl();
+  }
+
+  @Override
+  public TagContextBuilder currentBuilder() {
+    return toBuilder(CurrentTagContextUtils.getCurrentTagContext());
   }
 
   @Override
@@ -52,7 +58,7 @@ public final class TaggerImpl extends Tagger {
 
   @Override
   public Scope withTagContext(TagContext tags) {
-    return super.withTagContext(toTagContextImpl(tags));
+    return CurrentTagContextUtils.withTagContext(toTagContextImpl(tags));
   }
 
   private static TagContextImpl toTagContextImpl(TagContext tags) {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/CurrentTagContextUtilsTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/CurrentTagContextUtilsTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.implcore.tags;
 
 import static com.google.common.truth.Truth.assertThat;
 
@@ -22,7 +22,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import io.grpc.Context;
 import io.opencensus.common.Scope;
+import io.opencensus.tags.Tag;
 import io.opencensus.tags.Tag.TagString;
+import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.unsafe.ContextUtils;


### PR DESCRIPTION
This commit makes all methods in Tagger and TagContextBuilder abstract.  It also
changes the no-op Tagger and TagContextBuilder so that they do not access the
current context.

This change gives the implementation more flexibility to control when it
accesses the current context.  For example, it could avoid setting the current
context when tagging is not enabled.  It also simplifies the code by not
splitting the current context logic between the API and implementation classes.