### PR TITLE
Add ViewManager.getAllExportedViews().

### DIFF
--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -22,10 +22,12 @@ import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.stats.View.AggregationWindow;
 import io.opencensus.stats.ViewData.AggregationWindowData;
 import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
 import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
@@ -34,6 +36,7 @@ import io.opencensus.tags.TagValue;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.Immutable;
@@ -185,6 +188,19 @@ final class NoopStats {
                           IntervalData.create(ZERO_TIMESTAMP)),
                       Functions.<AggregationWindowData>throwAssertionError()));
         }
+      }
+    }
+
+    @Override
+    public Set<View> getAllExportedViews() {
+      synchronized (views) {
+        Set<View> exportedViews = Sets.newHashSet();
+        for (View view : views.values()) {
+          if (view.getWindow() instanceof AggregationWindow.Cumulative) {
+            exportedViews.add(view);
+          }
+        }
+        return Collections.unmodifiableSet(exportedViews);
       }
     }
   }

--- a/api/src/main/java/io/opencensus/stats/ViewManager.java
+++ b/api/src/main/java/io/opencensus/stats/ViewManager.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.stats;
 
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /**
@@ -42,4 +43,15 @@ public abstract class ViewManager {
    */
   @Nullable
   public abstract ViewData getView(View.Name view);
+
+  /**
+   * Returns all registered views that should be exported.
+   *
+   * <p>This method should be used by any stats exporter that automatically exports data for views
+   * registered with the {@link ViewManager}.
+   *
+   * @return all registered views that should be exported.
+   * @since 0.9
+   */
+  public abstract Set<View> getAllExportedViews();
 }

--- a/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
@@ -29,6 +29,7 @@ import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
 import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
 import io.opencensus.tags.TagKey;
 import java.util.Arrays;
