### PR TITLE
Rename StatsRecord to MeasureMap

### DIFF
--- a/api/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/api/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -23,7 +23,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 
 /** A map from {@link Measure}s to measured values to be recorded at the same time. */
 @NotThreadSafe
-public abstract class StatsRecord {
+public abstract class MeasureMap {
 
   /**
    * Associates the {@link MeasureDouble} with the given value. Subsequent updates to the same
@@ -33,7 +33,7 @@ public abstract class StatsRecord {
    * @param value the value to be associated with {@code measure}
    * @return this
    */
-  public abstract StatsRecord put(MeasureDouble measure, double value);
+  public abstract MeasureMap put(MeasureDouble measure, double value);
 
   /**
    * Associates the {@link MeasureLong} with the given value. Subsequent updates to the same {@link
@@ -43,19 +43,19 @@ public abstract class StatsRecord {
    * @param value the value to be associated with {@code measure}
    * @return this
    */
-  public abstract StatsRecord put(MeasureLong measure, long value);
+  public abstract MeasureMap put(MeasureLong measure, long value);
 
   /**
    * Records all of the measures at the same time, with the current {@link TagContext}.
    *
-   * <p>This method records all of the stats in the {@code StatsRecord} every time it is called.
+   * <p>This method records all of the stats in the {@code MeasureMap} every time it is called.
    */
   public abstract void record();
 
   /**
    * Records all of the measures at the same time, with an explicit {@link TagContext}.
    *
-   * <p>This method records all of the stats in the {@code StatsRecord} every time it is called.
+   * <p>This method records all of the stats in the {@code MeasureMap} every time it is called.
    *
    * @param tags the tags associated with the measurements.
    */

--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -61,12 +61,12 @@ final class NoopStats {
   }
 
   /**
-   * Returns a {@code StatsRecord} that ignores all calls to {@link StatsRecord#put}.
+   * Returns a {@code MeasureMap} that ignores all calls to {@link MeasureMap#put}.
    *
-   * @return a {@code StatsRecord} that ignores all calls to {@code StatsRecord#put}.
+   * @return a {@code MeasureMap} that ignores all calls to {@code MeasureMap#put}.
    */
-  static StatsRecord getNoopStatsRecord() {
-    return NoopStatsRecord.INSTANCE;
+  static MeasureMap getNoopMeasureMap() {
+    return NoopMeasureMap.INSTANCE;
   }
 
   /**
@@ -110,22 +110,22 @@ final class NoopStats {
     static final StatsRecorder INSTANCE = new NoopStatsRecorder();
 
     @Override
-    public StatsRecord newRecord() {
-      return getNoopStatsRecord();
+    public MeasureMap newMeasureMap() {
+      return getNoopMeasureMap();
     }
   }
 
   @Immutable
-  private static final class NoopStatsRecord extends StatsRecord {
-    static final StatsRecord INSTANCE = new NoopStatsRecord();
+  private static final class NoopMeasureMap extends MeasureMap {
+    static final MeasureMap INSTANCE = new NoopMeasureMap();
 
     @Override
-    public StatsRecord put(MeasureDouble measure, double value) {
+    public MeasureMap put(MeasureDouble measure, double value) {
       return this;
     }
 
     @Override
-    public StatsRecord put(MeasureLong measure, long value) {
+    public MeasureMap put(MeasureLong measure, long value) {
       return this;
     }
 

--- a/api/src/main/java/io/opencensus/stats/StatsRecorder.java
+++ b/api/src/main/java/io/opencensus/stats/StatsRecorder.java
@@ -25,5 +25,5 @@ public abstract class StatsRecorder {
    *
    * @return an object for recording multiple measurements.
    */
-  public abstract StatsRecord newRecord();
+  public abstract MeasureMap newMeasureMap();
 }

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -85,7 +85,7 @@ public final class NoopStatsTest {
   @Test
   public void noopStatsRecorder_Record() {
     NoopStats.getNoopStatsRecorder()
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE, 5)
         .record(tagContext);
   }
@@ -94,13 +94,13 @@ public final class NoopStatsTest {
   // exception.
   @Test
   public void noopStatsRecorder_RecordWithCurrentContext() {
-    NoopStats.getNoopStatsRecorder().newRecord().put(MEASURE, 6).record();
+    NoopStats.getNoopStatsRecorder().newMeasureMap().put(MEASURE, 6).record();
   }
 
   @Test
   public void noopStatsRecorder_Record_DisallowNullTagContext() {
-    StatsRecord record = NoopStats.getNoopStatsRecorder().newRecord();
+    MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
-    record.record(null);
+    measureMap.record(null);
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
@@ -18,31 +18,31 @@ package io.opencensus.implcore.stats;
 
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
-import io.opencensus.stats.StatsRecord;
+import io.opencensus.stats.MeasureMap;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.unsafe.ContextUtils;
 
-/** Implementation of {@link StatsRecord}. */
-final class StatsRecordImpl extends StatsRecord {
+/** Implementation of {@link MeasureMap}. */
+final class MeasureMapImpl extends MeasureMap {
   private final StatsManager statsManager;
-  private final MeasureMap.Builder builder = MeasureMap.builder();
+  private final MeasureMapInternal.Builder builder = MeasureMapInternal.builder();
 
-  static StatsRecordImpl create(StatsManager statsManager) {
-    return new StatsRecordImpl(statsManager);
+  static MeasureMapImpl create(StatsManager statsManager) {
+    return new MeasureMapImpl(statsManager);
   }
 
-  private StatsRecordImpl(StatsManager statsManager) {
+  private MeasureMapImpl(StatsManager statsManager) {
     this.statsManager = statsManager;
   }
 
   @Override
-  public StatsRecordImpl put(MeasureDouble measure, double value) {
+  public MeasureMapImpl put(MeasureDouble measure, double value) {
     builder.put(measure, value);
     return this;
   }
 
   @Override
-  public StatsRecordImpl put(MeasureLong measure, long value) {
+  public MeasureMapImpl put(MeasureLong measure, long value) {
     builder.put(measure, value);
     return this;
   }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureMapInternal.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureMapInternal.java
@@ -24,34 +24,35 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
 
+// TODO(songya): consider combining MeasureMapImpl and this class.
 /**
  * A map from {@link Measure}'s to measured values.
  */
-final class MeasureMap {
+final class MeasureMapInternal {
 
   /**
-   * Returns a {@link Builder} for the {@link MeasureMap} class.
+   * Returns a {@link Builder} for the {@link MeasureMapInternal} class.
    */
   static Builder builder() {
     return new Builder();
   }
 
   /**
-   * Returns an {@link Iterator} over the measure/value mappings in this {@link MeasureMap}.
+   * Returns an {@link Iterator} over the measure/value mappings in this {@link MeasureMapInternal}.
    * The {@code Iterator} does not support {@link Iterator#remove()}.
    */
   Iterator<Measurement> iterator() {
-    return new MeasureMapIterator();
+    return new MeasureMapInternalIterator();
   }
 
   private final ArrayList<Measurement> measurements;
 
-  private MeasureMap(ArrayList<Measurement> measurements) {
+  private MeasureMapInternal(ArrayList<Measurement> measurements) {
     this.measurements = measurements;
   }
 
   /**
-   * Builder for the {@link MeasureMap} class.
+   * Builder for the {@link MeasureMapInternal} class.
    */
   static class Builder {
     /**
@@ -81,12 +82,12 @@ final class MeasureMap {
     }
 
     /**
-     * Constructs a {@link MeasureMap} from the current measurements.
+     * Constructs a {@link MeasureMapInternal} from the current measurements.
      */
-    MeasureMap build() {
+    MeasureMapInternal build() {
       // Note: this makes adding measurements quadratic but is fastest for the sizes of
-      // MeasureMaps that we should see. We may want to go to a strategy of sort/eliminate
-      // for larger MeasureMaps.
+      // MeasureMapInternals that we should see. We may want to go to a strategy of sort/eliminate
+      // for larger MeasureMapInternals.
       for (int i = measurements.size() - 1; i >= 0; i--) {
         for (int j = i - 1; j >= 0; j--) {
           if (measurements.get(i).getMeasure() == measurements.get(j).getMeasure()) {
@@ -95,7 +96,7 @@ final class MeasureMap {
           }
         }
       }
-      return new MeasureMap(measurements);
+      return new MeasureMapInternal(measurements);
     }
 
     private final ArrayList<Measurement> measurements = new ArrayList<Measurement>();
@@ -105,7 +106,7 @@ final class MeasureMap {
   }
 
   // Provides an unmodifiable Iterator over this instance's measurements.
-  private final class MeasureMapIterator implements Iterator<Measurement> {
+  private final class MeasureMapInternalIterator implements Iterator<Measurement> {
     @Override
     public boolean hasNext() {
       return position < length;

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -108,7 +108,7 @@ final class MeasureToViewMap {
   }
 
   // Records stats with a set of tags.
-  synchronized void record(TagContext tags, MeasureMap stats, Timestamp timestamp) {
+  synchronized void record(TagContext tags, MeasureMapInternal stats, Timestamp timestamp) {
     Iterator<Measurement> iterator = stats.iterator();
     while (iterator.hasNext()) {
       Measurement measurement = iterator.next();

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -49,17 +49,17 @@ final class StatsManager {
     return measureToViewMap.getView(viewName, clock);
   }
 
-  void record(TagContext tags, MeasureMap measurementValues) {
+  void record(TagContext tags, MeasureMapInternal measurementValues) {
     queue.enqueue(new StatsEvent(this, tags, measurementValues));
   }
 
   // An EventQueue entry that records the stats from one call to StatsManager.record(...).
   private static final class StatsEvent implements EventQueue.Entry {
     private final TagContext tags;
-    private final MeasureMap stats;
+    private final MeasureMapInternal stats;
     private final StatsManager statsManager;
 
-    StatsEvent(StatsManager statsManager, TagContext tags, MeasureMap stats) {
+    StatsEvent(StatsManager statsManager, TagContext tags, MeasureMapInternal stats) {
       this.statsManager = statsManager;
       this.tags = tags;
       this.stats = stats;

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsRecorderImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsRecorderImpl.java
@@ -30,7 +30,7 @@ public final class StatsRecorderImpl extends StatsRecorder {
   }
 
   @Override
-  public StatsRecordImpl newRecord() {
-    return StatsRecordImpl.create(statsManager);
+  public MeasureMapImpl newMeasureMap() {
+    return MeasureMapImpl.create(statsManager);
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MeasureMapInternalTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MeasureMapInternalTest.java
@@ -30,19 +30,19 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link MeasureMap}. */
+/** Tests for {@link MeasureMapInternal}. */
 @RunWith(JUnit4.class)
-public class MeasureMapTest {
+public class MeasureMapInternalTest {
 
   @Test
   public void testPutDouble() {
-    MeasureMap metrics = MeasureMap.builder().put(M1, 44.4).build();
+    MeasureMapInternal metrics = MeasureMapInternal.builder().put(M1, 44.4).build();
     assertContains(metrics, MeasurementDouble.create(M1, 44.4));
   }
 
   @Test
   public void testPutLong() {
-    MeasureMap metrics = MeasureMap.builder().put(M3, 9999L).put(M4, 8888L).build();
+    MeasureMapInternal metrics = MeasureMapInternal.builder().put(M3, 9999L).put(M4, 8888L).build();
     assertContains(metrics,
         MeasurementLong.create(M3, 9999L),
         MeasurementLong.create(M4, 8888L));
@@ -50,8 +50,9 @@ public class MeasureMapTest {
 
   @Test
   public void testCombination() {
-    MeasureMap metrics =
-        MeasureMap.builder().put(M1, 44.4).put(M2, 66.6).put(M3, 9999L).put(M4, 8888L).build();
+    MeasureMapInternal metrics =
+        MeasureMapInternal.builder().put(M1, 44.4).put(M2, 66.6).put(M3, 9999L).put(M4, 8888L)
+            .build();
     assertContains(metrics,
         MeasurementDouble.create(M1, 44.4),
         MeasurementDouble.create(M2, 66.6),
@@ -61,14 +62,14 @@ public class MeasureMapTest {
 
   @Test
   public void testBuilderEmpty() {
-    MeasureMap metrics = MeasureMap.builder().build();
+    MeasureMapInternal metrics = MeasureMapInternal.builder().build();
     assertContains(metrics);
   }
 
   @Test
   public void testBuilder() {
     ArrayList<Measurement> expected = new ArrayList<Measurement>(10);
-    MeasureMap.Builder builder = MeasureMap.builder();
+    MeasureMapInternal.Builder builder = MeasureMapInternal.builder();
     for (int i = 1; i <= 10; i++) {
       expected
           .add(MeasurementDouble.create(makeSimpleMeasureDouble("m" + i), i * 11.1));
@@ -79,38 +80,38 @@ public class MeasureMapTest {
 
   @Test
   public void testDuplicateMeasureDoubles() {
-    assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).build(),
+    assertContains(MeasureMapInternal.builder().put(M1, 1.0).put(M1, 2.0).build(),
         MeasurementDouble.create(M1, 2.0));
-    assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).put(M1, 3.0).build(),
+    assertContains(MeasureMapInternal.builder().put(M1, 1.0).put(M1, 2.0).put(M1, 3.0).build(),
         MeasurementDouble.create(M1, 3.0));
-    assertContains(MeasureMap.builder().put(M1, 1.0).put(M2, 2.0).put(M1, 3.0).build(),
+    assertContains(MeasureMapInternal.builder().put(M1, 1.0).put(M2, 2.0).put(M1, 3.0).build(),
         MeasurementDouble.create(M1, 3.0),
         MeasurementDouble.create(M2, 2.0));
-    assertContains(MeasureMap.builder().put(M1, 1.0).put(M1, 2.0).put(M2, 2.0).build(),
+    assertContains(MeasureMapInternal.builder().put(M1, 1.0).put(M1, 2.0).put(M2, 2.0).build(),
         MeasurementDouble.create(M1, 2.0),
         MeasurementDouble.create(M2, 2.0));
   }
 
   @Test
   public void testDuplicateMeasureLongs() {
-    assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 100L).build(),
+    assertContains(MeasureMapInternal.builder().put(M3, 100L).put(M3, 100L).build(),
         MeasurementLong.create(M3, 100L));
-    assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 200L).put(M3, 300L).build(),
+    assertContains(MeasureMapInternal.builder().put(M3, 100L).put(M3, 200L).put(M3, 300L).build(),
         MeasurementLong.create(M3, 300L));
-    assertContains(MeasureMap.builder().put(M3, 100L).put(M4, 200L).put(M3, 300L).build(),
+    assertContains(MeasureMapInternal.builder().put(M3, 100L).put(M4, 200L).put(M3, 300L).build(),
         MeasurementLong.create(M3, 300L),
         MeasurementLong.create(M4, 200L));
-    assertContains(MeasureMap.builder().put(M3, 100L).put(M3, 200L).put(M4, 200L).build(),
+    assertContains(MeasureMapInternal.builder().put(M3, 100L).put(M3, 200L).put(M4, 200L).build(),
         MeasurementLong.create(M3, 200L),
         MeasurementLong.create(M4, 200L));
   }
 
   @Test
   public void testDuplicateMeasures() {
-    assertContains(MeasureMap.builder().put(M3, 100L).put(M1, 1.0).put(M3, 300L).build(),
+    assertContains(MeasureMapInternal.builder().put(M3, 100L).put(M1, 1.0).put(M3, 300L).build(),
         MeasurementLong.create(M3, 300L),
         MeasurementDouble.create(M1, 1.0));
-    assertContains(MeasureMap.builder().put(M2, 2.0).put(M3, 100L).put(M2, 3.0).build(),
+    assertContains(MeasureMapInternal.builder().put(M2, 2.0).put(M3, 100L).put(M2, 3.0).build(),
         MeasurementDouble.create(M2, 3.0),
         MeasurementLong.create(M3, 100L));
   }
@@ -128,7 +129,7 @@ public class MeasureMapTest {
     return Measure.MeasureLong.create(measure, measure + " description", "1");
   }
 
-  private static void assertContains(MeasureMap metrics, Measurement... measurements) {
+  private static void assertContains(MeasureMapInternal metrics, Measurement... measurements) {
     assertThat(Lists.newArrayList(metrics.iterator())).containsExactly((Object[]) measurements);
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
@@ -24,8 +24,8 @@ import io.grpc.Context;
 import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.Measure.MeasureDouble;
+import io.opencensus.stats.MeasureMap;
 import io.opencensus.stats.StatsComponent;
-import io.opencensus.stats.StatsRecord;
 import io.opencensus.stats.StatsRecorder;
 import io.opencensus.stats.View;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
@@ -72,7 +72,7 @@ public final class StatsRecorderImplTest {
             Arrays.asList(KEY),
             Cumulative.create());
     viewManager.registerView(view);
-    statsRecorder.newRecord().put(MEASURE_DOUBLE, 1.0).record();
+    statsRecorder.newMeasureMap().put(MEASURE_DOUBLE, 1.0).record();
     ViewData viewData = viewManager.getView(VIEW_NAME);
 
     // record() should have used the default TagContext, so the tag value should be null.
@@ -97,7 +97,7 @@ public final class StatsRecorderImplTest {
                 ContextUtils.TAG_CONTEXT_KEY, new SimpleTagContext(Tag.create(KEY, VALUE)))
             .attach();
     try {
-      statsRecorder.newRecord().put(MEASURE_DOUBLE, 1.0).record();
+      statsRecorder.newMeasureMap().put(MEASURE_DOUBLE, 1.0).record();
     } finally {
       Context.current().detach(orig);
     }
@@ -118,7 +118,7 @@ public final class StatsRecorderImplTest {
             Arrays.asList(KEY),
             Cumulative.create());
     viewManager.registerView(view);
-    StatsRecord statsRecord = statsRecorder.newRecord().put(MEASURE_DOUBLE, 1.0);
+    MeasureMap statsRecord = statsRecorder.newMeasureMap().put(MEASURE_DOUBLE, 1.0);
     statsRecord.record(new SimpleTagContext(Tag.create(KEY, VALUE)));
     statsRecord.record(new SimpleTagContext(Tag.create(KEY, VALUE_2)));
     ViewData viewData = viewManager.getView(VIEW_NAME);

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -37,7 +37,7 @@ import io.opencensus.stats.BucketBoundaries;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
-import io.opencensus.stats.StatsRecord;
+import io.opencensus.stats.MeasureMap;
 import io.opencensus.stats.View;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
@@ -229,7 +229,7 @@ public class ViewManagerImplTest {
     viewManager.registerView(view);
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
     for (double val : values) {
-      addMeasureToStatsRecord(statsRecorder.newRecord(), measure, val)
+      putToMeasureMap(statsRecorder.newMeasureMap(), measure, val)
           .record(tags);
     }
     clock.setTime(Timestamp.create(3, 4));
@@ -325,7 +325,7 @@ public class ViewManagerImplTest {
        * 5th value should fall into the third bucket [35.0, 37.5).
        */
       clock.setTime(Timestamp.fromMillis(startTimeMillis + i * MILLIS_PER_SECOND));
-      addMeasureToStatsRecord(statsRecorder.newRecord(), measure, initialValues[i - 1])
+      putToMeasureMap(statsRecorder.newMeasureMap(), measure, initialValues[i - 1])
           .record(tags);
     }
 
@@ -347,7 +347,7 @@ public class ViewManagerImplTest {
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 12 * MILLIS_PER_SECOND));
     // 42s, add a new value value1, should fall into bucket [40.0, 42.5)
-    addMeasureToStatsRecord(statsRecorder.newRecord(), measure, value6)
+    putToMeasureMap(statsRecorder.newMeasureMap(), measure, value6)
         .record(tags);
 
     clock.setTime(Timestamp.fromMillis(startTimeMillis + 17 * MILLIS_PER_SECOND));
@@ -360,7 +360,7 @@ public class ViewManagerImplTest {
 
     clock.setTime(Timestamp.fromMillis(60 * MILLIS_PER_SECOND));
     // 60s, all previous values should have expired, add another value value2
-    addMeasureToStatsRecord(statsRecorder.newRecord(), measure, value7)
+    putToMeasureMap(statsRecorder.newMeasureMap(), measure, value7)
         .record(tags);
     StatsTestUtil.assertAggregationMapEquals(
         viewManager.getView(VIEW_NAME).getAggregationMap(),
@@ -378,7 +378,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(10, 0));
     viewManager.registerView(view);
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
-    statsRecorder.newRecord().put(MEASURE_DOUBLE, 0.1).record(tags);
+    statsRecorder.newMeasureMap().put(MEASURE_DOUBLE, 0.1).record(tags);
     clock.setTime(Timestamp.create(11, 0));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
     assertThat(viewData1.getWindowData())
@@ -390,7 +390,7 @@ public class ViewManagerImplTest {
             StatsTestUtil.createAggregationData(DISTRIBUTION, MEASURE_DOUBLE, 0.1)),
         EPSILON);
 
-    statsRecorder.newRecord().put(MEASURE_DOUBLE, 0.2).record(tags);
+    statsRecorder.newMeasureMap().put(MEASURE_DOUBLE, 0.2).record(tags);
     clock.setTime(Timestamp.create(12, 0));
     ViewData viewData2 = viewManager.getView(VIEW_NAME);
 
@@ -411,15 +411,15 @@ public class ViewManagerImplTest {
     viewManager.registerView(
         createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, DISTRIBUTION, Arrays.asList(KEY)));
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 10.0)
         .record(tagger.emptyBuilder().put(KEY, VALUE).build());
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 30.0)
         .record(tagger.emptyBuilder().put(KEY, VALUE_2).build());
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 50.0)
         .record(tagger.emptyBuilder().put(KEY, VALUE_2).build());
     ViewData viewData = viewManager.getView(VIEW_NAME);
@@ -445,18 +445,18 @@ public class ViewManagerImplTest {
     // record for TagValue1 at 11s
     clock.setTime(Timestamp.fromMillis(11 * MILLIS_PER_SECOND));
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 10.0)
         .record(tagger.emptyBuilder().put(KEY, VALUE).build());
 
     // record for TagValue2 at 15s
     clock.setTime(Timestamp.fromMillis(15 * MILLIS_PER_SECOND));
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 30.0)
         .record(tagger.emptyBuilder().put(KEY, VALUE_2).build());
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 50.0)
         .record(tagger.emptyBuilder().put(KEY, VALUE_2).build());
 
@@ -475,7 +475,7 @@ public class ViewManagerImplTest {
     // record for TagValue2 again at 20s
     clock.setTime(Timestamp.fromMillis(20 * MILLIS_PER_SECOND));
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 40.0)
         .record(tagger.emptyBuilder().put(KEY, VALUE_2).build());
 
@@ -505,12 +505,12 @@ public class ViewManagerImplTest {
     assertThat(viewData4.getAggregationMap()).isEmpty();
   }
 
-  // This test checks that StatsRecorder.record(...) does not throw an exception when no views are
+  // This test checks that MeasureMaper.record(...) does not throw an exception when no views are
   // registered.
   @Test
   public void allowRecordingWithoutRegisteringMatchingViewData() {
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 10)
         .record(tagger.emptyBuilder().put(KEY, VALUE).build());
   }
@@ -521,7 +521,7 @@ public class ViewManagerImplTest {
         createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, DISTRIBUTION, Arrays.asList(KEY)));
     // DEFAULT doesn't have tags, but the view has tag key "KEY".
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 10.0)
         .record(tagger.empty());
     ViewData viewData = viewManager.getView(VIEW_NAME);
@@ -560,7 +560,7 @@ public class ViewManagerImplTest {
             MEAN,
             Arrays.asList(KEY)));
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
-    addMeasureToStatsRecord(statsRecorder.newRecord(), measure2, value)
+    putToMeasureMap(statsRecorder.newMeasureMap(), measure2, value)
         .record(tags);
     ViewData view = viewManager.getView(VIEW_NAME);
     assertThat(view.getAggregationMap()).isEmpty();
@@ -571,12 +571,12 @@ public class ViewManagerImplTest {
     viewManager.registerView(
         createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, DISTRIBUTION, Arrays.asList(KEY)));
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 10.0)
         .record(
             tagger.emptyBuilder().put(TagKey.create("wrong key"), VALUE).build());
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 50.0)
         .record(
             tagger.emptyBuilder().put(TagKey.create("another wrong key"), VALUE).build());
@@ -599,7 +599,7 @@ public class ViewManagerImplTest {
     viewManager.registerView(
         createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, DISTRIBUTION, Arrays.asList(key1, key2)));
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 1.1)
         .record(
             tagger
@@ -608,7 +608,7 @@ public class ViewManagerImplTest {
                 .put(key2, TagValue.create("v10"))
                 .build());
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 2.2)
         .record(
             tagger
@@ -617,7 +617,7 @@ public class ViewManagerImplTest {
                 .put(key2, TagValue.create("v20"))
                 .build());
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 3.3)
         .record(
             tagger
@@ -626,7 +626,7 @@ public class ViewManagerImplTest {
                 .put(key2, TagValue.create("v10"))
                 .build());
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 4.4)
         .record(
             tagger
@@ -658,7 +658,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(2, 2));
     viewManager.registerView(view2);
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 5.0)
         .record(tagger.emptyBuilder().put(KEY, VALUE).build());
     clock.setTime(Timestamp.create(3, 3));
@@ -712,10 +712,10 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(2, 0));
     viewManager.registerView(view2);
     TagContext tags = tagger.emptyBuilder().put(KEY, VALUE).build();
-    StatsRecord record = statsRecorder.newRecord();
-    addMeasureToStatsRecord(record, measure1, value1);
-    addMeasureToStatsRecord(record, measure2, value2);
-    record.record(tags);
+    MeasureMap measureMap = statsRecorder.newMeasureMap();
+    putToMeasureMap(measureMap, measure1, value1);
+    putToMeasureMap(measureMap, measure2, value2);
+    measureMap.record(tags);
     clock.setTime(Timestamp.create(3, 0));
     ViewData viewData1 = viewManager.getView(VIEW_NAME);
     clock.setTime(Timestamp.create(4, 0));
@@ -747,7 +747,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(1, 0));
     viewManager.registerView(view);
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 1.1)
         .record(tagger.emptyBuilder().put(KEY, VALUE).build());
     clock.setTime(Timestamp.create(3, 0));
@@ -769,7 +769,7 @@ public class ViewManagerImplTest {
     clock.setTime(Timestamp.create(1, 0));
     viewManager.registerView(view);
     statsRecorder
-        .newRecord()
+        .newMeasureMap()
         .put(MEASURE_DOUBLE, 1.1)
         .record(tagger.emptyBuilder().put(KEY, VALUE).build());
     clock.setTime(Timestamp.create(3, 0));
@@ -784,12 +784,12 @@ public class ViewManagerImplTest {
         EPSILON);
   }
 
-  private static StatsRecord addMeasureToStatsRecord(
-      StatsRecord record, Measure measure, double value) {
+  private static MeasureMap putToMeasureMap(
+      MeasureMap measureMap, Measure measure, double value) {
     if (measure instanceof MeasureDouble) {
-      return record.put((MeasureDouble) measure, value);
+      return measureMap.put((MeasureDouble) measure, value);
     } else if (measure instanceof MeasureLong) {
-      return record.put((MeasureLong) measure, Math.round(value));
+      return measureMap.put((MeasureLong) measure, Math.round(value));
     } else {
       // Future measures.
       throw new AssertionError();

--- a/examples/src/main/java/io/opencensus/examples/stats/StatsRunner.java
+++ b/examples/src/main/java/io/opencensus/examples/stats/StatsRunner.java
@@ -66,7 +66,7 @@ public class StatsRunner {
         System.out.println(
             "    Current == Default + tags1 + tags2: "
                 + tagger.getCurrentTagContext().equals(tags2));
-        statsRecorder.newRecord().put(M1, 0.2).put(M2, 0.4).record();
+        statsRecorder.newMeasureMap().put(M1, 0.2).put(M2, 0.4).record();
       }
     }
     System.out.println(


### PR DESCRIPTION
Fix https://github.com/census-instrumentation/opencensus-java/issues/726

Per our discussion today, we're renaming `StatsRecord` to `MeasureMap`. There are also some temporary changes to the implementation (renamed the old internal `MeasureMap` to `MeasureMapInternal`), which will be updated after the API release.