### PR TITLE
Add NoopRunningSpanStore and NoopSampledSpanStore.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/TraceComponent.java
+++ b/api/src/main/java/io/opencensus/trace/TraceComponent.java
@@ -79,6 +79,8 @@ public abstract class TraceComponent {
   }
 
   private static final class NoopTraceComponent extends TraceComponent {
+    private final ExportComponent noopExportComponent = ExportComponent.newNoopExportComponent();
+
     @Override
     public Tracer getTracer() {
       return Tracer.getNoopTracer();
@@ -96,7 +98,7 @@ public abstract class TraceComponent {
 
     @Override
     public ExportComponent getExportComponent() {
-      return ExportComponent.newNoopExportComponent();
+      return noopExportComponent;
     }
 
     @Override

--- a/api/src/main/java/io/opencensus/trace/TraceComponent.java
+++ b/api/src/main/java/io/opencensus/trace/TraceComponent.java
@@ -29,7 +29,6 @@ import io.opencensus.trace.propagation.PropagationComponent;
  * <p>Unless otherwise noted all methods (on component) results are cacheable.
  */
 public abstract class TraceComponent {
-  private static final NoopTraceComponent noopTraceComponent = new NoopTraceComponent();
 
   /**
    * Returns the {@link Tracer} with the provided implementations. If no implementation is provided
@@ -75,8 +74,8 @@ public abstract class TraceComponent {
    *
    * @return an instance that contains no-op implementations for all the instances.
    */
-  static TraceComponent getNoopTraceComponent() {
-    return noopTraceComponent;
+  static TraceComponent newNoopTraceComponent() {
+    return new NoopTraceComponent();
   }
 
   private static final class NoopTraceComponent extends TraceComponent {
@@ -97,7 +96,7 @@ public abstract class TraceComponent {
 
     @Override
     public ExportComponent getExportComponent() {
-      return ExportComponent.getNoopExportComponent();
+      return ExportComponent.newNoopExportComponent();
     }
 
     @Override

--- a/api/src/main/java/io/opencensus/trace/Tracing.java
+++ b/api/src/main/java/io/opencensus/trace/Tracing.java
@@ -103,7 +103,7 @@ public final class Tracing {
               + "default implementation for TraceComponent.",
           e);
     }
-    return TraceComponent.getNoopTraceComponent();
+    return TraceComponent.newNoopTraceComponent();
   }
 
   // No instance of this class.

--- a/api/src/main/java/io/opencensus/trace/export/ExportComponent.java
+++ b/api/src/main/java/io/opencensus/trace/export/ExportComponent.java
@@ -48,7 +48,7 @@ public abstract class ExportComponent {
    * Returns the {@link RunningSpanStore} that can be used to get useful debugging information about
    * all the current active spans.
    *
-   * @return the {@code RunningSpanStore} or {@code null} if not supported.
+   * @return the {@code RunningSpanStore}.
    */
   public abstract RunningSpanStore getRunningSpanStore();
 
@@ -56,11 +56,14 @@ public abstract class ExportComponent {
    * Returns the {@link SampledSpanStore} that can be used to get useful debugging information, such
    * as latency based sampled spans, error based sampled spans.
    *
-   * @return the {@code SampledSpanStore} or {@code null} if not supported.
+   * @return the {@code SampledSpanStore}.
    */
   public abstract SampledSpanStore getSampledSpanStore();
 
   private static final class NoopExportComponent extends ExportComponent {
+    private final SampledSpanStore noopSampledSpanStore =
+        SampledSpanStore.newNoopSampledSpanStore();
+
     @Override
     public SpanExporter getSpanExporter() {
       return SpanExporter.getNoopSpanExporter();
@@ -73,7 +76,7 @@ public abstract class ExportComponent {
 
     @Override
     public SampledSpanStore getSampledSpanStore() {
-      return SampledSpanStore.newNoopSampledSpanStore();
+      return noopSampledSpanStore;
     }
   }
 }

--- a/api/src/main/java/io/opencensus/trace/export/ExportComponent.java
+++ b/api/src/main/java/io/opencensus/trace/export/ExportComponent.java
@@ -17,7 +17,6 @@
 package io.opencensus.trace.export;
 
 import io.opencensus.trace.TraceOptions;
-import javax.annotation.Nullable;
 
 /**
  * Class that holds the implementation instances for {@link SpanExporter}, {@link RunningSpanStore}
@@ -27,15 +26,13 @@ import javax.annotation.Nullable;
  */
 public abstract class ExportComponent {
 
-  private static final NoopExportComponent NOOP_EXPORT_COMPONENT = new NoopExportComponent();
-
   /**
    * Returns the no-op implementation of the {@code ExportComponent}.
    *
    * @return the no-op implementation of the {@code ExportComponent}.
    */
-  public static ExportComponent getNoopExportComponent() {
-    return NOOP_EXPORT_COMPONENT;
+  public static ExportComponent newNoopExportComponent() {
+    return new NoopExportComponent();
   }
 
   /**
@@ -53,7 +50,6 @@ public abstract class ExportComponent {
    *
    * @return the {@code RunningSpanStore} or {@code null} if not supported.
    */
-  @Nullable
   public abstract RunningSpanStore getRunningSpanStore();
 
   /**
@@ -62,7 +58,6 @@ public abstract class ExportComponent {
    *
    * @return the {@code SampledSpanStore} or {@code null} if not supported.
    */
-  @Nullable
   public abstract SampledSpanStore getSampledSpanStore();
 
   private static final class NoopExportComponent extends ExportComponent {
@@ -71,16 +66,14 @@ public abstract class ExportComponent {
       return SpanExporter.getNoopSpanExporter();
     }
 
-    @Nullable
     @Override
     public RunningSpanStore getRunningSpanStore() {
-      return null;
+      return RunningSpanStore.getNoopRunningSpanStore();
     }
 
-    @Nullable
     @Override
     public SampledSpanStore getSampledSpanStore() {
-      return null;
+      return SampledSpanStore.newNoopSampledSpanStore();
     }
   }
 }

--- a/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
@@ -46,7 +46,7 @@ public abstract class RunningSpanStore {
    *
    * @return the no-op implementation of the {@code RunningSpanStore}.
    */
-  public static RunningSpanStore getNoopRunningSpanStore() {
+  static RunningSpanStore getNoopRunningSpanStore() {
     return NOOP_RUNNING_SPAN_STORE;
   }
 
@@ -165,9 +165,12 @@ public abstract class RunningSpanStore {
 
   private static final class NoopRunningSpanStore extends RunningSpanStore {
 
+    private static final Summary EMPTY_SUMMARY =
+        Summary.create(Collections.<String, PerSpanNameSummary>emptyMap());
+
     @Override
     public Summary getSummary() {
-      return Summary.create(Collections.<String, PerSpanNameSummary>emptyMap());
+      return EMPTY_SUMMARY;
     }
 
     @Override

--- a/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
@@ -37,7 +37,18 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public abstract class RunningSpanStore {
 
+  private static final RunningSpanStore NOOP_RUNNING_SPAN_STORE = new NoopRunningSpanStore();
+
   protected RunningSpanStore() {}
+
+  /**
+   * Returns the no-op implementation of the {@code RunningSpanStore}.
+   *
+   * @return the no-op implementation of the {@code RunningSpanStore}.
+   */
+  public static RunningSpanStore getNoopRunningSpanStore() {
+    return NOOP_RUNNING_SPAN_STORE;
+  }
 
   /**
    * Returns the summary of all available data such, as number of running spans.
@@ -150,5 +161,19 @@ public abstract class RunningSpanStore {
      * @return the maximum number of spans to be returned.
      */
     public abstract int getMaxSpansToReturn();
+  }
+
+  private static final class NoopRunningSpanStore extends RunningSpanStore {
+
+    @Override
+    public Summary getSummary() {
+      return Summary.create(Collections.<String, PerSpanNameSummary>emptyMap());
+    }
+
+    @Override
+    public Collection<SpanData> getRunningSpans(Filter filter) {
+      checkNotNull(filter, "filter");
+      return Collections.<SpanData>emptyList();
+    }
   }
 }

--- a/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import io.opencensus.trace.Span;
@@ -53,10 +52,10 @@ public abstract class SampledSpanStore {
   protected SampledSpanStore() {}
 
   /**
-   * Returns a {@code SampledSpanStore} that maintains a map of span names, but always returns an
+   * Returns a {@code SampledSpanStore} that maintains a set of span names, but always returns an
    * empty list of {@link SpanData}.
    *
-   * @return a {@code SampledSpanStore} that maintains a map of span names, but always returns an
+   * @return a {@code SampledSpanStore} that maintains a set of span names, but always returns an
    *     empty list of {@code SpanData}.
    */
   static SampledSpanStore newNoopSampledSpanStore() {
@@ -438,7 +437,7 @@ public abstract class SampledSpanStore {
     @Override
     public Set<String> getRegisteredSpanNamesForCollection() {
       synchronized (registeredSpanNames) {
-        return ImmutableSet.copyOf(registeredSpanNames);
+        return Collections.<String>unmodifiableSet(Sets.newHashSet(registeredSpanNames));
       }
     }
   }

--- a/api/src/test/java/io/opencensus/trace/TraceComponentTest.java
+++ b/api/src/test/java/io/opencensus/trace/TraceComponentTest.java
@@ -31,29 +31,29 @@ import org.junit.runners.JUnit4;
 public class TraceComponentTest {
   @Test
   public void defaultTracer() {
-    assertThat(TraceComponent.getNoopTraceComponent().getTracer()).isSameAs(Tracer.getNoopTracer());
+    assertThat(TraceComponent.newNoopTraceComponent().getTracer()).isSameAs(Tracer.getNoopTracer());
   }
 
   @Test
   public void defaultBinaryPropagationHandler() {
-    assertThat(TraceComponent.getNoopTraceComponent().getPropagationComponent())
+    assertThat(TraceComponent.newNoopTraceComponent().getPropagationComponent())
         .isSameAs(PropagationComponent.getNoopPropagationComponent());
   }
 
   @Test
   public void defaultClock() {
-    assertThat(TraceComponent.getNoopTraceComponent().getClock()).isInstanceOf(ZeroTimeClock.class);
+    assertThat(TraceComponent.newNoopTraceComponent().getClock()).isInstanceOf(ZeroTimeClock.class);
   }
 
   @Test
   public void defaultTraceExporter() {
-    assertThat(TraceComponent.getNoopTraceComponent().getExportComponent())
-        .isSameAs(ExportComponent.getNoopExportComponent());
+    assertThat(TraceComponent.newNoopTraceComponent().getExportComponent())
+        .isInstanceOf(ExportComponent.newNoopExportComponent().getClass());
   }
 
   @Test
   public void defaultTraceConfig() {
-    assertThat(TraceComponent.getNoopTraceComponent().getTraceConfig())
+    assertThat(TraceComponent.newNoopTraceComponent().getTraceConfig())
         .isSameAs(TraceConfig.getNoopTraceConfig());
   }
 }

--- a/api/src/test/java/io/opencensus/trace/TracingTest.java
+++ b/api/src/test/java/io/opencensus/trace/TracingTest.java
@@ -72,7 +72,8 @@ public class TracingTest {
 
   @Test
   public void defaultTraceExporter() {
-    assertThat(Tracing.getExportComponent()).isSameAs(ExportComponent.getNoopExportComponent());
+    assertThat(Tracing.getExportComponent())
+        .isInstanceOf(ExportComponent.newNoopExportComponent().getClass());
   }
 
   @Test

--- a/api/src/test/java/io/opencensus/trace/export/ExportComponentTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/ExportComponentTest.java
@@ -25,7 +25,7 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link ExportComponent}. */
 @RunWith(JUnit4.class)
 public class ExportComponentTest {
-  private final ExportComponent exportComponent = ExportComponent.getNoopExportComponent();
+  private final ExportComponent exportComponent = ExportComponent.newNoopExportComponent();
 
   @Test
   public void implementationOfSpanExporter() {
@@ -34,11 +34,13 @@ public class ExportComponentTest {
 
   @Test
   public void implementationOfActiveSpans() {
-    assertThat(exportComponent.getRunningSpanStore()).isNull();
+    assertThat(exportComponent.getRunningSpanStore())
+        .isEqualTo(RunningSpanStore.getNoopRunningSpanStore());
   }
 
   @Test
   public void implementationOfSampledSpanStore() {
-    assertThat(exportComponent.getSampledSpanStore()).isNull();
+    assertThat(exportComponent.getSampledSpanStore())
+        .isInstanceOf(SampledSpanStore.newNoopSampledSpanStore().getClass());
   }
 }

--- a/api/src/test/java/io/opencensus/trace/export/NoopRunningSpanStoreTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/NoopRunningSpanStoreTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.Collection;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoopRunningSpanStore}. */
+@RunWith(JUnit4.class)
+public final class NoopRunningSpanStoreTest {
+
+  private final RunningSpanStore runningSpanStore =
+      ExportComponent.newNoopExportComponent().getRunningSpanStore();
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void noopRunningSpanStore_GetSummary() {
+    RunningSpanStore.Summary summary = runningSpanStore.getSummary();
+    assertThat(summary.getPerSpanNameSummary()).isEmpty();
+  }
+
+  @Test
+  public void noopRunningSpanStore_GetRunningSpans_DisallowsNull() {
+    thrown.expect(NullPointerException.class);
+    runningSpanStore.getRunningSpans(null);
+  }
+
+  @Test
+  public void noopRunningSpanStore_GetRunningSpans() {
+    Collection<SpanData> runningSpans =
+        runningSpanStore.getRunningSpans(RunningSpanStore.Filter.create("TestSpan", 0));
+    assertThat(runningSpans).isEmpty();
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/export/NoopSampledSpanStoreTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/NoopSampledSpanStoreTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.Lists;
+import io.opencensus.trace.Status.CanonicalCode;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link NoopSampledSpanStore}. */
+@RunWith(JUnit4.class)
+public final class NoopSampledSpanStoreTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+  private final SampledSpanStore.PerSpanNameSummary emptyPerSpanNameSummary =
+      SampledSpanStore.PerSpanNameSummary.create(
+          Collections.<SampledSpanStore.LatencyBucketBoundaries, Integer>emptyMap(),
+          Collections.<CanonicalCode, Integer>emptyMap());
+
+  @Test
+  public void noopSampledSpanStore_RegisterUnregisterAndGetSummary() {
+    // should return empty before register
+    SampledSpanStore sampledSpanStore =
+        ExportComponent.newNoopExportComponent().getSampledSpanStore();
+    SampledSpanStore.Summary summary = sampledSpanStore.getSummary();
+    assertThat(summary.getPerSpanNameSummary()).isEmpty();
+
+    // should return non-empty summaries with zero latency/error sampled spans after register
+    sampledSpanStore.registerSpanNamesForCollection(
+        Collections.unmodifiableList(Lists.newArrayList("TestSpan1", "TestSpan2", "TestSpan3")));
+    summary = sampledSpanStore.getSummary();
+    assertThat(summary.getPerSpanNameSummary())
+        .containsExactly(
+            "TestSpan1", emptyPerSpanNameSummary,
+            "TestSpan2", emptyPerSpanNameSummary,
+            "TestSpan3", emptyPerSpanNameSummary);
+
+    // should unregister specific spanNames
+    sampledSpanStore.unregisterSpanNamesForCollection(
+        Collections.unmodifiableList(Lists.newArrayList("TestSpan1", "TestSpan3")));
+    summary = sampledSpanStore.getSummary();
+    assertThat(summary.getPerSpanNameSummary())
+        .containsExactly("TestSpan2", emptyPerSpanNameSummary);
+  }
+
+  @Test
+  public void noopSampledSpanStore_GetLatencySampledSpans() {
+    SampledSpanStore sampledSpanStore =
+        ExportComponent.newNoopExportComponent().getSampledSpanStore();
+    Collection<SpanData> latencySampledSpans =
+        sampledSpanStore.getLatencySampledSpans(
+            SampledSpanStore.LatencyFilter.create("TestLatencyFilter", 0, 0, 0));
+    assertThat(latencySampledSpans).isEmpty();
+  }
+
+  @Test
+  public void noopSampledSpanStore_GetErrorSampledSpans() {
+    SampledSpanStore sampledSpanStore =
+        ExportComponent.newNoopExportComponent().getSampledSpanStore();
+    Collection<SpanData> errorSampledSpans =
+        sampledSpanStore.getErrorSampledSpans(
+            SampledSpanStore.ErrorFilter.create("TestErrorFilter", null, 0));
+    assertThat(errorSampledSpans).isEmpty();
+  }
+
+  @Test
+  public void noopSampledSpanStore_GetRegisteredSpanNamesForCollection() {
+    SampledSpanStore sampledSpanStore =
+        ExportComponent.newNoopExportComponent().getSampledSpanStore();
+    sampledSpanStore.registerSpanNamesForCollection(
+        Collections.unmodifiableList(Lists.newArrayList("TestSpan3", "TestSpan4")));
+    Set<String> registeredSpanNames = sampledSpanStore.getRegisteredSpanNamesForCollection();
+    assertThat(registeredSpanNames).containsExactly("TestSpan3", "TestSpan4");
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/export/NoopSampledSpanStoreTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/NoopSampledSpanStoreTest.java
@@ -34,7 +34,7 @@ import org.junit.runners.JUnit4;
 public final class NoopSampledSpanStoreTest {
 
   @Rule public final ExpectedException thrown = ExpectedException.none();
-  private final SampledSpanStore.PerSpanNameSummary emptyPerSpanNameSummary =
+  private static final SampledSpanStore.PerSpanNameSummary EMPTY_PER_SPAN_NAME_SUMMARY =
       SampledSpanStore.PerSpanNameSummary.create(
           Collections.<SampledSpanStore.LatencyBucketBoundaries, Integer>emptyMap(),
           Collections.<CanonicalCode, Integer>emptyMap());
@@ -53,16 +53,16 @@ public final class NoopSampledSpanStoreTest {
     summary = sampledSpanStore.getSummary();
     assertThat(summary.getPerSpanNameSummary())
         .containsExactly(
-            "TestSpan1", emptyPerSpanNameSummary,
-            "TestSpan2", emptyPerSpanNameSummary,
-            "TestSpan3", emptyPerSpanNameSummary);
+            "TestSpan1", EMPTY_PER_SPAN_NAME_SUMMARY,
+            "TestSpan2", EMPTY_PER_SPAN_NAME_SUMMARY,
+            "TestSpan3", EMPTY_PER_SPAN_NAME_SUMMARY);
 
     // should unregister specific spanNames
     sampledSpanStore.unregisterSpanNamesForCollection(
         Collections.unmodifiableList(Lists.newArrayList("TestSpan1", "TestSpan3")));
     summary = sampledSpanStore.getSummary();
     assertThat(summary.getPerSpanNameSummary())
-        .containsExactly("TestSpan2", emptyPerSpanNameSummary);
+        .containsExactly("TestSpan2", EMPTY_PER_SPAN_NAME_SUMMARY);
   }
 
   @Test


### PR DESCRIPTION
This change is a follow up of a comment by @bogdandrutu in #677 .

[NoopRunningSpanStore](https://github.com/census-instrumentation/opencensus-java/compare/master...HailongWen:noop-span-store?expand=1#diff-23ac90b4be2dc7cd150cb6ee4d849721) will always return empty list when querying running SpanData.
[NoopSampledSpanStore](https://github.com/HailongWen/opencensus-java/blob/d89b938b29497ad234a466c97dedd3002c7aa414/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java) has a similar no-op implementation. It maintains a set of span names for data collections and return empty Summary for each span name.

Similar to [NoopViewManager](https://github.com/HailongWen/opencensus-java/blob/d89b938b29497ad234a466c97dedd3002c7aa414/api/src/main/java/io/opencensus/stats/NoopStats.java), since [NoopSampledSpanStore](https://github.com/HailongWen/opencensus-java/blob/d89b938b29497ad234a466c97dedd3002c7aa414/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java) is not stateless, several apis of "getXXXX()" has been refactored to "newXXXX()".