### PR TITLE
Use consistent wording in stats and tags 'setState' Javadocs.

### DIFF
--- a/api/src/main/java/io/opencensus/stats/Stats.java
+++ b/api/src/main/java/io/opencensus/stats/Stats.java
@@ -66,7 +66,7 @@ public final class Stats {
    * @deprecated This method is deprecated because other libraries could cache the result of {@link
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
    *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
-   *     has been called, in order to prevent the result of {@code getState()} from changing.
+   *     has been called, in order to limit changes to the result of {@code getState()}.
    */
   @Deprecated
   public static void setState(StatsCollectionState state) {

--- a/api/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/api/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -55,7 +55,7 @@ public abstract class StatsComponent {
    * @deprecated This method is deprecated because other libraries could cache the result of {@link
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
    *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
-   *     has been called, in order to prevent the result of {@code getState()} from changing.
+   *     has been called, in order to limit changes to the result of {@code getState()}.
    */
   @Deprecated
   public abstract void setState(StatsCollectionState state);


### PR DESCRIPTION
This commit updates the Javadocs for Stats.setState and StatsComponent.setState
to avoid guaranteeing that the state won't change.  It is consistent with Tags
and TagsComponent.