### PR TITLE
Rename ContextManager to ContextTrampoline.

### DIFF
--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/AgentMain.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 import static net.bytebuddy.matcher.ElementMatchers.none;
 
-import io.opencensus.contrib.agent.bootstrap.ContextManager;
 import io.opencensus.contrib.agent.bootstrap.ContextStrategy;
+import io.opencensus.contrib.agent.bootstrap.ContextTrampoline;
 import io.opencensus.contrib.agent.instrumentation.Instrumenter;
 import java.lang.instrument.Instrumentation;
 import java.util.ServiceLoader;
@@ -71,7 +71,7 @@ public final class AgentMain {
     instrumentation.appendToBootstrapClassLoaderSearch(
             new JarFile(Resources.getResourceAsTempFile("bootstrap.jar")));
 
-    checkLoadedByBootstrapClassloader(ContextManager.class);
+    checkLoadedByBootstrapClassloader(ContextTrampoline.class);
     checkLoadedByBootstrapClassloader(ContextStrategy.class);
 
     AgentBuilder agentBuilder = new AgentBuilder.Default()

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextTrampoline.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/bootstrap/ContextTrampoline.java
@@ -17,28 +17,28 @@
 package io.opencensus.contrib.agent.bootstrap;
 
 /**
- * {@code ContextManager} provides methods for accessing and manipulating the context from
+ * {@code ContextTrampoline} provides methods for accessing and manipulating the context from
  * instrumented bytecode.
  *
- * <p>{@code ContextManager} avoids tight coupling with the concrete implementation of the context
- * by accessing and manipulating the context through the {@link ContextStrategy} interface.
+ * <p>{@code ContextTrampoline} avoids tight coupling with the concrete implementation of the
+ * context by accessing and manipulating the context through the {@link ContextStrategy} interface.
  *
- * <p>Both {@link ContextManager} and {@link ContextStrategy} are loaded by the bootstrap
+ * <p>Both {@link ContextTrampoline} and {@link ContextStrategy} are loaded by the bootstrap
  * classloader so that they can be used from classes loaded by the bootstrap classloader.
  * A concrete implementation of {@link ContextStrategy} will be loaded by the system classloader.
  * This allows for using the same context implementation as the instrumented application.
  *
- * <p>{@code ContextManager} is implemented as a static class to allow for easy and fast use from
+ * <p>{@code ContextTrampoline} is implemented as a static class to allow for easy and fast use from
  * instrumented bytecode. We cannot use dependency injection for the instrumented bytecode.
  */
-public final class ContextManager {
+public final class ContextTrampoline {
 
   // Not synchronized to avoid any synchronization costs after initialization.
   // The agent is responsible for initializing this once (through #setContextStrategy) before any
   // other method of this class is called.
   private static ContextStrategy contextStrategy;
 
-  private ContextManager() {
+  private ContextTrampoline() {
   }
 
   /**
@@ -50,7 +50,7 @@ public final class ContextManager {
    * @param contextStrategy the concrete strategy for accessing and manipulating the context
    */
   public static void setContextStrategy(ContextStrategy contextStrategy) {
-    if (ContextManager.contextStrategy != null) {
+    if (ContextTrampoline.contextStrategy != null) {
       throw new IllegalStateException("contextStrategy was already set");
     }
 
@@ -58,7 +58,7 @@ public final class ContextManager {
       throw new NullPointerException("contextStrategy");
     }
 
-    ContextManager.contextStrategy = contextStrategy;
+    ContextTrampoline.contextStrategy = contextStrategy;
   }
 
   /**

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentation.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentation.java
@@ -26,7 +26,7 @@ import static net.bytebuddy.matcher.ElementMatchers.not;
 
 import com.google.auto.service.AutoService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.opencensus.contrib.agent.bootstrap.ContextManager;
+import io.opencensus.contrib.agent.bootstrap.ContextTrampoline;
 import java.util.concurrent.Executor;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
@@ -49,8 +49,8 @@ public final class ExecutorInstrumentation implements Instrumenter {
 
     // TODO(stschmidt): Gracefully handle the case of missing io.grpc.Context at runtime.
 
-    // Initialize the ContextManager with the concrete ContextStrategy.
-    ContextManager.setContextStrategy(new ContextStrategyImpl());
+    // Initialize the ContextTrampoline with the concrete ContextStrategy.
+    ContextTrampoline.setContextStrategy(new ContextStrategyImpl());
 
     return agentBuilder
             .type(createMatcher())
@@ -95,7 +95,7 @@ public final class ExecutorInstrumentation implements Instrumenter {
     @SuppressWarnings(value = "UnusedAssignment")
     @SuppressFBWarnings(value = {"DLS_DEAD_LOCAL_STORE", "UPM_UNCALLED_PRIVATE_METHOD",})
     private static void enter(@Advice.Argument(value = 0, readOnly = false) Runnable runnable) {
-      runnable = ContextManager.wrapInCurrentContext(runnable);
+      runnable = ContextTrampoline.wrapInCurrentContext(runnable);
     }
   }
 }

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentation.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentation.java
@@ -22,7 +22,7 @@ import static net.bytebuddy.matcher.ElementMatchers.named;
 
 import com.google.auto.service.AutoService;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.opencensus.contrib.agent.bootstrap.ContextManager;
+import io.opencensus.contrib.agent.bootstrap.ContextTrampoline;
 import net.bytebuddy.agent.builder.AgentBuilder;
 import net.bytebuddy.asm.Advice;
 import net.bytebuddy.description.type.TypeDescription;
@@ -76,7 +76,7 @@ public final class ThreadInstrumentation implements Instrumenter {
     @Advice.OnMethodEnter
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private static void enter(@Advice.This Thread thread) {
-      ContextManager.saveContextForThread(thread);
+      ContextTrampoline.saveContextForThread(thread);
     }
   }
 
@@ -93,7 +93,7 @@ public final class ThreadInstrumentation implements Instrumenter {
     @Advice.OnMethodEnter
     @SuppressFBWarnings("UPM_UNCALLED_PRIVATE_METHOD")
     private static void enter(@Advice.This Thread thread) {
-      ContextManager.attachContextForThread(thread);
+      ContextTrampoline.attachContextForThread(thread);
     }
   }
 }

--- a/contrib/agent/src/test/java/io/opencensus/contrib/agent/bootstrap/ContextTrampolineTest.java
+++ b/contrib/agent/src/test/java/io/opencensus/contrib/agent/bootstrap/ContextTrampolineTest.java
@@ -27,16 +27,16 @@ import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
 /**
- * Unit tests for {@link ContextManager}.
+ * Unit tests for {@link ContextTrampoline}.
  */
 @RunWith(MockitoJUnitRunner.class)
-public class ContextManagerTest {
+public class ContextTrampolineTest {
 
   private static final ContextStrategy mockContextStrategy;
 
   static {
     mockContextStrategy = mock(ContextStrategy.class);
-    ContextManager.setContextStrategy(mockContextStrategy);
+    ContextTrampoline.setContextStrategy(mockContextStrategy);
   }
 
   @Rule
@@ -52,26 +52,26 @@ public class ContextManagerTest {
   public void setContextStrategy_already_initialized() {
     exception.expect(IllegalStateException.class);
 
-    ContextManager.setContextStrategy(mockContextStrategy);
+    ContextTrampoline.setContextStrategy(mockContextStrategy);
   }
 
   @Test
   public void wrapInCurrentContext() {
-    ContextManager.wrapInCurrentContext(runnable);
+    ContextTrampoline.wrapInCurrentContext(runnable);
 
     Mockito.verify(mockContextStrategy).wrapInCurrentContext(runnable);
   }
 
   @Test
   public void saveContextForThread() {
-    ContextManager.saveContextForThread(thread);
+    ContextTrampoline.saveContextForThread(thread);
 
     Mockito.verify(mockContextStrategy).saveContextForThread(thread);
   }
 
   @Test
   public void attachContextForThread() {
-    ContextManager.attachContextForThread(thread);
+    ContextTrampoline.attachContextForThread(thread);
 
     Mockito.verify(mockContextStrategy).attachContextForThread(thread);
   }


### PR DESCRIPTION
This is a follow-up on https://github.com/census-instrumentation/opencensus-java/pull/548 (https://github.com/census-instrumentation/opencensus-java/pull/548#issuecomment-324511205, https://github.com/census-instrumentation/opencensus-java/pull/548#issuecomment-324781496), just renaming ContextManager to ContextTrampoline, which is better name. Going to add the TraceTrampoline (etc.) mentioned in https://github.com/census-instrumentation/opencensus-java/pull/548 in a separate PR.