### PR TITLE
Apply the Google Java Formatter on all source sets.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -190,14 +190,16 @@ subprojects {
             toolVersion '1.5'
         }
 
-        tasks.googleJavaFormat {
-            source = sourceSets*.allJava
-            include '**/*.java'
-        }
+        afterEvaluate {  // Allow subproject to add more source sets.
+            tasks.googleJavaFormat {
+                source = sourceSets*.allJava
+                include '**/*.java'
+            }
 
-        tasks.verifyGoogleJavaFormat {
-            source = sourceSets*.allJava
-            include '**/*.java'
+            tasks.verifyGoogleJavaFormat {
+                source = sourceSets*.allJava
+                include '**/*.java'
+            }
         }
     }
 

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentationIT.java
@@ -180,14 +180,11 @@ public class ExecutorInstrumentationIT {
                 assertThat(ste[0].getClassName()).doesNotContain("Context");
                 assertThat(ste[1].getClassName()).startsWith("io.grpc.Context$");
                 // NB: Actually, we want the Runnable to be wrapped only once, but currently it is
-                // still
-                // wrapped twice. The two places where the Runnable is wrapped are: (1) the executor
-                // implementation itself, e.g. ThreadPoolExecutor, to which the Agent added
-                // automatic
-                // context propagation, (2) CurrentContextExecutor.
+                // still wrapped twice. The two places where the Runnable is wrapped are: (1) the
+                // executor implementation itself, e.g. ThreadPoolExecutor, to which the Agent added
+                // automatic context propagation, (2) CurrentContextExecutor.
                 // ExecutorInstrumentation already avoids adding the automatic context propagation
-                // to
-                // CurrentContextExecutor, but does not make it a no-op yet. Also see
+                // to CurrentContextExecutor, but does not make it a no-op yet. Also see
                 // ExecutorInstrumentation#createMatcher.
                 assertThat(ste[2].getClassName()).startsWith("io.grpc.Context$");
                 assertThat(ste[3].getClassName()).doesNotContain("Context");

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ExecutorInstrumentationIT.java
@@ -33,8 +33,8 @@ import org.junit.runners.JUnit4;
 /**
  * Integration tests for {@link ExecutorInstrumentation}.
  *
- * <p>The integration tests are executed in a separate JVM that has the OpenCensus agent enabled
- * via the {@code -javaagent} command line option.
+ * <p>The integration tests are executed in a separate JVM that has the OpenCensus agent enabled via
+ * the {@code -javaagent} command line option.
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
@@ -64,19 +64,20 @@ public class ExecutorInstrumentationIT {
 
     final AtomicBoolean tested = new AtomicBoolean(false);
 
-    executor.execute(new Runnable() {
-      @Override
-      public void run() {
-        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
-        assertThat(Context.current()).isSameAs(context);
-        assertThat(KEY.get()).isEqualTo("myvalue");
-        tested.set(true);
+    executor.execute(
+        new Runnable() {
+          @Override
+          public void run() {
+            assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+            assertThat(Context.current()).isSameAs(context);
+            assertThat(KEY.get()).isEqualTo("myvalue");
+            tested.set(true);
 
-        synchronized (tested) {
-          tested.notify();
-        }
-      }
-    });
+            synchronized (tested) {
+              tested.notify();
+            }
+          }
+        });
 
     synchronized (tested) {
       tested.wait();
@@ -93,17 +94,20 @@ public class ExecutorInstrumentationIT {
 
     final AtomicBoolean tested = new AtomicBoolean(false);
 
-    executor.submit(new Callable<Void>() {
-      @Override
-      public Void call() throws Exception {
-        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
-        assertThat(Context.current()).isSameAs(context);
-        assertThat(KEY.get()).isEqualTo("myvalue");
-        tested.set(true);
+    executor
+        .submit(
+            new Callable<Void>() {
+              @Override
+              public Void call() throws Exception {
+                assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+                assertThat(Context.current()).isSameAs(context);
+                assertThat(KEY.get()).isEqualTo("myvalue");
+                tested.set(true);
 
-        return null;
-      }
-    }).get();
+                return null;
+              }
+            })
+        .get();
 
     assertThat(tested.get()).isTrue();
   }
@@ -116,15 +120,18 @@ public class ExecutorInstrumentationIT {
 
     final AtomicBoolean tested = new AtomicBoolean(false);
 
-    executor.submit(new Runnable() {
-      @Override
-      public void run() {
-        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
-        assertThat(Context.current()).isSameAs(context);
-        assertThat(KEY.get()).isEqualTo("myvalue");
-        tested.set(true);
-      }
-    }).get();
+    executor
+        .submit(
+            new Runnable() {
+              @Override
+              public void run() {
+                assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+                assertThat(Context.current()).isSameAs(context);
+                assertThat(KEY.get()).isEqualTo("myvalue");
+                tested.set(true);
+              }
+            })
+        .get();
 
     assertThat(tested.get()).isTrue();
   }
@@ -138,16 +145,19 @@ public class ExecutorInstrumentationIT {
     final AtomicBoolean tested = new AtomicBoolean(false);
     Object result = new Object();
 
-    Future<Object> future = executor.submit(new Runnable() {
-      @Override
-      public void run() {
-        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
-        assertThat(Context.current()).isNotSameAs(Context.ROOT);
-        assertThat(Context.current()).isSameAs(context);
-        assertThat(KEY.get()).isEqualTo("myvalue");
-        tested.set(true);
-      }
-    }, result);
+    Future<Object> future =
+        executor.submit(
+            new Runnable() {
+              @Override
+              public void run() {
+                assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+                assertThat(Context.current()).isNotSameAs(Context.ROOT);
+                assertThat(Context.current()).isSameAs(context);
+                assertThat(KEY.get()).isEqualTo("myvalue");
+                tested.set(true);
+              }
+            },
+            result);
 
     assertThat(future.get()).isSameAs(result);
     assertThat(tested.get()).isTrue();
@@ -161,32 +171,37 @@ public class ExecutorInstrumentationIT {
 
     final AtomicBoolean tested = new AtomicBoolean(false);
 
-    Context.currentContextExecutor(executor).execute(new Runnable() {
-      @Override
-      public void run() {
-        StackTraceElement[] ste = new Exception().fillInStackTrace().getStackTrace();
-        assertThat(ste[0].getClassName()).doesNotContain("Context");
-        assertThat(ste[1].getClassName()).startsWith("io.grpc.Context$");
-        // NB: Actually, we want the Runnable to be wrapped only once, but currently it is still
-        // wrapped twice. The two places where the Runnable is wrapped are: (1) the executor
-        // implementation itself, e.g. ThreadPoolExecutor, to which the Agent added automatic
-        // context propagation, (2) CurrentContextExecutor.
-        // ExecutorInstrumentation already avoids adding the automatic context propagation to
-        // CurrentContextExecutor, but does not make it a no-op yet. Also see
-        // ExecutorInstrumentation#createMatcher.
-        assertThat(ste[2].getClassName()).startsWith("io.grpc.Context$");
-        assertThat(ste[3].getClassName()).doesNotContain("Context");
+    Context.currentContextExecutor(executor)
+        .execute(
+            new Runnable() {
+              @Override
+              public void run() {
+                StackTraceElement[] ste = new Exception().fillInStackTrace().getStackTrace();
+                assertThat(ste[0].getClassName()).doesNotContain("Context");
+                assertThat(ste[1].getClassName()).startsWith("io.grpc.Context$");
+                // NB: Actually, we want the Runnable to be wrapped only once, but currently it is
+                // still
+                // wrapped twice. The two places where the Runnable is wrapped are: (1) the executor
+                // implementation itself, e.g. ThreadPoolExecutor, to which the Agent added
+                // automatic
+                // context propagation, (2) CurrentContextExecutor.
+                // ExecutorInstrumentation already avoids adding the automatic context propagation
+                // to
+                // CurrentContextExecutor, but does not make it a no-op yet. Also see
+                // ExecutorInstrumentation#createMatcher.
+                assertThat(ste[2].getClassName()).startsWith("io.grpc.Context$");
+                assertThat(ste[3].getClassName()).doesNotContain("Context");
 
-        assertThat(Thread.currentThread()).isNotSameAs(callerThread);
-        assertThat(Context.current()).isSameAs(context);
-        assertThat(KEY.get()).isEqualTo("myvalue");
-        tested.set(true);
+                assertThat(Thread.currentThread()).isNotSameAs(callerThread);
+                assertThat(Context.current()).isSameAs(context);
+                assertThat(KEY.get()).isEqualTo("myvalue");
+                tested.set(true);
 
-        synchronized (tested) {
-          tested.notify();
-        }
-      }
-    });
+                synchronized (tested) {
+                  tested.notify();
+                }
+              }
+            });
 
     synchronized (tested) {
       tested.wait();

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
@@ -29,8 +29,8 @@ import org.junit.runners.JUnit4;
 /**
  * Integration tests for {@link ThreadInstrumentation}.
  *
- * <p>The integration tests are executed in a separate JVM that has the OpenCensus agent enabled
- * via the {@code -javaagent} command line option.
+ * <p>The integration tests are executed in a separate JVM that has the OpenCensus agent enabled via
+ * the {@code -javaagent} command line option.
  */
 @RunWith(JUnit4.class)
 @SuppressWarnings("checkstyle:AbbreviationAsWordInName")
@@ -52,14 +52,16 @@ public class ThreadInstrumentationIT {
 
     final AtomicBoolean tested = new AtomicBoolean(false);
 
-    Thread thread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        assertThat(Context.current()).isSameAs(context);
-        assertThat(KEY.get()).isEqualTo("myvalue");
-        tested.set(true);
-      }
-    });
+    Thread thread =
+        new Thread(
+            new Runnable() {
+              @Override
+              public void run() {
+                assertThat(Context.current()).isSameAs(context);
+                assertThat(KEY.get()).isEqualTo("myvalue");
+                tested.set(true);
+              }
+            });
 
     thread.start();
     thread.join();
