### PR TITLE
Add the missing task dependency of integration tests on shadowJar.

### DIFF
--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -205,7 +205,6 @@ javaExecutables.eachWithIndex { javaExecutable, index ->
 }
 
 check.dependsOn integrationTest
-integrationTest.dependsOn shadowJar
 integrationTest.mustRunAfter test
 
 // JMH benchmarks

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -190,6 +190,8 @@ javaExecutables.eachWithIndex { javaExecutable, index ->
       exceptionFormat 'full'
     }
 
+    dependsOn shadowJar
+
     testClassesDirs = sourceSets.integrationTest.output.classesDirs
     classpath = sourceSets.integrationTest.runtimeClasspath
 


### PR DESCRIPTION
Integration tests obviously depend on shadowJar. Without this task dependency, e.g. `./gradlew clean opencensus-contrib-agent:check` reproducibly fails.