### PR TITLE
Fix probability sampler and sampling.

### DIFF
--- a/api/src/test/java/io/opencensus/trace/FakeSpan.java
+++ b/api/src/test/java/io/opencensus/trace/FakeSpan.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace;
+
+import java.util.EnumSet;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/**
+ * Class to be used in tests where an implementation for the Span is needed.
+ *
+ * <p>Not final to allow Mockito to "spy" this class.
+ */
+public class FakeSpan extends Span {
+
+  /**
+   * Creates a new {@code FakeSpan}.
+   */
+  public FakeSpan(SpanContext context, @Nullable EnumSet<Options> options) {
+    super(context, options);
+  }
+
+  @Override
+  public void putAttributes(Map<String, AttributeValue> attributes) {}
+
+  @Override
+  public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
+
+  @Override
+  public void addAnnotation(Annotation annotation) {}
+
+  @Override
+  public void addNetworkEvent(NetworkEvent networkEvent) {}
+
+  @Override
+  public void addLink(Link link) {}
+
+  @Override
+  public void end(EndSpanOptions options) {}
+}

--- a/api/src/test/java/io/opencensus/trace/NoopSpan.java
+++ b/api/src/test/java/io/opencensus/trace/NoopSpan.java
@@ -25,12 +25,10 @@ import javax.annotation.Nullable;
  *
  * <p>Not final to allow Mockito to "spy" this class.
  */
