### PR TITLE
Add no-op RunningSpanStore and SampledSpanStore

### DIFF
--- a/api/src/main/java/io/opencensus/trace/TraceComponent.java
+++ b/api/src/main/java/io/opencensus/trace/TraceComponent.java
@@ -29,7 +29,6 @@ import io.opencensus.trace.propagation.PropagationComponent;
  * <p>Unless otherwise noted all methods (on component) results are cacheable.
  */
 public abstract class TraceComponent {
-  private static final NoopTraceComponent noopTraceComponent = new NoopTraceComponent();
 
   /**
    * Returns the {@link Tracer} with the provided implementations. If no implementation is provided
@@ -75,8 +74,8 @@ public abstract class TraceComponent {
    *
    * @return an instance that contains no-op implementations for all the instances.
    */
-  static TraceComponent getNoopTraceComponent() {
-    return noopTraceComponent;
+  static TraceComponent newNoopTraceComponent() {
+    return new NoopTraceComponent();
   }
 
   private static final class NoopTraceComponent extends TraceComponent {
@@ -97,7 +96,7 @@ public abstract class TraceComponent {
 
     @Override
     public ExportComponent getExportComponent() {
-      return ExportComponent.getNoopExportComponent();
+      return ExportComponent.newNoopExportComponent();
     }
 
     @Override

--- a/api/src/main/java/io/opencensus/trace/Tracing.java
+++ b/api/src/main/java/io/opencensus/trace/Tracing.java
@@ -103,7 +103,7 @@ public final class Tracing {
               + "default implementation for TraceComponent.",
           e);
     }
-    return TraceComponent.getNoopTraceComponent();
+    return TraceComponent.newNoopTraceComponent();
   }
 
   // No instance of this class.

--- a/api/src/main/java/io/opencensus/trace/export/ExportComponent.java
+++ b/api/src/main/java/io/opencensus/trace/export/ExportComponent.java
@@ -17,7 +17,6 @@
 package io.opencensus.trace.export;
 
 import io.opencensus.trace.TraceOptions;
-import javax.annotation.Nullable;
 
 /**
  * Class that holds the implementation instances for {@link SpanExporter}, {@link RunningSpanStore}
@@ -27,15 +26,13 @@ import javax.annotation.Nullable;
  */
 public abstract class ExportComponent {
 
-  private static final NoopExportComponent NOOP_EXPORT_COMPONENT = new NoopExportComponent();
-
   /**
    * Returns the no-op implementation of the {@code ExportComponent}.
    *
    * @return the no-op implementation of the {@code ExportComponent}.
    */
-  public static ExportComponent getNoopExportComponent() {
-    return NOOP_EXPORT_COMPONENT;
+  public static ExportComponent newNoopExportComponent() {
+    return new NoopExportComponent();
   }
 
   /**
@@ -53,7 +50,6 @@ public abstract class ExportComponent {
    *
    * @return the {@code RunningSpanStore} or {@code null} if not supported.
    */
-  @Nullable
   public abstract RunningSpanStore getRunningSpanStore();
 
   /**
@@ -62,7 +58,6 @@ public abstract class ExportComponent {
    *
    * @return the {@code SampledSpanStore} or {@code null} if not supported.
    */
-  @Nullable
   public abstract SampledSpanStore getSampledSpanStore();
 
   private static final class NoopExportComponent extends ExportComponent {
@@ -71,16 +66,14 @@ public abstract class ExportComponent {
       return SpanExporter.getNoopSpanExporter();
     }
 
-    @Nullable
     @Override
     public RunningSpanStore getRunningSpanStore() {
-      return null;
+      return RunningSpanStore.getNoopRunningSpanStore();
     }
 
-    @Nullable
     @Override
     public SampledSpanStore getSampledSpanStore() {
-      return null;
+      return SampledSpanStore.newNoopSampledSpanStore();
     }
   }
 }

--- a/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
@@ -37,7 +37,18 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public abstract class RunningSpanStore {
 
+  private static final RunningSpanStore NOOP_RUNNING_SPAN_STORE = new NoopRunningSpanStore();
+
   protected RunningSpanStore() {}
+
+  /**
+   * Returns the no-op implementation of the {@code RunningSpanStore}.
+   *
+   * @return the no-op implementation of the {@code RunningSpanStore}.
+   */
+  public static RunningSpanStore getNoopRunningSpanStore() {
+    return NOOP_RUNNING_SPAN_STORE;
+  }
 
   /**
    * Returns the summary of all available data such, as number of running spans.
@@ -150,5 +161,19 @@ public abstract class RunningSpanStore {
      * @return the maximum number of spans to be returned.
      */
     public abstract int getMaxSpansToReturn();
+  }
+
+  private static final class NoopRunningSpanStore extends RunningSpanStore {
+
+    @Override
+    public Summary getSummary() {
+      return Summary.create(Collections.<String, PerSpanNameSummary>emptyMap());
+    }
+
+    @Override
+    public Collection<SpanData> getRunningSpans(Filter filter) {
+      checkNotNull(filter, "filter");
+      return Collections.<SpanData>emptyList();
+    }
   }
 }

--- a/api/src/test/java/io/opencensus/trace/TraceComponentTest.java
+++ b/api/src/test/java/io/opencensus/trace/TraceComponentTest.java
@@ -31,29 +31,29 @@ import org.junit.runners.JUnit4;
 public class TraceComponentTest {
   @Test
   public void defaultTracer() {
-    assertThat(TraceComponent.getNoopTraceComponent().getTracer()).isSameAs(Tracer.getNoopTracer());
+    assertThat(TraceComponent.newNoopTraceComponent().getTracer()).isSameAs(Tracer.getNoopTracer());
   }
 
   @Test
   public void defaultBinaryPropagationHandler() {
-    assertThat(TraceComponent.getNoopTraceComponent().getPropagationComponent())
+    assertThat(TraceComponent.newNoopTraceComponent().getPropagationComponent())
         .isSameAs(PropagationComponent.getNoopPropagationComponent());
   }
 
   @Test
   public void defaultClock() {
-    assertThat(TraceComponent.getNoopTraceComponent().getClock()).isInstanceOf(ZeroTimeClock.class);
+    assertThat(TraceComponent.newNoopTraceComponent().getClock()).isInstanceOf(ZeroTimeClock.class);
   }
 
   @Test
   public void defaultTraceExporter() {
-    assertThat(TraceComponent.getNoopTraceComponent().getExportComponent())
-        .isSameAs(ExportComponent.getNoopExportComponent());
+    assertThat(TraceComponent.newNoopTraceComponent().getExportComponent())
+        .isInstanceOf(ExportComponent.newNoopExportComponent().getClass());
   }
 
   @Test
   public void defaultTraceConfig() {
-    assertThat(TraceComponent.getNoopTraceComponent().getTraceConfig())
+    assertThat(TraceComponent.newNoopTraceComponent().getTraceConfig())
         .isSameAs(TraceConfig.getNoopTraceConfig());
   }
 }

--- a/api/src/test/java/io/opencensus/trace/TracingTest.java
+++ b/api/src/test/java/io/opencensus/trace/TracingTest.java
@@ -72,7 +72,8 @@ public class TracingTest {
 
   @Test
   public void defaultTraceExporter() {
-    assertThat(Tracing.getExportComponent()).isSameAs(ExportComponent.getNoopExportComponent());
+    assertThat(Tracing.getExportComponent())
+        .isInstanceOf(ExportComponent.newNoopExportComponent().getClass());
   }
 
   @Test

--- a/api/src/test/java/io/opencensus/trace/export/ExportComponentTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/ExportComponentTest.java
@@ -25,7 +25,7 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link ExportComponent}. */
 @RunWith(JUnit4.class)
 public class ExportComponentTest {
-  private final ExportComponent exportComponent = ExportComponent.getNoopExportComponent();
+  private final ExportComponent exportComponent = ExportComponent.newNoopExportComponent();
 
   @Test
   public void implementationOfSpanExporter() {
@@ -34,11 +34,13 @@ public class ExportComponentTest {
 
   @Test
   public void implementationOfActiveSpans() {
-    assertThat(exportComponent.getRunningSpanStore()).isNull();
+    assertThat(exportComponent.getRunningSpanStore())
+        .isEqualTo(RunningSpanStore.getNoopRunningSpanStore());
   }
 
   @Test
   public void implementationOfSampledSpanStore() {
-    assertThat(exportComponent.getSampledSpanStore()).isNull();
+    assertThat(exportComponent.getSampledSpanStore())
+        .isInstanceOf(SampledSpanStore.newNoopSampledSpanStore().getClass());
   }
 }

--- a/api/src/test/java/io/opencensus/trace/export/NoopRunningSpanStoreTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/NoopRunningSpanStoreTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoopRunningSpanStore}. */
+@RunWith(JUnit4.class)
+public final class NoopRunningSpanStoreTest {
+
+  private final RunningSpanStore runningSpanStore =
+      ExportComponent.newNoopExportComponent().getRunningSpanStore();
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void noopRunningSpanStore_GetSummary() {
+    RunningSpanStore.Summary summary = runningSpanStore.getSummary();
+    assertThat(summary.getPerSpanNameSummary()).isEmpty();
+  }
+
+  @Test
+  public void noopRunningSpanStore_GetRunningSpans_DisallowsNull() {
+    thrown.expect(NullPointerException.class);
+    runningSpanStore.getRunningSpans(null);
+  }
+
+  @Test
+  public void noopRunningSpanStore_GetRunningSpans() {
+    Collection<SpanData> runningSpans =
+        runningSpanStore.getRunningSpans(RunningSpanStore.Filter.create("TestSpan", 0));
+    assertThat(runningSpans).isEmpty();
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/export/NoopSampledSpanStoreTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/NoopSampledSpanStoreTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Lists;
+import io.opencensus.trace.Status.CanonicalCode;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoopSampledSpanStore}. */
+@RunWith(JUnit4.class)
+public final class NoopSampledSpanStoreTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  private final SampledSpanStore.PerSpanNameSummary emptyPerSpanNameSummary =
+      SampledSpanStore.PerSpanNameSummary.create(
+          Collections.<SampledSpanStore.LatencyBucketBoundaries, Integer>emptyMap(),
+          Collections.<CanonicalCode, Integer>emptyMap());
+
+  @Test
+  public void noopSampledSpanStore_RegisterUnregisterAndGetSummary() {
+    // should return empty before register
+    SampledSpanStore sampledSpanStore =
+        ExportComponent.newNoopExportComponent().getSampledSpanStore();
+    SampledSpanStore.Summary summary = sampledSpanStore.getSummary();
+    assertThat(summary.getPerSpanNameSummary()).isEmpty();
+
+    // should return non-empty summaries with zero latency/error sampled spans after register
+    sampledSpanStore.registerSpanNamesForCollection(
+        Collections.unmodifiableList(Lists.newArrayList("TestSpan1", "TestSpan2", "TestSpan3")));
+    summary = sampledSpanStore.getSummary();
+    assertThat(summary.getPerSpanNameSummary())
+        .containsExactly(
+            "TestSpan1", emptyPerSpanNameSummary,
+            "TestSpan2", emptyPerSpanNameSummary,
+            "TestSpan3", emptyPerSpanNameSummary);
+
+    // should unregister specific spanNames
+    sampledSpanStore.unregisterSpanNamesForCollection(
+        Collections.unmodifiableList(Lists.newArrayList("TestSpan1", "TestSpan3")));
+    summary = sampledSpanStore.getSummary();
+    assertThat(summary.getPerSpanNameSummary())
+        .containsExactly("TestSpan2", emptyPerSpanNameSummary);
+  }
+
+  @Test
+  public void noopSampledSpanStore_GetLatencySampledSpans() {
+    SampledSpanStore sampledSpanStore =
+        ExportComponent.newNoopExportComponent().getSampledSpanStore();
+    Collection<SpanData> latencySampledSpans =
+        sampledSpanStore.getLatencySampledSpans(
+            SampledSpanStore.LatencyFilter.create("TestLatencyFilter", 0, 0, 0));
+    assertThat(latencySampledSpans).isEmpty();
+  }
+
+  @Test
+  public void noopSampledSpanStore_GetErrorSampledSpans() {
+    SampledSpanStore sampledSpanStore =
+        ExportComponent.newNoopExportComponent().getSampledSpanStore();
+    Collection<SpanData> errorSampledSpans =
+        sampledSpanStore.getErrorSampledSpans(
+            SampledSpanStore.ErrorFilter.create("TestErrorFilter", null, 0));
+    assertThat(errorSampledSpans).isEmpty();
+  }
+
+  @Test
+  public void noopSampledSpanStore_GetRegisteredSpanNamesForCollection() {
+    SampledSpanStore sampledSpanStore =
+        ExportComponent.newNoopExportComponent().getSampledSpanStore();
+    sampledSpanStore.registerSpanNamesForCollection(
+        Collections.unmodifiableList(Lists.newArrayList("TestSpan3", "TestSpan4")));
+    Set<String> registeredSpanNames = sampledSpanStore.getRegisteredSpanNamesForCollection();
+    assertThat(registeredSpanNames).containsExactly("TestSpan3", "TestSpan4");
+  }
+}


### PR DESCRIPTION
This change is a follow up of a comment by @bogdandrutu in #677 .

NoopRunningSpanStore will always return empty list when querying running [SpanData](https://github.com/HailongWen/opencensus-java/blob/ff66e5a8ed7f1d2d0959232435d41a4ece87fc90/api/src/main/java/io/opencensus/trace/export/SpanData.java).
NoopSampledSpanStore has a similar no-op implementation. It maintains a set of span names for data collections and return empty [SampledSpanStore.Summary](https://github.com/HailongWen/opencensus-java/blob/ff66e5a8ed7f1d2d0959232435d41a4ece87fc90/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java) for each span name.

Similar to [NoopViewManager](https://github.com/HailongWen/opencensus-java/blob/ff66e5a8ed7f1d2d0959232435d41a4ece87fc90/api/src/main/java/io/opencensus/stats/NoopStats.java), since NoopSampledSpanStore is not stateless, several apis of "getXXXX()" has been refactored to "newXXXX()". 