### PR TITLE
Remove out of date TODO.

### DIFF
--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
@@ -28,9 +28,6 @@ public final class TaggerImpl extends Tagger {
   // All methods in this class use TagContextImpl and TagContextBuilderImpl. For example,
   // withTagContext(...) always puts a TagContextImpl into scope, even if the argument is another
   // TagContext subclass.
-  //
-  // TODO(sebright): Consider treating an unknown TagContext as empty.  That would allow us to
-  // remove TagContext.unsafeGetIterator().
 
   @Override
   public TagContextImpl empty() {


### PR DESCRIPTION
#658 moved the TagContext iterator method to an internal class.