### PR TITLE
Move tagging no-op classes into a new class, NoopTags.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -1,0 +1,179 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+import io.opencensus.tags.TagKey.TagKeyBoolean;
+import io.opencensus.tags.TagKey.TagKeyLong;
+import io.opencensus.tags.TagKey.TagKeyString;
+import io.opencensus.tags.TagValue.TagValueBoolean;
+import io.opencensus.tags.TagValue.TagValueLong;
+import io.opencensus.tags.TagValue.TagValueString;
+import java.util.Collections;
+import java.util.Iterator;
+import javax.annotation.concurrent.Immutable;
+
+/** No-op implementations of tagging classes. */
+final class NoopTags {
+
+  private NoopTags() {}
+
+  /**
+   * Returns a {@code TagsComponent} that has a no-op implementation for {@link Tagger}.
+   *
+   * @return a {@code TagsComponent} that has a no-op implementation for {@code Tagger}.
+   */
+  static TagsComponent getNoopTagsComponent() {
+    return NoopTagsComponent.INSTANCE;
+  }
+
+  /**
+   * Returns a {@code Tagger} that only produces {@link TagContext}s with no tags.
+   *
+   * @return a {@code Tagger} that only produces {@code TagContext}s with no tags.
+   */
+  static Tagger getNoopTagger() {
+    return NoopTagger.INSTANCE;
+  }
+
+  /**
+   * Returns a {@code TagContextBuilder} that ignores all calls to {@link TagContextBuilder#put}.
+   *
+   * @return a {@code TagContextBuilder} that ignores all calls to {@link TagContextBuilder#put}.
+   */
+  static TagContextBuilder getNoopTagContextBuilder() {
+    return NoopTagContextBuilder.INSTANCE;
+  }
+
+  /**
+   * Returns a {@code TagContext} that does not contain any tags.
+   *
+   * @return a {@code TagContext} that does not contain any tags.
+   */
+  static TagContext getNoopTagContext() {
+    return NoopTagContext.INSTANCE;
+  }
+
+  /** Returns a {@code TagPropagationComponent} that contains no-op serializers. */
+  static TagPropagationComponent getNoopTagPropagationComponent() {
+    return NoopTagPropagationComponent.INSTANCE;
+  }
+
+  /**
+   * Returns a {@code TagContextBinarySerializer} that serializes all {@code TagContext}s to zero
+   * bytes and deserializes all inputs to empty {@code TagContext}s.
+   */
+  static TagContextBinarySerializer getNoopTagContextBinarySerializer() {
+    return NoopTagContextBinarySerializer.INSTANCE;
+  }
+
+  @Immutable
+  private static final class NoopTagsComponent extends TagsComponent {
+    static final TagsComponent INSTANCE = new NoopTagsComponent();
+
+    @Override
+    public Tagger getTagger() {
+      return getNoopTagger();
+    }
+
+    @Override
+    public TagPropagationComponent getTagPropagationComponent() {
+      return getNoopTagPropagationComponent();
+    }
+  }
+
+  @Immutable
+  private static final class NoopTagger extends Tagger {
+    static final Tagger INSTANCE = new NoopTagger();
+
+    @Override
+    public TagContext empty() {
+      return getNoopTagContext();
+    }
+
+    @Override
+    public TagContextBuilder toBuilder(TagContext tags) {
+      return getNoopTagContextBuilder();
+    }
+  }
+
+  @Immutable
+  private static final class NoopTagContextBuilder extends TagContextBuilder {
+    static final TagContextBuilder INSTANCE = new NoopTagContextBuilder();
+
+    @Override
+    public TagContextBuilder put(TagKeyString key, TagValueString value) {
+      return this;
+    }
+
+    @Override
+    public TagContextBuilder put(TagKeyLong key, TagValueLong value) {
+      return this;
+    }
+
+    @Override
+    public TagContextBuilder put(TagKeyBoolean key, TagValueBoolean value) {
+      return this;
+    }
+
+    @Override
+    public TagContextBuilder remove(TagKey key) {
+      return this;
+    }
+
+    @Override
+    public TagContext build() {
+      return getNoopTagContext();
+    }
+  }
+
+  @Immutable
+  private static final class NoopTagContext extends TagContext {
+    static final TagContext INSTANCE = new NoopTagContext();
+
+    // TODO(sebright): Is there any way to let the user know that their tags were ignored?
+    @Override
+    public Iterator<Tag> unsafeGetIterator() {
+      return Collections.<Tag>emptySet().iterator();
+    }
+  }
+
+  @Immutable
+  private static final class NoopTagPropagationComponent extends TagPropagationComponent {
+    static final TagPropagationComponent INSTANCE = new NoopTagPropagationComponent();
+
+    @Override
+    public TagContextBinarySerializer getBinarySerializer() {
+      return getNoopTagContextBinarySerializer();
+    }
+  }
+
+  @Immutable
+  private static final class NoopTagContextBinarySerializer extends TagContextBinarySerializer {
+    static final TagContextBinarySerializer INSTANCE = new NoopTagContextBinarySerializer();
+    static final byte[] EMPTY_BYTE_ARRAY = {};
+
+    @Override
+    public byte[] toByteArray(TagContext tags) {
+      return EMPTY_BYTE_ARRAY;
+    }
+
+    @Override
+    public TagContext fromByteArray(byte[] bytes) {
+      return getNoopTagContext();
+    }
+  }
+}