-public class FakeSpan extends Span {
+public class NoopSpan extends Span {
 
-  /**
-   * Creates a new {@code FakeSpan}.
-   */
-  public FakeSpan(SpanContext context, @Nullable EnumSet<Options> options) {
+  /** Creates a new {@code NoopSpan}. */
+  public NoopSpan(SpanContext context, @Nullable EnumSet<Options> options) {
     super(context, options);
   }
 

--- a/api/src/test/java/io/opencensus/trace/SpanTest.java
+++ b/api/src/test/java/io/opencensus/trace/SpanTest.java
@@ -56,35 +56,35 @@ public class SpanTest {
 
   @Test(expected = NullPointerException.class)
   public void newSpan_WithNullContext() {
-    new FakeSpan(null, null);
+    new NoopSpan(null, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void newSpan_SampledContextAndNullOptions() {
-    new FakeSpan(spanContext, null);
+    new NoopSpan(spanContext, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void newSpan_SampledContextAndEmptyOptions() {
-    new FakeSpan(spanContext, EnumSet.noneOf(Span.Options.class));
+    new NoopSpan(spanContext, EnumSet.noneOf(Span.Options.class));
   }
 
   @Test
   public void getOptions_WhenNullOptions() {
-    Span span = new FakeSpan(notSampledSpanContext, null);
+    Span span = new NoopSpan(notSampledSpanContext, null);
     assertThat(span.getOptions()).isEmpty();
   }
 
   @Test
   public void getContextAndOptions() {
-    Span span = new FakeSpan(spanContext, spanOptions);
+    Span span = new NoopSpan(spanContext, spanOptions);
     assertThat(span.getContext()).isEqualTo(spanContext);
     assertThat(span.getOptions()).isEqualTo(spanOptions);
   }
 
   @Test
   public void putAttributeCallsAddAttributesByDefault() {
-    Span span = Mockito.spy(new FakeSpan(spanContext, spanOptions));
+    Span span = Mockito.spy(new NoopSpan(spanContext, spanOptions));
     span.putAttribute("MyKey", AttributeValue.booleanAttributeValue(true));
     span.end();
     verify(span)
@@ -94,7 +94,7 @@ public class SpanTest {
 
   @Test
   public void endCallsEndWithDefaultOptions() {
-    Span span = Mockito.spy(new FakeSpan(spanContext, spanOptions));
+    Span span = Mockito.spy(new NoopSpan(spanContext, spanOptions));
     span.end();
     verify(span).end(same(EndSpanOptions.DEFAULT));
   }

--- a/api/src/test/java/io/opencensus/trace/SpanTest.java
+++ b/api/src/test/java/io/opencensus/trace/SpanTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
 import java.util.EnumSet;
-import java.util.Map;
 import java.util.Random;
 import org.junit.Before;
 import org.junit.Test;
@@ -57,35 +56,35 @@ public class SpanTest {
 
   @Test(expected = NullPointerException.class)
   public void newSpan_WithNullContext() {
-    new NoopSpan(null, null);
+    new FakeSpan(null, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void newSpan_SampledContextAndNullOptions() {
-    new NoopSpan(spanContext, null);
+    new FakeSpan(spanContext, null);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void newSpan_SampledContextAndEmptyOptions() {
-    new NoopSpan(spanContext, EnumSet.noneOf(Span.Options.class));
+    new FakeSpan(spanContext, EnumSet.noneOf(Span.Options.class));
   }
 
   @Test
   public void getOptions_WhenNullOptions() {
-    Span span = new NoopSpan(notSampledSpanContext, null);
+    Span span = new FakeSpan(notSampledSpanContext, null);
     assertThat(span.getOptions()).isEmpty();
   }
 
   @Test
   public void getContextAndOptions() {
-    Span span = new NoopSpan(spanContext, spanOptions);
+    Span span = new FakeSpan(spanContext, spanOptions);
     assertThat(span.getContext()).isEqualTo(spanContext);
     assertThat(span.getOptions()).isEqualTo(spanOptions);
   }
 
   @Test
   public void putAttributeCallsAddAttributesByDefault() {
-    Span span = Mockito.spy(new NoopSpan(spanContext, spanOptions));
+    Span span = Mockito.spy(new FakeSpan(spanContext, spanOptions));
     span.putAttribute("MyKey", AttributeValue.booleanAttributeValue(true));
     span.end();
     verify(span)
@@ -95,33 +94,8 @@ public class SpanTest {
 
   @Test
   public void endCallsEndWithDefaultOptions() {
-    Span span = Mockito.spy(new NoopSpan(spanContext, spanOptions));
+    Span span = Mockito.spy(new FakeSpan(spanContext, spanOptions));
     span.end();
     verify(span).end(same(EndSpanOptions.DEFAULT));
-  }
-
-  // No-op implementation of the Span for testing only.
-  private static class NoopSpan extends Span {
-    private NoopSpan(SpanContext context, EnumSet<Span.Options> options) {
-      super(context, options);
-    }
-
-    @Override
-    public void putAttributes(Map<String, AttributeValue> attributes) {}
-
-    @Override
-    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
-
-    @Override
-    public void addAnnotation(Annotation annotation) {}
-
-    @Override
-    public void addNetworkEvent(NetworkEvent networkEvent) {}
-
-    @Override
-    public void addLink(Link link) {}
-
-    @Override
-    public void end(EndSpanOptions options) {}
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/SpanBuilderImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/SpanBuilderImpl.java
@@ -118,7 +118,16 @@ final class SpanBuilderImpl extends SpanBuilder {
           .shouldSample(parent, hasRemoteParent, traceId, spanId, name, parentLinks);
     }
     // Parent is always different than null because otherwise we use the default sampler.
-    return parent.getTraceOptions().isSampled();
+    return parent.getTraceOptions().isSampled() || isAnyParentLinkSampled(parentLinks);
+  }
+
+  private static boolean isAnyParentLinkSampled(List<Span> parentLinks) {
+    for (Span parentLink : parentLinks) {
+      if (parentLink.getContext().getTraceOptions().isSampled()) {
+        return true;
+      }
+    }
+    return false;
   }
 
   private static void linkSpans(Span span, List<Span> parentLinks) {


### PR DESCRIPTION
Summary:
* Revert the change of keeping the sampling decision in the probability sampler. I will come with a better fix in 0.8.0 version of the library. This change came after adding the test in SpanBuilderImplTest.
* Keep the sampling decision from links as well.
* Extract the FakeSpan into a separate class in tests for the moment to be reused by other test classes.

TODOs:
* In 0.8.0 cleanup this based on the https://github.com/census-instrumentation/opencensus-specs/pull/6
