### PR TITLE
Update Stats implementation to use Stats state

### DIFF
--- a/api/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/api/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -35,6 +35,9 @@ public abstract class StatsComponent {
    * <p>When no implementation is available, {@code getState} always returns {@link
    * StatsCollectionState#DISABLED}.
    *
+   * <p>Once {@link #getState()} is called, subsequent calls to {@link
+   * #setState(StatsCollectionState)} will throw an {@code IllegalStateException}.
+   *
    * @return the current {@code StatsCollectionState}.
    */
   public abstract StatsCollectionState getState();

--- a/api/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/api/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -44,6 +44,9 @@ public abstract class StatsComponent {
    *
    * <p>When no implementation is available, {@code setState} has no effect.
    *
+   * <p>If state is set to {@link StatsCollectionState#DISABLED}, all stats that are previously
+   * recorded will be cleared.
+   *
    * @param state the new {@code StatsCollectionState}.
    */
   public abstract void setState(StatsCollectionState state);

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
@@ -47,8 +47,15 @@ public final class CurrentStatsState {
     return currentState;
   }
 
-  synchronized void set(StatsCollectionState state) {
+  // Sets current state to the given state. Returns true if the current state is changed, false
+  // otherwise.
+  synchronized boolean set(StatsCollectionState state) {
     checkState(!isRead, "State was already read, cannot set state.");
-    currentState = checkNotNull(state, "state");
+    if (state == currentState) {
+      return false;
+    } else {
+      currentState = checkNotNull(state, "state");
+      return true;
+    }
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
@@ -17,6 +17,7 @@
 package io.opencensus.implcore.stats;
 
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.StatsComponent;
@@ -30,12 +31,18 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class CurrentStatsState {
   private volatile StatsCollectionState currentState = StatsCollectionState.ENABLED;
+  private volatile boolean isRead;
 
   public StatsCollectionState get() {
     return currentState;
   }
 
+  void setRead() {
+    isRead = true;
+  }
+
   void set(StatsCollectionState state) {
+    checkState(!isRead, "State was already read, cannot set state.");
     currentState = checkNotNull(state, "state");
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.stats;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.opencensus.stats.StatsCollectionState;
+import io.opencensus.stats.StatsComponent;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * The current {@link StatsCollectionState} for a {@link StatsComponent}.
+ *
+ * <p>This class allows different stats classes to share the state in a thread-safe way.
+ */
+@ThreadSafe
+public final class CurrentStatsState {
+  private volatile StatsCollectionState currentState = StatsCollectionState.ENABLED;
+
+  public StatsCollectionState get() {
+    return currentState;
+  }
+
+  void set(StatsCollectionState state) {
+    currentState = checkNotNull(state, "state");
+  }
+}

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/IntervalBucket.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/IntervalBucket.java
@@ -79,4 +79,8 @@ final class IntervalBucket {
         "This bucket must be current.");
     return ((double) toMillis(elapsedTime)) / toMillis(duration);
   }
+
+  void clearStats() {
+    tagValueAggregationMap.clear();
+  }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -35,6 +35,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -124,6 +125,15 @@ final class MeasureToViewMap {
             new RecordDoubleValueFunc(tags, view, timestamp),
             new RecordLongValueFunc(tags, view, timestamp),
             Functions.<Void>throwAssertionError());
+      }
+    }
+  }
+
+  // Clear stats for all the current MutableViewData
+  synchronized void clearStats() {
+    for (Entry<String, Collection<MutableViewData>> entry : mutableMap.asMap().entrySet()) {
+      for (MutableViewData mutableViewData : entry.getValue()) {
+        mutableViewData.clearStats();
       }
     }
   }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -27,6 +27,7 @@ import io.opencensus.stats.Measure;
 import io.opencensus.stats.Measurement;
 import io.opencensus.stats.Measurement.MeasurementDouble;
 import io.opencensus.stats.Measurement.MeasurementLong;
+import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.View;
 import io.opencensus.stats.ViewData;
 import io.opencensus.tags.TagContext;
@@ -56,9 +57,9 @@ final class MeasureToViewMap {
   private final Map<String, Measure> registeredMeasures = Maps.newHashMap();
 
   /** Returns a {@link ViewData} corresponding to the given {@link View.Name}. */
-  synchronized ViewData getView(View.Name viewName, Clock clock) {
+  synchronized ViewData getView(View.Name viewName, Clock clock, StatsCollectionState state) {
     MutableViewData view = getMutableViewData(viewName);
-    return view == null ? null : view.toViewData(clock.now());
+    return view == null ? null : view.toViewData(clock.now(), state);
   }
 
   @Nullable

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -138,6 +138,15 @@ final class MeasureToViewMap {
     }
   }
 
+  // Resume stats collection for all MutableViewData.
+  synchronized void resumeStatsCollection(Timestamp now) {
+    for (Entry<String, Collection<MutableViewData>> entry : mutableMap.asMap().entrySet()) {
+      for (MutableViewData mutableViewData : entry.getValue()) {
+        mutableViewData.resumeStatsCollection(now);
+      }
+    }
+  }
+
   private static final class RecordDoubleValueFunc implements Function<MeasurementDouble, Void> {
     @Override
     public Void apply(MeasurementDouble arg) {

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -43,6 +43,7 @@ import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.Measure;
+import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.View;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
@@ -68,6 +69,7 @@ abstract class MutableViewData {
   private static final long NANOS_PER_MILLI = 1000 * 1000;
 
   @VisibleForTesting static final TagValue UNKNOWN_TAG_VALUE = null;
+  @VisibleForTesting static final Timestamp ZERO_TIMESTAMP = Timestamp.create(0, 0);
 
   private final View view;
 
@@ -105,7 +107,7 @@ abstract class MutableViewData {
   }
 
   /** Convert this {@link MutableViewData} to {@link ViewData}. */
-  abstract ViewData toViewData(Timestamp now);
+  abstract ViewData toViewData(Timestamp now, StatsCollectionState state);
 
   private static Map<TagKey, TagValue> getTagMap(TagContext ctx) {
     if (ctx instanceof TagContextImpl) {
@@ -208,11 +210,19 @@ abstract class MutableViewData {
     }
 
     @Override
-    ViewData toViewData(Timestamp now) {
-      return ViewData.create(
-          super.view,
-          createAggregationMap(tagValueAggregationMap, super.view.getMeasure()),
-          CumulativeData.create(start, now));
+    ViewData toViewData(Timestamp now, StatsCollectionState state) {
+      if (state == StatsCollectionState.ENABLED) {
+        return ViewData.create(
+            super.view,
+            createAggregationMap(tagValueAggregationMap, super.view.getMeasure()),
+            CumulativeData.create(start, now));
+      } else {
+        // If Stats state is DISABLED, return an empty ViewData.
+        return ViewData.create(
+            super.view,
+            Maps.<List<TagValue>, AggregationData>newHashMap(),
+            CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP));
+      }
     }
   }
 
@@ -278,10 +288,18 @@ abstract class MutableViewData {
     }
 
     @Override
-    ViewData toViewData(Timestamp now) {
+    ViewData toViewData(Timestamp now, StatsCollectionState state) {
       refreshBucketList(now);
-      return ViewData.create(
-          super.view, combineBucketsAndGetAggregationMap(now), IntervalData.create(now));
+      if (state == StatsCollectionState.ENABLED) {
+        return ViewData.create(
+            super.view, combineBucketsAndGetAggregationMap(now), IntervalData.create(now));
+      } else {
+        // If Stats state is DISABLED, return an empty ViewData.
+        return ViewData.create(
+            super.view,
+            Maps.<List<TagValue>, AggregationData>newHashMap(),
+            IntervalData.create(ZERO_TIMESTAMP));
+      }
     }
 
     // Add new buckets and remove expired buckets by comparing the current timestamp with

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -329,6 +329,8 @@ abstract class MutableViewData {
 
     @Override
     void resumeStatsCollection(Timestamp now) {
+      // Refresh bucket list to be ready for stats recording, so that if record() is called right
+      // after stats state is turned back on, record() will be faster.
       refreshBucketList(now);
     }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -109,6 +109,9 @@ abstract class MutableViewData {
   /** Convert this {@link MutableViewData} to {@link ViewData}. */
   abstract ViewData toViewData(Timestamp now, StatsCollectionState state);
 
+  // Clear recorded stats.
+  abstract void clearStats();
+
   private static Map<TagKey, TagValue> getTagMap(TagContext ctx) {
     if (ctx instanceof TagContextImpl) {
       return ((TagContextImpl) ctx).getTags();
@@ -224,6 +227,11 @@ abstract class MutableViewData {
             CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP));
       }
     }
+
+    @Override
+    void clearStats() {
+      tagValueAggregationMap.clear();
+    }
   }
 
   /*
@@ -299,6 +307,13 @@ abstract class MutableViewData {
             super.view,
             Maps.<List<TagValue>, AggregationData>newHashMap(),
             IntervalData.create(ZERO_TIMESTAMP));
+      }
+    }
+
+    @Override
+    void clearStats() {
+      for (IntervalBucket bucket : buckets) {
+        bucket.clearStats();
       }
     }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -55,6 +55,7 @@ public class StatsComponentImplBase extends StatsComponent {
 
   @Override
   public StatsCollectionState getState() {
+    state.setRead();
     return state.get();
   }
 

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -25,11 +25,11 @@ import io.opencensus.stats.StatsComponent;
 /** Base implementation of {@link StatsComponent}. */
 public class StatsComponentImplBase extends StatsComponent {
 
+  // The StatsCollectionState shared between the StatsComponent, StatsRecorder and ViewManager.
+  private final CurrentStatsState state = new CurrentStatsState();
+
   private final ViewManagerImpl viewManager;
   private final StatsRecorderImpl statsRecorder;
-
-  // TODO(sebright): Implement stats collection state.
-  private volatile StatsCollectionState state = StatsCollectionState.ENABLED;
 
   /**
    * Creates a new {@code StatsComponentImplBase}.
@@ -38,7 +38,7 @@ public class StatsComponentImplBase extends StatsComponent {
    * @param clock the clock to use when recording stats.
    */
   public StatsComponentImplBase(EventQueue queue, Clock clock) {
-    StatsManager statsManager = new StatsManager(queue, clock);
+    StatsManager statsManager = new StatsManager(queue, clock, state);
     this.viewManager = new ViewManagerImpl(statsManager);
     this.statsRecorder = new StatsRecorderImpl(statsManager);
   }
@@ -55,11 +55,11 @@ public class StatsComponentImplBase extends StatsComponent {
 
   @Override
   public StatsCollectionState getState() {
-    return state;
+    return state.get();
   }
 
   @Override
   public void setState(StatsCollectionState newState) {
-    state = Preconditions.checkNotNull(newState, "newState");
+    state.set(Preconditions.checkNotNull(newState, "newState"));
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -55,15 +55,20 @@ public class StatsComponentImplBase extends StatsComponent {
 
   @Override
   public StatsCollectionState getState() {
-    state.setRead();
     return state.get();
   }
 
   @Override
   public void setState(StatsCollectionState newState) {
+    StatsCollectionState oldState = state.getInternal();
+    if (newState == oldState) {
+      return;
+    }
     state.set(Preconditions.checkNotNull(newState, "newState"));
     if (newState == StatsCollectionState.DISABLED) {
       viewManager.clearStats();
+    } else {
+      viewManager.resumeStatsCollection();
     }
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -60,15 +60,13 @@ public class StatsComponentImplBase extends StatsComponent {
 
   @Override
   public void setState(StatsCollectionState newState) {
-    StatsCollectionState oldState = state.getInternal();
-    if (newState == oldState) {
-      return;
-    }
-    state.set(Preconditions.checkNotNull(newState, "newState"));
-    if (newState == StatsCollectionState.DISABLED) {
-      viewManager.clearStats();
-    } else {
-      viewManager.resumeStatsCollection();
+    boolean stateChanged = state.set(Preconditions.checkNotNull(newState, "newState"));
+    if (stateChanged) {
+      if (newState == StatsCollectionState.DISABLED) {
+        viewManager.clearStats();
+      } else {
+        viewManager.resumeStatsCollection();
+      }
     }
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -62,5 +62,8 @@ public class StatsComponentImplBase extends StatsComponent {
   @Override
   public void setState(StatsCollectionState newState) {
     state.set(Preconditions.checkNotNull(newState, "newState"));
+    if (newState == StatsCollectionState.DISABLED) {
+      viewManager.clearStats();
+    }
   }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -50,17 +50,23 @@ final class StatsManager {
   }
 
   ViewData getView(View.Name viewName) {
-    return measureToViewMap.getView(viewName, clock, state.get());
+    return measureToViewMap.getView(viewName, clock, state.getInternal());
   }
 
   void record(TagContext tags, MeasureMapInternal measurementValues) {
-    if (state.get() == StatsCollectionState.ENABLED) {
+    // TODO(songya): consider exposing No-op MeasureMap and use it when stats state is DISABLED, so
+    // that we don't need to create actual MeasureMapImpl.
+    if (state.getInternal() == StatsCollectionState.ENABLED) {
       queue.enqueue(new StatsEvent(this, tags, measurementValues));
     }
   }
 
   void clearStats() {
     measureToViewMap.clearStats();
+  }
+
+  void resumeStatsCollection() {
+    measureToViewMap.resumeStatsCollection(clock.now());
   }
 
   // An EventQueue entry that records the stats from one call to StatsManager.record(...).

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -59,6 +59,10 @@ final class StatsManager {
     }
   }
 
+  void clearStats() {
+    measureToViewMap.clearStats();
+  }
+
   // An EventQueue entry that records the stats from one call to StatsManager.record(...).
   private static final class StatsEvent implements EventQueue.Entry {
     private final TagContext tags;

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -46,15 +46,11 @@ final class StatsManager {
   }
 
   void registerView(View view) {
-    if (state.get() == StatsCollectionState.ENABLED) {
-      measureToViewMap.registerView(view, clock);
-    }
+    measureToViewMap.registerView(view, clock);
   }
 
   ViewData getView(View.Name viewName) {
-    return state.get() == StatsCollectionState.ENABLED
-        ? measureToViewMap.getView(viewName, clock)
-        : null;
+    return measureToViewMap.getView(viewName, clock, state.get());
   }
 
   void record(TagContext tags, MeasureMapInternal measurementValues) {

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
@@ -41,4 +41,8 @@ public final class ViewManagerImpl extends ViewManager {
   void clearStats() {
     statsManager.clearStats();
   }
+
+  void resumeStatsCollection() {
+    statsManager.resumeStatsCollection();
+  }
 }

--- a/core_impl/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
+++ b/core_impl/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
@@ -37,4 +37,8 @@ public final class ViewManagerImpl extends ViewManager {
   public ViewData getView(View.Name viewName) {
     return statsManager.getView(viewName);
   }
+
+  void clearStats() {
+    statsManager.clearStats();
+  }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
@@ -39,10 +39,11 @@ public final class CurrentStatsStateTest {
   @Test
   public void setState() {
     CurrentStatsState state = new CurrentStatsState();
-    state.set(StatsCollectionState.DISABLED);
+    assertThat(state.set(StatsCollectionState.DISABLED)).isTrue();
     assertThat(state.getInternal()).isEqualTo(StatsCollectionState.DISABLED);
-    state.set(StatsCollectionState.ENABLED);
+    assertThat(state.set(StatsCollectionState.ENABLED)).isTrue();
     assertThat(state.getInternal()).isEqualTo(StatsCollectionState.ENABLED);
+    assertThat(state.set(StatsCollectionState.ENABLED)).isFalse();
   }
 
   @Test

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
@@ -40,9 +40,9 @@ public final class CurrentStatsStateTest {
   public void setState() {
     CurrentStatsState state = new CurrentStatsState();
     state.set(StatsCollectionState.DISABLED);
-    assertThat(state.get()).isEqualTo(StatsCollectionState.DISABLED);
+    assertThat(state.getInternal()).isEqualTo(StatsCollectionState.DISABLED);
     state.set(StatsCollectionState.ENABLED);
-    assertThat(state.get()).isEqualTo(StatsCollectionState.ENABLED);
+    assertThat(state.getInternal()).isEqualTo(StatsCollectionState.ENABLED);
   }
 
   @Test
@@ -56,7 +56,7 @@ public final class CurrentStatsStateTest {
   @Test
   public void preventSettingStateAfterReadingState() {
     CurrentStatsState state = new CurrentStatsState();
-    state.setRead();
+    state.get();
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("State was already read, cannot set state.");
     state.set(StatsCollectionState.DISABLED);

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
@@ -52,4 +52,13 @@ public final class CurrentStatsStateTest {
     thrown.expectMessage("state");
     state.set(null);
   }
+
+  @Test
+  public void preventSettingStateAfterReadingState() {
+    CurrentStatsState state = new CurrentStatsState();
+    state.setRead();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    state.set(StatsCollectionState.DISABLED);
+  }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.stats;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.stats.StatsCollectionState;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link CurrentStatsState}. */
+@RunWith(JUnit4.class)
+public final class CurrentStatsStateTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void defaultState() {
+    assertThat(new CurrentStatsState().get()).isEqualTo(StatsCollectionState.ENABLED);
+  }
+
+  @Test
+  public void setState() {
+    CurrentStatsState state = new CurrentStatsState();
+    state.set(StatsCollectionState.DISABLED);
+    assertThat(state.get()).isEqualTo(StatsCollectionState.DISABLED);
+    state.set(StatsCollectionState.ENABLED);
+    assertThat(state.get()).isEqualTo(StatsCollectionState.ENABLED);
+  }
+
+  @Test
+  public void preventNull() {
+    CurrentStatsState state = new CurrentStatsState();
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("state");
+    state.set(null);
+  }
+}

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MeasureToViewMapTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MeasureToViewMapTest.java
@@ -21,6 +21,7 @@ import static com.google.common.truth.Truth.assertThat;
 import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Measure;
+import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.View;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.Name;
@@ -59,7 +60,7 @@ public class MeasureToViewMapTest {
     TestClock clock = TestClock.create(Timestamp.create(10, 20));
     measureToViewMap.registerView(VIEW, clock);
     clock.setTime(Timestamp.create(30, 40));
-    ViewData viewData = measureToViewMap.getView(VIEW_NAME, clock);
+    ViewData viewData = measureToViewMap.getView(VIEW_NAME, clock, StatsCollectionState.ENABLED);
     assertThat(viewData.getView()).isEqualTo(VIEW);
     assertThat(viewData.getWindowData())
         .isEqualTo(CumulativeData.create(Timestamp.create(10, 20), Timestamp.create(30, 40)));

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/MutableViewDataTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/MutableViewDataTest.java
@@ -21,6 +21,7 @@ import static io.opencensus.implcore.stats.MutableViewData.toMillis;
 
 import com.google.common.collect.ImmutableMap;
 import io.opencensus.common.Duration;
+import io.opencensus.common.Timestamp;
 import io.opencensus.implcore.stats.MutableAggregation.MutableCount;
 import io.opencensus.implcore.stats.MutableAggregation.MutableDistribution;
 import io.opencensus.implcore.stats.MutableAggregation.MutableMean;
@@ -67,6 +68,7 @@ public class MutableViewDataTest {
   @Test
   public void testConstants() {
     assertThat(MutableViewData.UNKNOWN_TAG_VALUE).isNull();
+    assertThat(MutableViewData.ZERO_TIMESTAMP).isEqualTo(Timestamp.create(0, 0));
   }
 
   @Test

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
@@ -43,9 +43,14 @@ public final class StatsComponentImplBaseTest {
   }
 
   @Test
-  public void setState() {
+  public void setState_Disabled() {
     statsComponent.setState(StatsCollectionState.DISABLED);
     assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.DISABLED);
+  }
+
+  @Test
+  public void setState_Enabled() {
+    statsComponent.setState(StatsCollectionState.DISABLED);
     statsComponent.setState(StatsCollectionState.ENABLED);
     assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.ENABLED);
   }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
@@ -22,13 +22,18 @@ import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.StatsComponent;
 import io.opencensus.testing.common.TestClock;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link StatsComponentImplBase}. */
 @RunWith(JUnit4.class)
 public final class StatsComponentImplBaseTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
   private final StatsComponent statsComponent =
       new StatsComponentImplBase(new SimpleEventQueue(), TestClock.create());
 
@@ -45,8 +50,10 @@ public final class StatsComponentImplBaseTest {
     assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.ENABLED);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void setState_DisallowsNull() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("newState");
     statsComponent.setState(null);
   }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
@@ -56,4 +56,13 @@ public final class StatsComponentImplBaseTest {
     thrown.expectMessage("newState");
     statsComponent.setState(null);
   }
+
+  @Test
+  public void preventSettingStateAfterGettingState() {
+    statsComponent.setState(StatsCollectionState.DISABLED);
+    statsComponent.getState();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    statsComponent.setState(StatsCollectionState.ENABLED);
+  }
 }

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
@@ -25,6 +25,7 @@ import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.MeasureMap;
+import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.StatsComponent;
 import io.opencensus.stats.StatsRecorder;
 import io.opencensus.stats.View;
@@ -130,6 +131,59 @@ public final class StatsRecorderImplTest {
             StatsTestUtil.createAggregationData(Sum.create(), MEASURE_DOUBLE, 1.0),
             Arrays.asList(VALUE_2),
             StatsTestUtil.createAggregationData(Sum.create(), MEASURE_DOUBLE, 1.0)),
+        1e-6);
+  }
+
+  @Test
+  public void record_StatsDisabled() {
+    View view =
+        View.create(
+            VIEW_NAME,
+            "description",
+            MEASURE_DOUBLE,
+            Sum.create(),
+            Arrays.asList(KEY),
+            Cumulative.create());
+
+    viewManager.registerView(view);
+    statsComponent.setState(StatsCollectionState.DISABLED);
+    statsRecorder
+        .newMeasureMap()
+        .put(MEASURE_DOUBLE, 1.0)
+        .record(new SimpleTagContext(Tag.create(KEY, VALUE)));
+    assertThat(viewManager.getView(VIEW_NAME)).isNull();
+  }
+
+  @Test
+  public void record_StatsReenabled() {
+    View view =
+        View.create(
+            VIEW_NAME,
+            "description",
+            MEASURE_DOUBLE,
+            Sum.create(),
+            Arrays.asList(KEY),
+            Cumulative.create());
+    viewManager.registerView(view);
+
+    statsComponent.setState(StatsCollectionState.DISABLED);
+    statsRecorder
+        .newMeasureMap()
+        .put(MEASURE_DOUBLE, 1.0)
+        .record(new SimpleTagContext(Tag.create(KEY, VALUE)));
+    assertThat(viewManager.getView(VIEW_NAME)).isNull();
+
+    statsComponent.setState(StatsCollectionState.ENABLED);
+    assertThat(viewManager.getView(VIEW_NAME).getAggregationMap()).isEmpty();
+    statsRecorder
+        .newMeasureMap()
+        .put(MEASURE_DOUBLE, 4.0)
+        .record(new SimpleTagContext(Tag.create(KEY, VALUE)));
+    StatsTestUtil.assertAggregationMapEquals(
+        viewManager.getView(VIEW_NAME).getAggregationMap(),
+        ImmutableMap.of(
+            Arrays.asList(VALUE),
+            StatsTestUtil.createAggregationData(Sum.create(), MEASURE_DOUBLE, 4.0)),
         1e-6);
   }
 

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
@@ -17,6 +17,8 @@
 package io.opencensus.implcore.stats;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.implcore.stats.MutableViewData.ZERO_TIMESTAMP;
+import static io.opencensus.implcore.stats.StatsTestUtil.createEmptyViewData;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -31,6 +33,7 @@ import io.opencensus.stats.StatsRecorder;
 import io.opencensus.stats.View;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.ViewData;
+import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
 import io.opencensus.stats.ViewManager;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
@@ -151,7 +154,7 @@ public final class StatsRecorderImplTest {
         .newMeasureMap()
         .put(MEASURE_DOUBLE, 1.0)
         .record(new SimpleTagContext(Tag.create(KEY, VALUE)));
-    assertThat(viewManager.getView(VIEW_NAME)).isNull();
+    assertThat(viewManager.getView(VIEW_NAME)).isEqualTo(createEmptyViewData(view));
   }
 
   @Test
@@ -171,10 +174,12 @@ public final class StatsRecorderImplTest {
         .newMeasureMap()
         .put(MEASURE_DOUBLE, 1.0)
         .record(new SimpleTagContext(Tag.create(KEY, VALUE)));
-    assertThat(viewManager.getView(VIEW_NAME)).isNull();
+    assertThat(viewManager.getView(VIEW_NAME)).isEqualTo(createEmptyViewData(view));
 
     statsComponent.setState(StatsCollectionState.ENABLED);
     assertThat(viewManager.getView(VIEW_NAME).getAggregationMap()).isEmpty();
+    assertThat(viewManager.getView(VIEW_NAME).getWindowData())
+        .isNotEqualTo(CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP));
     statsRecorder
         .newMeasureMap()
         .put(MEASURE_DOUBLE, 4.0)

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/StatsTestUtil.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/StatsTestUtil.java
@@ -17,6 +17,7 @@
 package io.opencensus.implcore.stats;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.implcore.stats.MutableViewData.ZERO_TIMESTAMP;
 
 import com.google.common.collect.Iterables;
 import io.opencensus.common.Function;
@@ -29,8 +30,14 @@ import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.Measure;
+import io.opencensus.stats.View;
+import io.opencensus.stats.ViewData;
+import io.opencensus.stats.ViewData.AggregationWindowData;
+import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
+import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
 import io.opencensus.tags.TagValue;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -124,6 +131,20 @@ final class StatsTestUtil {
           }
         },
         Functions.<Void>throwIllegalArgumentException());
+  }
+
+  // Create an empty ViewData with the given View.
+  static ViewData createEmptyViewData(View view) {
+    return ViewData.create(
+        view,
+        Collections.<List<TagValue>, AggregationData>emptyMap(),
+        view.getWindow()
+            .match(
+                Functions.<AggregationWindowData>returnConstant(
+                    CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP)),
+                Functions.<AggregationWindowData>returnConstant(
+                    IntervalData.create(ZERO_TIMESTAMP)),
+                Functions.<AggregationWindowData>throwAssertionError()));
   }
 
   // Compare the expected and actual DistributionData within the given tolerance.

--- a/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/core_impl/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -903,7 +903,6 @@ public class ViewManagerImplTest {
     // non-zero TimeStamps.
     ViewData viewData = viewManager.getView(view.getName());
     assertThat(viewData.getAggregationMap()).isEmpty();
-    assertThat(viewData).isNotEqualTo(createEmptyViewData(view));
     AggregationWindowData windowData = viewData.getWindowData();
     if (windowData instanceof CumulativeData) {
       assertThat(windowData).isEqualTo(CumulativeData.create(timestamp3, timestamp4));


### PR DESCRIPTION
Implement stats collection state. Stats library has 3 major operations that are affected by state: `registerView()`, `record()` and `getView()`. I think there are 2 options for implementing state for them:

1. When state is `DISABLED`, implement all the 3 operations above as no-op. `registerView()` won't really add the view to `MeasureToViewMap`, and `getView()` will always return null. (It's not possible to return empty `ViewData` in this case, since no `View` will be preserved.)

2. When state is `DISABLED`, we still add `View`s to `MeasureToViewMap` when `registerView()` is called. `record()` will be ignored, and `getView()` will return an empty `ViewData` for registered `View`s. When users re-enabled stats collection, they don't need to register views again.

I think either of these two makes sense. ~~I went with the first option, since I think we expect users only set state at the very beginning and should not restore stats collection in the middle of other operations.~~

EDIT: update to go with option 2, to be more consistent with the No-op impl. Also, setting state to DISABLED will clear all previous stats. 