### PR TITLE
Rename TagContextParseException to TagContextDeserializationException. 

### DIFF
--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
@@ -45,8 +45,8 @@ public abstract class TagContextBinarySerializer {
    *
    * @param bytes on-the-wire representation of a {@code TagContext}.
    * @return a {@code TagContext} deserialized from {@code bytes}.
-   * @throws TagContextDeserializationException if there is a parse error or the serialized {@code
-   *     TagContext} contains invalid tags.
+   * @throws TagContextDeserializationException if there is a parse error, the input contains
+   *     invalid tags, or the input is larger than 8192 bytes.
    */
   public abstract TagContext fromByteArray(byte[] bytes) throws TagContextDeserializationException;
 }

--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
@@ -45,8 +45,8 @@ public abstract class TagContextBinarySerializer {
    *
    * @param bytes on-the-wire representation of a {@code TagContext}.
    * @return a {@code TagContext} deserialized from {@code bytes}.
-   * @throws TagContextParseException if there is a parse error or the serialized {@code TagContext}
-   *     contains invalid tags.
+   * @throws TagContextDeserializationException if there is a parse error or the serialized {@code
+   *     TagContext} contains invalid tags.
    */
-  public abstract TagContext fromByteArray(byte[] bytes) throws TagContextParseException;
+  public abstract TagContext fromByteArray(byte[] bytes) throws TagContextDeserializationException;
 }

