### PR TITLE
Check for null arguments in tagging no-op classes.

### DIFF
--- a/core/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/core/src/main/java/io/opencensus/tags/NoopTags.java
@@ -16,6 +16,8 @@
 
 package io.opencensus.tags;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
 import io.opencensus.common.Scope;
 import io.opencensus.internal.NoopScope;
 import io.opencensus.tags.TagKey.TagKeyBoolean;
@@ -120,6 +122,7 @@ final class NoopTags {
 
     @Override
     public TagContextBuilder toBuilder(TagContext tags) {
+      checkNotNull(tags, "tags");
       return getNoopTagContextBuilder();
     }
 
@@ -130,6 +133,7 @@ final class NoopTags {
 
     @Override
     public Scope withTagContext(TagContext tags) {
+      checkNotNull(tags, "tags");
       return NoopScope.getInstance();
     }
   }
@@ -140,21 +144,28 @@ final class NoopTags {
 
     @Override
     public TagContextBuilder put(TagKeyString key, TagValueString value) {
+      checkNotNull(key, "key");
+      checkNotNull(value, "value");
       return this;
     }
 
     @Override
     public TagContextBuilder put(TagKeyLong key, TagValueLong value) {
+      checkNotNull(key, "key");
+      checkNotNull(value, "value");
       return this;
     }
 
     @Override
     public TagContextBuilder put(TagKeyBoolean key, TagValueBoolean value) {
+      checkNotNull(key, "key");
+      checkNotNull(value, "value");
       return this;
     }
 
     @Override
     public TagContextBuilder remove(TagKey key) {
+      checkNotNull(key, "key");
       return this;
     }
 
@@ -197,11 +208,13 @@ final class NoopTags {
 
     @Override
     public byte[] toByteArray(TagContext tags) {
+      checkNotNull(tags, "tags");
       return EMPTY_BYTE_ARRAY;
     }
 
     @Override
     public TagContext fromByteArray(byte[] bytes) {
+      checkNotNull(bytes, "bytes");
       return getNoopTagContext();
     }
   }

--- a/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/core/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -21,28 +21,42 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.Lists;
 import io.opencensus.internal.NoopScope;
 import io.opencensus.tags.Tag.TagString;
+import io.opencensus.tags.TagKey.TagKeyBoolean;
+import io.opencensus.tags.TagKey.TagKeyLong;
 import io.opencensus.tags.TagKey.TagKeyString;
+import io.opencensus.tags.TagValue.TagValueBoolean;
+import io.opencensus.tags.TagValue.TagValueLong;
 import io.opencensus.tags.TagValue.TagValueString;
+import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagContextParseException;
 import java.util.Arrays;
 import java.util.Iterator;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link NoopTags}. */
 @RunWith(JUnit4.class)
 public final class NoopTagsTest {
+  private static final TagKeyString KEY_STRING = TagKeyString.create("key");
+  private static final TagValueString VALUE_STRING = TagValueString.create("value");
+  private static final TagKeyLong KEY_LONG = TagKeyLong.create("key");
+  private static final TagValueLong VALUE_LONG = TagValueLong.create(1L);
+  private static final TagKeyBoolean KEY_BOOLEAN = TagKeyBoolean.create("key");
+  private static final TagValueBoolean VALUE_BOOLEAN = TagValueBoolean.create(true);
+
   private static final TagContext TAG_CONTEXT =
       new TagContext() {
 
         @Override
         public Iterator<Tag> unsafeGetIterator() {
-          return Arrays.<Tag>asList(
-                  TagString.create(TagKeyString.create("key"), TagValueString.create("value")))
-              .iterator();
+          return Arrays.<Tag>asList(TagString.create(KEY_STRING, VALUE_STRING)).iterator();
         }
       };
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void noopTagsComponent() {
@@ -63,19 +77,76 @@ public final class NoopTagsTest {
   }
 
   @Test
+  public void noopTagger_ToBuilder_DisallowsNull() {
+    Tagger noopTagger = NoopTags.getNoopTagger();
+    thrown.expect(NullPointerException.class);
+    noopTagger.toBuilder(null);
+  }
+
+  @Test
+  public void noopTagger_WithTagContext_DisallowsNull() {
+    Tagger noopTagger = NoopTags.getNoopTagger();
+    thrown.expect(NullPointerException.class);
+    noopTagger.withTagContext(null);
+  }
+
+  @Test
   public void noopTagContextBuilder() {
     assertThat(NoopTags.getNoopTagContextBuilder().build()).isSameAs(NoopTags.getNoopTagContext());
-    assertThat(
-            NoopTags.getNoopTagContextBuilder()
-                .put(TagKeyString.create("key"), TagValueString.create("value"))
-                .build())
+    assertThat(NoopTags.getNoopTagContextBuilder().put(KEY_STRING, VALUE_STRING).build())
         .isSameAs(NoopTags.getNoopTagContext());
     assertThat(NoopTags.getNoopTagContextBuilder().buildScoped()).isSameAs(NoopScope.getInstance());
-    assertThat(
-            NoopTags.getNoopTagContextBuilder()
-                .put(TagKeyString.create("key"), TagValueString.create("value"))
-                .buildScoped())
+    assertThat(NoopTags.getNoopTagContextBuilder().put(KEY_STRING, VALUE_STRING).buildScoped())
         .isSameAs(NoopScope.getInstance());
+  }
+
+  @Test
+  public void noopTagContextBuilder_PutString_DisallowsNullKey() {
+    TagContextBuilder noopBuilder = NoopTags.getNoopTagContextBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(null, VALUE_STRING);
+  }
+
+  @Test
+  public void noopTagContextBuilder_PutString_DisallowsNullValue() {
+    TagContextBuilder noopBuilder = NoopTags.getNoopTagContextBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(KEY_STRING, null);
+  }
+
+  @Test
+  public void noopTagContextBuilder_PutLong_DisallowsNullKey() {
+    TagContextBuilder noopBuilder = NoopTags.getNoopTagContextBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(null, VALUE_LONG);
+  }
+
+  @Test
+  public void noopTagContextBuilder_PutLong_DisallowsNullValue() {
+    TagContextBuilder noopBuilder = NoopTags.getNoopTagContextBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(KEY_LONG, null);
+  }
+
+  @Test
+  public void noopTagContextBuilder_PutBoolean_DisallowsNullKey() {
+    TagContextBuilder noopBuilder = NoopTags.getNoopTagContextBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(null, VALUE_BOOLEAN);
+  }
+
+  @Test
+  public void noopTagContextBuilder_PutBoolean_DisallowsNullValue() {
+    TagContextBuilder noopBuilder = NoopTags.getNoopTagContextBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.put(KEY_BOOLEAN, null);
+  }
+
+  @Test
+  public void noopTagContextBuilder_Remove_DisallowsNullKey() {
+    TagContextBuilder noopBuilder = NoopTags.getNoopTagContextBuilder();
+    thrown.expect(NullPointerException.class);
+    noopBuilder.remove(null);
   }
 
   @Test
@@ -95,5 +166,20 @@ public final class NoopTagsTest {
         .isEqualTo(new byte[0]);
     assertThat(NoopTags.getNoopTagContextBinarySerializer().fromByteArray(new byte[5]))
         .isEqualTo(NoopTags.getNoopTagContext());
+  }
+
+  @Test
+  public void noopTagContextBinarySerializer_ToByteArray_DisallowsNull() {
+    TagContextBinarySerializer noopSerializer = NoopTags.getNoopTagContextBinarySerializer();
+    thrown.expect(NullPointerException.class);
+    noopSerializer.toByteArray(null);
+  }
+
+  @Test
+  public void noopTagContextBinarySerializer_FromByteArray_DisallowsNull()
+      throws TagContextParseException {
+    TagContextBinarySerializer noopSerializer = NoopTags.getNoopTagContextBinarySerializer();
+    thrown.expect(NullPointerException.class);
+    noopSerializer.fromByteArray(null);
   }
 }


### PR DESCRIPTION
This behavior is more consistent with the corresponding implementation classes.