### PR TITLE
Make TagContextBinarySerializer.toByteArray throw a checked exception.

### DIFF
--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
@@ -34,8 +34,9 @@ public abstract class TagContextBinarySerializer {
    *
    * @param tags the {@code TagContext} to serialize.
    * @return the on-the-wire representation of a {@code TagContext}.
+   * @throws TagContextSerializationException if the {@code TagContext} is too large to serialize.
    */
-  public abstract byte[] toByteArray(TagContext tags);
+  public abstract byte[] toByteArray(TagContext tags) throws TagContextSerializationException;
 
   /**
    * Creates a {@code TagContext} from the given on-the-wire encoded representation.

--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
@@ -34,7 +34,7 @@ public abstract class TagContextBinarySerializer {
    *
    * @param tags the {@code TagContext} to serialize.
    * @return the on-the-wire representation of a {@code TagContext}.
-   * @throws TagContextSerializationException if the {@code TagContext} is too large to serialize.
+   * @throws TagContextSerializationException if the result would be larger than 8192 bytes.
    */
   public abstract byte[] toByteArray(TagContext tags) throws TagContextSerializationException;
 

--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextSerializationException.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextSerializationException.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags.propagation;
+
+import io.opencensus.tags.TagContext;
+
+/** Exception thrown when a {@link TagContext} cannot be serialized. */
+public final class TagContextSerializationException extends Exception {
+  private static final long serialVersionUID = 0L;
+
+  /**
+   * Constructs a new {@code TagContextSerializationException} with the given message.
+   *
+   * @param message a message describing the error.
+   */
+  public TagContextSerializationException(String message) {
+    super(message);
+  }
+
+  /**
+   * Constructs a new {@code TagContextSerializationException} with the given message and cause.
+   *
+   * @param message a message describing the error.
+   * @param cause the cause of the error.
+   */
+  public TagContextSerializationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/api/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/api/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.Lists;
 import io.opencensus.internal.NoopScope;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagContextParseException;
+import io.opencensus.tags.propagation.TagContextSerializationException;
 import java.util.Arrays;
 import java.util.Iterator;
 import org.junit.Rule;
@@ -129,7 +130,8 @@ public final class NoopTagsTest {
   }
 
   @Test
-  public void noopTagContextBinarySerializer() throws TagContextParseException {
+  public void noopTagContextBinarySerializer()
+      throws TagContextParseException, TagContextSerializationException {
     assertThat(NoopTags.getNoopTagContextBinarySerializer().toByteArray(TAG_CONTEXT))
         .isEqualTo(new byte[0]);
     assertThat(NoopTags.getNoopTagContextBinarySerializer().fromByteArray(new byte[5]))
@@ -137,7 +139,8 @@ public final class NoopTagsTest {
   }
 
   @Test
-  public void noopTagContextBinarySerializer_ToByteArray_DisallowsNull() {
+  public void noopTagContextBinarySerializer_ToByteArray_DisallowsNull()
+      throws TagContextSerializationException {
     TagContextBinarySerializer noopSerializer = NoopTags.getNoopTagContextBinarySerializer();
     thrown.expect(NullPointerException.class);
     noopSerializer.toByteArray(null);

--- a/api/src/test/java/io/opencensus/tags/propagation/TagContextSerializationExceptionTest.java
+++ b/api/src/test/java/io/opencensus/tags/propagation/TagContextSerializationExceptionTest.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.tags.propagation;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.IOException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TagContextSerializationException}. */
+@RunWith(JUnit4.class)
+public final class TagContextSerializationExceptionTest {
+
+  @Test
+  public void createWithMessage() {
+    assertThat(new TagContextSerializationException("my message").getMessage())
+        .isEqualTo("my message");
+  }
+
+  @Test
+  public void createWithMessageAndCause() {
+    IOException cause = new IOException();
+    TagContextSerializationException exception =
+        new TagContextSerializationException("my message", cause);
+    assertThat(exception.getMessage()).isEqualTo("my message");
+    assertThat(exception.getCause()).isEqualTo(cause);
+  }
+}

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImplTest.java
@@ -29,6 +29,7 @@ import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagContextParseException;
+import io.opencensus.tags.propagation.TagContextSerializationException;
 import java.util.Iterator;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -56,13 +57,13 @@ public final class TagContextBinarySerializerImplTest {
       };
 
   @Test
-  public void toByteArray_TaggingDisabled() {
+  public void toByteArray_TaggingDisabled() throws TagContextSerializationException {
     tagsComponent.setState(TaggingState.DISABLED);
     assertThat(serializer.toByteArray(tagContext)).isEmpty();
   }
 
   @Test
-  public void toByteArray_TaggingReenabled() {
+  public void toByteArray_TaggingReenabled() throws TagContextSerializationException {
     final byte[] serialized = serializer.toByteArray(tagContext);
     tagsComponent.setState(TaggingState.DISABLED);
     assertThat(serializer.toByteArray(tagContext)).isEmpty();
@@ -71,14 +72,16 @@ public final class TagContextBinarySerializerImplTest {
   }
 
   @Test
-  public void fromByteArray_TaggingDisabled() throws TagContextParseException {
+  public void fromByteArray_TaggingDisabled()
+      throws TagContextParseException, TagContextSerializationException {
     byte[] serialized = serializer.toByteArray(tagContext);
     tagsComponent.setState(TaggingState.DISABLED);
     assertThat(TagsTestUtil.tagContextToList(serializer.fromByteArray(serialized))).isEmpty();
   }
 
   @Test
-  public void fromByteArray_TaggingReenabled() throws TagContextParseException {
+  public void fromByteArray_TaggingReenabled()
+      throws TagContextParseException, TagContextSerializationException {
     byte[] serialized = serializer.toByteArray(tagContext);
     tagsComponent.setState(TaggingState.DISABLED);
     assertThat(TagsTestUtil.tagContextToList(serializer.fromByteArray(serialized))).isEmpty();

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
@@ -29,6 +29,7 @@ import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
+import io.opencensus.tags.propagation.TagContextSerializationException;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.Arrays;
@@ -85,7 +86,7 @@ public class TagContextSerializationTest {
     testSerialize(T1, T2, T3, T4);
   }
 
-  private void testSerialize(Tag... tags) throws IOException {
+  private void testSerialize(Tag... tags) throws IOException, TagContextSerializationException {
     TagContextBuilder builder = tagger.emptyBuilder();
     for (Tag tag : tags) {
       builder.put(tag.getKey(), tag.getValue());


### PR DESCRIPTION
The first version of the implementation will throw
TagContextSerializationException when the serialized TagContext would be larger
than 8192 bytes.