### PR TITLE
Upgrade to Error Prone 2.1.2.

### DIFF
--- a/api/src/test/java/io/opencensus/trace/export/SpanDataTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/SpanDataTest.java
@@ -34,9 +34,9 @@ import io.opencensus.trace.export.SpanData.Attributes;
 import io.opencensus.trace.export.SpanData.Links;
 import io.opencensus.trace.export.SpanData.TimedEvent;
 import io.opencensus.trace.export.SpanData.TimedEvents;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -68,20 +68,11 @@ public class SpanDataTest {
           TraceId.generateRandomId(random), SpanId.generateRandomId(random), TraceOptions.DEFAULT);
   private final SpanId parentSpanId = SpanId.generateRandomId(random);
   private final Map<String, AttributeValue> attributesMap = new HashMap<String, AttributeValue>();
-
-  // TODO: Decide whether to use a different class instead of LinkedList.
-  @SuppressWarnings("JdkObsolete")
   private final List<TimedEvent<Annotation>> annotationsList =
-      new LinkedList<TimedEvent<Annotation>>();
-
-  // TODO: Decide whether to use a different class instead of LinkedList.
-  @SuppressWarnings("JdkObsolete")
+      new ArrayList<TimedEvent<Annotation>>();
   private final List<TimedEvent<NetworkEvent>> networkEventsList =
-      new LinkedList<SpanData.TimedEvent<NetworkEvent>>();
-
-  // TODO: Decide whether to use a different class instead of LinkedList.
-  @SuppressWarnings("JdkObsolete")
-  private final List<Link> linksList = new LinkedList<Link>();
+      new ArrayList<SpanData.TimedEvent<NetworkEvent>>();
+  private final List<Link> linksList = new ArrayList<Link>();
 
   private Attributes attributes;
   private TimedEvents<Annotation> annotations;

--- a/api/src/test/java/io/opencensus/trace/export/SpanDataTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/SpanDataTest.java
@@ -68,11 +68,21 @@ public class SpanDataTest {
           TraceId.generateRandomId(random), SpanId.generateRandomId(random), TraceOptions.DEFAULT);
   private final SpanId parentSpanId = SpanId.generateRandomId(random);
   private final Map<String, AttributeValue> attributesMap = new HashMap<String, AttributeValue>();
+
+  // TODO: Decide whether to use a different class instead of LinkedList.
+  @SuppressWarnings("JdkObsolete")
   private final List<TimedEvent<Annotation>> annotationsList =
       new LinkedList<TimedEvent<Annotation>>();
+
+  // TODO: Decide whether to use a different class instead of LinkedList.
+  @SuppressWarnings("JdkObsolete")
   private final List<TimedEvent<NetworkEvent>> networkEventsList =
       new LinkedList<SpanData.TimedEvent<NetworkEvent>>();
+
+  // TODO: Decide whether to use a different class instead of LinkedList.
+  @SuppressWarnings("JdkObsolete")
   private final List<Link> linksList = new LinkedList<Link>();
