### PR TITLE
Deprecate Tags.setState, and throw an exception when it is called after getState.

### DIFF
--- a/api/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/api/src/main/java/io/opencensus/tags/NoopTags.java
@@ -26,6 +26,7 @@ import io.opencensus.tags.propagation.TagPropagationComponent;
 import java.util.Collections;
 import java.util.Iterator;
 import javax.annotation.concurrent.Immutable;
+import javax.annotation.concurrent.ThreadSafe;
 
 /** No-op implementations of tagging classes. */
 final class NoopTags {
@@ -37,8 +38,8 @@ final class NoopTags {
    *
    * @return a {@code TagsComponent} that has a no-op implementation for {@code Tagger}.
    */
-  static TagsComponent getNoopTagsComponent() {
-    return NoopTagsComponent.INSTANCE;
+  static TagsComponent newNoopTagsComponent() {
+    return new NoopTagsComponent();
   }
 
   /**
@@ -81,9 +82,9 @@ final class NoopTags {
     return NoopTagContextBinarySerializer.INSTANCE;
   }
 
-  @Immutable
+  @ThreadSafe
   private static final class NoopTagsComponent extends TagsComponent {
-    static final TagsComponent INSTANCE = new NoopTagsComponent();
+    private volatile boolean isRead;
 
     @Override
     public Tagger getTagger() {
@@ -97,12 +98,15 @@ final class NoopTags {
 
     @Override
     public TaggingState getState() {
+      isRead = true;
       return TaggingState.DISABLED;
     }
 
     @Override
+    @Deprecated
     public void setState(TaggingState state) {
       Preconditions.checkNotNull(state, "state");
+      Preconditions.checkState(!isRead, "State was already read, cannot set state.");
     }
   }
 

--- a/api/src/main/java/io/opencensus/tags/Tags.java
+++ b/api/src/main/java/io/opencensus/tags/Tags.java
@@ -74,7 +74,7 @@ public final class Tags {
    * @deprecated This method is deprecated because other libraries could cache the result of {@link
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
    *     initialization. This method throws {@link IllegalStateException} after {@link #getState()}
-   *     has been called, in order to prevent the result of {@code getState()} from changing.
+   *     has been called, in order to limit changes to the result of {@code getState()}.
    */
   @Deprecated
   public static void setState(TaggingState state) {

--- a/api/src/main/java/io/opencensus/tags/Tags.java
+++ b/api/src/main/java/io/opencensus/tags/Tags.java
@@ -55,6 +55,9 @@ public final class Tags {
    * <p>When no implementation is available, {@code getState} always returns {@link
    * TaggingState#DISABLED}.
    *
+   * <p>Once {@link #getState()} is called, subsequent calls to {@link #setState(TaggingState)} will
+   * throw an {@code IllegalStateException}.
+   *
    * @return the current {@code TaggingState}.
    */
   public static TaggingState getState() {
@@ -64,10 +67,16 @@ public final class Tags {
   /**
    * Sets the current {@code TaggingState}.
    *
-   * <p>When no implementation is available, {@code setState} has no effect.
+   * <p>When no implementation is available, {@code setState} does not change the state.
    *
    * @param state the new {@code TaggingState}.
+   * @throws IllegalStateException if {@link #getState()} was previously called.
+   * @deprecated This method is deprecated because other libraries could cache the result of {@link
+   *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
+   *     initialization. This method throws {@link IllegalStateException} after {@link #getState()}
+   *     has been called, in order to prevent the result of {@code getState()} from changing.
    */
+  @Deprecated
   public static void setState(TaggingState state) {
     tagsComponent.setState(state);
   }
@@ -99,6 +108,6 @@ public final class Tags {
               + "default implementation for TagsComponent.",
           e);
     }
-    return NoopTags.getNoopTagsComponent();
+    return NoopTags.newNoopTagsComponent();
   }
 }

--- a/api/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/api/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -37,6 +37,9 @@ public abstract class TagsComponent {
    * <p>When no implementation is available, {@code getState} always returns {@link
    * TaggingState#DISABLED}.
    *
+   * <p>Once {@link #getState()} is called, subsequent calls to {@link #setState(TaggingState)} will
+   * throw an {@code IllegalStateException}.
+   *
    * @return the current {@code TaggingState}.
    */
   public abstract TaggingState getState();
@@ -44,9 +47,15 @@ public abstract class TagsComponent {
   /**
    * Sets the current {@code TaggingState}.
    *
-   * <p>When no implementation is available, {@code setState} has no effect.
+   * <p>When no implementation is available, {@code setState} does not change the state.
    *
    * @param state the new {@code TaggingState}.
+   * @throws IllegalStateException if {@link #getState()} was previously called.
+   * @deprecated This method is deprecated because other libraries could cache the result of {@link
+   *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
+   *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
+   *     has been called, in order to prevent the result of {@code getState()} from changing.
    */
+  @Deprecated
   public abstract void setState(TaggingState state);
 }

--- a/api/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/api/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -54,7 +54,7 @@ public abstract class TagsComponent {
    * @deprecated This method is deprecated because other libraries could cache the result of {@link
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
    *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
-   *     has been called, in order to prevent the result of {@code getState()} from changing.
+   *     has been called, in order to limit changes to the result of {@code getState()}.
    */
   @Deprecated
   public abstract void setState(TaggingState state);

--- a/api/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/api/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -50,16 +50,39 @@ public final class NoopTagsTest {
 
   @Test
   public void noopTagsComponent() {
-    assertThat(NoopTags.getNoopTagsComponent().getTagger()).isSameAs(NoopTags.getNoopTagger());
-    assertThat(NoopTags.getNoopTagsComponent().getTagPropagationComponent())
+    assertThat(NoopTags.newNoopTagsComponent().getTagger()).isSameAs(NoopTags.getNoopTagger());
+    assertThat(NoopTags.newNoopTagsComponent().getTagPropagationComponent())
         .isSameAs(NoopTags.getNoopTagPropagationComponent());
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void noopTagsComponent_SetState_DisallowsNull() {
-    TagsComponent noopTagsComponent = NoopTags.getNoopTagsComponent();
+    TagsComponent noopTagsComponent = NoopTags.newNoopTagsComponent();
     thrown.expect(NullPointerException.class);
     noopTagsComponent.setState(null);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void preventSettingStateAfterGettingState_DifferentState() {
+    TagsComponent noopTagsComponent = NoopTags.newNoopTagsComponent();
+    noopTagsComponent.setState(TaggingState.DISABLED);
+    noopTagsComponent.getState();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    noopTagsComponent.setState(TaggingState.ENABLED);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void preventSettingStateAfterGettingState_SameState() {
+    TagsComponent noopTagsComponent = NoopTags.newNoopTagsComponent();
+    noopTagsComponent.setState(TaggingState.DISABLED);
+    noopTagsComponent.getState();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    noopTagsComponent.setState(TaggingState.DISABLED);
   }
 
   @Test

--- a/api/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/api/src/test/java/io/opencensus/tags/TagsTest.java
@@ -62,12 +62,14 @@ public class TagsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void setState_IgnoresInput() {
     Tags.setState(TaggingState.ENABLED);
     assertThat(Tags.getState()).isEqualTo(TaggingState.DISABLED);
   }
 
   @Test(expected = NullPointerException.class)
+  @SuppressWarnings("deprecation")
   public void setState_DisallowsNull() {
     Tags.setState(null);
   }

--- a/api/src/test/java/io/opencensus/tags/TagsTest.java
+++ b/api/src/test/java/io/opencensus/tags/TagsTest.java
@@ -56,22 +56,20 @@ public class TagsTest {
         .isEqualTo("io.opencensus.tags.NoopTags$NoopTagsComponent");
   }
 
-  @Test
-  public void getState() {
-    assertThat(Tags.getState()).isEqualTo(TaggingState.DISABLED);
-  }
-
+  // There is only one test that modifies tagging state in the Tags class, since the state is
+  // global, and it could affect other tests. NoopTagsTest has more thorough tests for tagging
+  // state.
   @Test
   @SuppressWarnings("deprecation")
-  public void setState_IgnoresInput() {
+  public void testState() {
+    // Test that setState ignores its input.
     Tags.setState(TaggingState.ENABLED);
     assertThat(Tags.getState()).isEqualTo(TaggingState.DISABLED);
-  }
 
-  @Test(expected = NullPointerException.class)
-  @SuppressWarnings("deprecation")
-  public void setState_DisallowsNull() {
-    Tags.setState(null);
+    // Test that setState cannot be called after getState.
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    Tags.setState(TaggingState.ENABLED);
   }
 
   @Test

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
@@ -29,6 +29,7 @@ import javax.annotation.concurrent.ThreadSafe;
  *
  * <p>This class allows different stats classes to share the state in a thread-safe way.
  */
+// TODO(sebright): Remove the locking from this class, since it is used as global state.
 @ThreadSafe
 public final class CurrentStatsState {
 

--- a/impl_core/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/TaggerImpl.java
@@ -44,35 +44,35 @@ public final class TaggerImpl extends Tagger {
 
   @Override
   public TagContextImpl getCurrentTagContext() {
-    return state.get() == TaggingState.DISABLED
+    return state.getInternal() == TaggingState.DISABLED
         ? TagContextImpl.EMPTY
         : toTagContextImpl(CurrentTagContextUtils.getCurrentTagContext());
   }
 
   @Override
   public TagContextBuilder emptyBuilder() {
-    return state.get() == TaggingState.DISABLED
+    return state.getInternal() == TaggingState.DISABLED
         ? NoopTagContextBuilder.INSTANCE
         : new TagContextBuilderImpl();
   }
 
   @Override
   public TagContextBuilder currentBuilder() {
-    return state.get() == TaggingState.DISABLED
+    return state.getInternal() == TaggingState.DISABLED
         ? NoopTagContextBuilder.INSTANCE
         : toBuilder(CurrentTagContextUtils.getCurrentTagContext());
   }
 
   @Override
   public TagContextBuilder toBuilder(TagContext tags) {
-    return state.get() == TaggingState.DISABLED
+    return state.getInternal() == TaggingState.DISABLED
         ? NoopTagContextBuilder.INSTANCE
         : toTagContextBuilderImpl(tags);
   }
 
   @Override
   public Scope withTagContext(TagContext tags) {
-    return state.get() == TaggingState.DISABLED
+    return state.getInternal() == TaggingState.DISABLED
         ? NoopScope.getInstance()
         : CurrentTagContextUtils.withTagContext(toTagContextImpl(tags));
   }

--- a/impl_core/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/TagsComponentImplBase.java
@@ -50,6 +50,7 @@ public class TagsComponentImplBase extends TagsComponent {
   }
 
   @Override
+  @Deprecated
   public void setState(TaggingState newState) {
     state.set(checkNotNull(newState, "newState"));
   }

--- a/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
@@ -34,14 +34,14 @@ final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
 
   @Override
   public byte[] toByteArray(TagContext tags) {
-    return state.get() == TaggingState.DISABLED
+    return state.getInternal() == TaggingState.DISABLED
         ? EMPTY_BYTE_ARRAY
         : SerializationUtils.serializeBinary(tags);
   }
 
   @Override
   public TagContext fromByteArray(byte[] bytes) throws TagContextDeserializationException {
-    return state.get() == TaggingState.DISABLED
+    return state.getInternal() == TaggingState.DISABLED
         ? TagContextImpl.EMPTY
         : SerializationUtils.deserializeBinary(bytes);
   }

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/CurrentTaggingStateTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/CurrentTaggingStateTest.java
@@ -19,13 +19,17 @@ package io.opencensus.implcore.tags;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.tags.TaggingState;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link CurrentTaggingState}. */
 @RunWith(JUnit4.class)
 public final class CurrentTaggingStateTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
   public void defaultState() {
@@ -36,8 +40,25 @@ public final class CurrentTaggingStateTest {
   public void setState() {
     CurrentTaggingState state = new CurrentTaggingState();
     state.set(TaggingState.DISABLED);
-    assertThat(state.get()).isEqualTo(TaggingState.DISABLED);
+    assertThat(state.getInternal()).isEqualTo(TaggingState.DISABLED);
     state.set(TaggingState.ENABLED);
-    assertThat(state.get()).isEqualTo(TaggingState.ENABLED);
+    assertThat(state.getInternal()).isEqualTo(TaggingState.ENABLED);
+  }
+
+  @Test
+  public void preventNull() {
+    CurrentTaggingState state = new CurrentTaggingState();
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("state");
+    state.set(null);
+  }
+
+  @Test
+  public void preventSettingStateAfterReadingState() {
+    CurrentTaggingState state = new CurrentTaggingState();
+    state.get();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    state.set(TaggingState.DISABLED);
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/TagsComponentImplBaseTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/TagsComponentImplBaseTest.java
@@ -20,13 +20,18 @@ import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.TagsComponent;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Tests for {@link TagsComponentImplBase}. */
 @RunWith(JUnit4.class)
 public class TagsComponentImplBaseTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
   private final TagsComponent tagsComponent = new TagsComponentImplBase();
 
   @Test
@@ -35,15 +40,45 @@ public class TagsComponentImplBaseTest {
   }
 
   @Test
-  public void setState() {
+  @SuppressWarnings("deprecation")
+  public void setState_Disabled() {
     tagsComponent.setState(TaggingState.DISABLED);
     assertThat(tagsComponent.getState()).isEqualTo(TaggingState.DISABLED);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void setState_Enabled() {
+    tagsComponent.setState(TaggingState.DISABLED);
     tagsComponent.setState(TaggingState.ENABLED);
     assertThat(tagsComponent.getState()).isEqualTo(TaggingState.ENABLED);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
+  @SuppressWarnings("deprecation")
   public void setState_DisallowsNull() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("newState");
     tagsComponent.setState(null);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void preventSettingStateAfterGettingState_DifferentState() {
+    tagsComponent.setState(TaggingState.DISABLED);
+    tagsComponent.getState();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    tagsComponent.setState(TaggingState.ENABLED);
+  }
+
+  @Test
+  @SuppressWarnings("deprecation")
+  public void preventSettingStateAfterGettingState_SameState() {
+    tagsComponent.setState(TaggingState.DISABLED);
+    tagsComponent.getState();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    tagsComponent.setState(TaggingState.DISABLED);
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImplTest.java
@@ -57,12 +57,14 @@ public final class TagContextBinarySerializerImplTest {
       };
 
   @Test
+  @SuppressWarnings("deprecation")
   public void toByteArray_TaggingDisabled() throws TagContextSerializationException {
     tagsComponent.setState(TaggingState.DISABLED);
     assertThat(serializer.toByteArray(tagContext)).isEmpty();
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void toByteArray_TaggingReenabled() throws TagContextSerializationException {
     final byte[] serialized = serializer.toByteArray(tagContext);
     tagsComponent.setState(TaggingState.DISABLED);
@@ -72,6 +74,7 @@ public final class TagContextBinarySerializerImplTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void fromByteArray_TaggingDisabled()
       throws TagContextDeserializationException, TagContextSerializationException {
     byte[] serialized = serializer.toByteArray(tagContext);


### PR DESCRIPTION
This commit is related to #608.  It deprecates Tags.setState and
TagsComponent.setState and makes NoopTagsComponent.setState and
TagsComponentImplBase.setState throw IllegalStateException when they are called
after getState.

_________________________________________________________________

This PR is similar to #789, but applied to tagging.