--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextDeserializationException.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextDeserializationException.java
@@ -25,7 +25,7 @@ public final class TagContextDeserializationException extends Exception {
   /**
    * Constructs a new {@code TagContextParseException} with the given message.
    *
-   * @param message a message describing the parse error.
+   * @param message a message describing the error.
    */
   public TagContextDeserializationException(String message) {
     super(message);
@@ -34,8 +34,8 @@ public final class TagContextDeserializationException extends Exception {
   /**
    * Constructs a new {@code TagContextParseException} with the given message and cause.
    *
-   * @param message a message describing the parse error.
-   * @param cause the cause of the parse error.
+   * @param message a message describing the error.
+   * @param cause the cause of the error.
    */
   public TagContextDeserializationException(String message, Throwable cause) {
     super(message, cause);

--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextDeserializationException.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextDeserializationException.java
@@ -19,7 +19,7 @@ package io.opencensus.tags.propagation;
 import io.opencensus.tags.TagContext;
 
 /** Exception thrown when a {@link TagContext} cannot be parsed. */
-public final class TagContextParseException extends Exception {
+public final class TagContextDeserializationException extends Exception {
   private static final long serialVersionUID = 0L;
 
   /**
@@ -27,7 +27,7 @@ public final class TagContextParseException extends Exception {
    *
    * @param message a message describing the parse error.
    */
-  public TagContextParseException(String message) {
+  public TagContextDeserializationException(String message) {
     super(message);
   }
 
@@ -37,7 +37,7 @@ public final class TagContextParseException extends Exception {
    * @param message a message describing the parse error.
    * @param cause the cause of the parse error.
    */
-  public TagContextParseException(String message, Throwable cause) {
+  public TagContextDeserializationException(String message, Throwable cause) {
     super(message, cause);
   }
 }

--- a/api/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/api/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -21,7 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.collect.Lists;
 import io.opencensus.internal.NoopScope;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
-import io.opencensus.tags.propagation.TagContextParseException;
+import io.opencensus.tags.propagation.TagContextDeserializationException;
 import io.opencensus.tags.propagation.TagContextSerializationException;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -131,7 +131,7 @@ public final class NoopTagsTest {
 
   @Test
   public void noopTagContextBinarySerializer()
-      throws TagContextParseException, TagContextSerializationException {
+      throws TagContextDeserializationException, TagContextSerializationException {
     assertThat(NoopTags.getNoopTagContextBinarySerializer().toByteArray(TAG_CONTEXT))
         .isEqualTo(new byte[0]);
     assertThat(NoopTags.getNoopTagContextBinarySerializer().fromByteArray(new byte[5]))
@@ -148,7 +148,7 @@ public final class NoopTagsTest {
 
   @Test
   public void noopTagContextBinarySerializer_FromByteArray_DisallowsNull()
-      throws TagContextParseException {
+      throws TagContextDeserializationException {
     TagContextBinarySerializer noopSerializer = NoopTags.getNoopTagContextBinarySerializer();
     thrown.expect(NullPointerException.class);
     noopSerializer.fromByteArray(null);

--- a/api/src/test/java/io/opencensus/tags/propagation/TagContextDeserializationExceptionTest.java
+++ b/api/src/test/java/io/opencensus/tags/propagation/TagContextDeserializationExceptionTest.java
@@ -23,20 +23,22 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link TagContextParseException}. */
+/** Unit tests for {@link TagContextDeserializationException}. */
 @RunWith(JUnit4.class)
-public final class TagContextParseExceptionTest {
+public final class TagContextDeserializationExceptionTest {
 
   @Test
   public void createWithMessage() {
-    assertThat(new TagContextParseException("my message").getMessage()).isEqualTo("my message");
+    assertThat(new TagContextDeserializationException("my message").getMessage())
+        .isEqualTo("my message");
   }
 
   @Test
   public void createWithMessageAndCause() {
     IOException cause = new IOException();
-    TagContextParseException parseException = new TagContextParseException("my message", cause);
-    assertThat(parseException.getMessage()).isEqualTo("my message");
-    assertThat(parseException.getCause()).isEqualTo(cause);
+    TagContextDeserializationException exception =
+        new TagContextDeserializationException("my message", cause);
+    assertThat(exception.getMessage()).isEqualTo("my message");
+    assertThat(exception.getCause()).isEqualTo(cause);
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
@@ -21,7 +21,7 @@ import io.opencensus.implcore.tags.TagContextImpl;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
-import io.opencensus.tags.propagation.TagContextParseException;
+import io.opencensus.tags.propagation.TagContextDeserializationException;
 
 final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   private static final byte[] EMPTY_BYTE_ARRAY = {};
@@ -40,7 +40,7 @@ final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   }
 
   @Override
-  public TagContext fromByteArray(byte[] bytes) throws TagContextParseException {
+  public TagContext fromByteArray(byte[] bytes) throws TagContextDeserializationException {
     return state.get() == TaggingState.DISABLED
         ? TagContextImpl.EMPTY
         : SerializationUtils.deserializeBinary(bytes);

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImplTest.java
@@ -28,7 +28,7 @@ import io.opencensus.tags.TagValue;
 import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
-import io.opencensus.tags.propagation.TagContextParseException;
+import io.opencensus.tags.propagation.TagContextDeserializationException;
 import io.opencensus.tags.propagation.TagContextSerializationException;
 import java.util.Iterator;
 import org.junit.Test;
@@ -73,7 +73,7 @@ public final class TagContextBinarySerializerImplTest {
 
   @Test
   public void fromByteArray_TaggingDisabled()
-      throws TagContextParseException, TagContextSerializationException {
+      throws TagContextDeserializationException, TagContextSerializationException {
     byte[] serialized = serializer.toByteArray(tagContext);
     tagsComponent.setState(TaggingState.DISABLED);
     assertThat(TagsTestUtil.tagContextToList(serializer.fromByteArray(serialized))).isEmpty();
@@ -81,7 +81,7 @@ public final class TagContextBinarySerializerImplTest {
 
   @Test
   public void fromByteArray_TaggingReenabled()
-      throws TagContextParseException, TagContextSerializationException {
+      throws TagContextDeserializationException, TagContextSerializationException {
     byte[] serialized = serializer.toByteArray(tagContext);
     tagsComponent.setState(TaggingState.DISABLED);
     assertThat(TagsTestUtil.tagContextToList(serializer.fromByteArray(serialized))).isEmpty();

--- a/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
@@ -29,7 +29,7 @@ import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.TagsComponent;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
-import io.opencensus.tags.propagation.TagContextParseException;
+import io.opencensus.tags.propagation.TagContextDeserializationException;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -58,7 +58,7 @@ public class TagContextDeserializationTest {
   }
 
   @Test
-  public void testDeserializeNoTags() throws TagContextParseException {
+  public void testDeserializeNoTags() throws TagContextDeserializationException {
     TagContext expected = tagger.empty();
     TagContext actual =
         serializer.fromByteArray(
@@ -67,14 +67,15 @@ public class TagContextDeserializationTest {
   }
 
   @Test
-  public void testDeserializeEmptyByteArrayThrowException() throws TagContextParseException {
-    thrown.expect(TagContextParseException.class);
+  public void testDeserializeEmptyByteArrayThrowException()
+      throws TagContextDeserializationException {
+    thrown.expect(TagContextDeserializationException.class);
     thrown.expectMessage("Input byte[] can not be empty.");
     serializer.fromByteArray(new byte[0]);
   }
 
   @Test
-  public void testDeserializeInvalidTagKey() throws TagContextParseException {
+  public void testDeserializeInvalidTagKey() throws TagContextDeserializationException {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
 
@@ -82,13 +83,13 @@ public class TagContextDeserializationTest {
     encodeTagToOutput("\2key", "value", output);
     final byte[] bytes = output.toByteArray();
 
-    thrown.expect(TagContextParseException.class);
+    thrown.expect(TagContextDeserializationException.class);
     thrown.expectMessage("Invalid tag key: \2key");
     serializer.fromByteArray(bytes);
   }
 
   @Test
-  public void testDeserializeInvalidTagValue() throws TagContextParseException {
+  public void testDeserializeInvalidTagValue() throws TagContextDeserializationException {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
 
@@ -96,13 +97,13 @@ public class TagContextDeserializationTest {
     encodeTagToOutput("my key", "val\3", output);
     final byte[] bytes = output.toByteArray();
 
-    thrown.expect(TagContextParseException.class);
+    thrown.expect(TagContextDeserializationException.class);
     thrown.expectMessage("Invalid tag value for key TagKey{name=my key}: val\3");
     serializer.fromByteArray(bytes);
   }
 
   @Test
-  public void testDeserializeOneTag() throws TagContextParseException {
+  public void testDeserializeOneTag() throws TagContextDeserializationException {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
     encodeTagToOutput("Key", "Value", output);
@@ -115,7 +116,7 @@ public class TagContextDeserializationTest {
   }
 
   @Test
-  public void testDeserializeMultipleTags() throws TagContextParseException {
+  public void testDeserializeMultipleTags() throws TagContextDeserializationException {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
     encodeTagToOutput("Key1", "Value1", output);
@@ -130,7 +131,7 @@ public class TagContextDeserializationTest {
   }
 
   @Test
-  public void stopParsingAtUnknownField() throws TagContextParseException {
+  public void stopParsingAtUnknownField() throws TagContextDeserializationException {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
     encodeTagToOutput("Key1", "Value1", output);
@@ -153,7 +154,7 @@ public class TagContextDeserializationTest {
   }
 
   @Test
-  public void stopParsingAtUnknownTagAtStart() throws TagContextParseException {
+  public void stopParsingAtUnknownTagAtStart() throws TagContextDeserializationException {
     ByteArrayDataOutput output = ByteStreams.newDataOutput();
     output.write(SerializationUtils.VERSION_ID);
 
@@ -166,15 +167,15 @@ public class TagContextDeserializationTest {
   }
 
   @Test
-  public void testDeserializeWrongFormat() throws TagContextParseException {
+  public void testDeserializeWrongFormat() throws TagContextDeserializationException {
     // encoded tags should follow the format <version_id>(<tag_field_id><tag_encoding>)*
-    thrown.expect(TagContextParseException.class);
+    thrown.expect(TagContextDeserializationException.class);
     serializer.fromByteArray(new byte[3]);
   }
 
   @Test
-  public void testDeserializeWrongVersionId() throws TagContextParseException {
-    thrown.expect(TagContextParseException.class);
+  public void testDeserializeWrongVersionId() throws TagContextDeserializationException {
+    thrown.expect(TagContextDeserializationException.class);
     thrown.expectMessage("Wrong Version ID: 1. Currently supported version is: 0");
     serializer.fromByteArray(new byte[] {(byte) (SerializationUtils.VERSION_ID + 1)});
   }


### PR DESCRIPTION
The new name is more consistent with TagContextSerializationException.