### PR TITLE
Add a no-op ViewManager (closes #614).

### DIFF
--- a/core/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/core/src/main/java/io/opencensus/stats/NoopStats.java
@@ -129,7 +129,6 @@ final class NoopStats {
               existing
                   .getWindow()
                   .match(
-                      // TODO(sebright): Should we use the zero timestamp or the current time?
                       Functions.<AggregationWindowData>returnConstant(
                           CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP)),
                       Functions.<AggregationWindowData>returnConstant(

--- a/core/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/core/src/main/java/io/opencensus/stats/NoopStats.java
@@ -16,11 +16,23 @@
 
 package io.opencensus.stats;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.collect.Maps;
+import io.opencensus.common.Functions;
+import io.opencensus.common.Timestamp;
+import io.opencensus.stats.ViewData.AggregationWindowData;
+import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
+import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
 import io.opencensus.tags.TagContext;
-import javax.annotation.Nullable;
+import io.opencensus.tags.TagValue;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /** No-op implementations of stats classes. */
 final class NoopStats {
@@ -32,8 +44,8 @@ final class NoopStats {
    *
    * @return a {@code StatsComponent} that has a no-op implementation for {@code StatsRecorder}.
    */
-  static StatsComponent getNoopStatsComponent() {
-    return NoopStatsComponent.INSTANCE;
+  static StatsComponent newNoopStatsComponent() {
+    return new NoopStatsComponent();
   }
 
   /**
@@ -45,15 +57,24 @@ final class NoopStats {
     return NoopStatsRecorder.INSTANCE;
   }
 
-  @Immutable
+  /**
+   * Returns a {@code ViewManager} that maintains a map of views, but always returns empty {@link
+   * ViewData}s.
+   *
+   * @return a {@code ViewManager} that maintains a map of views, but always returns empty {@code
+   *     ViewData}s.
+   */
+  static ViewManager newNoopViewManager() {
+    return new NoopViewManager();
+  }
+
+  @ThreadSafe
   private static final class NoopStatsComponent extends StatsComponent {
-    static final StatsComponent INSTANCE = new NoopStatsComponent();
+    private final ViewManager viewManager = newNoopViewManager();
 
     @Override
-    @Nullable
     public ViewManager getViewManager() {
-      // TODO(sebright): Decide whether to also provide a no-op implementation for the ViewManager.
-      return null;
+      return viewManager;
     }
 
     @Override
@@ -70,6 +91,52 @@ final class NoopStats {
     public void record(TagContext tags, MeasureMap measureValues) {
       checkNotNull(tags, "tags");
       checkNotNull(measureValues, "measureValues");
+    }
+  }
+
+  @ThreadSafe
+  private static final class NoopViewManager extends ViewManager {
+    private static final Timestamp ZERO_TIMESTAMP = Timestamp.create(0, 0);
+
+    @GuardedBy("views")
+    private final Map<View.Name, View> views = Maps.newHashMap();
+
+    @Override
+    public void registerView(View newView) {
+      checkNotNull(newView, "newView");
+      synchronized (views) {
+        View existing = views.get(newView.getName());
+        checkArgument(
+            existing == null || newView.equals(existing),
+            "A different view with the same name already exists.");
+        if (existing == null) {
+          views.put(newView.getName(), newView);
+        }
+      }
+    }
+
+    @Override
+    public ViewData getView(View view) {
+      checkNotNull(view, "view");
+      synchronized (views) {
+        View existing = views.get(view.getName());
+        if (existing == null) {
+          throw new IllegalArgumentException("View is not registered.");
+        } else {
+          return ViewData.create(
+              existing,
+              Collections.<List<TagValue>, AggregationData>emptyMap(),
+              existing
+                  .getWindow()
+                  .match(
+                      // TODO(sebright): Should we use the zero timestamp or the current time?
+                      Functions.<AggregationWindowData>returnConstant(
+                          CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP)),
+                      Functions.<AggregationWindowData>returnConstant(
+                          IntervalData.create(ZERO_TIMESTAMP)),
+                      Functions.<AggregationWindowData>throwAssertionError()));
+        }
+      }
     }
   }
 }

--- a/core/src/main/java/io/opencensus/stats/Stats.java
+++ b/core/src/main/java/io/opencensus/stats/Stats.java
@@ -67,7 +67,7 @@ public final class Stats {
               + "default implementation for StatsComponent.",
           e);
     }
-    return NoopStats.getNoopStatsComponent();
+    return NoopStats.newNoopStatsComponent();
   }
 
   private Stats() {}

--- a/core/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/core/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -32,7 +32,10 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link NoopStats}. */
+/**
+ * Unit tests for {@link NoopStats}. Tests for {@link NoopStats#newNoopViewManager} are in {@link
+ * NoopViewManagerTest}
+ */
 @RunWith(JUnit4.class)
 public final class NoopStatsTest {
   private static final TagString TAG =
@@ -53,9 +56,10 @@ public final class NoopStatsTest {
 
   @Test
   public void noopStatsComponent() {
-    assertThat(NoopStats.getNoopStatsComponent().getStatsRecorder())
+    assertThat(NoopStats.newNoopStatsComponent().getStatsRecorder())
         .isSameAs(NoopStats.getNoopStatsRecorder());
-    assertThat(NoopStats.getNoopStatsComponent().getViewManager()).isNull();
+    assertThat(NoopStats.newNoopStatsComponent().getViewManager())
+        .isInstanceOf(NoopStats.newNoopViewManager().getClass());
   }
 
   // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an

--- a/core/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
+++ b/core/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.common.Duration;
+import io.opencensus.common.Timestamp;
+import io.opencensus.stats.Aggregation.Sum;
+import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.View.AggregationWindow.Cumulative;
+import io.opencensus.stats.View.AggregationWindow.Interval;
+import io.opencensus.stats.View.Name;
+import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
+import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
+import io.opencensus.tags.TagKey.TagKeyString;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoopStats#newNoopViewManager}. */
+@RunWith(JUnit4.class)
+public final class NoopViewManagerTest {
+  private static final MeasureDouble MEASURE =
+      Measure.MeasureDouble.create("my measure", "description", "s");
+  private static final TagKeyString KEY = TagKeyString.create("KEY");
+  private static final Name VIEW_NAME = Name.create("my view");
+  private static final String VIEW_DESCRIPTION = "view description";
+  private static final Sum AGGREGATION = Sum.create();
+  private static final Cumulative CUMULATIVE = Cumulative.create();
+  private static final Duration TEN_SECONDS = Duration.create(10, 0);
+  private static final Interval INTERVAL = Interval.create(TEN_SECONDS);
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void noopViewManager_RegisterView_DisallowRegisteringDifferentViewWithSameName() {
+    final View view1 =
+        View.create(
+            VIEW_NAME, "description 1", MEASURE, AGGREGATION, Arrays.asList(KEY), CUMULATIVE);
+    final View view2 =
+        View.create(
+            VIEW_NAME, "description 2", MEASURE, AGGREGATION, Arrays.asList(KEY), CUMULATIVE);
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+    viewManager.registerView(view1);
+
+    try {
+      thrown.expect(IllegalArgumentException.class);
+      thrown.expectMessage("A different view with the same name already exists.");
+      viewManager.registerView(view2);
+    } finally {
+      // TODO(sebright): Test getting the view with a method that gets a view by name, once we
+      // support that.
+      assertThat(viewManager.getView(view2).getView()).isEqualTo(view1);
+    }
+  }
+
+  @Test
+  public void noopViewManager_RegisterView_AllowRegisteringSameViewTwice() {
+    View view =
+        View.create(
+            VIEW_NAME, VIEW_DESCRIPTION, MEASURE, AGGREGATION, Arrays.asList(KEY), CUMULATIVE);
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+    viewManager.registerView(view);
+    viewManager.registerView(view);
+  }
+
+  @Test
+  public void noopViewManager_RegisterView_DisallowNull() {
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+    thrown.expect(NullPointerException.class);
+    viewManager.registerView(null);
+  }
+
+  @Test
+  public void noopViewManager_GetView_DisallowGettingNonExistentView() {
+    View view =
+        View.create(
+            VIEW_NAME, VIEW_DESCRIPTION, MEASURE, AGGREGATION, Arrays.asList(KEY), CUMULATIVE);
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("View is not registered.");
+    viewManager.getView(view);
+  }
+
+  @Test
+  public void noopViewManager_GetView_Cumulative() {
+    View view =
+        View.create(
+            VIEW_NAME, VIEW_DESCRIPTION, MEASURE, AGGREGATION, Arrays.asList(KEY), CUMULATIVE);
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+    viewManager.registerView(view);
+
+    ViewData viewData = viewManager.getView(view);
+    assertThat(viewData.getView()).isEqualTo(view);
+    assertThat(viewData.getAggregationMap()).isEmpty();
+    assertThat(viewData.getWindowData())
+        .isEqualTo(CumulativeData.create(Timestamp.create(0, 0), Timestamp.create(0, 0)));
+  }
+
+  @Test
+  public void noopViewManager_GetView_Interval() {
+    View view =
+        View.create(
+            VIEW_NAME, VIEW_DESCRIPTION, MEASURE, AGGREGATION, Arrays.asList(KEY), INTERVAL);
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+    viewManager.registerView(view);
+
+    ViewData viewData = viewManager.getView(view);
+    assertThat(viewData.getView()).isEqualTo(view);
+    assertThat(viewData.getAggregationMap()).isEmpty();
+    assertThat(viewData.getWindowData()).isEqualTo(IntervalData.create(Timestamp.create(0, 0)));
+  }
+
+  @Test
+  public void noopViewManager_GetView_DisallowNull() {
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+    thrown.expect(NullPointerException.class);
+    viewManager.getView(null);
+  }
+}

--- a/core/src/test/java/io/opencensus/stats/StatsTest.java
+++ b/core/src/test/java/io/opencensus/stats/StatsTest.java
@@ -61,6 +61,6 @@ public final class StatsTest {
   @Test
   public void defaultValues() {
     assertThat(Stats.getStatsRecorder()).isEqualTo(NoopStats.getNoopStatsRecorder());
-    assertThat(Stats.getViewManager()).isNull();
+    assertThat(Stats.getViewManager()).isInstanceOf(NoopStats.newNoopViewManager().getClass());
   }
 }


### PR DESCRIPTION
NoopViewManager maintains a map of views so that it can return empty ViewDatas
from getView.  It also prevents different views with the same name from being
registered.