### PR TITLE
 Remove StackdriverStatsExporter.registerView() and rearrange unit tests.

### DIFF
--- a/exporters/stats/stackdriver/README.md
+++ b/exporters/stats/stackdriver/README.md
@@ -48,7 +48,7 @@ for details about how to configure the authentication see [here](https://github.
 
 If you prefer to manually set the credentials use:
 ```
-StackdriverStatsExporter.createWithCredentialsAndProjectId(
+StackdriverStatsExporter.createAndRegisterWithCredentialsAndProjectId(
     new GoogleCredentials(new AccessToken(accessToken, expirationTime)), 
     "MyStackdriverProjectId",
     Duration.create(10, 0));
@@ -61,7 +61,7 @@ for details about how to configure the project ID see [here](https://github.com/
 
 If you prefer to manually set the project ID use:
 ```
-StackdriverStatsExporter.createWithProjectId("MyStackdriverProjectId", Duration.create(10, 0));
+StackdriverStatsExporter.createAndRegisterWithProjectId("MyStackdriverProjectId", Duration.create(10, 0));
 ```
 
 #### Java Versions

--- a/exporters/stats/stackdriver/README.md
+++ b/exporters/stats/stackdriver/README.md
@@ -37,7 +37,6 @@ public class MyMainClass {
   public static void main(String[] args) {
     // Exporter will export to Stackdriver every 10 seconds.
     StackdriverStatsExporter.createWithProjectId("MyStackdriverProjectId", Duration.create(10, 0));
-    StackdriverStatsExporter.registerView(myView);
   }
 }
 ```

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThread.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThread.java
@@ -29,12 +29,17 @@ import io.opencensus.stats.ViewManager;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
 
 /**
  * Worker {@code Thread} that polls ViewData from Stats library and batch export to StackDriver.
  *
  * <p>{@code StackdriverExporterWorkerThread} is a daemon {@code Thread}.
+ *
+ * <p>The state of this class should only be accessed from the {@link
+ * StackdriverExporterWorkerThread} thread.
  */
+@NotThreadSafe
 final class StackdriverExporterWorkerThread extends Thread {
 
   private final long scheduleDelayMillis;
@@ -67,8 +72,8 @@ final class StackdriverExporterWorkerThread extends Thread {
         // Ignore views that are already registered.
         return;
       } else {
-        // TODO(songya): Do we still need to check this? Or can we assume that
-        // ViewManager.getAllExportedViews() will always return correct results?
+        // If we upload a view that has the same name with a registered view but with different
+        // attributes, Stackdriver client will throw an exception.
         throw new IllegalArgumentException(
             "A different view with the same name is already registered: " + existing);
       }

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThread.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThread.java
@@ -29,6 +29,8 @@ import io.opencensus.stats.ViewManager;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -41,6 +43,9 @@ import javax.annotation.concurrent.NotThreadSafe;
  */
 @NotThreadSafe
 final class StackdriverExporterWorkerThread extends Thread {
+
+  private static final Logger logger =
+      Logger.getLogger(StackdriverExporterWorkerThread.class.getName());
 
   private final long scheduleDelayMillis;
   private final String projectId;
@@ -74,8 +79,10 @@ final class StackdriverExporterWorkerThread extends Thread {
       } else {
         // If we upload a view that has the same name with a registered view but with different
         // attributes, Stackdriver client will throw an exception.
-        throw new IllegalArgumentException(
+        logger.log(
+            Level.WARNING,
             "A different view with the same name is already registered: " + existing);
+        return;
       }
     }
     registeredViews.put(view.getName(), view);

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -41,7 +41,7 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * <pre><code>
  *   public static void main(String[] args) {
- *     StackdriverStatsExporter.createWithProjectId(
+ *     StackdriverStatsExporter.createAndRegisterWithProjectId(
  *         "MyStackdriverProjectId", Duration.fromMillis(100000));
  *     ... // Do work.
  *   }
@@ -80,7 +80,7 @@ public final class StackdriverStatsExporter {
    * @param exportInterval the interval between pushing stats to StackDriver.
    * @throws IllegalStateException if a Stackdriver exporter already exists.
    */
-  public static void createWithCredentialsAndProjectId(
+  public static void createAndRegisterWithCredentialsAndProjectId(
       Credentials credentials, String projectId, Duration exportInterval) throws IOException {
     checkNotNull(credentials, "credentials");
     checkNotNull(projectId, "projectId");
@@ -107,7 +107,7 @@ public final class StackdriverStatsExporter {
    * @param exportInterval the interval between pushing stats to StackDriver.
    * @throws IllegalStateException if a Stackdriver exporter is already created.
    */
-  public static void createWithProjectId(String projectId, Duration exportInterval)
+  public static void createAndRegisterWithProjectId(String projectId, Duration exportInterval)
       throws IOException {
     checkNotNull(projectId, "projectId");
     checkNotNull(exportInterval, "exportInterval");
@@ -133,7 +133,7 @@ public final class StackdriverStatsExporter {
    * @param exportInterval the interval between pushing stats to StackDriver.
    * @throws IllegalStateException if a Stackdriver exporter is already created.
    */
-  public static void create(Duration exportInterval) throws IOException {
+  public static void createAndRegister(Duration exportInterval) throws IOException {
     checkNotNull(exportInterval, "exportInterval");
     createInternal(null, ServiceOptions.getDefaultProjectId(), exportInterval);
   }
@@ -162,14 +162,11 @@ public final class StackdriverStatsExporter {
     }
   }
 
-  // Method for setting exporter to a fake exporter or null (reset) for unit tests.
+  // Resets exporter to null. Used only for unit tests.
   @VisibleForTesting
-  static void unsafeSetExporter(StackdriverStatsExporter exporter) {
+  static void unsafeResetExporter() {
     synchronized (monitor) {
-      StackdriverStatsExporter.exporter = exporter;
-      if (exporter != null) {
-        exporter.workerThread.start();
-      }
+      StackdriverStatsExporter.exporter = null;
     }
   }
 }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -105,7 +105,6 @@ public class StackdriverExportUtilsTest {
                 .setDescription(StackdriverExportUtils.LABEL_DESCRIPTION)
                 .setValueType(ValueType.STRING)
                 .build());
-    // TODO(songya): test TagKeyLong and TagKeyBoolean once they are exposed
   }
 
   @Test

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThreadTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThreadTest.java
@@ -154,13 +154,15 @@ public class StackdriverExporterWorkerThreadTest {
   }
 
   @Test
-  public void preventRegisteringDifferentViewWithSameName() throws IOException {
+  public void skipDifferentViewWithSameName() throws IOException {
     StackdriverExporterWorkerThread workerThread =
         new StackdriverExporterWorkerThread(
             PROJECT_ID, new FakeMetricServiceClient(mockStub), ONE_SECOND, mockViewManager);
     View view1 =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
     workerThread.registerView(view1);
+    verify(mockStub, times(1)).createMetricDescriptorCallable();
+
     View view2 =
         View.create(
             VIEW_NAME,
@@ -169,10 +171,8 @@ public class StackdriverExporterWorkerThreadTest {
             SUM,
             Arrays.asList(KEY),
             CUMULATIVE);
-
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("A different view with the same name is already registered: ");
     workerThread.registerView(view2);
+    verify(mockStub, times(1)).createMetricDescriptorCallable();
   }
 
   @Test

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThreadTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThreadTest.java
@@ -1,0 +1,164 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.stackdriver;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.api.MetricDescriptor;
+import com.google.api.gax.rpc.UnaryCallable;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
+import com.google.cloud.monitoring.v3.stub.MetricServiceStub;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.monitoring.v3.CreateMetricDescriptorRequest;
+import com.google.monitoring.v3.CreateTimeSeriesRequest;
+import com.google.monitoring.v3.TimeSeries;
+import com.google.protobuf.Empty;
+import io.opencensus.common.Duration;
+import io.opencensus.common.Timestamp;
+import io.opencensus.stats.Aggregation.Sum;
+import io.opencensus.stats.AggregationData.SumDataLong;
+import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.stats.View;
+import io.opencensus.stats.View.AggregationWindow.Cumulative;
+import io.opencensus.stats.View.Name;
+import io.opencensus.stats.ViewData;
+import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
+import io.opencensus.stats.ViewManager;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link StackdriverExporterWorkerThread}. */
+@RunWith(JUnit4.class)
+public class StackdriverExporterWorkerThreadTest {
+
+  private static final String PROJECT_ID = "projectId";
+  private static final Duration ONE_SECOND = Duration.create(1, 0);
+  private static final TagKey KEY = TagKey.create("KEY");
+  private static final TagValue VALUE = TagValue.create("VALUE");
+  private static final String MEASURE_NAME = "my measurement";
+  private static final String MEASURE_UNIT = "us";
+  private static final String MEASURE_DESCRIPTION = "measure description";
+  private static final MeasureLong MEASURE =
+      MeasureLong.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT);
+  private static final Name VIEW_NAME = Name.create("my view");
+  private static final String VIEW_DESCRIPTION = "view description";
+  private static final Cumulative CUMULATIVE = Cumulative.create();
+  private static final Sum SUM = Sum.create();
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Mock private ViewManager mockViewManager;
+
+  @Mock private MetricServiceStub mockStub;
+
+  @Mock
+  private UnaryCallable<CreateMetricDescriptorRequest, MetricDescriptor>
+      mockCreateMetricDescriptorCallable;
+
+  @Mock private UnaryCallable<CreateTimeSeriesRequest, Empty> mockCreateTimeSeriesCallable;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+
+    doReturn(mockCreateMetricDescriptorCallable).when(mockStub).createMetricDescriptorCallable();
+    doReturn(mockCreateTimeSeriesCallable).when(mockStub).createTimeSeriesCallable();
+    doReturn(null)
+        .when(mockCreateMetricDescriptorCallable)
+        .call(any(CreateMetricDescriptorRequest.class));
+    doReturn(null).when(mockCreateTimeSeriesCallable).call(any(CreateTimeSeriesRequest.class));
+  }
+
+  @Test
+  public void export() throws IOException {
+    View view =
+        View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
+    ViewData viewData =
+        ViewData.create(
+            view,
+            ImmutableMap.of(Arrays.asList(VALUE), SumDataLong.create(1)),
+            CumulativeData.create(Timestamp.fromMillis(100), Timestamp.fromMillis(200)));
+    doReturn(ImmutableSet.of(view)).when(mockViewManager).getAllExportedViews();
+    doReturn(viewData).when(mockViewManager).getView(VIEW_NAME);
+
+    StackdriverExporterWorkerThread workerThread =
+        new StackdriverExporterWorkerThread(
+            PROJECT_ID, new FakeMetricServiceClient(mockStub), ONE_SECOND, mockViewManager);
+    workerThread.export();
+
+    verify(mockStub, times(1)).createMetricDescriptorCallable();
+    verify(mockStub, times(1)).createTimeSeriesCallable();
+
+    MetricDescriptor descriptor = StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID);
+    List<TimeSeries> timeSeries = StackdriverExportUtils.createTimeSeriesList(viewData, PROJECT_ID);
+    verify(mockCreateMetricDescriptorCallable, times(1))
+        .call(
+            eq(CreateMetricDescriptorRequest.newBuilder().setMetricDescriptor(descriptor).build()));
+    verify(mockCreateTimeSeriesCallable, times(1))
+        .call(eq(CreateTimeSeriesRequest.newBuilder().addAllTimeSeries(timeSeries).build()));
+  }
+
+  @Test
+  public void preventRegisteringDifferentViewWithSameName() throws IOException {
+    StackdriverExporterWorkerThread workerThread =
+        new StackdriverExporterWorkerThread(
+            PROJECT_ID, new FakeMetricServiceClient(mockStub), ONE_SECOND, mockViewManager);
+    View view1 =
+        View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
+    workerThread.registerView(view1);
+    View view2 =
+        View.create(
+            VIEW_NAME,
+            "This is a different description.",
+            MEASURE,
+            SUM,
+            Arrays.asList(KEY),
+            CUMULATIVE);
+
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("A different view with the same name is already registered: ");
+    workerThread.registerView(view2);
+  }
+
+  /*
+   * MetricServiceClient.createMetricDescriptor() and MetricServiceClient.createTimeSeries() are
+   * final methods and cannot be mocked. We have to use a mock MetricServiceStub in order to verify
+   * the output.
+   */
+  private static final class FakeMetricServiceClient extends MetricServiceClient {
+
+    protected FakeMetricServiceClient(MetricServiceStub stub) {
+      super(stub);
+    }
+  }
+}

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -16,49 +16,14 @@
 
 package io.opencensus.exporter.stats.stackdriver;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.atLeast;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.timeout;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
-import com.google.api.MetricDescriptor;
-import com.google.api.gax.rpc.UnaryCallable;
 import com.google.auth.oauth2.GoogleCredentials;
-import com.google.cloud.monitoring.v3.MetricServiceClient;
-import com.google.cloud.monitoring.v3.stub.MetricServiceStub;
-import com.google.common.collect.ImmutableMap;
-import com.google.monitoring.v3.CreateMetricDescriptorRequest;
-import com.google.monitoring.v3.CreateTimeSeriesRequest;
-import com.google.monitoring.v3.TimeSeries;
-import com.google.protobuf.Empty;
 import io.opencensus.common.Duration;
-import io.opencensus.common.Timestamp;
-import io.opencensus.stats.Aggregation.Sum;
-import io.opencensus.stats.AggregationData.SumDataLong;
-import io.opencensus.stats.Measure.MeasureLong;
-import io.opencensus.stats.View;
-import io.opencensus.stats.View.AggregationWindow.Cumulative;
-import io.opencensus.stats.View.Name;
-import io.opencensus.stats.ViewData;
-import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
-import io.opencensus.stats.ViewManager;
-import io.opencensus.tags.TagKey;
-import io.opencensus.tags.TagValue;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.MockitoAnnotations;
 
 /** Unit tests for {@link StackdriverStatsExporter}. */
 @RunWith(JUnit4.class)
@@ -66,41 +31,8 @@ public class StackdriverStatsExporterTest {
 
   private static final String PROJECT_ID = "projectId";
   private static final Duration ONE_SECOND = Duration.create(1, 0);
-  private static final TagKey KEY = TagKey.create("KEY");
-  private static final TagValue VALUE = TagValue.create("VALUE");
-  private static final String MEASURE_NAME = "my measurement";
-  private static final String MEASURE_UNIT = "us";
-  private static final String MEASURE_DESCRIPTION = "measure description";
-  private static final MeasureLong MEASURE =
-      MeasureLong.create(MEASURE_NAME, MEASURE_DESCRIPTION, MEASURE_UNIT);
-  private static final Name VIEW_NAME = Name.create("my view");
-  private static final String VIEW_DESCRIPTION = "view description";
-  private static final Cumulative CUMULATIVE = Cumulative.create();
-  private static final Sum SUM = Sum.create();
-
-  @Mock private ViewManager mockViewManager;
-
-  @Mock private MetricServiceStub mockStub;
-
-  @Mock
-  private UnaryCallable<CreateMetricDescriptorRequest, MetricDescriptor>
-      mockCreateMetricDescriptorCallable;
-
-  @Mock private UnaryCallable<CreateTimeSeriesRequest, Empty> mockCreateTimeSeriesCallable;
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
-
-  @Before
-  public void setUp() {
-    MockitoAnnotations.initMocks(this);
-
-    doReturn(mockCreateMetricDescriptorCallable).when(mockStub).createMetricDescriptorCallable();
-    doReturn(mockCreateTimeSeriesCallable).when(mockStub).createTimeSeriesCallable();
-    doReturn(null)
-        .when(mockCreateMetricDescriptorCallable)
-        .call(any(CreateMetricDescriptorRequest.class));
-    doReturn(null).when(mockCreateTimeSeriesCallable).call(any(CreateTimeSeriesRequest.class));
-  }
 
   @Test
   public void createWithNullCredentials() throws IOException {
@@ -134,7 +66,7 @@ public class StackdriverStatsExporterTest {
   }
 
   @Test
-  public void createHandlerTwice() throws IOException {
+  public void createExporterTwice() throws IOException {
     StackdriverStatsExporter.createWithCredentialsAndProjectId(
         GoogleCredentials.newBuilder().build(), PROJECT_ID, ONE_SECOND);
     try {
@@ -144,94 +76,6 @@ public class StackdriverStatsExporterTest {
           GoogleCredentials.newBuilder().build(), PROJECT_ID, ONE_SECOND);
     } finally {
       StackdriverStatsExporter.unsafeSetExporter(null);
-    }
-  }
-
-  @Test
-  public void registerViewAndExport() throws IOException {
-    View view =
-        View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
-    ViewData viewData =
-        ViewData.create(
-            view,
-            ImmutableMap.of(Arrays.asList(VALUE), SumDataLong.create(1)),
-            CumulativeData.create(Timestamp.fromMillis(100), Timestamp.fromMillis(200)));
-    doNothing().when(mockViewManager).registerView(view);
-    doReturn(viewData).when(mockViewManager).getView(VIEW_NAME);
-
-    try {
-      StackdriverStatsExporter.unsafeSetExporter(
-          new StackdriverStatsExporter(
-              PROJECT_ID, new FakeMetricServiceClient(mockStub), ONE_SECOND, mockViewManager));
-      StackdriverStatsExporter.registerView(view);
-
-      verify(mockStub, times(1)).createMetricDescriptorCallable();
-      // createTimeSeriesCallable() should be called once per second. This test uses a timeout that
-      // is longer than the export interval in order to decrease the chance of failures due to
-      // timing.
-      // TODO(songya): consider how to avoid blocking the thread and making this test deterministic
-      verify(mockStub, timeout(2000).atLeast(1)).createTimeSeriesCallable();
-
-      MetricDescriptor descriptor = StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID);
-      List<TimeSeries> timeSeries =
-          StackdriverExportUtils.createTimeSeriesList(viewData, PROJECT_ID);
-      verify(mockCreateMetricDescriptorCallable, times(1))
-          .call(
-              eq(
-                  CreateMetricDescriptorRequest.newBuilder()
-                      .setMetricDescriptor(descriptor)
-                      .build()));
-      verify(mockCreateTimeSeriesCallable, atLeast(1))
-          .call(eq(CreateTimeSeriesRequest.newBuilder().addAllTimeSeries(timeSeries).build()));
-    } finally {
-      StackdriverStatsExporter.unsafeSetExporter(null);
-    }
-  }
-
-  @Test
-  public void preventRegisterViewBeforeCreateExporter() throws IOException {
-    View view1 =
-        View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Stackdriver stats exporter has not been created.");
-    StackdriverStatsExporter.registerView(view1);
-  }
-
-  @Test
-  public void preventRegisteringDifferentViewWithSameName() throws IOException {
-    doNothing().when(mockViewManager).registerView(any(View.class));
-    StackdriverStatsExporter.unsafeSetExporter(
-        new StackdriverStatsExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), ONE_SECOND, mockViewManager));
-    View view1 =
-        View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
-    StackdriverStatsExporter.registerView(view1);
-    View view2 =
-        View.create(
-            VIEW_NAME,
-            "This is a different description.",
-            MEASURE,
-            SUM,
-            Arrays.asList(KEY),
-            CUMULATIVE);
-    try {
-      thrown.expect(IllegalArgumentException.class);
-      thrown.expectMessage("A different view with the same name is already registered: ");
-      StackdriverStatsExporter.registerView(view2);
-    } finally {
-      StackdriverStatsExporter.unsafeSetExporter(null);
-    }
-  }
-
-  /*
-   * MetricServiceClient.createMetricDescriptor() and MetricServiceClient.createTimeSeries() are
-   * final methods and cannot be mocked. We have to use a mock MetricServiceStub in order to verify
-   * the output.
-   */
-  private static final class FakeMetricServiceClient extends MetricServiceClient {
-
-    protected FakeMetricServiceClient(MetricServiceStub stub) {
-      super(stub);
     }
   }
 }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -38,14 +38,15 @@ public class StackdriverStatsExporterTest {
   public void createWithNullCredentials() throws IOException {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("credentials");
-    StackdriverStatsExporter.createWithCredentialsAndProjectId(null, PROJECT_ID, ONE_SECOND);
+    StackdriverStatsExporter.createAndRegisterWithCredentialsAndProjectId(
+        null, PROJECT_ID, ONE_SECOND);
   }
 
   @Test
   public void createWithNullProjectId() throws IOException {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("projectId");
-    StackdriverStatsExporter.createWithCredentialsAndProjectId(
+    StackdriverStatsExporter.createAndRegisterWithCredentialsAndProjectId(
         GoogleCredentials.newBuilder().build(), null, ONE_SECOND);
   }
 
@@ -53,7 +54,7 @@ public class StackdriverStatsExporterTest {
   public void createWithNullDuration() throws IOException {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("exportInterval");
-    StackdriverStatsExporter.createWithCredentialsAndProjectId(
+    StackdriverStatsExporter.createAndRegisterWithCredentialsAndProjectId(
         GoogleCredentials.newBuilder().build(), PROJECT_ID, null);
   }
 
@@ -61,21 +62,21 @@ public class StackdriverStatsExporterTest {
   public void createWithNegativeDuration() throws IOException {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Duration must be positive");
-    StackdriverStatsExporter.createWithCredentialsAndProjectId(
+    StackdriverStatsExporter.createAndRegisterWithCredentialsAndProjectId(
         GoogleCredentials.newBuilder().build(), PROJECT_ID, Duration.create(-1, 0));
   }
 
   @Test
   public void createExporterTwice() throws IOException {
-    StackdriverStatsExporter.createWithCredentialsAndProjectId(
+    StackdriverStatsExporter.createAndRegisterWithCredentialsAndProjectId(
         GoogleCredentials.newBuilder().build(), PROJECT_ID, ONE_SECOND);
     try {
       thrown.expect(IllegalStateException.class);
       thrown.expectMessage("Stackdriver stats exporter is already created.");
-      StackdriverStatsExporter.createWithCredentialsAndProjectId(
+      StackdriverStatsExporter.createAndRegisterWithCredentialsAndProjectId(
           GoogleCredentials.newBuilder().build(), PROJECT_ID, ONE_SECOND);
     } finally {
-      StackdriverStatsExporter.unsafeSetExporter(null);
+      StackdriverStatsExporter.unsafeResetExporter();
     }
   }
 }


### PR DESCRIPTION
~~This PR depends on #794.~~

Remove `StackdriverStatsExporter.registerView()`. Instead, export views that are returned by `ViewManager.getAllExportedViews()`. Now `StackdriverStatsExporter` only has factory methods, and uploading `View` to Stackdriver will be handled by the worker thread.

In addition, due to the changes above, I've also moved tests on `register()` and `export()` to `StackdriverExporterWorkerThreadTest`. This also resolves a TODO from https://github.com/census-instrumentation/opencensus-java/pull/797, since there are no asynchronous verification in the unit tests now.