### PR TITLE
Revert "Fix opencensus agent to be java6 compatible. (#619)"

### DIFF
--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/Resources.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/Resources.java
@@ -61,11 +61,8 @@ final class Resources {
 
     file.deleteOnExit();
 
-    InputStream is = getResourceAsStream(resourceName);
-    try {
+    try (InputStream is = getResourceAsStream(resourceName)) {
       ByteStreams.copy(is, outputStream);
-    } finally {
-      is.close();
     }
   }
 


### PR DESCRIPTION
This reverts commit d2263490e5353b005657bed1fbd60585559a85f2.

I'm reverting this because it seems unrelated to the issue in https://github.com/census-instrumentation/opencensus-java/issues/616#issue-256872886, which is actually about a different code location (line 52).

These "Undefined reference" warnings come from Animal Sniffer. In theory, Animal Sniffer may have seen the class files before they were processed by Retrolambda. However, the gradle task dependency tree (from dorongold/gradle-task-tree) doesn't support this theory.

In any case, we have test coverage for running on Java 6 since https://github.com/census-instrumentation/opencensus-java/pull/638.
