### PR TITLE
Implement Tags.getState and Tags.setState (part of #608).

### DIFF
--- a/core_impl/src/main/java/io/opencensus/implcore/tags/CurrentTaggingState.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/CurrentTaggingState.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.tags;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.opencensus.tags.TaggingState;
+import io.opencensus.tags.TagsComponent;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * The current {@link TaggingState} for a {@link TagsComponent}.
+ *
+ * <p>This class allows different tagging classes to share the state in a thread-safe way.
+ */
+@ThreadSafe
+public final class CurrentTaggingState {
+  private volatile TaggingState currentState = TaggingState.ENABLED;
+
+  public TaggingState get() {
+    return currentState;
+  }
+
+  void set(TaggingState state) {
+    currentState = checkNotNull(state, "state");
+  }
+}

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/NoopTagContextBuilder.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/NoopTagContextBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.tags;
+
+import io.opencensus.common.Scope;
+import io.opencensus.internal.NoopScope;
+import io.opencensus.tags.TagContext;
+import io.opencensus.tags.TagContextBuilder;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagKey.TagKeyBoolean;
+import io.opencensus.tags.TagKey.TagKeyLong;
+import io.opencensus.tags.TagKey.TagKeyString;
+import io.opencensus.tags.TagValue.TagValueBoolean;
+import io.opencensus.tags.TagValue.TagValueLong;
+import io.opencensus.tags.TagValue.TagValueString;
+
+/** {@link TagContextBuilder} that is used when tagging is disabled. */
+final class NoopTagContextBuilder extends TagContextBuilder {
+  static final NoopTagContextBuilder INSTANCE = new NoopTagContextBuilder();
+
+  private NoopTagContextBuilder() {}
+
+  @Override
+  public TagContextBuilder put(TagKeyString key, TagValueString value) {
+    return this;
+  }
+
+  @Override
+  public TagContextBuilder put(TagKeyLong key, TagValueLong value) {
+    return this;
+  }
+
+  @Override
+  public TagContextBuilder put(TagKeyBoolean key, TagValueBoolean value) {
+    return this;
+  }
+
+  @Override
+  public TagContextBuilder remove(TagKey key) {
+    return this;
+  }
+
+  @Override
+  public TagContext build() {
+    return TagContextImpl.EMPTY;
+  }
+
+  @Override
+  public Scope buildScoped() {
+    return NoopScope.getInstance();
+  }
+}

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
@@ -41,7 +41,8 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public final class TagContextImpl extends TagContext {
 
-  static final TagContextImpl EMPTY = new TagContextImpl(Collections.<TagKey, TagValue>emptyMap());
+  public static final TagContextImpl EMPTY =
+      new TagContextImpl(Collections.<TagKey, TagValue>emptyMap());
 
   // The types of the TagKey and value must match for each entry.
   private final Map<TagKey, TagValue> tags;

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
@@ -25,7 +25,6 @@ import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.TaggingState;
 import java.util.Iterator;
-import java.util.concurrent.atomic.AtomicReference;
 
 public final class TaggerImpl extends Tagger {
   // All methods in this class use TagContextImpl and TagContextBuilderImpl. For example,
@@ -35,9 +34,9 @@ public final class TaggerImpl extends Tagger {
   // TODO(sebright): Consider treating an unknown TagContext as empty.  That would allow us to
   // remove TagContext.unsafeGetIterator().
 
-  private final AtomicReference<TaggingState> state;
+  private final CurrentTaggingState state;
 
-  TaggerImpl(AtomicReference<TaggingState> state) {
+  TaggerImpl(CurrentTaggingState state) {
     this.state = state;
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -23,12 +23,13 @@ import io.opencensus.tags.Tagger;
 import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagPropagationComponent;
-import java.util.concurrent.atomic.AtomicReference;
 
 /** Base implementation of {@link TagsComponent}. */
 public class TagsComponentImplBase extends TagsComponent {
-  private final AtomicReference<TaggingState> state =
-      new AtomicReference<TaggingState>(TaggingState.ENABLED);
+
+  // The TaggingState shared between the TagsComponent, Tagger, and TagPropagationComponent
+  private final CurrentTaggingState state = new CurrentTaggingState();
+
   private final Tagger tagger = new TaggerImpl(state);
   private final TagPropagationComponent tagPropagationComponent =
       new TagPropagationComponentImpl(state);

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -29,8 +29,9 @@ import java.util.concurrent.atomic.AtomicReference;
 public class TagsComponentImplBase extends TagsComponent {
   private final AtomicReference<TaggingState> state =
       new AtomicReference<TaggingState>(TaggingState.ENABLED);
-  private final Tagger tagger = new TaggerImpl();
-  private final TagPropagationComponent tagPropagationComponent = new TagPropagationComponentImpl();
+  private final Tagger tagger = new TaggerImpl(state);
+  private final TagPropagationComponent tagPropagationComponent =
+      new TagPropagationComponentImpl(state);
 
   @Override
   public Tagger getTagger() {
@@ -50,6 +51,5 @@ public class TagsComponentImplBase extends TagsComponent {
   @Override
   public void setState(TaggingState newState) {
     state.set(checkNotNull(newState, "newState"));
-    // TODO(sebright): Avoid setting tags when tagging is disabled.
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
@@ -16,19 +16,19 @@
 
 package io.opencensus.implcore.tags.propagation;
 
+import io.opencensus.implcore.tags.CurrentTaggingState;
 import io.opencensus.implcore.tags.TagContextImpl;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagContextParseException;
-import java.util.concurrent.atomic.AtomicReference;
 
 final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   private static final byte[] EMPTY_BYTE_ARRAY = {};
 
-  private final AtomicReference<TaggingState> state;
+  private final CurrentTaggingState state;
 
-  TagContextBinarySerializerImpl(AtomicReference<TaggingState> state) {
+  TagContextBinarySerializerImpl(CurrentTaggingState state) {
     this.state = state;
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagPropagationComponentImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagPropagationComponentImpl.java
@@ -16,12 +16,17 @@
 
 package io.opencensus.implcore.tags.propagation;
 
+import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagPropagationComponent;
+import java.util.concurrent.atomic.AtomicReference;
 
 public final class TagPropagationComponentImpl extends TagPropagationComponent {
-  private final TagContextBinarySerializer tagContextBinarySerializer =
-      new TagContextBinarySerializerImpl();
+  private final TagContextBinarySerializer tagContextBinarySerializer;
+
+  public TagPropagationComponentImpl(AtomicReference<TaggingState> state) {
+    tagContextBinarySerializer = new TagContextBinarySerializerImpl(state);
+  }
 
   @Override
   public TagContextBinarySerializer getBinarySerializer() {

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagPropagationComponentImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagPropagationComponentImpl.java
@@ -16,15 +16,14 @@
 
 package io.opencensus.implcore.tags.propagation;
 
-import io.opencensus.tags.TaggingState;
+import io.opencensus.implcore.tags.CurrentTaggingState;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagPropagationComponent;
-import java.util.concurrent.atomic.AtomicReference;
 
 public final class TagPropagationComponentImpl extends TagPropagationComponent {
   private final TagContextBinarySerializer tagContextBinarySerializer;
 
-  public TagPropagationComponentImpl(AtomicReference<TaggingState> state) {
+  public TagPropagationComponentImpl(CurrentTaggingState state) {
     tagContextBinarySerializer = new TagContextBinarySerializerImpl(state);
   }
 

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -24,7 +24,7 @@ import com.google.common.collect.ImmutableMap;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Timestamp;
 import io.opencensus.implcore.internal.SimpleEventQueue;
-import io.opencensus.implcore.tags.TaggerImpl;
+import io.opencensus.implcore.tags.TagsComponentImplBase;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.Aggregation.Mean;
@@ -49,6 +49,7 @@ import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.TagsComponent;
 import io.opencensus.testing.common.TestClock;
 import java.util.Arrays;
 import java.util.Collections;
@@ -108,8 +109,9 @@ public class ViewManagerImplTest {
 
   private final StatsComponentImplBase statsComponent =
       new StatsComponentImplBase(new SimpleEventQueue(), clock);
+  private final TagsComponent tagsComponent = new TagsComponentImplBase();
 
-  private final Tagger tagger = new TaggerImpl();
+  private final Tagger tagger = tagsComponent.getTagger();
   private final ViewManagerImpl viewManager = statsComponent.getViewManager();
   private final StatsRecorderImpl statsRecorder = statsComponent.getStatsRecorder();
 

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/CurrentTaggingStateTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/CurrentTaggingStateTest.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.tags;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.tags.TaggingState;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link CurrentTaggingState}. */
+@RunWith(JUnit4.class)
+public final class CurrentTaggingStateTest {
+
+  @Test
+  public void defaultState() {
+    assertThat(new CurrentTaggingState().get()).isEqualTo(TaggingState.ENABLED);
+  }
+
+  @Test
+  public void setState() {
+    CurrentTaggingState state = new CurrentTaggingState();
+    state.set(TaggingState.DISABLED);
+    assertThat(state.get()).isEqualTo(TaggingState.DISABLED);
+    state.set(TaggingState.ENABLED);
+    assertThat(state.get()).isEqualTo(TaggingState.ENABLED);
+  }
+}

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/ScopedTagContextsTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/ScopedTagContextsTest.java
@@ -25,6 +25,8 @@ import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.TaggingState;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -41,7 +43,8 @@ public class ScopedTagContextsTest {
   private static final TagValueString VALUE_1 = TagValueString.create("value 1");
   private static final TagValueString VALUE_2 = TagValueString.create("value 2");
 
-  private final Tagger tagger = new TaggerImpl();
+  private final Tagger tagger =
+      new TaggerImpl(new AtomicReference<TaggingState>(TaggingState.ENABLED));
 
   @Test
   public void defaultTagContext() {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/ScopedTagContextsTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/ScopedTagContextsTest.java
@@ -25,8 +25,6 @@ import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
-import io.opencensus.tags.TaggingState;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -43,8 +41,7 @@ public class ScopedTagContextsTest {
   private static final TagValueString VALUE_1 = TagValueString.create("value 1");
   private static final TagValueString VALUE_2 = TagValueString.create("value 2");
 
-  private final Tagger tagger =
-      new TaggerImpl(new AtomicReference<TaggingState>(TaggingState.ENABLED));
+  private final Tagger tagger = new TaggerImpl(new CurrentTaggingState());
 
   @Test
   public void defaultTagContext() {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
@@ -36,12 +36,10 @@ import io.opencensus.tags.TagValue.TagValueBoolean;
 import io.opencensus.tags.TagValue.TagValueLong;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
-import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.UnreleasedApiAccessor;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
-import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -52,8 +50,7 @@ import org.junit.runners.JUnit4;
 // TODO(sebright): Add more tests once the API is finalized.
 @RunWith(JUnit4.class)
 public class TagContextImplTest {
-  private final Tagger tagger =
-      new TaggerImpl(new AtomicReference<TaggingState>(TaggingState.ENABLED));
+  private final Tagger tagger = new TaggerImpl(new CurrentTaggingState());
 
   private static final TagKeyString KS1 = TagKeyString.create("k1");
   private static final TagKeyString KS2 = TagKeyString.create("k2");

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TagContextImplTest.java
@@ -36,10 +36,12 @@ import io.opencensus.tags.TagValue.TagValueBoolean;
 import io.opencensus.tags.TagValue.TagValueLong;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.UnreleasedApiAccessor;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -50,7 +52,8 @@ import org.junit.runners.JUnit4;
 // TODO(sebright): Add more tests once the API is finalized.
 @RunWith(JUnit4.class)
 public class TagContextImplTest {
-  private final Tagger tagger = new TaggerImpl();
+  private final Tagger tagger =
+      new TaggerImpl(new AtomicReference<TaggingState>(TaggingState.ENABLED));
 
   private static final TagKeyString KS1 = TagKeyString.create("k1");
   private static final TagKeyString KS2 = TagKeyString.create("k2");

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImplTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.tags.propagation;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import io.opencensus.implcore.tags.TagsComponentImplBase;
+import io.opencensus.implcore.tags.TagsTestUtil;
+import io.opencensus.tags.Tag;
+import io.opencensus.tags.Tag.TagString;
+import io.opencensus.tags.TagContext;
+import io.opencensus.tags.TagKey.TagKeyString;
+import io.opencensus.tags.TagValue.TagValueString;
+import io.opencensus.tags.TaggingState;
+import io.opencensus.tags.TagsComponent;
+import io.opencensus.tags.propagation.TagContextBinarySerializer;
+import io.opencensus.tags.propagation.TagContextParseException;
+import java.util.Iterator;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link TagContextBinarySerializerImpl}.
+ *
+ * <p>Thorough serialization/deserialization tests are in {@link TagContextSerializationTest},
+ * {@link TagContextDeserializationTest}, and {@link TagContextRoundtripTest}.
+ */
+@RunWith(JUnit4.class)
+public final class TagContextBinarySerializerImplTest {
+  private final TagsComponent tagsComponent = new TagsComponentImplBase();
+  private final TagContextBinarySerializer serializer =
+      tagsComponent.getTagPropagationComponent().getBinarySerializer();
+
+  private final TagContext tagContext =
+      new TagContext() {
+        @Override
+        public Iterator<Tag> getIterator() {
+          return ImmutableSet.<Tag>of(
+                  TagString.create(TagKeyString.create("key"), TagValueString.create("value")))
+              .iterator();
+        }
+      };
+
+  @Test
+  public void toByteArray_TaggingDisabled() {
+    tagsComponent.setState(TaggingState.DISABLED);
+    assertThat(serializer.toByteArray(tagContext)).isEmpty();
+  }
+
+  @Test
+  public void toByteArray_TaggingReenabled() {
+    final byte[] serialized = serializer.toByteArray(tagContext);
+    tagsComponent.setState(TaggingState.DISABLED);
+    assertThat(serializer.toByteArray(tagContext)).isEmpty();
+    tagsComponent.setState(TaggingState.ENABLED);
+    assertThat(serializer.toByteArray(tagContext)).isEqualTo(serialized);
+  }
+
+  @Test
+  public void fromByteArray_TaggingDisabled() throws TagContextParseException {
+    byte[] serialized = serializer.toByteArray(tagContext);
+    tagsComponent.setState(TaggingState.DISABLED);
+    assertThat(TagsTestUtil.tagContextToList(serializer.fromByteArray(serialized))).isEmpty();
+  }
+
+  @Test
+  public void fromByteArray_TaggingReenabled() throws TagContextParseException {
+    byte[] serialized = serializer.toByteArray(tagContext);
+    tagsComponent.setState(TaggingState.DISABLED);
+    assertThat(TagsTestUtil.tagContextToList(serializer.fromByteArray(serialized))).isEmpty();
+    tagsComponent.setState(TaggingState.ENABLED);
+    assertThat(serializer.fromByteArray(serialized)).isEqualTo(tagContext);
+  }
+}

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
@@ -19,11 +19,12 @@ package io.opencensus.implcore.tags.propagation;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.implcore.internal.VarInt;
-import io.opencensus.implcore.tags.TaggerImpl;
+import io.opencensus.implcore.tags.TagsComponentImplBase;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagContextParseException;
 import java.io.ByteArrayOutputStream;
@@ -47,8 +48,10 @@ public class TagContextDeserializationTest {
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
-  private final TagContextBinarySerializer serializer = new TagContextBinarySerializerImpl();
-  private final Tagger tagger = new TaggerImpl();
+  private final TagsComponent tagsComponent = new TagsComponentImplBase();
+  private final TagContextBinarySerializer serializer =
+      tagsComponent.getTagPropagationComponent().getBinarySerializer();
+  private final Tagger tagger = tagsComponent.getTagger();
 
   @Test
   public void testVersionAndValueTypeConstants() {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
@@ -18,11 +18,12 @@ package io.opencensus.implcore.tags.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opencensus.implcore.tags.TaggerImpl;
+import io.opencensus.implcore.tags.TagsComponentImplBase;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -42,8 +43,10 @@ public class TagContextRoundtripTest {
   private static final TagValueString V2 = TagValueString.create("v2");
   private static final TagValueString V3 = TagValueString.create("v3");
 
-  private final TagContextBinarySerializer serializer = new TagContextBinarySerializerImpl();
-  private final Tagger tagger = new TaggerImpl();
+  private final TagsComponent tagsComponent = new TagsComponentImplBase();
+  private final TagContextBinarySerializer serializer =
+      tagsComponent.getTagPropagationComponent().getBinarySerializer();
+  private final Tagger tagger = tagsComponent.getTagger();
 
   @Test
   public void testRoundtripSerialization() throws Exception {

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
@@ -21,12 +21,13 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.base.Charsets;
 import com.google.common.collect.Collections2;
 import io.opencensus.implcore.internal.VarInt;
-import io.opencensus.implcore.tags.TaggerImpl;
+import io.opencensus.implcore.tags.TagsComponentImplBase;
 import io.opencensus.tags.Tag.TagString;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey.TagKeyString;
 import io.opencensus.tags.TagValue.TagValueString;
 import io.opencensus.tags.Tagger;
+import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -64,8 +65,10 @@ public class TagContextSerializationTest {
   private static final TagString T3 = TagString.create(K3, V3);
   private static final TagString T4 = TagString.create(K4, V4);
 
-  private final TagContextBinarySerializer serializer = new TagContextBinarySerializerImpl();
-  private final Tagger tagger = new TaggerImpl();
+  private final TagsComponent tagsComponent = new TagsComponentImplBase();
+  private final TagContextBinarySerializer serializer =
+      tagsComponent.getTagPropagationComponent().getBinarySerializer();
+  private final Tagger tagger = tagsComponent.getTagger();
 
   @Test
   public void testSerializeDefault() throws Exception {


### PR DESCRIPTION
Disabling tagging does not disable stats collection, so disabling tagging could
cause stats to be recorded with empty or out-of-date tags.

/cc @adriancole 