### PR TITLE
Increase timeout for an asynchronous verification

### DIFF
--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -165,8 +165,9 @@ public class StackdriverStatsExporterTest {
       StackdriverStatsExporter.registerView(view);
 
       verify(mockStub, times(1)).createMetricDescriptorCallable();
-      // The timeout for verifying createTimeSeries needs to match the export interval of exporter.
-      verify(mockStub, timeout(1000).times(1)).createTimeSeriesCallable();
+      // This verification is slower on some machine. Relax the timeout be greater than the export
+      // interval to make this more steady.
+      verify(mockStub, timeout(2000).times(1)).createTimeSeriesCallable();
 
       MetricDescriptor descriptor = StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID);
       List<TimeSeries> timeSeries =

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -18,6 +18,7 @@ package io.opencensus.exporter.stats.stackdriver;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.timeout;
@@ -165,9 +166,10 @@ public class StackdriverStatsExporterTest {
       StackdriverStatsExporter.registerView(view);
 
       verify(mockStub, times(1)).createMetricDescriptorCallable();
-      // This verification is slower on some machine. Relax the timeout be greater than the export
-      // interval to make this more steady.
-      verify(mockStub, timeout(2000).times(1)).createTimeSeriesCallable();
+      // createTimeSeriesCallable() should be called once per second. This test uses a timeout that
+      // is longer than the export interval in order to decrease the chance of failures due to
+      // timing.
+      verify(mockStub, timeout(2000).atLeast(1)).createTimeSeriesCallable();
 
       MetricDescriptor descriptor = StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID);
       List<TimeSeries> timeSeries =
@@ -178,7 +180,7 @@ public class StackdriverStatsExporterTest {
                   CreateMetricDescriptorRequest.newBuilder()
                       .setMetricDescriptor(descriptor)
                       .build()));
-      verify(mockCreateTimeSeriesCallable, times(1))
+      verify(mockCreateTimeSeriesCallable, atLeast(1))
           .call(eq(CreateTimeSeriesRequest.newBuilder().addAllTimeSeries(timeSeries).build()));
     } finally {
       StackdriverStatsExporter.unsafeSetExporter(null);

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -169,6 +169,7 @@ public class StackdriverStatsExporterTest {
       // createTimeSeriesCallable() should be called once per second. This test uses a timeout that
       // is longer than the export interval in order to decrease the chance of failures due to
       // timing.
+      // TODO(songya): consider how to avoid blocking the thread and making this test deterministic
       verify(mockStub, timeout(2000).atLeast(1)).createTimeSeriesCallable();
 
       MetricDescriptor descriptor = StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID);


### PR DESCRIPTION
`StackdriverStatsExporterTest.registerViewAndExport()` is slower on some machine. Previously it has an 1 second timeout for the asynchronous verification, however this limit seems too strict. Relax the timeout to 2 seconds to make it more stable.

Test failures:
https://travis-ci.org/census-instrumentation/opencensus-java/jobs/299758118