### PR TITLE
Revert "Use the current release version of Mockito. (#751)"

### DIFF
--- a/api/src/test/java/io/opencensus/trace/ScopedSpanHandleTest.java
+++ b/api/src/test/java/io/opencensus/trace/ScopedSpanHandleTest.java
@@ -17,7 +17,7 @@
 package io.opencensus.trace;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.verify;
 
 import io.opencensus.common.Scope;

--- a/api/src/test/java/io/opencensus/trace/SpanTest.java
+++ b/api/src/test/java/io/opencensus/trace/SpanTest.java
@@ -17,8 +17,8 @@
 package io.opencensus.trace;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.verify;
 
 import java.util.Collections;

--- a/api/src/test/java/io/opencensus/trace/TracerTest.java
+++ b/api/src/test/java/io/opencensus/trace/TracerTest.java
@@ -17,7 +17,7 @@
 package io.opencensus.trace;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.when;
 
 import io.grpc.Context;

--- a/build.gradle
+++ b/build.gradle
@@ -132,7 +132,7 @@ subprojects {
                 // Test dependencies.
                 guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
                 junit: 'junit:junit:4.12',
-                mockito: 'org.mockito:mockito-core:2.11.0',
+                mockito: 'org.mockito:mockito-core:1.9.5',
                 truth: 'com.google.truth:truth:0.30',
         ]
     }

--- a/contrib/agent/src/test/java/io/opencensus/contrib/agent/ResourcesTest.java
+++ b/contrib/agent/src/test/java/io/opencensus/contrib/agent/ResourcesTest.java
@@ -31,7 +31,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 /** Unit tests for {@link Resources}. */
 @RunWith(MockitoJUnitRunner.class)

--- a/contrib/agent/src/test/java/io/opencensus/contrib/agent/bootstrap/ContextTrampolineTest.java
+++ b/contrib/agent/src/test/java/io/opencensus/contrib/agent/bootstrap/ContextTrampolineTest.java
@@ -24,7 +24,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 /** Unit tests for {@link ContextTrampoline}. */
 @RunWith(MockitoJUnitRunner.class)

--- a/contrib/agent/src/test/java/io/opencensus/contrib/agent/bootstrap/TraceTrampolineTest.java
+++ b/contrib/agent/src/test/java/io/opencensus/contrib/agent/bootstrap/TraceTrampolineTest.java
@@ -25,7 +25,7 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.mockito.Mockito;
-import org.mockito.junit.MockitoJUnitRunner;
+import org.mockito.runners.MockitoJUnitRunner;
 
 /** Unit tests for {@link TraceTrampoline}. */
 @RunWith(MockitoJUnitRunner.class)

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -16,8 +16,8 @@
 
 package io.opencensus.exporter.stats.stackdriver;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.doReturn;

--- a/exporters/trace/logging/src/test/java/io/opencensus/exporter/trace/logging/LoggingExporterTest.java
+++ b/exporters/trace/logging/src/test/java/io/opencensus/exporter/trace/logging/LoggingExporterTest.java
@@ -16,8 +16,8 @@
 
 package io.opencensus.exporter.trace.logging;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
 
 import io.opencensus.exporter.trace.logging.LoggingExporter.LoggingExporterHandler;

--- a/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverExporterTest.java
+++ b/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverExporterTest.java
@@ -16,8 +16,8 @@
 
 package io.opencensus.exporter.trace.stackdriver;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.verify;
 
 import io.opencensus.trace.export.SpanExporter;

--- a/exporters/trace/zipkin/src/test/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterTest.java
+++ b/exporters/trace/zipkin/src/test/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterTest.java
@@ -16,8 +16,8 @@
 
 package io.opencensus.exporter.trace.zipkin;
 
-import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.same;
 import static org.mockito.Mockito.verify;
 
 import io.opencensus.trace.export.SpanExporter;

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/SpanExporterImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/SpanExporterImplTest.java
@@ -17,7 +17,7 @@
 package io.opencensus.implcore.trace.export;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.ArgumentMatchers.anyListOf;
+import static org.mockito.Matchers.anyListOf;
 import static org.mockito.Mockito.doThrow;
 
 import io.opencensus.implcore.common.MillisClock;


### PR DESCRIPTION
This reverts commit 3f946d748ea171c70c297cf3188e4b0dbadab1ad.

Reverting due to integration issues.