### PR TITLE
Extract the DeamonThreadFactory from Disruptor and clean code.

### DIFF
--- a/impl_core/src/main/java/io/opencensus/implcore/internal/DaemonThreadFactory.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/DaemonThreadFactory.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.internal;
+
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/** A {@link ThreadFactory} implementation that starts all {@link Thread} as daemons. */
+public final class DaemonThreadFactory implements ThreadFactory {
+  private static final String DELIMITER = "-";
+  private final AtomicInteger threadIdGen = new AtomicInteger();
+  private final String threadPrefix;
+
+  /**
+   * Constructs a new {@code DaemonThreadFactory}.
+   *
+   * @param threadPrefix used to prefix all thread names. (E.g. "CensusDisruptor").
+   */
+  public DaemonThreadFactory(String threadPrefix) {
+    this.threadPrefix = threadPrefix + DELIMITER;
+  }
+
+  @Override
+  public Thread newThread(Runnable r) {
+    Thread thread = new Thread(r, threadPrefix + threadIdGen.getAndIncrement());
+    thread.setDaemon(true);
+    return thread;
+  }
+}

--- a/impl_core/src/main/java/io/opencensus/implcore/internal/EventQueue.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/EventQueue.java
@@ -24,7 +24,7 @@ public interface EventQueue {
    * Base interface to be used for all entries in {@link EventQueue}. For example usage, see {@code
    * DisruptorEventQueue}.
    */
-  public interface Entry {
+  interface Entry {
     /**
      * Process the event associated with this entry. This will be called for every event in the
      * associated {@link EventQueue}.


### PR DESCRIPTION
This is a cleanup of the Disruptor code and extract the DeamonThreadFactory to be reused by exporters and other classes.