### PR TITLE
TagContext serialization test cleanup

### DIFF
--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
@@ -68,14 +68,14 @@ public class TagContextDeserializationTest {
   public void testDeserializeNoTags() throws TagContextParseException {
     TagContext expected = tagger.empty();
     TagContext actual =
-        testDeserialize(
+        serializer.fromByteArray(
             new byte[] {SerializationUtils.VERSION_ID}); // One byte that represents Version ID.
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeEmptyByteArrayThrowException() throws TagContextParseException {
-    testDeserialize(new byte[0]);
+    serializer.fromByteArray(new byte[0]);
   }
 
   @Test
@@ -113,7 +113,8 @@ public class TagContextDeserializationTest {
   @Test
   public void testDeserializeValueTypeString() throws TagContextParseException {
     TagContext actual =
-        testDeserialize(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_STRING));
+        serializer.fromByteArray(
+            constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_STRING));
     TagContext expected =
         tagger
             .emptyBuilder()
@@ -132,7 +133,7 @@ public class TagContextDeserializationTest {
     output.write(SerializationUtils.VALUE_TYPE_STRING);
     encodeString("Key2", output);
     encodeString("String2", output);
-    TagContext actual = testDeserialize(output.toByteArray());
+    TagContext actual = serializer.fromByteArray(output.toByteArray());
     TagContext expected =
         tagger
             .emptyBuilder()
@@ -147,40 +148,38 @@ public class TagContextDeserializationTest {
   @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeInteger() throws TagContextParseException {
     // TODO(songya): test should pass after we add support for type integer
-    testDeserialize(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_INTEGER));
+    serializer.fromByteArray(
+        constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_INTEGER));
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeTrue() throws TagContextParseException {
     // TODO(songya): test should pass after we add support for type boolean
-    testDeserialize(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_TRUE));
+    serializer.fromByteArray(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_TRUE));
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeFalse() throws TagContextParseException {
     // TODO(songya): test should pass after we add support for type boolean
-    testDeserialize(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_FALSE));
+    serializer.fromByteArray(
+        constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_FALSE));
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeMultipleValueType() throws TagContextParseException {
     // TODO(songya): test should pass after we add support for type integer and boolean
-    testDeserialize(constructMultiTypeTagInputStream());
+    serializer.fromByteArray(constructMultiTypeTagInputStream());
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeWrongFormat() throws TagContextParseException {
     // encoded tags should follow the format <version_id>(<tag_field_id><tag_encoding>)*
-    testDeserialize(new byte[3]);
+    serializer.fromByteArray(new byte[3]);
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeWrongVersionId() throws TagContextParseException {
-    testDeserialize(new byte[] {(byte) (SerializationUtils.VERSION_ID + 1)});
-  }
-
-  private TagContext testDeserialize(byte[] bytes) throws TagContextParseException {
-    return serializer.fromByteArray(bytes);
+    serializer.fromByteArray(new byte[] {(byte) (SerializationUtils.VERSION_ID + 1)});
   }
 
   /*

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
@@ -113,8 +113,7 @@ public class TagContextDeserializationTest {
   @Test
   public void testDeserializeValueTypeString() throws TagContextParseException {
     TagContext actual =
-        serializer.fromByteArray(
-            constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_STRING));
+        serializer.fromByteArray(constructSingleTypeTagBytes(SerializationUtils.VALUE_TYPE_STRING));
     TagContext expected =
         tagger
             .emptyBuilder()
@@ -129,7 +128,7 @@ public class TagContextDeserializationTest {
   public void testDeserializeMultipleString() throws TagContextParseException {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
-    encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_STRING, output);
+    encodeSingleTypeTagToOutput(SerializationUtils.VALUE_TYPE_STRING, output);
     output.write(SerializationUtils.VALUE_TYPE_STRING);
     encodeString("Key2", output);
     encodeString("String2", output);
@@ -148,27 +147,25 @@ public class TagContextDeserializationTest {
   @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeInteger() throws TagContextParseException {
     // TODO(songya): test should pass after we add support for type integer
-    serializer.fromByteArray(
-        constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_INTEGER));
+    serializer.fromByteArray(constructSingleTypeTagBytes(SerializationUtils.VALUE_TYPE_INTEGER));
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeTrue() throws TagContextParseException {
     // TODO(songya): test should pass after we add support for type boolean
-    serializer.fromByteArray(constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_TRUE));
+    serializer.fromByteArray(constructSingleTypeTagBytes(SerializationUtils.VALUE_TYPE_TRUE));
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeValueTypeFalse() throws TagContextParseException {
     // TODO(songya): test should pass after we add support for type boolean
-    serializer.fromByteArray(
-        constructSingleTypeTagInputStream(SerializationUtils.VALUE_TYPE_FALSE));
+    serializer.fromByteArray(constructSingleTypeTagBytes(SerializationUtils.VALUE_TYPE_FALSE));
   }
 
   @Test(expected = TagContextParseException.class)
   public void testDeserializeMultipleValueType() throws TagContextParseException {
     // TODO(songya): test should pass after we add support for type integer and boolean
-    serializer.fromByteArray(constructMultiTypeTagInputStream());
+    serializer.fromByteArray(constructMultiTypeTagBytes());
   }
 
   @Test(expected = TagContextParseException.class)
@@ -183,32 +180,32 @@ public class TagContextDeserializationTest {
   }
 
   /*
-   * Construct an InputStream with the given type of tag.
+   * Construct a byte[] with the given type of tag.
    * The input format is:
    *   <version_id><encoded_tags>, and <encoded_tags> == (<tag_field_id><tag_encoding>)*
    * TODO(songya): after supporting serialize integer and boolean,
    * remove this method and use StatsContext.serialize() instead.
    * Currently StatsContext.serialize() can only serialize strings.
    */
-  private static byte[] constructSingleTypeTagInputStream(int valueType) {
+  private static byte[] constructSingleTypeTagBytes(int valueType) {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
-    encodeSingleTypeTagToOutputStream(valueType, output);
+    encodeSingleTypeTagToOutput(valueType, output);
     return output.toByteArray();
   }
 
-  // Construct an InputStream with all 4 types of tags.
-  private static byte[] constructMultiTypeTagInputStream() {
+  // Construct a byte[] with all 4 types of tags.
+  private static byte[] constructMultiTypeTagBytes() {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
-    encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_STRING, output);
-    encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_INTEGER, output);
-    encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_TRUE, output);
-    encodeSingleTypeTagToOutputStream(SerializationUtils.VALUE_TYPE_FALSE, output);
+    encodeSingleTypeTagToOutput(SerializationUtils.VALUE_TYPE_STRING, output);
+    encodeSingleTypeTagToOutput(SerializationUtils.VALUE_TYPE_INTEGER, output);
+    encodeSingleTypeTagToOutput(SerializationUtils.VALUE_TYPE_TRUE, output);
+    encodeSingleTypeTagToOutput(SerializationUtils.VALUE_TYPE_FALSE, output);
     return output.toByteArray();
   }
 
-  private static void encodeSingleTypeTagToOutputStream(int valueType, ByteArrayDataOutput output) {
+  private static void encodeSingleTypeTagToOutput(int valueType, ByteArrayDataOutput output) {
     output.write(valueType);
 
     // encode <tag_key_len><tag_key>, tag key is a string "KEY" appended by the field id here.

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
@@ -18,6 +18,7 @@ package io.opencensus.implcore.tags.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.base.Charsets;
 import io.opencensus.implcore.internal.VarInt;
 import io.opencensus.implcore.tags.TagsComponentImplBase;
 import io.opencensus.tags.TagContext;
@@ -242,7 +243,7 @@ public class TagContextDeserializationTest {
   private static void encodeString(String input, ByteArrayOutputStream byteArrayOutputStream)
       throws IOException {
     VarInt.putVarInt(input.length(), byteArrayOutputStream);
-    byteArrayOutputStream.write(input.getBytes("UTF-8"));
+    byteArrayOutputStream.write(input.getBytes(Charsets.UTF_8));
   }
 
   //     <tag_encoding> (tag_field_id == 1) ==

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
@@ -112,6 +112,6 @@ public class TagContextSerializationTest {
   private static void encodeString(String input, ByteArrayOutputStream byteArrayOutputStream)
       throws IOException {
     VarInt.putVarInt(input.length(), byteArrayOutputStream);
-    byteArrayOutputStream.write(input.getBytes("UTF-8"));
+    byteArrayOutputStream.write(input.getBytes(Charsets.UTF_8));
   }
 }


### PR DESCRIPTION
#### Use Charsets.UTF_8 instead of "UTF-8" string in tests.

#### Use ByteArrayDataOutput in TagContextDeserializationTest to avoid IOException.

EDIT:
#### Call TagContextBinarySerializer.fromByteArray directly in deserialization test.