### PR TITLE
Enforce size limit when serializing and deserializing TagContext.

### DIFF
--- a/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
@@ -155,7 +155,8 @@ final class SerializationUtils {
     }
   }
 
-  private static final void encodeTag(Tag tag, ByteArrayDataOutput byteArrayDataOutput) {
+  @VisibleForTesting
+  static final void encodeTag(Tag tag, ByteArrayDataOutput byteArrayDataOutput) {
     byteArrayDataOutput.write(TAG_FIELD_ID);
     encodeString(tag.getKey().getName(), byteArrayDataOutput);
     encodeString(tag.getValue().asString(), byteArrayDataOutput);

--- a/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
@@ -155,8 +155,7 @@ final class SerializationUtils {
     }
   }
 
-  @VisibleForTesting
-  static final void encodeTag(Tag tag, ByteArrayDataOutput byteArrayDataOutput) {
+  private static final void encodeTag(Tag tag, ByteArrayDataOutput byteArrayDataOutput) {
     byteArrayDataOutput.write(TAG_FIELD_ID);
     encodeString(tag.getKey().getName(), byteArrayDataOutput);
     encodeString(tag.getValue().asString(), byteArrayDataOutput);

--- a/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/TagContextBinarySerializerImpl.java
@@ -22,6 +22,7 @@ import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TaggingState;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagContextDeserializationException;
+import io.opencensus.tags.propagation.TagContextSerializationException;
 
 final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   private static final byte[] EMPTY_BYTE_ARRAY = {};
@@ -33,7 +34,7 @@ final class TagContextBinarySerializerImpl extends TagContextBinarySerializer {
   }
 
   @Override
-  public byte[] toByteArray(TagContext tags) {
+  public byte[] toByteArray(TagContext tags) throws TagContextSerializationException {
     return state.getInternal() == TaggingState.DISABLED
         ? EMPTY_BYTE_ARRAY
         : SerializationUtils.serializeBinary(tags);

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
@@ -51,10 +51,11 @@ public class TagContextDeserializationTest {
   private final Tagger tagger = tagsComponent.getTagger();
 
   @Test
-  public void testVersionAndValueTypeConstants() {
+  public void testConstants() {
     // Refer to the JavaDoc on SerializationUtils for the definitions on these constants.
     assertThat(SerializationUtils.VERSION_ID).isEqualTo(0);
     assertThat(SerializationUtils.TAG_FIELD_ID).isEqualTo(0);
+    assertThat(SerializationUtils.TAGCONTEXT_SERIALIZED_SIZE_LIMIT).isEqualTo(8192);
   }
 
   @Test
@@ -72,6 +73,14 @@ public class TagContextDeserializationTest {
     thrown.expect(TagContextDeserializationException.class);
     thrown.expectMessage("Input byte[] can not be empty.");
     serializer.fromByteArray(new byte[0]);
+  }
+
+  @Test
+  public void testDeserializeTooLargeByteArrayThrowException()
+      throws TagContextDeserializationException {
+    thrown.expect(TagContextDeserializationException.class);
+    thrown.expectMessage("Size of input byte[] exceeds the maximum serialized size ");
+    serializer.fromByteArray(new byte[SerializationUtils.TAGCONTEXT_SERIALIZED_SIZE_LIMIT + 1]);
   }
 
   @Test

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
@@ -18,10 +18,7 @@ package io.opencensus.implcore.tags.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.io.ByteArrayDataOutput;
-import com.google.common.io.ByteStreams;
 import io.opencensus.implcore.tags.TagsComponentImplBase;
-import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey;
@@ -63,15 +60,13 @@ public class TagContextRoundtripTest {
   public void testRoundtrip_TagContextWithMaximumSize() throws Exception {
     TagContextBuilder builder = tagger.emptyBuilder();
     int i = 0;
-    ByteArrayDataOutput byteArrayDataOutput = ByteStreams.newDataOutput();
 
     // This loop should fill in tags that have a total size of 8185
-    while (byteArrayDataOutput.toByteArray().length
+    while (serializer.toByteArray(builder.build()).length
         < SerializationUtils.TAGCONTEXT_SERIALIZED_SIZE_LIMIT - 8) {
       TagKey key = TagKey.create("k" + i);
       TagValue value = TagValue.create("v" + i);
       builder.put(key, value);
-      SerializationUtils.encodeTag(Tag.create(key, value), byteArrayDataOutput);
       i++;
     }
     // The last tag has size 7, after putting it, the size of TagContext should just meet the limit

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextRoundtripTest.java
@@ -18,8 +18,12 @@ package io.opencensus.implcore.tags.propagation;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.common.io.ByteArrayDataOutput;
+import com.google.common.io.ByteStreams;
 import io.opencensus.implcore.tags.TagsComponentImplBase;
+import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
+import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
@@ -48,11 +52,35 @@ public class TagContextRoundtripTest {
   private final Tagger tagger = tagsComponent.getTagger();
 
   @Test
-  public void testRoundtripSerialization() throws Exception {
+  public void testRoundtripSerialization_NormalTagContext() throws Exception {
     testRoundtripSerialization(tagger.empty());
     testRoundtripSerialization(tagger.emptyBuilder().put(K1, V1).build());
     testRoundtripSerialization(tagger.emptyBuilder().put(K1, V1).put(K2, V2).put(K3, V3).build());
     testRoundtripSerialization(tagger.emptyBuilder().put(K1, V_EMPTY).build());
+  }
+
+  @Test
+  public void testRoundtrip_TagContextWithMaximumSize() throws Exception {
+    TagContextBuilder builder = tagger.emptyBuilder();
+    int i = 0;
+    ByteArrayDataOutput byteArrayDataOutput = ByteStreams.newDataOutput();
+
+    // This loop should fill in tags that have a total size of 8185
+    while (byteArrayDataOutput.toByteArray().length
+        < SerializationUtils.TAGCONTEXT_SERIALIZED_SIZE_LIMIT - 8) {
+      TagKey key = TagKey.create("k" + i);
+      TagValue value = TagValue.create("v" + i);
+      builder.put(key, value);
+      SerializationUtils.encodeTag(Tag.create(key, value), byteArrayDataOutput);
+      i++;
+    }
+    // The last tag has size 7, after putting it, the size of TagContext should just meet the limit
+    builder.put(TagKey.create("last"), TagValue.create(""));
+
+    TagContext expected = builder.build();
+    assertThat(serializer.toByteArray(expected).length)
+        .isEqualTo(SerializationUtils.TAGCONTEXT_SERIALIZED_SIZE_LIMIT);
+    testRoundtripSerialization(expected);
   }
 
   private void testRoundtripSerialization(TagContext expected) throws Exception {

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Collections2;
 import io.opencensus.implcore.internal.VarInt;
 import io.opencensus.implcore.tags.TagsComponentImplBase;
 import io.opencensus.tags.Tag;
+import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagContextBuilder;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
@@ -93,9 +94,10 @@ public class TagContextSerializationTest {
     for (int i = 0; i < SerializationUtils.TAGCONTEXT_SERIALIZED_SIZE_LIMIT; i++) {
       builder.put(TagKey.create("k" + i), TagValue.create("v" + i));
     }
+    TagContext tagContext = builder.build();
     thrown.expect(TagContextSerializationException.class);
     thrown.expectMessage("Size of serialized TagContext exceeds the maximum serialized size ");
-    serializer.toByteArray(builder.build());
+    serializer.toByteArray(tagContext);
   }
 
   private void testSerialize(Tag... tags) throws IOException, TagContextSerializationException {

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
@@ -91,9 +91,20 @@ public class TagContextSerializationTest {
   @Test
   public void testSerializeTooLargeTagContext() throws TagContextSerializationException {
     TagContextBuilder builder = tagger.emptyBuilder();
-    for (int i = 0; i < SerializationUtils.TAGCONTEXT_SERIALIZED_SIZE_LIMIT; i++) {
-      builder.put(TagKey.create("k" + i), TagValue.create("v" + i));
+    int i = 0;
+
+    // This loop should fill in tags that have a total size of 8185
+    while (serializer.toByteArray(builder.build()).length
+        < SerializationUtils.TAGCONTEXT_SERIALIZED_SIZE_LIMIT - 8) {
+      TagKey key = TagKey.create("k" + i);
+      TagValue value = TagValue.create("v" + i);
+      builder.put(key, value);
+      i++;
     }
+    // The last tag has size 8, after putting it, the size of TagContext (8193) should just exceed
+    // the limit
+    builder.put(TagKey.create("last"), TagValue.create("1"));
+
     TagContext tagContext = builder.build();
     thrown.expect(TagContextSerializationException.class);
     thrown.expectMessage("Size of serialized TagContext exceeds the maximum serialized size ");


### PR DESCRIPTION
Fix https://github.com/census-instrumentation/opencensus-java/issues/761.