### PR TITLE
Move TagContext serialization classes into io.opencensus.tags.propagation.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -22,6 +22,8 @@ import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueBoolean;
 import io.opencensus.tags.TagValue.TagValueLong;
 import io.opencensus.tags.TagValue.TagValueString;
+import io.opencensus.tags.propagation.TagContextBinarySerializer;
+import io.opencensus.tags.propagation.TagPropagationComponent;
 import java.util.Collections;
 import java.util.Iterator;
 import javax.annotation.concurrent.Immutable;

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -18,6 +18,7 @@ package io.opencensus.tags;
 
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.internal.Provider;
+import io.opencensus.tags.propagation.TagPropagationComponent;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -16,6 +16,8 @@
 
 package io.opencensus.tags;
 
+import io.opencensus.tags.propagation.TagPropagationComponent;
+
 /**
  * Class that holds the implementation for {@link Tagger}.
  *

--- a/core/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
+++ b/core/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.tags.propagation;
+
+import io.opencensus.tags.TagContext;
 
 /** Object for serializing and deserializing {@link TagContext}s with the binary format. */
 public abstract class TagContextBinarySerializer {

--- a/core/src/main/java/io/opencensus/tags/propagation/TagContextParseException.java
+++ b/core/src/main/java/io/opencensus/tags/propagation/TagContextParseException.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.tags.propagation;
+
+import io.opencensus.tags.TagContext;
 
 /** Exception thrown when a {@link TagContext} cannot be parsed. */
 public final class TagContextParseException extends Exception {

--- a/core/src/main/java/io/opencensus/tags/propagation/TagPropagationComponent.java
+++ b/core/src/main/java/io/opencensus/tags/propagation/TagPropagationComponent.java
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.tags.propagation;
+
+import io.opencensus.tags.TagContext;
 
 /** Object containing all supported {@link TagContext} propagation formats. */
 // TODO(sebright): Add a link to the specification for the cross-language OpenCensus tag context

--- a/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import io.opencensus.tags.Tag.TagString;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
+import io.opencensus.tags.propagation.TagContextParseException;
 import java.util.Arrays;
 import java.util.Iterator;
 import org.junit.Test;

--- a/core/src/test/java/io/opencensus/tags/propagation/TagContextParseExceptionTest.java
+++ b/core/src/test/java/io/opencensus/tags/propagation/TagContextParseExceptionTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags;
+package io.opencensus.tags.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
@@ -46,7 +46,7 @@ public final class TagContextImpl extends TagContext {
   // The types of the TagKey and value must match for each entry.
   private final Map<TagKey, TagValue> tags;
 
-  TagContextImpl(Map<? extends TagKey, ? extends TagValue> tags) {
+  public TagContextImpl(Map<? extends TagKey, ? extends TagValue> tags) {
     this.tags = Collections.unmodifiableMap(new HashMap<TagKey, TagValue>(tags));
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -16,9 +16,10 @@
 
 package io.opencensus.implcore.tags;
 
-import io.opencensus.tags.TagPropagationComponent;
+import io.opencensus.implcore.tags.propagation.TagPropagationComponentImpl;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.TagsComponent;
+import io.opencensus.tags.propagation.TagPropagationComponent;
 
 /** Base implementation of {@link TagsComponent}. */
 public abstract class TagsComponentImplBase extends TagsComponent {

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opencensus.implcore.tags;
+package io.opencensus.implcore.tags.propagation;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
@@ -23,16 +23,17 @@ import com.google.common.io.ByteStreams;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
 import io.opencensus.implcore.internal.VarInt;
+import io.opencensus.implcore.tags.TagContextImpl;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.Tag.TagBoolean;
 import io.opencensus.tags.Tag.TagLong;
 import io.opencensus.tags.Tag.TagString;
 import io.opencensus.tags.TagContext;
-import io.opencensus.tags.TagContextParseException;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.TagValue.TagValueString;
+import io.opencensus.tags.propagation.TagContextParseException;
 import java.nio.BufferUnderflowException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
@@ -14,11 +14,11 @@
  * limitations under the License.
  */
 
-package io.opencensus.implcore.tags;
+package io.opencensus.implcore.tags.propagation;
 
 import io.opencensus.tags.TagContext;
-import io.opencensus.tags.TagContextBinarySerializer;
-import io.opencensus.tags.TagContextParseException;
+import io.opencensus.tags.propagation.TagContextBinarySerializer;
+import io.opencensus.tags.propagation.TagContextParseException;
 
 final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   @Override

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagPropagationComponentImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagPropagationComponentImpl.java
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package io.opencensus.implcore.tags;
+package io.opencensus.implcore.tags.propagation;
 
-import io.opencensus.tags.TagContextBinarySerializer;
-import io.opencensus.tags.TagPropagationComponent;
+import io.opencensus.tags.propagation.TagContextBinarySerializer;
+import io.opencensus.tags.propagation.TagPropagationComponent;
 
 public final class TagPropagationComponentImpl extends TagPropagationComponent {
   private final TagContextBinarySerializer tagContextBinarySerializer =

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
@@ -14,17 +14,18 @@
  * limitations under the License.
  */
 
-package io.opencensus.implcore.tags;
+package io.opencensus.implcore.tags.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.implcore.internal.VarInt;
+import io.opencensus.implcore.tags.TaggerImpl;
 import io.opencensus.tags.TagContext;
-import io.opencensus.tags.TagContextBinarySerializer;
-import io.opencensus.tags.TagContextParseException;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.propagation.TagContextBinarySerializer;
+import io.opencensus.tags.propagation.TagContextParseException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import org.junit.Test;

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package io.opencensus.implcore.tags;
+package io.opencensus.implcore.tags.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opencensus.implcore.tags.TaggerImpl;
 import io.opencensus.tags.TagContext;
-import io.opencensus.tags.TagContextBinarySerializer;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
@@ -14,19 +14,20 @@
  * limitations under the License.
  */
 
-package io.opencensus.implcore.tags;
+package io.opencensus.implcore.tags.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.base.Charsets;
 import com.google.common.collect.Collections2;
 import io.opencensus.implcore.internal.VarInt;
+import io.opencensus.implcore.tags.TaggerImpl;
 import io.opencensus.tags.Tag.TagString;
-import io.opencensus.tags.TagContextBinarySerializer;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;

--- a/core_impl_android/src/test/java/io/opencensus/impllite/tags/TagsTest.java
+++ b/core_impl_android/src/test/java/io/opencensus/impllite/tags/TagsTest.java
@@ -18,8 +18,8 @@ package io.opencensus.impllite.tags;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opencensus.implcore.tags.TagPropagationComponentImpl;
 import io.opencensus.implcore.tags.TaggerImpl;
+import io.opencensus.implcore.tags.propagation.TagPropagationComponentImpl;
 import io.opencensus.tags.Tags;
 import io.opencensus.tags.TagsComponent;
 import org.junit.Test;

--- a/core_impl_java/src/test/java/io/opencensus/impl/tags/TagsTest.java
+++ b/core_impl_java/src/test/java/io/opencensus/impl/tags/TagsTest.java
@@ -18,8 +18,8 @@ package io.opencensus.impl.tags;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opencensus.implcore.tags.TagPropagationComponentImpl;
 import io.opencensus.implcore.tags.TaggerImpl;
+import io.opencensus.implcore.tags.propagation.TagPropagationComponentImpl;
 import io.opencensus.tags.Tags;
 import io.opencensus.tags.TagsComponent;
 import org.junit.Test;


### PR DESCRIPTION
Closes #641.