### PR TITLE
Add API for enabling/disabling tagging (part of #608).

### DIFF
--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -102,6 +102,11 @@ final class NoopTags {
     }
 
     @Override
+    public boolean isTaggingAvailable() {
+      return false;
+    }
+
+    @Override
     public TaggingState getState() {
       return TaggingState.DISABLED;
     }

--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -18,6 +18,7 @@ package io.opencensus.tags;
 
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Preconditions;
 import io.opencensus.common.Scope;
 import io.opencensus.internal.NoopScope;
 import io.opencensus.tags.TagKey.TagKeyBoolean;
@@ -98,6 +99,16 @@ final class NoopTags {
     @Override
     public TagPropagationComponent getTagPropagationComponent() {
       return getNoopTagPropagationComponent();
+    }
+
+    @Override
+    public TaggingState getState() {
+      return TaggingState.DISABLED;
+    }
+
+    @Override
+    public void setState(TaggingState state) {
+      Preconditions.checkNotNull(state);
     }
   }
 

--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -102,7 +102,7 @@ final class NoopTags {
     }
 
     @Override
-    public boolean isTaggingAvailable() {
+    public boolean isImplementationAvailable() {
       return false;
     }
 

--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -108,7 +108,7 @@ final class NoopTags {
 
     @Override
     public void setState(TaggingState state) {
-      Preconditions.checkNotNull(state);
+      Preconditions.checkNotNull(state, "state");
     }
   }
 

--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -102,11 +102,6 @@ final class NoopTags {
     }
 
     @Override
-    public boolean isImplementationAvailable() {
-      return false;
-    }
-
-    @Override
     public TaggingState getState() {
       return TaggingState.DISABLED;
     }

--- a/core/src/main/java/io/opencensus/tags/TaggingState.java
+++ b/core/src/main/java/io/opencensus/tags/TaggingState.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags;
+
+/** State of the {@link TagsComponent}. */
+public enum TaggingState {
+  // TODO(sebright): Should we add a state that propagates the tags, but doesn't allow
+  // modifications?
+
+  /**
+   * State that fully enables tagging.
+   *
+   * <p>The {@link TagsComponent} can add tags to {@link TagContext}s, propagate {@code TagContext}s
+   * in the current context, and serialize {@code TagContext}s.
+   */
+  ENABLED,
+
+  /**
+   * State that disables tagging.
+   *
+   * <p>The {@link TagsComponent} may not add tags to {@link TagContext}s, propagate {@code
+   * TagContext}s in the current context, or serialize {@code TagContext}s.
+   */
+  DISABLED
+}

--- a/core/src/main/java/io/opencensus/tags/TaggingState.java
+++ b/core/src/main/java/io/opencensus/tags/TaggingState.java
@@ -35,5 +35,6 @@ public enum TaggingState {
    * <p>The {@link TagsComponent} may not add tags to {@link TagContext}s, propagate {@code
    * TagContext}s in the current context, or serialize {@code TagContext}s.
    */
+  // TODO(sebright): Document how this interacts with stats collection.
   DISABLED
 }

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -50,21 +50,10 @@ public final class Tags {
   }
 
   /**
-   * Returns {@code true} if a tagging implementation is available.
-   *
-   * <p>When an implementation is not available, calling {@link #setState} has no effect.
-   *
-   * @return {@code true} if a tagging implementation is available.
-   */
-  public static boolean isImplementationAvailable() {
-    return tagsComponent.isImplementationAvailable();
-  }
-
-  /**
    * Returns the current {@code TaggingState}.
    *
-   * <p>When {@link #isImplementationAvailable} returns {@code false}, {@code getState} always
-   * returns {@link TaggingState#DISABLED}.
+   * <p>When no implementation is available, {@code getState} always returns {@link
+   * TaggingState#DISABLED}.
    *
    * @return the current {@code TaggingState}.
    */
@@ -75,8 +64,7 @@ public final class Tags {
   /**
    * Sets the current {@code TaggingState}.
    *
-   * <p>When {@link #isImplementationAvailable} returns {@code false}, {@code setState} has no
-   * effect.
+   * <p>When no implementation is available, {@code setState} has no effect.
    *
    * @param state the new {@code TaggingState}.
    */

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -56,8 +56,8 @@ public final class Tags {
    *
    * @return {@code true} if a tagging implementation is available.
    */
-  public static boolean isTaggingAvailable() {
-    return tagsComponent.isTaggingAvailable();
+  public static boolean isImplementationAvailable() {
+    return tagsComponent.isImplementationAvailable();
   }
 
   /**

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -49,6 +49,24 @@ public final class Tags {
     return tagsComponent.getTagPropagationComponent();
   }
 
+  /**
+   * Returns the current {@code TaggingState}.
+   *
+   * @return the current {@code TaggingState}.
+   */
+  public static TaggingState getState() {
+    return tagsComponent.getState();
+  }
+
+  /**
+   * Sets the current {@code TaggingState}.
+   *
+   * @param state the new {@code TaggingState}.
+   */
+  public static void setState(TaggingState state) {
+    tagsComponent.setState(state);
+  }
+
   // Any provider that may be used for TagsComponent can be added here.
   @VisibleForTesting
   static TagsComponent loadTagsComponent(ClassLoader classLoader) {

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -50,6 +50,17 @@ public final class Tags {
   }
 
   /**
+   * Returns {@code true} if a tagging implementation is available.
+   *
+   * <p>When tagging is not available, calling {@link #setState} has no effect.
+   *
+   * @return {@code true} if a tagging implementation is available.
+   */
+  public static boolean isTaggingAvailable() {
+    return tagsComponent.isTaggingAvailable();
+  }
+
+  /**
    * Returns the current {@code TaggingState}.
    *
    * @return the current {@code TaggingState}.

--- a/core/src/main/java/io/opencensus/tags/Tags.java
+++ b/core/src/main/java/io/opencensus/tags/Tags.java
@@ -52,7 +52,7 @@ public final class Tags {
   /**
    * Returns {@code true} if a tagging implementation is available.
    *
-   * <p>When tagging is not available, calling {@link #setState} has no effect.
+   * <p>When an implementation is not available, calling {@link #setState} has no effect.
    *
    * @return {@code true} if a tagging implementation is available.
    */
@@ -63,6 +63,9 @@ public final class Tags {
   /**
    * Returns the current {@code TaggingState}.
    *
+   * <p>When {@link #isImplementationAvailable} returns {@code false}, {@code getState} always
+   * returns {@link TaggingState#DISABLED}.
+   *
    * @return the current {@code TaggingState}.
    */
   public static TaggingState getState() {
@@ -71,6 +74,9 @@ public final class Tags {
 
   /**
    * Sets the current {@code TaggingState}.
+   *
+   * <p>When {@link #isImplementationAvailable} returns {@code false}, {@code setState} has no
+   * effect.
    *
    * @param state the new {@code TaggingState}.
    */

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -30,4 +30,18 @@ public abstract class TagsComponent {
 
   /** Returns the {@link TagPropagationComponent} for this implementation. */
   public abstract TagPropagationComponent getTagPropagationComponent();
+
+  /**
+   * Returns the current {@code TaggingState}.
+   *
+   * @return the current {@code TaggingState}.
+   */
+  public abstract TaggingState getState();
+
+  /**
+   * Sets the current {@code TaggingState}.
+   *
+   * @param state the new {@code TaggingState}.
+   */
+  public abstract void setState(TaggingState state);
 }

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -32,19 +32,10 @@ public abstract class TagsComponent {
   public abstract TagPropagationComponent getTagPropagationComponent();
 
   /**
-   * Returns {@code true} if a tagging implementation is available.
-   *
-   * <p>When an implementation is not available, calling {@link #setState} has no effect.
-   *
-   * @return {@code true} if a tagging implementation is available.
-   */
-  public abstract boolean isImplementationAvailable();
-
-  /**
    * Returns the current {@code TaggingState}.
    *
-   * <p>When {@link #isImplementationAvailable} returns {@code false}, {@code getState} always
-   * returns {@link TaggingState#DISABLED}.
+   * <p>When no implementation is available, {@code getState} always returns {@link
+   * TaggingState#DISABLED}.
    *
    * @return the current {@code TaggingState}.
    */
@@ -53,8 +44,7 @@ public abstract class TagsComponent {
   /**
    * Sets the current {@code TaggingState}.
    *
-   * <p>When {@link #isImplementationAvailable} returns {@code false}, {@code setState} has no
-   * effect.
+   * <p>When no implementation is available, {@code setState} has no effect.
    *
    * @param state the new {@code TaggingState}.
    */

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -34,7 +34,7 @@ public abstract class TagsComponent {
   /**
    * Returns {@code true} if a tagging implementation is available.
    *
-   * <p>When tagging is not available, calling {@link #setState} has no effect.
+   * <p>When an implementation is not available, calling {@link #setState} has no effect.
    *
    * @return {@code true} if a tagging implementation is available.
    */
@@ -43,12 +43,18 @@ public abstract class TagsComponent {
   /**
    * Returns the current {@code TaggingState}.
    *
+   * <p>When {@link #isImplementationAvailable} returns {@code false}, {@code getState} always
+   * returns {@link TaggingState#DISABLED}.
+   *
    * @return the current {@code TaggingState}.
    */
   public abstract TaggingState getState();
 
   /**
    * Sets the current {@code TaggingState}.
+   *
+   * <p>When {@link #isImplementationAvailable} returns {@code false}, {@code setState} has no
+   * effect.
    *
    * @param state the new {@code TaggingState}.
    */

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -32,6 +32,15 @@ public abstract class TagsComponent {
   public abstract TagPropagationComponent getTagPropagationComponent();
 
   /**
+   * Returns {@code true} if a tagging implementation is available.
+   *
+   * <p>When tagging is not available, calling {@link #setState} has no effect.
+   *
+   * @return {@code true} if a tagging implementation is available.
+   */
+  public abstract boolean isTaggingAvailable();
+
+  /**
    * Returns the current {@code TaggingState}.
    *
    * @return the current {@code TaggingState}.

--- a/core/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/core/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -38,7 +38,7 @@ public abstract class TagsComponent {
    *
    * @return {@code true} if a tagging implementation is available.
    */
-  public abstract boolean isTaggingAvailable();
+  public abstract boolean isImplementationAvailable();
 
   /**
    * Returns the current {@code TaggingState}.

--- a/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -66,6 +66,13 @@ public final class NoopTagsTest {
   }
 
   @Test
+  public void noopTagsComponent_SetState_DisallowsNull() {
+    TagsComponent noopTagsComponent = NoopTags.getNoopTagsComponent();
+    thrown.expect(NullPointerException.class);
+    noopTagsComponent.setState(null);
+  }
+
+  @Test
   public void noopTagger() {
     Tagger noopTagger = NoopTags.getNoopTagger();
     assertThat(noopTagger.empty()).isSameAs(NoopTags.getNoopTagContext());

--- a/core/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagsTest.java
@@ -58,8 +58,8 @@ public class TagsTest {
   }
 
   @Test
-  public void isTaggingAvailable() {
-    assertFalse(Tags.isTaggingAvailable());
+  public void isImplementationAvailable() {
+    assertFalse(Tags.isImplementationAvailable());
   }
 
   @Test

--- a/core/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagsTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.tags;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -54,6 +55,11 @@ public class TagsTest {
         };
     assertThat(Tags.loadTagsComponent(classLoader).getClass().getName())
         .isEqualTo("io.opencensus.tags.NoopTags$NoopTagsComponent");
+  }
+
+  @Test
+  public void isTaggingAvailable() {
+    assertFalse(Tags.isTaggingAvailable());
   }
 
   @Test

--- a/core/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagsTest.java
@@ -17,7 +17,6 @@
 package io.opencensus.tags;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertFalse;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -55,11 +54,6 @@ public class TagsTest {
         };
     assertThat(Tags.loadTagsComponent(classLoader).getClass().getName())
         .isEqualTo("io.opencensus.tags.NoopTags$NoopTagsComponent");
-  }
-
-  @Test
-  public void isImplementationAvailable() {
-    assertFalse(Tags.isImplementationAvailable());
   }
 
   @Test

--- a/core/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/TagsTest.java
@@ -57,6 +57,22 @@ public class TagsTest {
   }
 
   @Test
+  public void getState() {
+    assertThat(Tags.getState()).isEqualTo(TaggingState.DISABLED);
+  }
+
+  @Test
+  public void setState_IgnoresInput() {
+    Tags.setState(TaggingState.ENABLED);
+    assertThat(Tags.getState()).isEqualTo(TaggingState.DISABLED);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void setState_DisallowsNull() {
+    Tags.setState(null);
+  }
+
+  @Test
   public void defaultTagger() {
     assertThat(Tags.getTagger()).isEqualTo(NoopTags.getNoopTagger());
   }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -43,6 +43,11 @@ public class TagsComponentImplBase extends TagsComponent {
   }
 
   @Override
+  public boolean isTaggingAvailable() {
+    return true;
+  }
+
+  @Override
   public TaggingState getState() {
     return state.get();
   }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -49,7 +49,7 @@ public class TagsComponentImplBase extends TagsComponent {
 
   @Override
   public void setState(TaggingState newState) {
-    state.set(checkNotNull(newState));
+    state.set(checkNotNull(newState, "newState"));
     // TODO(sebright): Avoid setting tags when tagging is disabled.
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -43,7 +43,7 @@ public class TagsComponentImplBase extends TagsComponent {
   }
 
   @Override
-  public boolean isTaggingAvailable() {
+  public boolean isImplementationAvailable() {
     return true;
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -43,11 +43,6 @@ public class TagsComponentImplBase extends TagsComponent {
   }
 
   @Override
-  public boolean isImplementationAvailable() {
-    return true;
-  }
-
-  @Override
   public TaggingState getState() {
     return state.get();
   }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -16,13 +16,19 @@
 
 package io.opencensus.implcore.tags;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.opencensus.implcore.tags.propagation.TagPropagationComponentImpl;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagPropagationComponent;
+import java.util.concurrent.atomic.AtomicReference;
 
 /** Base implementation of {@link TagsComponent}. */
-public abstract class TagsComponentImplBase extends TagsComponent {
+public class TagsComponentImplBase extends TagsComponent {
+  private final AtomicReference<TaggingState> state =
+      new AtomicReference<TaggingState>(TaggingState.ENABLED);
   private final Tagger tagger = new TaggerImpl();
   private final TagPropagationComponent tagPropagationComponent = new TagPropagationComponentImpl();
 
@@ -34,5 +40,16 @@ public abstract class TagsComponentImplBase extends TagsComponent {
   @Override
   public TagPropagationComponent getTagPropagationComponent() {
     return tagPropagationComponent;
+  }
+
+  @Override
+  public TaggingState getState() {
+    return state.get();
+  }
+
+  @Override
+  public void setState(TaggingState newState) {
+    state.set(checkNotNull(newState));
+    // TODO(sebright): Avoid setting tags when tagging is disabled.
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagComponentImplBaseTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.tags.TaggingState;
+import io.opencensus.tags.TagsComponent;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link TagsComponentImplBase}. */
+@RunWith(JUnit4.class)
+public class TagComponentImplBaseTest {
+  private final TagsComponent tagsComponent = new TagsComponentImplBase();
+
+  @Test
+  public void defaultState() {
+    assertThat(tagsComponent.getState()).isEqualTo(TaggingState.ENABLED);
+  }
+
+  @Test
+  public void setState() {
+    tagsComponent.setState(TaggingState.DISABLED);
+    assertThat(tagsComponent.getState()).isEqualTo(TaggingState.DISABLED);
+    tagsComponent.setState(TaggingState.ENABLED);
+    assertThat(tagsComponent.getState()).isEqualTo(TaggingState.ENABLED);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void setState_DisallowsNull() {
+    tagsComponent.setState(null);
+  }
+}

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagComponentImplBaseTest.java
@@ -31,8 +31,8 @@ public class TagComponentImplBaseTest {
   private final TagsComponent tagsComponent = new TagsComponentImplBase();
 
   @Test
-  public void isTaggingAvailable() {
-    assertTrue(tagsComponent.isTaggingAvailable());
+  public void isImplementationAvailable() {
+    assertTrue(tagsComponent.isImplementationAvailable());
   }
 
   @Test

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagComponentImplBaseTest.java
@@ -17,7 +17,6 @@
 package io.opencensus.implcore.tags;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertTrue;
 
 import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.TagsComponent;
@@ -29,11 +28,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TagComponentImplBaseTest {
   private final TagsComponent tagsComponent = new TagsComponentImplBase();
-
-  @Test
-  public void isImplementationAvailable() {
-    assertTrue(tagsComponent.isImplementationAvailable());
-  }
 
   @Test
   public void defaultState() {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagComponentImplBaseTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.implcore.tags;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.TagsComponent;
@@ -28,6 +29,11 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TagComponentImplBaseTest {
   private final TagsComponent tagsComponent = new TagsComponentImplBase();
+
+  @Test
+  public void isTaggingAvailable() {
+    assertTrue(tagsComponent.isTaggingAvailable());
+  }
 
   @Test
   public void defaultState() {


### PR DESCRIPTION
This commit adds an enum to represent the tagging state (TaggingState) and adds
getters and setters for the state to TagsComponent and Tags.  The state has no
effect yet.

/cc @adriancole 