--- a/core/src/main/java/io/opencensus/tags/TagContext.java
+++ b/core/src/main/java/io/opencensus/tags/TagContext.java
@@ -21,7 +21,6 @@ import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multiset;
 import io.opencensus.tags.TagValue.TagValueString;
-import java.util.Collections;
 import java.util.Iterator;
 import javax.annotation.concurrent.Immutable;
 
@@ -37,7 +36,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public abstract class TagContext {
-  private static final TagContext NOOP_TAG_CONTEXT = new NoopTagContext();
 
   // TODO(sebright): Consider removing TagContext.unsafeGetIterator() so that we don't need to
   // support fast access to tags.
@@ -86,24 +84,5 @@ public abstract class TagContext {
       }
     }
     return hashCode;
-  }
-
-  /**
-   * Returns a {@code TagContext} that does not contain any tags.
-   *
-   * @return a {@code TagContext} that does not contain any tags.
-   */
-  static TagContext getNoopTagContext() {
-    return NOOP_TAG_CONTEXT;
-  }
-
-  @Immutable
-  private static final class NoopTagContext extends TagContext {
-
-    // TODO(sebright): Is there any way to let the user know that their tags were ignored?
-    @Override
-    public Iterator<Tag> unsafeGetIterator() {
-      return Collections.<Tag>emptySet().iterator();
-    }
   }
 }

--- a/core/src/main/java/io/opencensus/tags/TagContextBinarySerializer.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBinarySerializer.java
@@ -16,12 +16,8 @@
 
 package io.opencensus.tags;
 
-import javax.annotation.concurrent.Immutable;
-
 /** Object for serializing and deserializing {@link TagContext}s with the binary format. */
 public abstract class TagContextBinarySerializer {
-  private static final TagContextBinarySerializer NOOP_TAG_CONTEXT_BINARY_SERIALIZER =
-      new NoopTagContextBinarySerializer();
 
   /**
    * Serializes the {@code TagContext} into the on-the-wire representation.
@@ -44,27 +40,4 @@ public abstract class TagContextBinarySerializer {
    */
   // TODO(sebright): Use a more appropriate exception type, since this method doesn't do IO.
   public abstract TagContext fromByteArray(byte[] bytes) throws TagContextParseException;
-
-  /**
-   * Returns a {@code TagContextBinarySerializer} that serializes all {@code TagContext}s to zero
-   * bytes and deserializes all inputs to empty {@code TagContext}s.
-   */
-  static TagContextBinarySerializer getNoopTagContextBinarySerializer() {
-    return NOOP_TAG_CONTEXT_BINARY_SERIALIZER;
-  }
-
-  @Immutable
-  private static final class NoopTagContextBinarySerializer extends TagContextBinarySerializer {
-    private static final byte[] EMPTY_BYTE_ARRAY = {};
-
-    @Override
-    public byte[] toByteArray(TagContext tags) {
-      return EMPTY_BYTE_ARRAY;
-    }
-
-    @Override
-    public TagContext fromByteArray(byte[] bytes) {
-      return TagContext.getNoopTagContext();
-    }
-  }
 }

--- a/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
+++ b/core/src/main/java/io/opencensus/tags/TagContextBuilder.java
@@ -23,13 +23,11 @@ import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueBoolean;
 import io.opencensus.tags.TagValue.TagValueLong;
 import io.opencensus.tags.TagValue.TagValueString;
