### PR TITLE
Add the Jacoco agent first so that it can instrument our agent.

### DIFF
--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -188,7 +188,15 @@ javaExecutables.eachWithIndex { javaExecutable, index ->
     classpath = sourceSets.integrationTest.runtimeClasspath
 
     executable = javaExecutable
-    jvmArgs "-javaagent:${shadowJar.archivePath}"
+
+    // The JaCoCo agent must be specified first so that it can instrument our agent.
+    // This is a work around for the issue that the JaCoCo agent is added last, cf.
+    // https://discuss.gradle.org/t/jacoco-gradle-adds-the-agent-last-to-jvm-args/7124.
+    doFirst {
+      jvmArgs jacoco.asJvmArg  // JaCoCo agent first.
+      jvmArgs "-javaagent:${shadowJar.archivePath}"  // Our agent second.
+      jacoco.enabled = false  // Don't add the JaCoCo agent again.
+    }
 
     doFirst { logger.lifecycle("Running integration tests using ${javaExecutable}.") }
   }


### PR DESCRIPTION
We are missing the Jacoco execution data for integration tests because the JaCoCo agent is added after our agent and thus cannot instrument our agent. This change fixes that.

There are a few more issues (e.g. merging execution data) that need to be fixed before the test coverage from integration tests is reflected in jacoco reports (and coveralls.io). I haven't yet figured out a complete solution, but this change is definitely part of it.