### PR TITLE
Disable setting min/max for Stackdriver export

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.api.Distribution;
 import com.google.api.Distribution.BucketOptions;
 import com.google.api.Distribution.BucketOptions.Explicit;
-import com.google.api.Distribution.Range;
 import com.google.api.LabelDescriptor;
 import com.google.api.LabelDescriptor.ValueType;
 import com.google.api.Metric;
@@ -278,11 +277,12 @@ final class StackdriverExportUtils {
         .addAllBucketCounts(distributionData.getBucketCounts())
         .setCount(distributionData.getCount())
         .setMean(distributionData.getMean())
-        .setRange(
-            Range.newBuilder()
-                .setMax(distributionData.getMax())
-                .setMin(distributionData.getMin())
-                .build())
+        // TODO(songya): uncomment this once Stackdriver supports setting max and min.
+        // .setRange(
+        //    Range.newBuilder()
+        //        .setMax(distributionData.getMax())
+        //        .setMin(distributionData.getMin())
+        //        .build())
         .setSumOfSquaredDeviation(distributionData.getSumOfSquaredDeviations())
         .build();
   }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -208,6 +208,7 @@ public class StackdriverExportUtilsTest {
             com.google.api.Distribution.newBuilder()
                 .setMean(2)
                 .setCount(3)
+                // TODO(songya): uncomment this once Stackdriver supports setting max and min.
                 // .setRange(
                 //     com.google.api.Distribution.Range.newBuilder().setMin(0).setMax(5).build())
                 .setBucketOptions(StackdriverExportUtils.createBucketOptions(BUCKET_BOUNDARIES))

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -208,8 +208,8 @@ public class StackdriverExportUtilsTest {
             com.google.api.Distribution.newBuilder()
                 .setMean(2)
                 .setCount(3)
-                .setRange(
-                    com.google.api.Distribution.Range.newBuilder().setMin(0).setMax(5).build())
+                // .setRange(
+                //     com.google.api.Distribution.Range.newBuilder().setMin(0).setMax(5).build())
                 .setBucketOptions(StackdriverExportUtils.createBucketOptions(BUCKET_BOUNDARIES))
                 .addAllBucketCounts(Arrays.asList(0L, 1L, 1L, 0L, 1L))
                 .setSumOfSquaredDeviation(14)


### PR DESCRIPTION
Fix https://github.com/census-instrumentation/opencensus-java/issues/831