+
   private Attributes attributes;
   private TimedEvents<Annotation> annotations;
   private TimedEvents<NetworkEvent> networkEvents;

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath 'ru.vyarus:gradle-animalsniffer-plugin:1.4.2'
-        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.11'
+        classpath 'net.ltgt.gradle:gradle-errorprone-plugin:0.0.13'
         classpath "net.ltgt.gradle:gradle-apt-plugin:0.10"
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.15.0'
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6"

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,7 @@ subprojects {
         // https://groups.google.com/forum/#!topic/bazel-discuss/_R3A9TJSoPM
         it.options.compilerArgs += ["-Xlint:all", "-Xlint:-try", "-Xlint:-processing"]
         if (JavaVersion.current().isJava8Compatible()) {
+            it.options.compilerArgs += ["-XepDisableWarningsInGeneratedCode"]
             // TODO(bdrutu): Read files directly instead of reading from properties.
             if (rootProject.hasProperty("errorProneWarnings")) {
                 it.options.compilerArgs += rootProject.properties["errorProneWarnings"].split(',').collect {

--- a/build.gradle
+++ b/build.gradle
@@ -107,6 +107,7 @@ subprojects {
     ext {
         autoValueVersion = '1.4'
         findBugsVersion = '3.0.1'
+        errorProneVersion = '2.1.2'
         grpcVersion = '1.7.0'
         guavaVersion = '19.0'
         googleAuthVersion = '0.8.0'
@@ -118,7 +119,7 @@ subprojects {
                 auto_service: 'com.google.auto.service:auto-service:1.0-rc3',
                 byte_buddy: 'net.bytebuddy:byte-buddy:1.7.8',
                 disruptor: 'com.lmax:disruptor:3.3.6',
-                errorprone: 'com.google.errorprone:error_prone_annotations:2.0.19',
+                errorprone: "com.google.errorprone:error_prone_annotations:${errorProneVersion}",
                 findbugs_annotations: "com.google.code.findbugs:annotations:${findBugsVersion}",
                 google_auth: "com.google.auth:google-auth-library-credentials:${googleAuthVersion}",
                 google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudVersion}",
@@ -150,7 +151,7 @@ subprojects {
         if (JavaVersion.current().isJava8Compatible()) {
             // The ErrorProne plugin defaults to the latest, which would break our
             // build if error prone releases a new version with a new check
-            errorprone 'com.google.errorprone:error_prone_core:2.0.19'
+            errorprone "com.google.errorprone:error_prone_core:${errorProneVersion}"
         }
     }
 

--- a/gradle/errorprone/experimental_errors
+++ b/gradle/errorprone/experimental_errors
@@ -1,5 +1,4 @@
 errorProneExperimentalErrors = \
--Xep:ArgumentParameterSwap:ERROR,\
 -Xep:AssistedInjectAndInjectOnSameConstructor:ERROR,\
 -Xep:AutoFactoryAtInject:ERROR,\
 -Xep:ClassName:ERROR,\
@@ -22,6 +21,5 @@ errorProneExperimentalErrors = \
 -Xep:NumericEquality:ERROR,\
 -Xep:ParameterPackage:OFF,\
 -Xep:ProtoStringFieldReferenceEquality:ERROR,\
--Xep:QualifierOnMethodWithoutProvides:ERROR,\
 -Xep:StaticOrDefaultInterfaceMethod:ERROR,\
 -Xep:UnlockMethod:ERROR

--- a/gradle/errorprone/experimental_warnings
+++ b/gradle/errorprone/experimental_warnings
@@ -1,5 +1,4 @@
 errorProneExperimentalWarnings = \
--Xep:ArgumentParameterMismatch:OFF,\
 -Xep:AssertFalse:ERROR,\
 -Xep:AssistedInjectAndInjectOnConstructors:ERROR,\
 -Xep:BigDecimalLiteralDouble:ERROR,\

--- a/gradle/errorprone/warnings
+++ b/gradle/errorprone/warnings
@@ -8,7 +8,6 @@ errorProneWarnings = \
 -Xep:ClassNewInstance:ERROR,\
 -Xep:DefaultCharset:ERROR,\
 -Xep:DoubleCheckedLocking:ERROR,\
--Xep:ElementsCountedInLoop:ERROR,\
 -Xep:EqualsHashCode:ERROR,\
 -Xep:EqualsIncompatibleType:ERROR,\
 -Xep:Finally:ERROR,-Xep:FloatingPointLiteralPrecision:ERROR,\
@@ -25,11 +24,9 @@ errorProneWarnings = \
 -Xep:IterableAndIterator:ERROR,\
 -Xep:JUnit3FloatingPointComparisonWithoutDelta:ERROR,\
 -Xep:JUnitAmbiguousTestClass:ERROR,\
--Xep:LiteralClassName:ERROR,\
 -Xep:MissingFail:ERROR,\
 -Xep:MissingOverride:ERROR,\
 -Xep:MutableConstantField:ERROR,\
--Xep:NarrowingCompoundAssignment:ERROR,\
 -Xep:NonAtomicVolatileUpdate:ERROR,\
 -Xep:NonOverridingEquals:ERROR,\
 -Xep:NullableConstructor:ERROR,\

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -282,7 +282,10 @@ abstract class MutableViewData {
     // TODO(songya): allow customizable bucket size in the future.
     private static final int N = 4; // IntervalView has N + 1 buckets
 
+    // TODO(sebright): Decide whether to use a different class instead of LinkedList.
+    @SuppressWarnings("JdkObsolete")
     private final LinkedList<IntervalBucket> buckets = new LinkedList<IntervalBucket>();
+
     private final Duration totalDuration; // Duration of the whole interval.
     private final Duration bucketDuration; // Duration of a single bucket (totalDuration / N)
 
@@ -385,7 +388,11 @@ abstract class MutableViewData {
     // tag values to aggregation data.
     private Map<List<TagValue>, AggregationData> combineBucketsAndGetAggregationMap(Timestamp now) {
       Multimap<List<TagValue>, MutableAggregation> multimap = HashMultimap.create();
+
+      // TODO(sebright): Decide whether to use a different class instead of LinkedList.
+      @SuppressWarnings("JdkObsolete")
       LinkedList<IntervalBucket> shallowCopy = new LinkedList<IntervalBucket>(buckets);
+
       Aggregation aggregation = super.view.getAggregation();
       putBucketsIntoMultiMap(shallowCopy, multimap, aggregation, now);
       Map<List<TagValue>, MutableAggregation> singleMap =

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/SpanExporterImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/SpanExporterImpl.java
@@ -138,6 +138,8 @@ public final class SpanExporterImpl extends SpanExporter {
       }
     }
 
+    // TODO: Decide whether to use a different class instead of LinkedList.
+    @SuppressWarnings("JdkObsolete")
     private WorkerThread(int bufferSize, long scheduleDelayMillis) {
       spans = new LinkedList<SpanImpl>();
       this.bufferSize = bufferSize;

--- a/testing/src/main/java/io/opencensus/testing/export/TestHandler.java
+++ b/testing/src/main/java/io/opencensus/testing/export/TestHandler.java
@@ -29,7 +29,9 @@ public final class TestHandler extends SpanExporter.Handler {
 
   private final Object monitor = new Object();
 
+  // TODO: Decide whether to use a different class instead of LinkedList.
   @GuardedBy("monitor")
+  @SuppressWarnings("JdkObsolete")
   private final List<SpanData> spanDataList = new LinkedList<SpanData>();
 
   @Override


### PR DESCRIPTION
#### net.ltgt.gradle:gradle-errorprone-plugin: 0.0.11 -> 0.0.13.

#### Suppress Error Prone warnings in generated code.

#### Force gradle-errorprone-plugin to use newer Error Prone, version 2.1.2.

Other changes:

 - Remove references to warnings that were removed from Error Prone.

 - Suppress occurrences of a new warning, JdkObsolete. All of the warnings are
   about uses of LinkedList. We need to decide whether to use a different class
   or continue suppressing the warnings. I left TODOs, since each occurrence may
   need to be handled differently.

________________________________________________________________

@bogdandrutu I wasn't sure how to update the build file, so let me know if there is a better way to specify the Error Prone version.