### PR TITLE
Just target Java 1.6, it simplifies a few things.

### DIFF
--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -6,9 +6,6 @@ plugins {
 
 description = 'OpenCensus Agent'
 
-sourceCompatibility = JavaVersion.VERSION_1_6
-targetCompatibility = JavaVersion.VERSION_1_6
-
 def agentPackage = 'io.opencensus.contrib.agent'
 def agentMainClass = "${agentPackage}.AgentMain"
 
@@ -32,12 +29,6 @@ dependencies {
   compile libraries.byte_buddy
 
   signature 'org.codehaus.mojo.signature:java16:+@signature'
-}
-
-// Don't bother about Java 1.6 for test classes. Let Animalsniffer check main sources only,
-// cf. https://github.com/xvik/gradle-animalsniffer-plugin#scope.
-animalsniffer {
-  sourceSets = [ sourceSets.main ]
 }
 
 jar {

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -1,21 +1,13 @@
 plugins {
   id 'com.github.johnrengelman.shadow' version '2.0.1'
-  id 'me.tatarka.retrolambda' version '3.7.0' 
   id 'me.champeau.gradle.jmh' version '0.4.4'
   id 'io.morethan.jmhreport' version '0.6.2.1'
 }
 
 description = 'OpenCensus Agent'
 
-sourceCompatibility = JavaVersion.VERSION_1_7
-targetCompatibility = JavaVersion.VERSION_1_7
-
-// Experimental support for legacy Java 1.6 JVMs. Animalsniffer (applied by the root project) is
-// used to check for unexpected references to later APIs. Also see dependencies/signature.
-// Retrolambda itself requires JDK 8, which it finds at $JAVA8_HOME.
-retrolambda {
-  javaVersion JavaVersion.VERSION_1_6
-}
+sourceCompatibility = JavaVersion.VERSION_1_6
+targetCompatibility = JavaVersion.VERSION_1_6
 
 def agentPackage = 'io.opencensus.contrib.agent'
 def agentMainClass = "${agentPackage}.AgentMain"
@@ -54,10 +46,6 @@ jar {
     // https://docs.oracle.com/javase/8/docs/api/java/lang/instrument/package-summary.html.
     attributes 'Premain-Class': agentMainClass
     attributes 'Can-Retransform-Classes': true
-
-    // Let the java plugin use the overridden values instead of the root project's values.
-    attributes 'Source-Compatibility': JavaVersion.VERSION_1_6
-    attributes 'Target-Compatibility': JavaVersion.VERSION_1_6
   }
 }
 

--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/Resources.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/Resources.java
@@ -43,9 +43,12 @@ final class Resources {
     checkArgument(!Strings.isNullOrEmpty(resourceName), "resourceName");
 
     File file = File.createTempFile(resourceName, ".tmp");
-    try (OutputStream os = new FileOutputStream(file)) {
+    OutputStream os = new FileOutputStream(file);
+    try {
       getResourceAsTempFile(resourceName, file, os);
       return file;
+    } finally {
+      os.close();
     }
   }
 

--- a/contrib/agent/src/test/java/io/opencensus/contrib/agent/ResourcesTest.java
+++ b/contrib/agent/src/test/java/io/opencensus/contrib/agent/ResourcesTest.java
@@ -20,6 +20,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.verify;
 
 import com.google.common.base.Charsets;
+import com.google.common.io.Files;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -51,8 +52,7 @@ public class ResourcesTest {
   public void getResourceAsTempFile_contents() throws IOException {
     File file = Resources.getResourceAsTempFile("some_resource.txt");
 
-    assertThat(new String(java.nio.file.Files.readAllBytes(file.toPath()), Charsets.UTF_8))
-        .isEqualTo("A resource!");
+    assertThat(Files.toString(file, Charsets.UTF_8)).isEqualTo("A resource!");
   }
 
   @Test


### PR DESCRIPTION
There's not enough benefit from 1.7 and then using retrolambda for
targetting 1.6. Just use plain 1.6 and get rid some of the otherwise
required magic.

Also fixes #445 by removing retrolambda.