+import java.util.Set;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -127,5 +128,67 @@ public final class NoopViewManagerTest {
     ViewManager viewManager = NoopStats.newNoopViewManager();
     thrown.expect(NullPointerException.class);
     viewManager.getView(null);
+  }
+
+  @Test
+  public void getAllExportedViews() {
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+    assertThat(viewManager.getAllExportedViews()).isEmpty();
+    View cumulativeView1 =
+        View.create(
+            View.Name.create("View 1"),
+            VIEW_DESCRIPTION,
+            MEASURE,
+            AGGREGATION,
+            Arrays.asList(KEY),
+            CUMULATIVE);
+    View cumulativeView2 =
+        View.create(
+            View.Name.create("View 2"),
+            VIEW_DESCRIPTION,
+            MEASURE,
+            AGGREGATION,
+            Arrays.asList(KEY),
+            CUMULATIVE);
+    View intervalView =
+        View.create(
+            View.Name.create("View 3"),
+            VIEW_DESCRIPTION,
+            MEASURE,
+            AGGREGATION,
+            Arrays.asList(KEY),
+            INTERVAL);
+    viewManager.registerView(cumulativeView1);
+    viewManager.registerView(cumulativeView2);
+    viewManager.registerView(intervalView);
+
+    // Only cumulative views should be exported.
+    assertThat(viewManager.getAllExportedViews()).containsExactly(cumulativeView1, cumulativeView2);
+  }
+
+  @Test
+  public void getAllExportedViews_ResultIsUnmodifiable() {
+    ViewManager viewManager = NoopStats.newNoopViewManager();
+    View view1 =
+        View.create(
+            View.Name.create("View 1"),
+            VIEW_DESCRIPTION,
+            MEASURE,
+            AGGREGATION,
+            Arrays.asList(KEY),
+            CUMULATIVE);
+    viewManager.registerView(view1);
+    Set<View> exported = viewManager.getAllExportedViews();
+
+    View view2 =
+        View.create(
+            View.Name.create("View 2"),
+            VIEW_DESCRIPTION,
+            MEASURE,
+            AGGREGATION,
+            Arrays.asList(KEY),
+            CUMULATIVE);
+    thrown.expect(UnsupportedOperationException.class);
+    exported.add(view2);
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -69,27 +69,6 @@ final class MeasureToViewMap {
     return Sets.newHashSet(registeredViews.values());
   }
 
-  @Nullable
-  private synchronized MutableViewData getMutableViewData(View.Name viewName) {
-    View view = registeredViews.get(viewName);
-    if (view == null) {
-      return null;
-    }
-    Collection<MutableViewData> views = mutableMap.get(view.getMeasure().getName());
-    for (MutableViewData viewData : views) {
-      if (viewData.getView().getName().equals(viewName)) {
-        return viewData;
-      }
-    }
-    throw new AssertionError(
-        "Internal error: Not recording stats for view: \""
-            + viewName
-            + "\" registeredViews="
-            + registeredViews
-            + ", mutableMap="
-            + mutableMap);
-  }
-
   /** Enable stats collection for the given {@link View}. */
   synchronized void registerView(View view, Clock clock) {
     View existing = registeredViews.get(view.getName());
@@ -113,6 +92,27 @@ final class MeasureToViewMap {
       registeredMeasures.put(measure.getName(), measure);
     }
     mutableMap.put(view.getMeasure().getName(), MutableViewData.create(view, clock.now()));
+  }
+
+  @Nullable
+  private synchronized MutableViewData getMutableViewData(View.Name viewName) {
+    View view = registeredViews.get(viewName);
+    if (view == null) {
+      return null;
+    }
+    Collection<MutableViewData> views = mutableMap.get(view.getMeasure().getName());
+    for (MutableViewData viewData : views) {
+      if (viewData.getView().getName().equals(viewName)) {
+        return viewData;
+      }
+    }
+    throw new AssertionError(
+        "Internal error: Not recording stats for view: \""
+            + viewName
+            + "\" registeredViews="
+            + registeredViews
+            + ", mutableMap="
+            + mutableMap);
   }
 
   // Records stats with a set of tags.

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -19,6 +19,7 @@ package io.opencensus.implcore.stats;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Multimap;
+import com.google.common.collect.Sets;
 import io.opencensus.common.Clock;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
@@ -62,6 +63,10 @@ final class MeasureToViewMap {
   synchronized ViewData getView(View.Name viewName, Clock clock, StatsCollectionState state) {
     MutableViewData view = getMutableViewData(viewName);
     return view == null ? null : view.toViewData(clock.now(), state);
+  }
+
+  synchronized Collection<View> getAllViews() {
+    return Sets.newHashSet(registeredViews.values());
   }
 
   @Nullable

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -24,7 +24,7 @@ import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.View;
 import io.opencensus.stats.ViewData;
 import io.opencensus.tags.TagContext;
-import java.util.Collection;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Object that stores all views and stats. */
@@ -56,8 +56,8 @@ final class StatsManager {
     return measureToViewMap.getView(viewName, clock, state.getInternal());
   }
 
-  Collection<View> getAllViews() {
-    return measureToViewMap.getAllViews();
+  Set<View> getExportedViews() {
+    return measureToViewMap.getExportedViews();
   }
 
   void record(TagContext tags, MeasureMapInternal measurementValues) {

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -24,6 +24,7 @@ import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.View;
 import io.opencensus.stats.ViewData;
 import io.opencensus.tags.TagContext;
+import java.util.Collection;
 import javax.annotation.Nullable;
 
 /** Object that stores all views and stats. */
@@ -53,6 +54,10 @@ final class StatsManager {
   @Nullable
   ViewData getView(View.Name viewName) {
     return measureToViewMap.getView(viewName, clock, state.getInternal());
+  }
+
+  Collection<View> getAllViews() {
+    return measureToViewMap.getAllViews();
   }
 
   void record(TagContext tags, MeasureMapInternal measurementValues) {

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
@@ -16,9 +16,13 @@
 
 package io.opencensus.implcore.stats;
 
+import com.google.common.collect.Sets;
 import io.opencensus.stats.View;
+import io.opencensus.stats.View.AggregationWindow;
 import io.opencensus.stats.ViewData;
 import io.opencensus.stats.ViewManager;
+import java.util.Collections;
+import java.util.Set;
 import javax.annotation.Nullable;
 
 /** Implementation of {@link ViewManager}. */
@@ -38,6 +42,17 @@ public final class ViewManagerImpl extends ViewManager {
   @Nullable
   public ViewData getView(View.Name viewName) {
     return statsManager.getView(viewName);
+  }
+
+  @Override
+  public Set<View> getAllExportedViews() {
+    Set<View> exportedViews = Sets.newHashSet();
+    for (View view : statsManager.getAllViews()) {
+      if (view.getWindow() instanceof AggregationWindow.Cumulative) {
+        exportedViews.add(view);
+      }
+    }
+    return Collections.unmodifiableSet(exportedViews);
   }
 
   void clearStats() {

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/ViewManagerImpl.java
@@ -16,12 +16,9 @@
 
 package io.opencensus.implcore.stats;
 
-import com.google.common.collect.Sets;
 import io.opencensus.stats.View;
-import io.opencensus.stats.View.AggregationWindow;
 import io.opencensus.stats.ViewData;
 import io.opencensus.stats.ViewManager;
-import java.util.Collections;
 import java.util.Set;
 import javax.annotation.Nullable;
 
@@ -46,13 +43,7 @@ public final class ViewManagerImpl extends ViewManager {
 
   @Override
   public Set<View> getAllExportedViews() {
-    Set<View> exportedViews = Sets.newHashSet();
-    for (View view : statsManager.getAllViews()) {
-      if (view.getWindow() instanceof AggregationWindow.Cumulative) {
-        exportedViews.add(view);
-      }
-    }
-    return Collections.unmodifiableSet(exportedViews);
+    return statsManager.getExportedViews();
   }
 
   void clearStats() {


### PR DESCRIPTION
This method currently returns all registered cumulative views.  We could add a
way to specify which views should be exported later.  The API is currently
needed for the StackDriver exporter.

The NoopViewManager also returns all cumulative views.  However, the exporter
could choose to not export data when stats collection isn't enabled.