### PR TITLE
Add API for enabling/disabling stats collection (part of #608).

### DIFF
--- a/core/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/core/src/main/java/io/opencensus/stats/NoopStats.java
@@ -19,6 +19,7 @@ package io.opencensus.stats;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
@@ -80,6 +81,16 @@ final class NoopStats {
     @Override
     public StatsRecorder getStatsRecorder() {
       return getNoopStatsRecorder();
+    }
+
+    @Override
+    public StatsCollectionState getState() {
+      return StatsCollectionState.DISABLED;
+    }
+
+    @Override
+    public void setState(StatsCollectionState state) {
+      Preconditions.checkNotNull(state, "state");
     }
   }
 

--- a/core/src/main/java/io/opencensus/stats/Stats.java
+++ b/core/src/main/java/io/opencensus/stats/Stats.java
@@ -38,6 +38,29 @@ public final class Stats {
     return statsComponent.getViewManager();
   }
 
+  /**
+   * Returns the current {@code StatsCollectionState}.
+   *
+   * <p>When no implementation is available, {@code getState} always returns {@link
+   * StatsCollectionState#DISABLED}.
+   *
+   * @return the current {@code StatsCollectionState}.
+   */
+  public static StatsCollectionState getState() {
+    return statsComponent.getState();
+  }
+
+  /**
+   * Sets the current {@code StatsCollectionState}.
+   *
+   * <p>When no implementation is available, {@code setState} has no effect.
+   *
+   * @param state the new {@code StatsCollectionState}.
+   */
+  public static void setState(StatsCollectionState state) {
+    statsComponent.setState(state);
+  }
+
   // Any provider that may be used for StatsComponent can be added here.
   @VisibleForTesting
   static StatsComponent loadStatsComponent(ClassLoader classLoader) {

--- a/core/src/main/java/io/opencensus/stats/StatsCollectionState.java
+++ b/core/src/main/java/io/opencensus/stats/StatsCollectionState.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.stats;
+
+/** State of the {@link StatsComponent}. */
+public enum StatsCollectionState {
+
+  /**
+   * State that fully enables stats collection.
+   *
+   * <p>The {@link StatsComponent} collects stats for registered views.
+   */
+  ENABLED,
+
+  /**
+   * State that disables stats collection.
+   *
+   * <p>The {@link StatsComponent} does not need to collect stats for registered views and may
+   * return empty {@link ViewData}s from {@link ViewManager#getView(View.Name)}.
+   */
+  DISABLED
+}

--- a/core/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/core/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -28,4 +28,23 @@ public abstract class StatsComponent {
 
   /** Returns the default {@link StatsRecorder}. */
   public abstract StatsRecorder getStatsRecorder();
+
+  /**
+   * Returns the current {@code StatsCollectionState}.
+   *
+   * <p>When no implementation is available, {@code getState} always returns {@link
+   * StatsCollectionState#DISABLED}.
+   *
+   * @return the current {@code StatsCollectionState}.
+   */
+  public abstract StatsCollectionState getState();
+
+  /**
+   * Sets the current {@code StatsCollectionState}.
+   *
+   * <p>When no implementation is available, {@code setState} has no effect.
+   *
+   * @param state the new {@code StatsCollectionState}.
+   */
+  public abstract void setState(StatsCollectionState state);
 }

--- a/core/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/core/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -62,6 +62,26 @@ public final class NoopStatsTest {
         .isInstanceOf(NoopStats.newNoopViewManager().getClass());
   }
 
+  @Test
+  public void noopStatsComponent_GetState() {
+    assertThat(NoopStats.newNoopStatsComponent().getState())
+        .isEqualTo(StatsCollectionState.DISABLED);
+  }
+
+  @Test
+  public void noopStatsComponent_SetState_IgnoresInput() {
+    StatsComponent noopStatsComponent = NoopStats.newNoopStatsComponent();
+    noopStatsComponent.setState(StatsCollectionState.ENABLED);
+    assertThat(noopStatsComponent.getState()).isEqualTo(StatsCollectionState.DISABLED);
+  }
+
+  @Test
+  public void noopStatsComponent_SetState_DisallowsNull() {
+    StatsComponent noopStatsComponent = NoopStats.newNoopStatsComponent();
+    thrown.expect(NullPointerException.class);
+    noopStatsComponent.setState(null);
+  }
+
   // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
   // exception.
   @Test

--- a/core/src/test/java/io/opencensus/stats/StatsTest.java
+++ b/core/src/test/java/io/opencensus/stats/StatsTest.java
@@ -63,4 +63,20 @@ public final class StatsTest {
     assertThat(Stats.getStatsRecorder()).isEqualTo(NoopStats.getNoopStatsRecorder());
     assertThat(Stats.getViewManager()).isInstanceOf(NoopStats.newNoopViewManager().getClass());
   }
+
+  @Test
+  public void getState() {
+    assertThat(Stats.getState()).isEqualTo(StatsCollectionState.DISABLED);
+  }
+
+  @Test
+  public void setState_IgnoresInput() {
+    Stats.setState(StatsCollectionState.ENABLED);
+    assertThat(Stats.getState()).isEqualTo(StatsCollectionState.DISABLED);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void setState_DisallowsNull() {
+    Stats.setState(null);
+  }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -16,8 +16,10 @@
 
 package io.opencensus.implcore.stats;
 
+import com.google.common.base.Preconditions;
 import io.opencensus.common.Clock;
 import io.opencensus.implcore.internal.EventQueue;
+import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.StatsComponent;
 
 /** Base implementation of {@link StatsComponent}. */
@@ -25,6 +27,9 @@ public class StatsComponentImplBase extends StatsComponent {
 
   private final ViewManagerImpl viewManager;
   private final StatsRecorderImpl statsRecorder;
+
+  // TODO(sebright): Implement stats collection state.
+  private volatile StatsCollectionState state = StatsCollectionState.ENABLED;
 
   /**
    * Creates a new {@code StatsComponentImplBase}.
@@ -46,5 +51,15 @@ public class StatsComponentImplBase extends StatsComponent {
   @Override
   public StatsRecorderImpl getStatsRecorder() {
     return statsRecorder;
+  }
+
+  @Override
+  public StatsCollectionState getState() {
+    return state;
+  }
+
+  @Override
+  public void setState(StatsCollectionState newState) {
+    state = Preconditions.checkNotNull(newState, "newState");
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.implcore.internal.SimpleEventQueue;
+import io.opencensus.stats.StatsCollectionState;
+import io.opencensus.stats.StatsComponent;
+import io.opencensus.testing.common.TestClock;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link StatsComponentImplBase}. */
+@RunWith(JUnit4.class)
+public final class StatsComponentImplBaseTest {
+  private final StatsComponent statsComponent =
+      new StatsComponentImplBase(new SimpleEventQueue(), TestClock.create());
+
+  @Test
+  public void defaultState() {
+    assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.ENABLED);
+  }
+
+  @Test
+  public void setState() {
+    statsComponent.setState(StatsCollectionState.DISABLED);
+    assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.DISABLED);
+    statsComponent.setState(StatsCollectionState.ENABLED);
+    assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.ENABLED);
+  }
+
+  @Test(expected = NullPointerException.class)
+  public void setState_DisallowsNull() {
+    statsComponent.setState(null);
+  }
+}


### PR DESCRIPTION
This commit adds an enum that represents the state of the StatsComponent,
StatsCollectionState, and getters and setters for that state.  The state has no
effect yet.

____________________________________________________________

/cc @adriancole 
