### PR TITLE
Remove contention between threads and worker thread when register span names.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Status.CanonicalCode;
@@ -109,6 +110,7 @@ public abstract class SampledSpanStore {
    *
    * @return the set of unique span names registered to the library.
    */
+  @VisibleForTesting
   public abstract Set<String> getRegisteredSpanNamesForCollection();
 
   /** The summary of all available data. */

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/TraceComponentImplBase.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/TraceComponentImplBase.java
@@ -41,7 +41,6 @@ public final class TraceComponentImplBase {
   private final ExportComponentImpl exportComponent;
   private final PropagationComponent propagationComponent = new PropagationComponentImpl();
   private final Clock clock;
-  private final StartEndHandler startEndHandler;
   private final TraceConfig traceConfig = new TraceConfigImpl();
   private final Tracer tracer;
 
@@ -56,11 +55,11 @@ public final class TraceComponentImplBase {
     this.clock = clock;
     // TODO(bdrutu): Add a config/argument for supportInProcessStores.
     if (eventQueue instanceof SimpleEventQueue) {
-      exportComponent = ExportComponentImpl.createWithoutInProcessStores();
+      exportComponent = ExportComponentImpl.createWithoutInProcessStores(eventQueue);
     } else {
-      exportComponent = ExportComponentImpl.createWithInProcessStores();
+      exportComponent = ExportComponentImpl.createWithInProcessStores(eventQueue);
     }
-    startEndHandler =
+    StartEndHandler startEndHandler =
         new StartEndHandlerImpl(
             exportComponent.getSpanExporter(),
             exportComponent.getRunningSpanStore(),

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/ExportComponentImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/ExportComponentImpl.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.implcore.trace.export;
 
+import io.opencensus.implcore.internal.EventQueue;
 import io.opencensus.trace.export.ExportComponent;
 import io.opencensus.trace.export.RunningSpanStore;
 import io.opencensus.trace.export.SampledSpanStore;
@@ -54,8 +55,8 @@ public final class ExportComponentImpl extends ExportComponent {
    *
    * @return a new {@code ExportComponentImpl}.
    */
-  public static ExportComponentImpl createWithInProcessStores() {
-    return new ExportComponentImpl(true);
+  public static ExportComponentImpl createWithInProcessStores(EventQueue eventQueue) {
+    return new ExportComponentImpl(true, eventQueue);
   }
 
   /**
@@ -64,8 +65,8 @@ public final class ExportComponentImpl extends ExportComponent {
    *
    * @return a new {@code ExportComponentImpl}.
    */
-  public static ExportComponentImpl createWithoutInProcessStores() {
-    return new ExportComponentImpl(false);
+  public static ExportComponentImpl createWithoutInProcessStores(EventQueue eventQueue) {
+    return new ExportComponentImpl(false, eventQueue);
   }
 
   /**
@@ -74,9 +75,9 @@ public final class ExportComponentImpl extends ExportComponent {
    * @param supportInProcessStores {@code true} to instantiate {@link RunningSpanStore} and {@link
    *     SampledSpanStore}.
    */
-  private ExportComponentImpl(boolean supportInProcessStores) {
+  private ExportComponentImpl(boolean supportInProcessStores, EventQueue eventQueue) {
     this.spanExporter = SpanExporterImpl.create(EXPORTER_BUFFER_SIZE, EXPORTER_SCHEDULE_DELAY_MS);
     this.runningSpanStore = supportInProcessStores ? new RunningSpanStoreImpl() : null;
-    this.sampledSpanStore = supportInProcessStores ? new SampledSpanStoreImpl() : null;
+    this.sampledSpanStore = supportInProcessStores ? new SampledSpanStoreImpl(eventQueue) : null;
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/ExportComponentImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/ExportComponentImplTest.java
@@ -18,6 +18,7 @@ package io.opencensus.implcore.trace.export;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.trace.export.ExportComponent;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -27,9 +28,9 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ExportComponentImplTest {
   private final ExportComponent exportComponentWithInProcess =
-      ExportComponentImpl.createWithInProcessStores();
+      ExportComponentImpl.createWithInProcessStores(new SimpleEventQueue());
   private final ExportComponent exportComponentWithoutInProcess =
-      ExportComponentImpl.createWithoutInProcessStores();
+      ExportComponentImpl.createWithoutInProcessStores(new SimpleEventQueue());
 
   @Test
   public void implementationOfSpanExporter() {

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/SampledSpanStoreImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/SampledSpanStoreImplTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Duration;
 import io.opencensus.common.Timestamp;
+import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.implcore.trace.SpanImpl;
 import io.opencensus.implcore.trace.SpanImpl.StartEndHandler;
 import io.opencensus.testing.common.TestClock;
@@ -67,7 +68,7 @@ public class SampledSpanStoreImplTest {
   private final SpanId parentSpanId = SpanId.generateRandomId(random);
   private final EnumSet<Options> recordSpanOptions = EnumSet.of(Options.RECORD_EVENTS);
   private final TestClock testClock = TestClock.create(Timestamp.create(12345, 54321));
-  private final SampledSpanStoreImpl sampleStore = new SampledSpanStoreImpl();
+  private final SampledSpanStoreImpl sampleStore = new SampledSpanStoreImpl(new SimpleEventQueue());
   private final StartEndHandler startEndHandler =
       new StartEndHandler() {
         @Override


### PR DESCRIPTION
Change the logic of register/unregister the span name to local span store form directly accessing the lock to log an event into our event queue and consume it by the worker thread.

This way we remove a global lock (contention) between main threads and the worker thread.

Fixes https://github.com/census-instrumentation/opencensus-java/issues/711

Reason to not use https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentHashMap.html is that the map is read intense not write and ConcurrentHashMap is optimized for writes.