### PR TITLE
Slightly reword Javadoc on SpanBuilder#startScopedSpan.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/SpanBuilder.java
+++ b/api/src/main/java/io/opencensus/trace/SpanBuilder.java
@@ -168,8 +168,8 @@ public abstract class SpanBuilder {
    * Starts a new span and sets it as the {@link Tracer#getCurrentSpan current span}.
    *
    * <p>Enters the scope of code where the newly created {@code Span} is in the current Context, and
-   * returns an object that represents that scope. The scope is exited when the returned object is
-   * closed then the previous Context is restored and the newly created {@code Span} is ended using
+   * returns an object that represents that scope. When the returned object is closed, the scope is
+   * exited, the previous Context is restored, and the newly created {@code Span} is ended using
    * {@link Span#end}.
    *
    * <p>Supports try-with-resource idiom.


### PR DESCRIPTION
FWIW, I've reused parts of SpanBuilder#startScopedSpan's Javadoc in https://github.com/census-instrumentation/opencensus-java/pull/766/files#diff-cdc21ce534c8e27c5a611a054d00c6a2R70, but reworded it only slightly. Sound better to me, but then again, English is not my first language.