### PR TITLE
 Remove dependency between i.o.implcore.tags and i.o.internal.

### DIFF
--- a/core_impl/src/main/java/io/opencensus/implcore/tags/NoopTagContextBuilder.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/NoopTagContextBuilder.java
@@ -17,7 +17,7 @@
 package io.opencensus.implcore.tags;
 
 import io.opencensus.common.Scope;
-import io.opencensus.internal.NoopScope;
+import io.opencensus.implcore.internal.NoopScope;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey;

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
@@ -17,7 +17,7 @@
 package io.opencensus.implcore.tags;
 
 import io.opencensus.common.Scope;
-import io.opencensus.internal.NoopScope;
+import io.opencensus.implcore.internal.NoopScope;
 import io.opencensus.tags.InternalUtils;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/TaggerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/TaggerImplTest.java
@@ -22,6 +22,7 @@ import static io.opencensus.implcore.tags.TagsTestUtil.tagContextToList;
 import com.google.common.collect.Lists;
 import io.grpc.Context;
 import io.opencensus.common.Scope;
+import io.opencensus.implcore.internal.NoopScope;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.Tag.TagBoolean;
 import io.opencensus.tags.Tag.TagLong;
@@ -280,6 +281,12 @@ public class TaggerImplTest {
     TagContext tagContextWithNullTag = new SimpleTagContext(TAG1, null, TAG2);
     TagContext result = getResultOfWithTagContext(tagContextWithNullTag);
     assertThat(tagContextToList(result)).containsExactly(TAG1, TAG2);
+  }
+
+  @Test
+  public void withTagContext_ReturnsNoopScopeWhenTaggingIsDisabled() {
+    tagsComponent.setState(TaggingState.DISABLED);
+    assertThat(tagger.withTagContext(new SimpleTagContext(TAG1))).isSameAs(NoopScope.getInstance());
   }
 
   @Test

--- a/impl_core/src/main/java/io/opencensus/implcore/internal/NoopScope.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/NoopScope.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.internal;
+
+import io.opencensus.common.Scope;
+
+/**
+ * A {@link Scope} that does nothing when it is created or closed.
+ */
+public final class NoopScope implements Scope {
+  private static final Scope INSTANCE = new NoopScope();
+
+  private NoopScope() {}
+
+  /**
+   * Returns a {@code NoopScope}.
+   *
+   * @return a {@code NoopScope}.
+   */
+  public static Scope getInstance() {
+    return INSTANCE;
+  }
+
+  @Override
+  public void close() {}
+}


### PR DESCRIPTION
The tagging implementation was using NoopScope from the API library, even though
it was in an "internal" package.  This commit adds a NoopScope class to
io.opencensus.implcore.internal.

______________________________________

It would be nice if we could check for access to internal packages in CI, but I'm not sure how.
