### PR TITLE
Run integration tests of contrib/agent on Java 9, too.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ script:
         export JAVA8_HOME="$(jdk_switcher home oraclejdk8)" ;
         case "$TRAVIS_JDK_VERSION" in
           "oraclejdk8")
-            export JAVA_HOMES="$(jdk_switcher home openjdk6)/jre:$(jdk_switcher home openjdk7)/jre:$(jdk_switcher home oraclejdk8)/jre" ;
+            export JAVA_HOMES="$(jdk_switcher home openjdk6)/jre:$(jdk_switcher home openjdk7)/jre:$(jdk_switcher home oraclejdk8)/jre:$(jdk_switcher home oraclejdk9)" ;
             ./gradlew clean assemble --stacktrace ;
             ./gradlew check :opencensus-all:jacocoTestReport ;;
           "openjdk7")


### PR DESCRIPTION
The integration tests of contrib/agent work fine on Oracle JDK 9 so far, thus enabling these tests on Travis, too.

There's a warning about an illegal reflective access operation, which is triggered by Gradle and should be fixed in a future version of Gradle (https://github.com/gradle/gradle/issues/2995).

```
WARNING: An illegal reflective access operation has occurred
WARNING: Illegal reflective access by worker.org.gradle.internal.reflect.JavaMethod (file:/home/travis/.gradle/caches/4.0.1/workerMain/gradle-worker.jar) to method java.lang.ClassLoader.getPackages()
WARNING: Please consider reporting this to the maintainers of worker.org.gradle.internal.reflect.JavaMethod
WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
WARNING: All illegal access operations will be denied in a future release
```