### PR TITLE
Add a separate case for OS X to .travis.yml (fixes #691).

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,22 +48,37 @@ script:
   # "./gradlew classes testClasses" is a workaround for
   # https://github.com/gradle/gradle/issues/2421.
   # See https://github.com/gradle/gradle/issues/2421#issuecomment-319916874.
+
+  # OS X is a separate case, because the JDK version is determined by the OS X image:
+  # https://docs.travis-ci.com/user/reference/osx/#JDK-and-OS-X
   - case "$TASK" in
       "CHECK_GIT_HISTORY")
         python check-git-history.py ;;
       "BUILD")
-        export JAVA8_HOME="$(jdk_switcher home oraclejdk8)" ;
-        case "$TRAVIS_JDK_VERSION" in
-          "oraclejdk8")
-            export JAVA_HOMES="$(jdk_switcher home openjdk6)/jre:$(jdk_switcher home openjdk7)/jre:$(jdk_switcher home oraclejdk8)/jre:$(jdk_switcher home oraclejdk9)" ;
-            ./gradlew clean assemble --stacktrace ;
-            ./gradlew check :opencensus-all:jacocoTestReport ;;
-          "openjdk7")
-            jdk_switcher use oraclejdk8 ;
-            ./gradlew classes testClasses ;
-            jdk_switcher use openjdk7 ;
+        case "$TRAVIS_OS_NAME" in
+          "linux")
+            export JAVA8_HOME="$(jdk_switcher home oraclejdk8)" ;
+            case "$TRAVIS_JDK_VERSION" in
+              "oraclejdk8")
+                export JAVA_HOMES="$(jdk_switcher home openjdk6)/jre:$(jdk_switcher home openjdk7)/jre:$(jdk_switcher home oraclejdk8)/jre:$(jdk_switcher home oraclejdk9)" ;
+                ./gradlew clean assemble --stacktrace ;
+                ./gradlew check :opencensus-all:jacocoTestReport ;;
+              "openjdk7")
+                jdk_switcher use oraclejdk8 ;
+                ./gradlew classes testClasses ;
+                jdk_switcher use openjdk7 ;
+                ./gradlew clean assemble --stacktrace ;
+                ./gradlew check ;;
+              *)
+                echo "Unknown JDK version $TRAVIS_JDK_VERSION" ;
+                exit 1 ;;
+            esac ;;
+          "osx")
             ./gradlew clean assemble --stacktrace ;
             ./gradlew check ;;
+          *)
+            echo "Unknown OS name $TRAVIS_OS_NAME" ;
+            exit 1 ;;
         esac ;;
       *)
         echo "Unknown task $TASK" ;


### PR DESCRIPTION
This commit fixes a bug where TRAVIS_JDK_VERSION didn't match any cases on OS X,
because it wasn't set.  It probably wasn't set because the OS X image determines
the Java version, and the "jdk" field is ignored
(https://docs.travis-ci.com/user/reference/osx/#JDK-and-OS-X).

The OS X case avoids using jdk_switcher, because it isn't available on OS X.

This commit also adds a default case to fail the build when there is an unknown
OS or JDK.  The default case would have prevented the silent failure in #691.