### PR TITLE
Deprecate Stats.setState, and throw an exception when it is called after getState.

### DIFF
--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -103,6 +103,7 @@ final class NoopStats {
     }
 
     @Override
+    @Deprecated
     public void setState(StatsCollectionState state) {
       Preconditions.checkNotNull(state, "state");
       checkState(!isRead, "State was already read, cannot set state.");

--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -18,6 +18,7 @@ package io.opencensus.stats;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -83,6 +84,7 @@ final class NoopStats {
   @ThreadSafe
   private static final class NoopStatsComponent extends StatsComponent {
     private final ViewManager viewManager = newNoopViewManager();
+    private volatile boolean isRead;
 
     @Override
     public ViewManager getViewManager() {
@@ -96,12 +98,14 @@ final class NoopStats {
 
     @Override
     public StatsCollectionState getState() {
+      isRead = true;
       return StatsCollectionState.DISABLED;
     }
 
     @Override
     public void setState(StatsCollectionState state) {
       Preconditions.checkNotNull(state, "state");
+      checkState(!isRead, "State was already read, cannot set state.");
     }
   }
 

--- a/api/src/main/java/io/opencensus/stats/Stats.java
+++ b/api/src/main/java/io/opencensus/stats/Stats.java
@@ -44,6 +44,9 @@ public final class Stats {
    * <p>When no implementation is available, {@code getState} always returns {@link
    * StatsCollectionState#DISABLED}.
    *
+   * <p>Once {@link #getState()} is called, subsequent calls to {@link
+   * #setState(StatsCollectionState)} will throw an {@code IllegalStateException}.
+   *
    * @return the current {@code StatsCollectionState}.
    */
   public static StatsCollectionState getState() {
@@ -53,9 +56,13 @@ public final class Stats {
   /**
    * Sets the current {@code StatsCollectionState}.
    *
-   * <p>When no implementation is available, {@code setState} has no effect.
+   * <p>When no implementation is available, {@code setState} does not change the state.
+   *
+   * <p>If state is set to {@link StatsCollectionState#DISABLED}, all stats that are previously
+   * recorded will be cleared.
    *
    * @param state the new {@code StatsCollectionState}.
+   * @throws IllegalStateException if {@link #getState()} was previously called.
    */
   public static void setState(StatsCollectionState state) {
     statsComponent.setState(state);

--- a/api/src/main/java/io/opencensus/stats/Stats.java
+++ b/api/src/main/java/io/opencensus/stats/Stats.java
@@ -63,7 +63,12 @@ public final class Stats {
    *
    * @param state the new {@code StatsCollectionState}.
    * @throws IllegalStateException if {@link #getState()} was previously called.
+   * @deprecated This method is deprecated because other libraries could cache the result of {@link
+   *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
+   *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
+   *     has been called, in order to prevent the result of {@code getState()} from changing.
    */
+  @Deprecated
   public static void setState(StatsCollectionState state) {
     statsComponent.setState(state);
   }

--- a/api/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/api/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -52,6 +52,11 @@ public abstract class StatsComponent {
    *
    * @param state the new {@code StatsCollectionState}.
    * @throws IllegalStateException if {@link #getState()} was previously called.
+   * @deprecated This method is deprecated because other libraries could cache the result of {@link
+   *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
+   *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
+   *     has been called, in order to prevent the result of {@code getState()} from changing.
    */
+  @Deprecated
   public abstract void setState(StatsCollectionState state);
 }

--- a/api/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/api/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -45,12 +45,13 @@ public abstract class StatsComponent {
   /**
    * Sets the current {@code StatsCollectionState}.
    *
-   * <p>When no implementation is available, {@code setState} has no effect.
+   * <p>When no implementation is available, {@code setState} does not change the state.
    *
    * <p>If state is set to {@link StatsCollectionState#DISABLED}, all stats that are previously
    * recorded will be cleared.
    *
    * @param state the new {@code StatsCollectionState}.
+   * @throws IllegalStateException if {@link #getState()} was previously called.
    */
   public abstract void setState(StatsCollectionState state);
 }

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -80,6 +80,16 @@ public final class NoopStatsTest {
     noopStatsComponent.setState(null);
   }
 
+  @Test
+  public void noopStatsComponent_DisallowsSetStateAfterGetState() {
+    StatsComponent noopStatsComponent = NoopStats.newNoopStatsComponent();
+    noopStatsComponent.setState(StatsCollectionState.DISABLED);
+    noopStatsComponent.getState();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    noopStatsComponent.setState(StatsCollectionState.ENABLED);
+  }
+
   // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
   // exception.
   @Test

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -67,6 +67,7 @@ public final class NoopStatsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void noopStatsComponent_SetState_IgnoresInput() {
     StatsComponent noopStatsComponent = NoopStats.newNoopStatsComponent();
     noopStatsComponent.setState(StatsCollectionState.ENABLED);
@@ -74,6 +75,7 @@ public final class NoopStatsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void noopStatsComponent_SetState_DisallowsNull() {
     StatsComponent noopStatsComponent = NoopStats.newNoopStatsComponent();
     thrown.expect(NullPointerException.class);
@@ -81,6 +83,7 @@ public final class NoopStatsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void noopStatsComponent_DisallowsSetStateAfterGetState() {
     StatsComponent noopStatsComponent = NoopStats.newNoopStatsComponent();
     noopStatsComponent.setState(StatsCollectionState.DISABLED);

--- a/api/src/test/java/io/opencensus/stats/StatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/StatsTest.java
@@ -82,13 +82,4 @@ public final class StatsTest {
     thrown.expectMessage("state");
     Stats.setState(null);
   }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void disallowSetStateAfterGetState() {
-    Stats.getState();
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("State was already read, cannot set state.");
-    Stats.setState(StatsCollectionState.DISABLED);
-  }
 }

--- a/api/src/test/java/io/opencensus/stats/StatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/StatsTest.java
@@ -74,8 +74,18 @@ public final class StatsTest {
     assertThat(Stats.getState()).isEqualTo(StatsCollectionState.DISABLED);
   }
 
-  @Test(expected = NullPointerException.class)
+  @Test
   public void setState_DisallowsNull() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("state");
     Stats.setState(null);
+  }
+
+  @Test
+  public void disallowSetStateAfterGetState() {
+    Stats.getState();
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("State was already read, cannot set state.");
+    Stats.setState(StatsCollectionState.DISABLED);
   }
 }

--- a/api/src/test/java/io/opencensus/stats/StatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/StatsTest.java
@@ -69,12 +69,14 @@ public final class StatsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void setState_IgnoresInput() {
     Stats.setState(StatsCollectionState.ENABLED);
     assertThat(Stats.getState()).isEqualTo(StatsCollectionState.DISABLED);
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void setState_DisallowsNull() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("state");
@@ -82,6 +84,7 @@ public final class StatsTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void disallowSetStateAfterGetState() {
     Stats.getState();
     thrown.expect(IllegalStateException.class);

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -59,7 +59,7 @@ public class StatsComponentImplBase extends StatsComponent {
   }
 
   @Override
-  @Deprecated
+  @SuppressWarnings("deprecation")
   public void setState(StatsCollectionState newState) {
     boolean stateChanged = state.set(Preconditions.checkNotNull(newState, "newState"));
     if (stateChanged) {

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -59,6 +59,7 @@ public class StatsComponentImplBase extends StatsComponent {
   }
 
   @Override
+  @Deprecated
   public void setState(StatsCollectionState newState) {
     boolean stateChanged = state.set(Preconditions.checkNotNull(newState, "newState"));
     if (stateChanged) {

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
@@ -43,12 +43,14 @@ public final class StatsComponentImplBaseTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void setState_Disabled() {
     statsComponent.setState(StatsCollectionState.DISABLED);
     assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.DISABLED);
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void setState_Enabled() {
     statsComponent.setState(StatsCollectionState.DISABLED);
     statsComponent.setState(StatsCollectionState.ENABLED);
@@ -56,6 +58,7 @@ public final class StatsComponentImplBaseTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void setState_DisallowsNull() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("newState");
@@ -63,6 +66,7 @@ public final class StatsComponentImplBaseTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void preventSettingStateAfterGettingState() {
     statsComponent.setState(StatsCollectionState.DISABLED);
     statsComponent.getState();

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
@@ -138,6 +138,7 @@ public final class StatsRecorderImplTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void record_StatsDisabled() {
     View view =
         View.create(
@@ -158,6 +159,7 @@ public final class StatsRecorderImplTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void record_StatsReenabled() {
     View view =
         View.create(

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -785,6 +785,7 @@ public class ViewManagerImplTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void registerRecordAndGetView_StatsDisabled() {
     statsComponent.setState(StatsCollectionState.DISABLED);
     View view = createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY));
@@ -797,6 +798,7 @@ public class ViewManagerImplTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void registerRecordAndGetView_StatsReenabled() {
     statsComponent.setState(StatsCollectionState.DISABLED);
     statsComponent.setState(StatsCollectionState.ENABLED);
@@ -814,6 +816,7 @@ public class ViewManagerImplTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void registerViewWithStatsDisabled_RecordAndGetViewWithStatsEnabled() {
     statsComponent.setState(StatsCollectionState.DISABLED);
     View view = createCumulativeView(VIEW_NAME, MEASURE_DOUBLE, MEAN, Arrays.asList(KEY));
@@ -832,6 +835,7 @@ public class ViewManagerImplTest {
   }
 
   @Test
+  @SuppressWarnings("deprecation")
   public void registerDifferentViewWithSameNameWithStatsDisabled() {
     statsComponent.setState(StatsCollectionState.DISABLED);
     View view1 =
@@ -873,6 +877,7 @@ public class ViewManagerImplTest {
     settingStateToDisabledWillClearStats(intervalView);
   }
 
+  @SuppressWarnings("deprecation")
   private void settingStateToDisabledWillClearStats(View view) {
     Timestamp timestamp1 = Timestamp.create(1, 0);
     clock.setTime(timestamp1);


### PR DESCRIPTION
Changes on Stats state APIs, similar to https://github.com/census-instrumentation/opencensus-java/pull/790.

Closes https://github.com/census-instrumentation/opencensus-java/issues/762.