### PR TITLE
Make TagKey and TagValue tests consistent.

### DIFF
--- a/api/src/test/java/io/opencensus/tags/TagKeyTest.java
+++ b/api/src/test/java/io/opencensus/tags/TagKeyTest.java
@@ -29,7 +29,6 @@ import org.junit.runners.JUnit4;
 /** Tests for {@link TagKey}. */
 @RunWith(JUnit4.class)
 public final class TagKeyTest {
-
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
@@ -44,17 +43,19 @@ public final class TagKeyTest {
 
   @Test
   public void create_AllowTagKeyNameWithMaxLength() {
-    char[] key = new char[TagKey.MAX_LENGTH];
-    Arrays.fill(key, 'k');
-    TagKey.create(new String(key));
+    char[] chars = new char[TagKey.MAX_LENGTH];
+    Arrays.fill(chars, 'k');
+    String key = new String(chars);
+    assertThat(TagKey.create(key).getName()).isEqualTo(key);
   }
 
   @Test
   public void create_DisallowTagKeyNameOverMaxLength() {
-    char[] key = new char[TagKey.MAX_LENGTH + 1];
-    Arrays.fill(key, 'k');
+    char[] chars = new char[TagKey.MAX_LENGTH + 1];
+    Arrays.fill(chars, 'k');
+    String key = new String(chars);
     thrown.expect(IllegalArgumentException.class);
-    TagKey.create(new String(key));
+    TagKey.create(key);
   }
 
   @Test

--- a/api/src/test/java/io/opencensus/tags/TagValueTest.java
+++ b/api/src/test/java/io/opencensus/tags/TagValueTest.java
@@ -37,7 +37,12 @@ public final class TagValueTest {
   }
 
   @Test
-  public void allowTagValueWithMaxLength() {
+  public void testAsString() {
+    assertThat(TagValue.create("foo").asString()).isEqualTo("foo");
+  }
+
+  @Test
+  public void create_AllowTagValueWithMaxLength() {
     char[] chars = new char[TagValue.MAX_LENGTH];
     Arrays.fill(chars, 'v');
     String value = new String(chars);
@@ -45,7 +50,7 @@ public final class TagValueTest {
   }
 
   @Test
-  public void disallowTagValueOverMaxLength() {
+  public void create_DisallowTagValueOverMaxLength() {
     char[] chars = new char[TagValue.MAX_LENGTH + 1];
     Arrays.fill(chars, 'v');
     String value = new String(chars);


### PR DESCRIPTION
This commit adds a test for TagValue.asString and ensures that only one method
is called after ExpectedException.expect is called.