-import javax.annotation.concurrent.Immutable;
 
 /** Builder for the {@link TagContext} class. */
 // TODO(sebright): Decide what to do when 'put' is called with a key that has the same name as an
 // existing key, but a different type.  We currently keep both keys.
 public abstract class TagContextBuilder {
-  private static final TagContextBuilder NOOP_TAG_CONTEXT_BUILDER = new NoopTagContextBuilder();
 
   /**
    * Adds the key/value pair regardless of whether the key is present.
@@ -83,43 +81,5 @@ public abstract class TagContextBuilder {
    */
   public final Scope buildScoped() {
     return CurrentTagContextUtils.withTagContext(build());
-  }
-
-  /**
-   * Returns a {@code TagContextBuilder} that ignores all calls to {@link #put}.
-   *
-   * @return a {@code TagContextBuilder} that ignores all calls to {@link #put}.
-   */
-  static TagContextBuilder getNoopTagContextBuilder() {
-    return NOOP_TAG_CONTEXT_BUILDER;
-  }
-
-  @Immutable
-  private static final class NoopTagContextBuilder extends TagContextBuilder {
-
-    @Override
-    public TagContextBuilder put(TagKeyString key, TagValueString value) {
-      return this;
-    }
-
-    @Override
-    public TagContextBuilder put(TagKeyLong key, TagValueLong value) {
-      return this;
-    }
-
-    @Override
-    public TagContextBuilder put(TagKeyBoolean key, TagValueBoolean value) {
-      return this;
-    }
-
-    @Override
-    public TagContextBuilder remove(TagKey key) {
-      return this;
-    }
-
-    @Override
-    public TagContext build() {
-      return TagContext.getNoopTagContext();
-    }
   }
 }

--- a/core/src/main/java/io/opencensus/tags/TagPropagationComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagPropagationComponent.java
@@ -16,15 +16,11 @@
 
 package io.opencensus.tags;
 
-import javax.annotation.concurrent.Immutable;
-
 /** Object containing all supported {@link TagContext} propagation formats. */
 // TODO(sebright): Add a link to the specification for the cross-language OpenCensus tag context
 // serialization format.
 // TODO(sebright): Add an HTTP serializer.
 public abstract class TagPropagationComponent {
-  private static final TagPropagationComponent NOOP_TAG_PROPAGATION_COMPONENT =
-      new NoopTagPropagationComponent();
 
   /**
    * Returns the {@link TagContextBinarySerializer} for this implementation.
@@ -32,18 +28,4 @@ public abstract class TagPropagationComponent {
    * @return the {@code TagContextBinarySerializer} for this implementation.
    */
   public abstract TagContextBinarySerializer getBinarySerializer();
-
-  /** Returns a {@code TagPropagationComponent} that contains no-op serializers. */
-  static TagPropagationComponent getNoopTagPropagationComponent() {
-    return NOOP_TAG_PROPAGATION_COMPONENT;
-  }
-
-  @Immutable
-  private static final class NoopTagPropagationComponent extends TagPropagationComponent {
-
-    @Override
-    public TagContextBinarySerializer getBinarySerializer() {
-      return TagContextBinarySerializer.getNoopTagContextBinarySerializer();
-    }
-  }
 }

--- a/core/src/main/java/io/opencensus/tags/Tagger.java
+++ b/core/src/main/java/io/opencensus/tags/Tagger.java
@@ -17,7 +17,6 @@
 package io.opencensus.tags;
 
 import io.opencensus.common.Scope;
-import javax.annotation.concurrent.Immutable;
 
 /**
  * Object for creating new {@link TagContext}s and {@code TagContext}s based on the current context.
@@ -30,7 +29,6 @@ import javax.annotation.concurrent.Immutable;
  * context} is the same instance as the one {@link #withTagContext(TagContext) placed into scope}.
  */
 public abstract class Tagger {
-  private static final Tagger NOOP_TAGGER = new NoopTagger();
 
   /**
    * Returns an empty {@code TagContext}.
@@ -84,28 +82,5 @@ public abstract class Tagger {
    */
   public Scope withTagContext(TagContext tags) {
     return CurrentTagContextUtils.withTagContext(tags);
-  }
-
-  /**
-   * Returns a {@code Tagger} that only produces {@link TagContext}s with no tags.
-   *
-   * @return a {@code Tagger} that only produces {@code TagContext}s with no tags.
-   */
-  static Tagger getNoopTagger() {
-    return NOOP_TAGGER;
-  }
-
-  @Immutable
-  private static final class NoopTagger extends Tagger {
-
-    @Override
-    public TagContext empty() {
-      return TagContext.getNoopTagContext();
-    }
-
-    @Override
-    public TagContextBuilder toBuilder(TagContext tags) {
-      return TagContextBuilder.getNoopTagContextBuilder();
-    }
   }
 }

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -75,6 +75,6 @@ public final class Tags {
               + "default implementation for TagsComponent.",
           e);
     }
-    return TagsComponent.getNoopTagsComponent();
+    return NoopTags.getNoopTagsComponent();
   }
 }

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -16,42 +16,16 @@
 
 package io.opencensus.tags;
 
