### PR TITLE
Batch export 3 Timeseries at one RPC call

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThread.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThread.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.CreateTimeSeriesRequest;
 import com.google.monitoring.v3.ProjectName;
+import com.google.monitoring.v3.TimeSeries;
 import io.opencensus.common.Duration;
 import io.opencensus.stats.View;
 import io.opencensus.stats.ViewData;
@@ -47,6 +48,8 @@ final class StackdriverExporterWorkerThread extends Thread {
 
   private static final Logger logger =
       Logger.getLogger(StackdriverExporterWorkerThread.class.getName());
+
+  @VisibleForTesting static final int MAX_BATCH_EXPORT_SIZE = 3;
 
   private final long scheduleDelayMillis;
   private final String projectId;
@@ -113,13 +116,23 @@ final class StackdriverExporterWorkerThread extends Thread {
       registerView(view);
       viewDataList.add(viewManager.getView(view.getName()));
     }
-    CreateTimeSeriesRequest.Builder builder =
-        CreateTimeSeriesRequest.newBuilder().setNameWithProjectName(projectName);
+    List<TimeSeries> timeSeriesList = Lists.newArrayList();
     for (ViewData viewData : viewDataList) {
-      builder.addAllTimeSeries(StackdriverExportUtils.createTimeSeriesList(viewData, projectId));
+      timeSeriesList.addAll(StackdriverExportUtils.createTimeSeriesList(viewData, projectId));
     }
-    if (!builder.getTimeSeriesList().isEmpty()) {
-      metricServiceClient.createTimeSeries(builder.build());
+
+    for (int i = 0; i < timeSeriesList.size(); i += MAX_BATCH_EXPORT_SIZE) {
+      // Batch export 3 TimeSeries at one call, to avoid exceeding RPC header size limit.
+      CreateTimeSeriesRequest.Builder builder =
+          CreateTimeSeriesRequest.newBuilder().setNameWithProjectName(projectName);
+      for (int j = i; j < i + MAX_BATCH_EXPORT_SIZE && j < timeSeriesList.size(); j++) {
+        builder.addTimeSeries(timeSeriesList.get(j));
+      }
+      try {
+        metricServiceClient.createTimeSeries(builder.build());
+      } catch (Throwable e) {
+        logger.log(Level.WARNING, "Exception thrown when exporting.", e);
+      }
     }
   }
 

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThreadTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerThreadTest.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.exporter.stats.stackdriver;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -101,6 +102,11 @@ public class StackdriverExporterWorkerThreadTest {
         .when(mockCreateMetricDescriptorCallable)
         .call(any(CreateMetricDescriptorRequest.class));
     doReturn(null).when(mockCreateTimeSeriesCallable).call(any(CreateTimeSeriesRequest.class));
+  }
+
+  @Test
+  public void testConstants() {
+    assertThat(StackdriverExporterWorkerThread.MAX_BATCH_EXPORT_SIZE).isEqualTo(3);
   }
 
   @Test


### PR DESCRIPTION
If we batch export too many `Timeseries` with one `CreateTimeSeriesRequest`, Stackdriver client might throw an `Http2Exception: Header size exceeded max allowed size (10240)`

Fix https://github.com/census-instrumentation/opencensus-java/issues/840