@@ -103,36 +105,41 @@ public class ThreadInstrumentationIT {
 
     final AtomicBoolean tested = new AtomicBoolean(false);
 
-    Executor newThreadExecutor = new Executor() {
-      @Override
-      public void execute(Runnable command) {
-        // Attach a new context before starting a new thread. This new context will be propagated to
-        // the new thread as in #start_Runnable. However, since the Runnable has been wrapped in a
-        // different context (by automatic instrumentation of Executor#execute), that context will
-        // be attached when executing the Runnable.
-        Context context2 = Context.current().withValue(KEY, "wrong context");
-        context2.attach();
-        Thread thread = new Thread(command);
-        thread.start();
-        try {
-          thread.join();
-        } catch (InterruptedException ex) {
-          Thread.currentThread().interrupt();
-        }
-        context2.detach(context);
-      }
-    };
+    Executor newThreadExecutor =
+        new Executor() {
+          @Override
+          public void execute(Runnable command) {
+            // Attach a new context before starting a new thread. This new context will be
+            // propagated to
+            // the new thread as in #start_Runnable. However, since the Runnable has been wrapped in
+            // a
+            // different context (by automatic instrumentation of Executor#execute), that context
+            // will
+            // be attached when executing the Runnable.
+            Context context2 = Context.current().withValue(KEY, "wrong context");
+            context2.attach();
+            Thread thread = new Thread(command);
+            thread.start();
+            try {
+              thread.join();
+            } catch (InterruptedException ex) {
+              Thread.currentThread().interrupt();
+            }
+            context2.detach(context);
+          }
+        };
 
-    newThreadExecutor.execute(new Runnable() {
-      @Override
-      public void run() {
-        // Assert that the automatic context propagation added by ThreadInstrumentation did not
-        // interfere with the automatically propagated context from Executor#execute.
-        assertThat(Context.current()).isSameAs(context);
-        assertThat(KEY.get()).isEqualTo("myvalue");
-        tested.set(true);
-      }
-    });
+    newThreadExecutor.execute(
+        new Runnable() {
+          @Override
+          public void run() {
+            // Assert that the automatic context propagation added by ThreadInstrumentation did not
+            // interfere with the automatically propagated context from Executor#execute.
+            assertThat(Context.current()).isSameAs(context);
+            assertThat(KEY.get()).isEqualTo("myvalue");
+            tested.set(true);
+          }
+        });
 
     assertThat(tested.get()).isTrue();
   }

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
@@ -110,12 +110,9 @@ public class ThreadInstrumentationIT {
           @Override
           public void execute(Runnable command) {
             // Attach a new context before starting a new thread. This new context will be
-            // propagated to
-            // the new thread as in #start_Runnable. However, since the Runnable has been wrapped in
-            // a
-            // different context (by automatic instrumentation of Executor#execute), that context
-            // will
-            // be attached when executing the Runnable.
+            // propagated to the new thread as in #start_Runnable. However, since the Runnable has
+            // been wrapped in a different context (by automatic instrumentation of
+            // Executor#execute), that context will be attached when executing the Runnable.
             Context context2 = Context.current().withValue(KEY, "wrong context");
             context2.attach();
             Thread thread = new Thread(command);

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
@@ -52,16 +52,16 @@ public class ThreadInstrumentationIT {
 
     final AtomicBoolean tested = new AtomicBoolean(false);
 
-    Thread thread =
-        new Thread(
-            new Runnable() {
-              @Override
-              public void run() {
-                assertThat(Context.current()).isSameAs(context);
-                assertThat(KEY.get()).isEqualTo("myvalue");
-                tested.set(true);
-              }
-            });
+    Runnable runnable =
+        new Runnable() {
+          @Override
+          public void run() {
+            assertThat(Context.current()).isSameAs(context);
+            assertThat(KEY.get()).isEqualTo("myvalue");
+            tested.set(true);
+          }
+        };
+    Thread thread = new Thread(runnable);
 
     thread.start();
     thread.join();

--- a/contrib/agent/src/jmh/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationBenchmark.java
+++ b/contrib/agent/src/jmh/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationBenchmark.java
@@ -25,7 +25,7 @@ import org.openjdk.jmh.annotations.Mode;
 import org.openjdk.jmh.annotations.OutputTimeUnit;
 import org.openjdk.jmh.infra.Blackhole;
 
-/** Naive benchmarks for automatic context propagation added by {@link ThreadInstrumentation}.*/
+/** Naive benchmarks for automatic context propagation added by {@link ThreadInstrumentation}. */
 public class ThreadInstrumentationBenchmark {
 
   private static final class MyRunnable implements Runnable {


### PR DESCRIPTION
The formatter plugin only saw the main and test source sets, but not the additional source sets defined in the agent subproject. Thus, evaluate the subproject first, then configure the formatter. (also see "afterEvaluate" in https://docs.gradle.org/current/userguide/multi_project_builds.html)