### PR TITLE
Adds TextFormat and usage example

### DIFF
--- a/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
@@ -33,6 +33,14 @@ public abstract class PropagationComponent {
   public abstract BinaryFormat getBinaryFormat();
 
   /**
+   * Returns the {@link TextFormat} with the provided implementations. If no implementation
+   * is provided then no-op implementation will be used.
+   *
+   * @return the {@code TextFormat} implementation.
+   */
+  public abstract TextFormat getTextFormat();
+
+  /**
    * Returns an instance that contains no-op implementations for all the instances.
    *
    * @return an instance that contains no-op implementations for all the instances.
@@ -45,6 +53,10 @@ public abstract class PropagationComponent {
     @Override
     public BinaryFormat getBinaryFormat() {
       return BinaryFormat.getNoopBinaryFormat();
+    }
+    @Override
+    public TextFormat getTextFormat() {
+      return TextFormat.getNoopTextFormat();
     }
   }
 }

--- a/api/src/main/java/io/opencensus/trace/propagation/TextFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/TextFormat.java
@@ -1,0 +1,91 @@
+package io.opencensus.trace.propagation;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.opencensus.trace.SpanContext;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Injects and extracts {@link SpanContext trace identifiers} as text into carriers that travel
+ * in-band across process boundaries. Identifiers are often encoded as messaging or RPC request
+ * headers.
+ *
+ * <h3>Propagation example: Http</h3>
+ *
+ * <p>When using http, the carrier of propagated data on both the client (injector) and server
+ * (extractor) side is usually an http request. Propagation is usually implemented via library-
+ * specific request interceptors, where the client-side injects span identifiers and the server-side
+ * extracts them.
+ */
+public abstract class TextFormat {
+
+  static final NoopTextFormat NOOP_TEXT_FORMAT = new NoopTextFormat();
+
+  /**
+   * The propagation fields defined. If your carrier is reused, you should delete the fields here
+   * before calling {@link #putContext(SpanContext, Object, Setter)}.
+   *
+   * <p>For example, if the carrier is a single-use or immutable request object, you don't need to
+   * clear fields as they couldn't have been set before. If it is a mutable, retryable object,
+   * successive calls should clear these fields first.
+   */
+  // The use cases of this are:
+  // * allow pre-allocation of fields, especially in systems like gRPC Metadata
+  // * allow a single-pass over an iterator (ex OpenTracing has no getter in TextMap)
+  public abstract List<String> fields();
+
+  /**
+   * Used to send the trace context downstream. For example, as http headers.
+   *
+   * For example, to put the context on an {@link java.net.HttpURLConnection}, you would do this:
+   * <pre>{@code
+   * HttpURLConnection connection = (HttpURLConnection) new URL("http://myserver").openConnection();
+   * textFormat.putContext(spanContext, connection, URLConnection::setRequestProperty);
+   * }</pre>
+   *
+   * @param spanContext possibly unsampled.
+   * @param carrier holds propagation fields. For example, an outgoing message or http request.
+   * @param setter invoked for each propagation key to add or remove.
+   */
+  public abstract <C> void putContext(SpanContext spanContext, C carrier, Setter<C> setter);
+
+  /**
+   * Replaces a propagated field with the given value. Saved as a constant to avoid runtime
+   * allocations.
+   *
+   * For example, a setter for an {@link java.net.HttpURLConnection} would be the method reference
+   * {@link java.net.HttpURLConnection#addRequestProperty(String, String)}
+   *
+   * @param <C> carrier of propagation fields, such as an http request
+   */
+  public interface Setter<C> {
+
+    void put(C carrier, String field, String value);
+  }
+
+  /**
+   * Returns the no-op implementation of the {@code TextFormat}.
+   *
+   * @return the no-op implementation of the {@code TextFormat}.
+   */
+  static TextFormat getNoopTextFormat() {
+    return NOOP_TEXT_FORMAT;
+  }
+
+  private static final class NoopTextFormat extends TextFormat {
+
+    private NoopTextFormat() {
+    }
+
+    @Override
+    public List<String> fields() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public <C> void putContext(SpanContext spanContext, C carrier, Setter<C> setter) {
+      checkNotNull(spanContext, "spanContext");
+    }
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/propagation/TextFormatTest.java
+++ b/api/src/test/java/io/opencensus/trace/propagation/TextFormatTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.propagation;
+
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.propagation.TextFormat.Setter;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.net.URLConnection;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Unit tests for {@link TextFormat}.
+ */
+@RunWith(JUnit4.class)
+public class TextFormatTest {
+
+  private static final TextFormat textFormat = TextFormat.getNoopTextFormat();
+  private static final SpanContext spanContext = SpanContext.INVALID;
+
+  @Test
+  public void howThisWorks() throws Exception {
+    HttpURLConnection connection = (HttpURLConnection) new URL("http://myserver").openConnection();
+
+    // same as the method reference:
+    //    textFormat.putContext(spanContext, connection, URLConnection::setRequestProperty);
+    textFormat.putContext(spanContext, connection, new Setter<HttpURLConnection>() {
+      @Override
+      public void put(HttpURLConnection carrier, String field, String value) {
+        carrier.setRequestProperty(field, value);
+      }
+    });
+  }
+}

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/B3TextFormatImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/B3TextFormatImpl.java
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.trace.propagation;
+
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.propagation.TextFormat;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public final class B3TextFormatImpl extends TextFormat {
+
+  /**
+   * 128 or 64-bit trace ID lower-hex encoded into 32 or 16 characters (required)
+   */
+  static final String TRACE_ID_NAME = "X-B3-TraceId";
+  /**
+   * 64-bit span ID lower-hex encoded into 16 characters (required)
+   */
+  static final String SPAN_ID_NAME = "X-B3-SpanId";
+  /**
+   * 64-bit parent span ID lower-hex encoded into 16 characters (absent on root span)
+   */
+  static final String PARENT_SPAN_ID_NAME = "X-B3-ParentSpanId";
+  /**
+   * "1" means report this span to the tracing system, "0" means do not. (absent means defer the
+   * decision to the receiver of this header).
+   */
+  static final String SAMPLED_NAME = "X-B3-Sampled";
+  /**
+   * "1" implies sampled and is a request to override collection-tier sampling policy.
+   */
+  static final String FLAGS_NAME = "X-B3-Flags";
+
+  static final List<String> FIELDS = Collections.unmodifiableList(
+      Arrays.asList(TRACE_ID_NAME, SPAN_ID_NAME, PARENT_SPAN_ID_NAME, SAMPLED_NAME, FLAGS_NAME)
+  );
+
+  @Override
+  public List<String> fields() {
+    return FIELDS;
+  }
+
+  /**
+   * Replaces keys in the carrier, notably excluding {@link #PARENT_SPAN_ID_NAME} and {@link
+   * #FLAGS_NAME} which aren't available.
+   */
+  @Override
+  public <C> void putContext(SpanContext spanContext, C carrier, Setter<C> setter) {
+    setter.put(carrier, TRACE_ID_NAME, spanContext.getTraceId().toString());
+    setter.put(carrier, SPAN_ID_NAME, spanContext.getSpanId().toString());
+    if (spanContext.getTraceOptions().isSampled()) {
+      setter.put(carrier, SAMPLED_NAME, "1");
+    } else {
+      setter.put(carrier, SAMPLED_NAME, "0");
+    }
+  }
+}

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/PropagationComponentImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/PropagationComponentImpl.java
@@ -18,13 +18,21 @@ package io.opencensus.implcore.trace.propagation;
 
 import io.opencensus.trace.propagation.BinaryFormat;
 import io.opencensus.trace.propagation.PropagationComponent;
+import io.opencensus.trace.propagation.TextFormat;
 
 /** Implementation of the {@link PropagationComponent}. */
 public class PropagationComponentImpl extends PropagationComponent {
+
   private final BinaryFormat binaryFormat = new BinaryFormatImpl();
+  private final TextFormat b3Format = new B3TextFormatImpl();
 
   @Override
   public BinaryFormat getBinaryFormat() {
     return binaryFormat;
+  }
+
+  @Override
+  public TextFormat getTextFormat() {
+    return b3Format;
   }
 }


### PR DESCRIPTION
This is a WIP to show how a text format injector adapted from Brave
might be used in census. This is a simplified variant, which can only
use String keys (as opposed to gRPC metadata keys, which are not
strings).

Ex.
```java
HttpURLConnection connection = (HttpURLConnection) new URL("http://myserver").openConnection();

// if using a method reference, you just do it directly
textFormat.putContext(spanContext, connection, URLConnection::setRequestProperty);

// if you can't use a method reference or lambda, you should save off
// a setter instead of allocating one for each request like below does
textFormat.putContext(spanContext, connection, new Setter<HttpURLConnection>() {
  @Override
  public void put(HttpURLConnection carrier, String field, String value) {
    carrier.setRequestProperty(field, value);
  }
});
```