### PR TITLE
Change Measurement value fields to primitive double and long.

### DIFF
--- a/core/src/main/java/io/opencensus/stats/Measurement.java
+++ b/core/src/main/java/io/opencensus/stats/Measurement.java
@@ -59,7 +59,7 @@ public abstract class Measurement {
     @Override
     public abstract MeasureDouble getMeasure();
 
-    public abstract Double getValue();
+    public abstract double getValue();
 
     @Override
     public <T> T match(
@@ -86,7 +86,7 @@ public abstract class Measurement {
     @Override
     public abstract MeasureLong getMeasure();
 
-    public abstract Long getValue();
+    public abstract long getValue();
 
     @Override
     public <T> T match(


### PR DESCRIPTION
The values are set as primitives, so this change avoids unnecessary boxing.

/cc @dinooliva 