### PR TITLE
Update MutableViewData.toViewData()

### DIFF
--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -63,7 +63,7 @@ final class MeasureToViewMap {
   /** Returns a {@link ViewData} corresponding to the given {@link View.Name}. */
   synchronized ViewData getView(View.Name viewName, Clock clock) {
     MutableViewData view = getMutableViewData(viewName);
-    return view == null ? null : view.toViewData(clock);
+    return view == null ? null : view.toViewData(clock.now());
   }
 
   @Nullable

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
-import io.opencensus.common.Clock;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
@@ -140,7 +139,7 @@ abstract class MutableViewData {
   /**
    * Convert this {@link MutableViewData} to {@link ViewData}.
    */
-  abstract ViewData toViewData(Clock clock);
+  abstract ViewData toViewData(Timestamp now);
 
   private static Map<TagKey, TagValue> getTagMap(TagContext ctx) {
     if (ctx instanceof TagContextImpl) {
@@ -250,10 +249,10 @@ abstract class MutableViewData {
     }
 
     @Override
-    ViewData toViewData(Clock clock) {
+    ViewData toViewData(Timestamp now) {
       return ViewData.create(
           super.view, createAggregationMap(tagValueAggregationMap, super.view.getMeasure()),
-          CumulativeData.create(start, clock.now()));
+          CumulativeData.create(start, now));
     }
   }
 
@@ -319,8 +318,7 @@ abstract class MutableViewData {
     }
 
     @Override
-    ViewData toViewData(Clock clock) {
-      Timestamp now = clock.now();
+    ViewData toViewData(Timestamp now) {
       refreshBucketList(now);
       return ViewData.create(
           super.view, combineBucketsAndGetAggregationMap(now), IntervalData.create(now));


### PR DESCRIPTION
Previously `MutableViewData.create()` and `record()` both takes a `Timestamp`, while `toViewData()` takes a `Clock`. Update `toViewData()` to take a `Timestamp` instead.