### PR TITLE
Clean up tests for tagging implementation.

### DIFF
--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextDeserializationTest.java
@@ -18,7 +18,6 @@ package io.opencensus.implcore.tags;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.Lists;
 import io.opencensus.implcore.internal.VarInt;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBinarySerializer;
@@ -62,7 +61,7 @@ public class TagContextDeserializationTest {
     TagContext actual =
         testDeserialize(
             new byte[] {SerializationUtils.VERSION_ID}); // One byte that represents Version ID.
-    assertTagContextsEqual(actual, expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test(expected = TagContextParseException.class)
@@ -81,7 +80,7 @@ public class TagContextDeserializationTest {
                 TagKeyString.create(KEY + SerializationUtils.VALUE_TYPE_STRING),
                 TagValueString.create(VALUE_STRING))
             .build();
-    assertTagContextsEqual(actual, expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test
@@ -102,7 +101,7 @@ public class TagContextDeserializationTest {
                 TagValueString.create(VALUE_STRING))
             .put(TagKeyString.create("Key2"), TagValueString.create("String2"))
             .build();
-    assertTagContextsEqual(actual, expected);
+    assertThat(actual).isEqualTo(expected);
   }
 
   @Test(expected = TagContextParseException.class)
@@ -213,10 +212,5 @@ public class TagContextDeserializationTest {
   //         <int_tag_value> == 8 bytes, little-endian integer
   private static void encodeInteger(int input, ByteArrayOutputStream byteArrayOutputStream) {
     byteArrayOutputStream.write((byte) input);
-  }
-
-  private static void assertTagContextsEqual(TagContext actual, TagContext expected) {
-    assertThat(Lists.newArrayList(actual.unsafeGetIterator()))
-        .containsExactlyElementsIn(Lists.newArrayList(expected.unsafeGetIterator()));
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.implcore.tags;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.implcore.tags.TagsTestUtil.tagContextToList;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -37,7 +38,6 @@ import io.opencensus.tags.Tagger;
 import io.opencensus.tags.UnreleasedApiAccessor;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
 import java.util.NoSuchElementException;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,7 +65,7 @@ public class TagContextImplTest {
     TagKeyLong longKey = UnreleasedApiAccessor.createTagKeyLong("key");
     TagKeyBoolean boolKey = UnreleasedApiAccessor.createTagKeyBoolean("key");
     assertThat(
-            asList(
+            tagContextToList(
                 tagger
                     .emptyBuilder()
                     .put(stringKey, TagValueString.create("value"))
@@ -81,17 +81,17 @@ public class TagContextImplTest {
   @Test
   public void testSet() {
     TagContext tags = tagger.emptyBuilder().put(KS1, V1).build();
-    assertThat(asList(tagger.toBuilder(tags).put(KS1, V2).build()))
+    assertThat(tagContextToList(tagger.toBuilder(tags).put(KS1, V2).build()))
         .containsExactly(TagString.create(KS1, V2));
-    assertThat(asList(tagger.toBuilder(tags).put(KS2, V2).build()))
+    assertThat(tagContextToList(tagger.toBuilder(tags).put(KS2, V2).build()))
         .containsExactly(TagString.create(KS1, V1), TagString.create(KS2, V2));
   }
 
   @Test
   public void testClear() {
     TagContext tags = tagger.emptyBuilder().put(KS1, V1).build();
-    assertThat(asList(tagger.toBuilder(tags).remove(KS1).build())).isEmpty();
-    assertThat(asList(tagger.toBuilder(tags).remove(KS2).build()))
+    assertThat(tagContextToList(tagger.toBuilder(tags).remove(KS1).build())).isEmpty();
+    assertThat(tagContextToList(tagger.toBuilder(tags).remove(KS2).build()))
         .containsExactly(TagString.create(KS1, V1));
   }
 
@@ -136,9 +136,5 @@ public class TagContextImplTest {
         .addEqualityGroup(tagger.emptyBuilder().put(KS1, V1).put(KS2, V1).build())
         .addEqualityGroup(tagger.emptyBuilder().put(KS1, V2).put(KS2, V1).build())
         .testEquals();
-  }
-
-  private static List<Tag> asList(TagContext tags) {
-    return Lists.newArrayList(tags.unsafeGetIterator());
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TaggerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TaggerImplTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.implcore.tags;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.implcore.tags.TagsTestUtil.tagContextToList;
 
 import com.google.common.collect.Lists;
 import io.grpc.Context;
@@ -63,7 +64,7 @@ public class TaggerImplTest {
 
   @Test
   public void empty() {
-    assertThat(asList(tagger.empty())).isEmpty();
+    assertThat(tagContextToList(tagger.empty())).isEmpty();
     assertThat(tagger.empty()).isInstanceOf(TagContextImpl.class);
   }
 
@@ -71,14 +72,14 @@ public class TaggerImplTest {
   public void emptyBuilder() {
     TagContextBuilder builder = tagger.emptyBuilder();
     assertThat(builder).isInstanceOf(TagContextBuilderImpl.class);
-    assertThat(asList(builder.build())).isEmpty();
+    assertThat(tagContextToList(builder.build())).isEmpty();
   }
 
   @Test
   public void toBuilder_ConvertUnknownTagContextToTagContextImpl() {
     TagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
     TagContext newTagContext = tagger.toBuilder(unknownTagContext).build();
-    assertThat(asList(newTagContext)).containsExactly(TAG1, TAG2, TAG3);
+    assertThat(tagContextToList(newTagContext)).containsExactly(TAG1, TAG2, TAG3);
     assertThat(newTagContext).isInstanceOf(TagContextImpl.class);
   }
 
@@ -88,20 +89,20 @@ public class TaggerImplTest {
     Tag tag2 = TagString.create(KS, VS2);
     TagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
     TagContext newTagContext = tagger.toBuilder(tagContextWithDuplicateTags).build();
-    assertThat(asList(newTagContext)).containsExactly(tag2);
+    assertThat(tagContextToList(newTagContext)).containsExactly(tag2);
   }
 
   @Test
   public void toBuilder_SkipNullTag() {
     TagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
     TagContext newTagContext = tagger.toBuilder(tagContextWithNullTag).build();
-    assertThat(asList(newTagContext)).containsExactly(TAG1, TAG2);
+    assertThat(tagContextToList(newTagContext)).containsExactly(TAG1, TAG2);
   }
 
   @Test
   public void getCurrentTagContext_DefaultIsEmptyTagContextImpl() {
     TagContext currentTagContext = tagger.getCurrentTagContext();
-    assertThat(asList(currentTagContext)).isEmpty();
+    assertThat(tagContextToList(currentTagContext)).isEmpty();
     assertThat(currentTagContext).isInstanceOf(TagContextImpl.class);
   }
 
@@ -110,7 +111,7 @@ public class TaggerImplTest {
     TagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
     TagContext result = getResultOfGetCurrentTagContext(unknownTagContext);
     assertThat(result).isInstanceOf(TagContextImpl.class);
-    assertThat(asList(result)).containsExactly(TAG1, TAG2, TAG3);
+    assertThat(tagContextToList(result)).containsExactly(TAG1, TAG2, TAG3);
   }
 
   @Test
@@ -119,14 +120,14 @@ public class TaggerImplTest {
     Tag tag2 = TagString.create(KS, VS2);
     TagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
     TagContext result = getResultOfGetCurrentTagContext(tagContextWithDuplicateTags);
-    assertThat(asList(result)).containsExactly(tag2);
+    assertThat(tagContextToList(result)).containsExactly(tag2);
   }
 
   @Test
   public void getCurrentTagContext_SkipNullTag() {
     TagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
     TagContext result = getResultOfGetCurrentTagContext(tagContextWithNullTag);
-    assertThat(asList(result)).containsExactly(TAG1, TAG2);
+    assertThat(tagContextToList(result)).containsExactly(TAG1, TAG2);
   }
 
   private TagContext getResultOfGetCurrentTagContext(TagContext tagsToSet) {
@@ -143,7 +144,7 @@ public class TaggerImplTest {
     TagContext unknownTagContext = new SimpleTagContext(TAG1, TAG2, TAG3);
     TagContext result = getResultOfWithTagContext(unknownTagContext);
     assertThat(result).isInstanceOf(TagContextImpl.class);
-    assertThat(asList(result)).containsExactly(TAG1, TAG2, TAG3);
+    assertThat(tagContextToList(result)).containsExactly(TAG1, TAG2, TAG3);
   }
 
   @Test
@@ -152,14 +153,14 @@ public class TaggerImplTest {
     Tag tag2 = TagString.create(KS, VS2);
     TagContext tagContextWithDuplicateTags = new SimpleTagContext(tag1, tag2);
     TagContext result = getResultOfWithTagContext(tagContextWithDuplicateTags);
-    assertThat(asList(result)).containsExactly(tag2);
+    assertThat(tagContextToList(result)).containsExactly(tag2);
   }
 
   @Test
   public void withTagContext_SkipNullTag() {
     TagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
     TagContext result = getResultOfWithTagContext(tagContextWithNullTag);
-    assertThat(asList(result)).containsExactly(TAG1, TAG2);
+    assertThat(tagContextToList(result)).containsExactly(TAG1, TAG2);
   }
 
   private TagContext getResultOfWithTagContext(TagContext tagsToSet) {
@@ -169,10 +170,6 @@ public class TaggerImplTest {
     } finally {
       scope.close();
     }
-  }
-
-  private static List<Tag> asList(TagContext tags) {
-    return Lists.newArrayList(tags.unsafeGetIterator());
   }
 
   private static final class SimpleTagContext extends TagContext {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagsTestUtil.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagsTestUtil.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.tags;
+
+import com.google.common.collect.Lists;
+import io.opencensus.tags.Tag;
+import io.opencensus.tags.TagContext;
+import java.util.Collection;
+
+/** Test utilities for tagging. */
+public class TagsTestUtil {
+
+  /** Returns a collection of all tags in a {@link TagContext}. */
+  public static Collection<Tag> tagContextToList(TagContext tags) {
+    return Lists.newArrayList(tags.unsafeGetIterator());
+  }
+}


### PR DESCRIPTION
#### Simplify TagContextDeserializationTest by calling TagContext.equals.

#### Add a utility class for testing tagging.
