### PR TITLE
Change ViewManager.getView to take a View.Name instead of a View.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/core/src/main/java/io/opencensus/stats/NoopStats.java
@@ -116,18 +116,17 @@ final class NoopStats {
     }
 
     @Override
-    public ViewData getView(View view) {
-      checkNotNull(view, "view");
+    public ViewData getView(View.Name name) {
+      checkNotNull(name, "name");
       synchronized (views) {
-        View existing = views.get(view.getName());
-        if (existing == null) {
+        View view = views.get(name);
+        if (view == null) {
           throw new IllegalArgumentException("View is not registered.");
         } else {
           return ViewData.create(
-              existing,
+              view,
               Collections.<List<TagValue>, AggregationData>emptyMap(),
-              existing
-                  .getWindow()
+              view.getWindow()
                   .match(
                       Functions.<AggregationWindowData>returnConstant(
                           CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP)),

--- a/core/src/main/java/io/opencensus/stats/ViewManager.java
+++ b/core/src/main/java/io/opencensus/stats/ViewManager.java
@@ -23,13 +23,12 @@ package io.opencensus.stats;
 public abstract class ViewManager {
   /**
    * Pull model for stats. Registers a {@link View} that will collect data to be accessed
-   * via {@link #getView(View)}.
+   * via {@link #getView(View.Name)}.
    */
   public abstract void registerView(View view);
 
   /**
-   * Returns the current stats data, {@link ViewData}, associated with the given
-   * {@link View}.
+   * Returns the current stats data, {@link ViewData}, associated with the given view name.
    */
-  public abstract ViewData getView(View view);
+  public abstract ViewData getView(View.Name view);
 }

--- a/core/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
+++ b/core/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
@@ -66,9 +66,7 @@ public final class NoopViewManagerTest {
       thrown.expectMessage("A different view with the same name already exists.");
       viewManager.registerView(view2);
     } finally {
-      // TODO(sebright): Test getting the view with a method that gets a view by name, once we
-      // support that.
-      assertThat(viewManager.getView(view2).getView()).isEqualTo(view1);
+      assertThat(viewManager.getView(VIEW_NAME).getView()).isEqualTo(view1);
     }
   }
 
@@ -91,14 +89,11 @@ public final class NoopViewManagerTest {
 
   @Test
   public void noopViewManager_GetView_DisallowGettingNonExistentView() {
-    View view =
-        View.create(
-            VIEW_NAME, VIEW_DESCRIPTION, MEASURE, AGGREGATION, Arrays.asList(KEY), CUMULATIVE);
     ViewManager viewManager = NoopStats.newNoopViewManager();
 
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("View is not registered.");
-    viewManager.getView(view);
+    viewManager.getView(VIEW_NAME);
   }
 
   @Test
@@ -109,7 +104,7 @@ public final class NoopViewManagerTest {
     ViewManager viewManager = NoopStats.newNoopViewManager();
     viewManager.registerView(view);
 
-    ViewData viewData = viewManager.getView(view);
+    ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
     assertThat(viewData.getWindowData())
@@ -124,7 +119,7 @@ public final class NoopViewManagerTest {
     ViewManager viewManager = NoopStats.newNoopViewManager();
     viewManager.registerView(view);
 
-    ViewData viewData = viewManager.getView(view);
+    ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
     assertThat(viewData.getWindowData()).isEqualTo(IntervalData.create(Timestamp.create(0, 0)));

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
@@ -33,14 +33,8 @@ public final class ViewManagerImpl extends ViewManager {
     statsManager.registerView(view);
   }
 
-  // TODO(sebright): Expose this method.
-  ViewData getView(View.Name viewName) {
-    return statsManager.getView(viewName);
-  }
-
-  // TODO(sebright): Replace this method with the View.Name version.
   @Override
-  public ViewData getView(View view) {
-    return statsManager.getView(view.getName());
+  public ViewData getView(View.Name viewName) {
+    return statsManager.getView(viewName);
   }
 }


### PR DESCRIPTION
Only one view can be registered per name, so only the name is needed to
unambiguously look up a registered view.

One benefit of this change is that users don't need to provide as much data.
This difference could be important when clients query views over the network.
Another benefit is that it eliminates the possibility that the input View's
non-name fields don't match the registered view.  One way to handle that case in
getView(View) is to check that the other fields match.  However, that is more
expensive than only looking up the name.