### PR TITLE
Make DistributionData.create take a List instead of a long[] for bucket counts.

### DIFF
--- a/api/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/api/src/main/java/io/opencensus/stats/AggregationData.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.collect.Lists;
 import io.opencensus.common.Function;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -239,20 +239,19 @@ public abstract class AggregationData {
      */
     public static DistributionData create(
         double mean, long count, double min, double max, double sumOfSquaredDeviations,
-        long[] bucketCounts) {
+        List<Long> bucketCounts) {
       if (min != Double.POSITIVE_INFINITY || max != Double.NEGATIVE_INFINITY) {
         checkArgument(min <= max, "max should be greater or equal to min.");
       }
 
       checkNotNull(bucketCounts, "bucket counts should not be null.");
-      List<Long> boxedBucketCounts = new ArrayList<Long>();
-      for (long bucketCount : bucketCounts) {
-        boxedBucketCounts.add(bucketCount);
+      List<Long> bucketCountsCopy = Collections.unmodifiableList(Lists.newArrayList(bucketCounts));
+      for (Long bucket : bucketCountsCopy) {
+        checkNotNull(bucket, "bucket should not be null.");
       }
 
       return new AutoValue_AggregationData_DistributionData(
-          mean, count, min, max, sumOfSquaredDeviations,
-          Collections.unmodifiableList(boxedBucketCounts));
+          mean, count, min, max, sumOfSquaredDeviations, bucketCountsCopy);
     }
 
     /**

--- a/api/src/test/java/io/opencensus/stats/AggregationDataTest.java
+++ b/api/src/test/java/io/opencensus/stats/AggregationDataTest.java
@@ -47,7 +47,7 @@ public class AggregationDataTest {
   @Test
   public void testCreateDistributionData() {
     DistributionData distributionData = DistributionData.create(
-        7.7, 10, 1.1, 9.9, 32.2, new long[]{4, 1, 5});
+        7.7, 10, 1.1, 9.9, 32.2, Arrays.asList(4L, 1L, 5L));
     assertThat(distributionData.getMean()).isWithin(TOLERANCE).of(7.7);
     assertThat(distributionData.getCount()).isEqualTo(10);
     assertThat(distributionData.getMin()).isWithin(TOLERANCE).of(1.1);
@@ -57,17 +57,24 @@ public class AggregationDataTest {
   }
 
   @Test
-  public void preventNullBucketCountData() {
+  public void preventNullBucketCountList() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("bucket counts should not be null.");
     DistributionData.create(1, 1, 1, 1, 0, null);
   }
 
   @Test
+  public void preventNullBucket() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("bucket should not be null.");
+    DistributionData.create(1, 1, 1, 1, 0, Arrays.asList(0L, 1L, null));
+  }
+
+  @Test
   public void preventMinIsGreaterThanMax() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("max should be greater or equal to min.");
-    DistributionData.create(1, 1, 10, 1, 0, new long[]{0, 1, 0});
+    DistributionData.create(1, 1, 10, 1, 0, Arrays.asList(0L, 1L, 0L));
   }
 
   @Test
@@ -89,20 +96,20 @@ public class AggregationDataTest {
             CountData.create(80),
             CountData.create(80))
         .addEqualityGroup(
-            DistributionData.create(10, 10, 1, 1, 0, new long[]{0, 10, 0}),
-            DistributionData.create(10, 10, 1, 1, 0, new long[]{0, 10, 0}))
+            DistributionData.create(10, 10, 1, 1, 0, Arrays.asList(0L, 10L, 0L)),
+            DistributionData.create(10, 10, 1, 1, 0, Arrays.asList(0L, 10L, 0L)))
         .addEqualityGroup(
-            DistributionData.create(10, 10, 1, 1, 0, new long[]{0, 10, 100}))
+            DistributionData.create(10, 10, 1, 1, 0, Arrays.asList(0L, 10L, 100L)))
         .addEqualityGroup(
-            DistributionData.create(110, 10, 1, 1, 0, new long[]{0, 10, 0}))
+            DistributionData.create(110, 10, 1, 1, 0, Arrays.asList(0L, 10L, 0L)))
         .addEqualityGroup(
-            DistributionData.create(10, 110, 1, 1, 0, new long[]{0, 10, 0}))
+            DistributionData.create(10, 110, 1, 1, 0, Arrays.asList(0L, 10L, 0L)))
         .addEqualityGroup(
-            DistributionData.create(10, 10, -1, 1, 0, new long[]{0, 10, 0}))
+            DistributionData.create(10, 10, -1, 1, 0, Arrays.asList(0L, 10L, 0L)))
         .addEqualityGroup(
-            DistributionData.create(10, 10, 1, 5, 0, new long[]{0, 10, 0}))
+            DistributionData.create(10, 10, 1, 5, 0, Arrays.asList(0L, 10L, 0L)))
         .addEqualityGroup(
-            DistributionData.create(10, 10, 1, 1, 55.5, new long[]{0, 10, 0}))
+            DistributionData.create(10, 10, 1, 1, 55.5, Arrays.asList(0L, 10L, 0L)))
         .addEqualityGroup(
             MeanData.create(5.0, 1),
             MeanData.create(5.0, 1))
@@ -119,7 +126,7 @@ public class AggregationDataTest {
         SumDataLong.create(100000000),
         CountData.create(40),
         MeanData.create(5.0, 1),
-        DistributionData.create(1, 1, 1, 1, 0, new long[]{0, 10, 0}));
+        DistributionData.create(1, 1, 1, 1, 0, Arrays.asList(0L, 10L, 0L)));
 
     final List<Object> actual = new ArrayList<Object>();
     for (AggregationData aggregation : aggregations) {

--- a/api/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/api/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -205,9 +205,9 @@ public final class ViewDataTest {
   private static final ImmutableMap<List<TagValueString>, DistributionData> ENTRIES =
       ImmutableMap.of(
           Arrays.asList(V1, V2),
-          DistributionData.create(1, 1, 1, 1, 0, new long[]{0, 1, 0}),
+          DistributionData.create(1, 1, 1, 1, 0, Arrays.asList(0L, 1L, 0L)),
           Arrays.asList(V10, V20),
-          DistributionData.create(-5, 6, -20, 5, 100.1, new long[]{5, 0, 1}));
+          DistributionData.create(-5, 6, -20, 5, 100.1, Arrays.asList(5L, 0L, 1L)));
 
   // name
   private static final View.Name NAME = View.Name.create("test-view");

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -531,8 +531,12 @@ abstract class MutableViewData {
       implements Function<MutableDistribution, AggregationData> {
     @Override
     public AggregationData apply(MutableDistribution arg) {
+      List<Long> boxedBucketCounts = new ArrayList<Long>();
+      for (long bucketCount : arg.getBucketCounts()) {
+        boxedBucketCounts.add(bucketCount);
+      }
       return DistributionData.create(arg.getMean(), arg.getCount(), arg.getMin(), arg.getMax(),
-          arg.getSumOfSquaredDeviations(), arg.getBucketCounts());
+          arg.getSumOfSquaredDeviations(), boxedBucketCounts);
     }
 
     private static final CreateDistributionData INSTANCE = new CreateDistributionData();

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MutableViewDataTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MutableViewDataTest.java
@@ -118,13 +118,19 @@ public class MutableViewDataTest {
       aggregates.add(MutableViewData.createAggregationData(mutableAggregation, MEASURE_DOUBLE));
     }
 
-    assertThat(aggregates).containsExactly(
-        SumDataDouble.create(0),
-        SumDataLong.create(0),
-        CountData.create(0),
-        MeanData.create(0, 0),
-        DistributionData.create(
-            0, 0, Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY, 0, new long[4]))
+    assertThat(aggregates)
+        .containsExactly(
+            SumDataDouble.create(0),
+            SumDataLong.create(0),
+            CountData.create(0),
+            MeanData.create(0, 0),
+            DistributionData.create(
+                0,
+                0,
+                Double.POSITIVE_INFINITY,
+                Double.NEGATIVE_INFINITY,
+                0,
+                Arrays.asList(new Long[] {0L, 0L, 0L, 0L})))
         .inOrder();
   }
 


### PR DESCRIPTION
`List<Long>` is consistent with the return type of
`DistributionData.getBucketCounts()`.