### PR TITLE
Clean up io.opencensus.internal.StringUtil.

### DIFF
--- a/api/src/main/java/io/opencensus/internal/StringUtil.java
+++ b/api/src/main/java/io/opencensus/internal/StringUtil.java
@@ -19,33 +19,6 @@ package io.opencensus.internal;
 /** Internal utility methods for working with tag keys, tag values, and metric names. */
 public final class StringUtil {
 
-  public static final int MAX_LENGTH = 255;
-  public static final char UNPRINTABLE_CHAR_SUBSTITUTE = '_';
-
-  /**
-   * Transforms the given {@code String} into a valid tag key, tag value, or metric name. This
-   * method replaces non-printable characters with underscores and truncates to {@link
-   * StringUtil#MAX_LENGTH}.
-   *
-   * @param str the {@code String} to be sanitized.
-   * @return the {@code String} with all non-printable characters replaced by underscores, truncated
-   *     to {@code MAX_LENGTH}.
-   */
-  public static String sanitize(String str) {
-    if (str.length() > MAX_LENGTH) {
-      str = str.substring(0, MAX_LENGTH);
-    }
-    if (isPrintableString(str)) {
-      return str;
-    }
-    StringBuilder builder = new StringBuilder(str.length());
-    for (int i = 0; i < str.length(); i++) {
-      char ch = str.charAt(i);
-      builder.append(isPrintableChar(ch) ? ch : UNPRINTABLE_CHAR_SUBSTITUTE);
-    }
-    return builder.toString();
-  }
-
   /**
    * Determines whether the {@code String} contains only printable characters.
    *
@@ -65,8 +38,5 @@ public final class StringUtil {
     return ch >= ' ' && ch <= '~';
   }
 
-  // Visible for testing
-  StringUtil() {
-    throw new AssertionError();
-  }
+  private StringUtil() {}
 }

--- a/api/src/test/java/io/opencensus/internal/StringUtilTest.java
+++ b/api/src/test/java/io/opencensus/internal/StringUtilTest.java
@@ -16,9 +16,9 @@
 
 package io.opencensus.internal;
 
-import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,23 +26,10 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link StringUtil}. */
 @RunWith(JUnit4.class)
 public final class StringUtilTest {
-  @Test
-  public void testMaxLength() {
-    char[] string = new char[StringUtil.MAX_LENGTH];
-    char[] truncString = new char[StringUtil.MAX_LENGTH + 10];
-    Arrays.fill(string, 'v');
-    Arrays.fill(truncString, 'v');
-    assertThat(StringUtil.sanitize(new String(truncString))).isEqualTo(new String(string));
-  }
 
   @Test
-  public void testBadChar() {
-    String string = "\2ab\3cd";
-    assertThat(StringUtil.sanitize(string)).isEqualTo("_ab_cd");
-  }
-
-  @Test(expected = AssertionError.class)
-  public void testConstructor() {
-    new StringUtil();
+  public void isPrintableString() {
+    assertTrue(StringUtil.isPrintableString("abcd"));
+    assertFalse(StringUtil.isPrintableString("\2ab\3cd"));
   }
 }


### PR DESCRIPTION
We don't need StringUtil.sanitize, since we no longer sanitize tags.
Additionally, we don't need to throw an AssertionError from the constructor to
discourage instantiation of the class, because the class is now in the internal
package.

_________________________________________________________________

@songy23 Do you think we can remove these constants and methods now?