### PR TITLE
Silently skip unknown TagContext fields during deserialization (issue #655).

### DIFF
--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
@@ -108,16 +108,14 @@ final class SerializationUtils {
     int limit = buffer.limit();
     while (buffer.position() < limit) {
       int type = buffer.get();
-      switch (type) {
-        case TAG_FIELD_ID:
-          TagKey key = createTagKey(decodeString(buffer));
-          TagValue val = createTagValue(key, decodeString(buffer));
-          tags.put(key, val);
-          break;
-        default:
-          // Stop parsing at the first unknown field ID, since there is no way to know its length.
-          // TODO(sebright): Consider storing the rest of the byte array in the TagContext.
-          return tags;
+      if (type == TAG_FIELD_ID) {
+        TagKey key = createTagKey(decodeString(buffer));
+        TagValue val = createTagValue(key, decodeString(buffer));
+        tags.put(key, val);
+      } else {
+        // Stop parsing at the first unknown field ID, since there is no way to know its length.
+        // TODO(sebright): Consider storing the rest of the byte array in the TagContext.
+        return tags;
       }
     }
     return tags;

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
@@ -116,6 +116,7 @@ final class SerializationUtils {
           break;
         default:
           // Stop parsing at the first unknown field ID, since there is no way to know its length.
+          // TODO(sebright): Consider storing the rest of the byte array in the TagContext.
           return tags;
       }
     }


### PR DESCRIPTION
Now TagContextBinarySerializerImpl.fromByteArray skips the rest of the output
when it encounters an unknown field, instead of throwing a
TagContextParseException.

This change will increase compatibility between the first version of the tagging
implementation and later versions, because the first version will be able to
accept TagContexts even when they contain newer fields.

_______________________________________________________________

This PR is #704 rebased onto #710.  It is much simpler than #704, because it doesn't need to handle unsupported tag types differently from unknown fields.

EDIT: The first three commits are from #710.