### PR TITLE
Remove an obsolete TODO from TagKey.java.

### DIFF
--- a/api/src/main/java/io/opencensus/tags/TagKey.java
+++ b/api/src/main/java/io/opencensus/tags/TagKey.java
@@ -54,7 +54,6 @@ public abstract class TagKey {
    * @throws IllegalArgumentException if the name is not valid.
    */
   public static TagKey create(String name) {
-    // TODO(sebright): Should we disallow an empty name?
     checkArgument(isValid(name));
     return new AutoValue_TagKey(name);
   }


### PR DESCRIPTION
We decided not to allow empty tag key names in
https://github.com/census-instrumentation/opencensus-specs/issues/12.