-import javax.annotation.concurrent.Immutable;
-
 /**
  * Class that holds the implementation for {@link Tagger}.
  *
  * <p>All objects returned by methods on {@code TagsComponent} are cacheable.
  */
 public abstract class TagsComponent {
-  private static final TagsComponent NOOP_TAGS_COMPONENT = new NoopTagsComponent();
 
   /** Returns the {@link Tagger} for this implementation. */
   public abstract Tagger getTagger();
 
   /** Returns the {@link TagPropagationComponent} for this implementation. */
   public abstract TagPropagationComponent getTagPropagationComponent();
-
-  /**
-   * Returns a {@code TagsComponent} that has a no-op implementation for {@link Tagger}.
-   *
-   * @return a {@code TagsComponent} that has a no-op implementation for {@code Tagger}.
-   */
-  static TagsComponent getNoopTagsComponent() {
-    return NOOP_TAGS_COMPONENT;
-  }
-
-  @Immutable
-  private static final class NoopTagsComponent extends TagsComponent {
-
-    @Override
-    public Tagger getTagger() {
-      return Tagger.getNoopTagger();
-    }
-
-    @Override
-    public TagPropagationComponent getTagPropagationComponent() {
-      return TagPropagationComponent.getNoopTagPropagationComponent();
-    }
-  }
 }

--- a/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Lists;
+import io.opencensus.tags.Tag.TagString;
+import io.opencensus.tags.TagKey.TagKeyString;
+import io.opencensus.tags.TagValue.TagValueString;
+import java.util.Arrays;
+import java.util.Iterator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoopTags}. */
+@RunWith(JUnit4.class)
+public final class NoopTagsTest {
+  private static final TagContext TAG_CONTEXT =
+      new TagContext() {
+
+        @Override
+        public Iterator<Tag> unsafeGetIterator() {
+          return Arrays.<Tag>asList(
+                  TagString.create(TagKeyString.create("key"), TagValueString.create("value")))
+              .iterator();
+        }
+      };
+
+  @Test
+  public void noopTagsComponent() {
+    assertThat(NoopTags.getNoopTagsComponent().getTagger()).isSameAs(NoopTags.getNoopTagger());
+    assertThat(NoopTags.getNoopTagsComponent().getTagPropagationComponent())
+        .isSameAs(NoopTags.getNoopTagPropagationComponent());
+  }
+
+  @Test
+  public void noopTagger() {
+    assertThat(NoopTags.getNoopTagger().empty()).isSameAs(NoopTags.getNoopTagContext());
+    assertThat(NoopTags.getNoopTagger().toBuilder(TAG_CONTEXT))
+        .isSameAs(NoopTags.getNoopTagContextBuilder());
+  }
+
+  @Test
+  public void noopTagContextBuilder() {
+    assertThat(NoopTags.getNoopTagContextBuilder().build()).isSameAs(NoopTags.getNoopTagContext());
+    assertThat(
+            NoopTags.getNoopTagContextBuilder()
+                .put(TagKeyString.create("key"), TagValueString.create("value"))
+                .build())
+        .isSameAs(NoopTags.getNoopTagContext());
+  }
+
+  @Test
+  public void noopTagContext() {
+    assertThat(Lists.newArrayList(NoopTags.getNoopTagContext().unsafeGetIterator())).isEmpty();
+  }
+
+  @Test
+  public void noopTagPropagationComponent() {
+    assertThat(NoopTags.getNoopTagPropagationComponent().getBinarySerializer())
+        .isSameAs(NoopTags.getNoopTagContextBinarySerializer());
+  }
+
+  @Test
+  public void noopTagContextBinarySerializer() throws TagContextParseException {
+    assertThat(NoopTags.getNoopTagContextBinarySerializer().toByteArray(TAG_CONTEXT))
+        .isEqualTo(new byte[0]);
+    assertThat(NoopTags.getNoopTagContextBinarySerializer().fromByteArray(new byte[5]))
+        .isEqualTo(NoopTags.getNoopTagContext());
+  }
+}

--- a/core/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagsTest.java
@@ -53,17 +53,17 @@ public class TagsTest {
           }
         };
     assertThat(Tags.loadTagsComponent(classLoader).getClass().getName())
-        .isEqualTo("io.opencensus.tags.TagsComponent$NoopTagsComponent");
+        .isEqualTo("io.opencensus.tags.NoopTags$NoopTagsComponent");
   }
 
   @Test
   public void defaultTagger() {
-    assertThat(Tags.getTagger()).isEqualTo(Tagger.getNoopTagger());
+    assertThat(Tags.getTagger()).isEqualTo(NoopTags.getNoopTagger());
   }
 
   @Test
   public void defaultTagContextSerializer() {
     assertThat(Tags.getTagPropagationComponent())
-        .isEqualTo(TagPropagationComponent.getNoopTagPropagationComponent());
+        .isEqualTo(NoopTags.getNoopTagPropagationComponent());
   }
 }


### PR DESCRIPTION
This change will allow us to move the public serialization-related classes into
a new package without moving their no-op implementations.  Then the no-op classes
can remain package-private.

_____________________________________________________________________

This is needed for #641.