### PR TITLE
Add new API SpanBuilder#setRegisterNameForSampledSpanStore().

### DIFF
--- a/api/src/main/java/io/opencensus/trace/SpanBuilder.java
+++ b/api/src/main/java/io/opencensus/trace/SpanBuilder.java
@@ -135,6 +135,16 @@ public abstract class SpanBuilder {
   public abstract SpanBuilder setRecordEvents(boolean recordEvents);
 
   /**
+   * Sets the newly created {@code Span} to be registered in {@code SampledSpanStore} for data
+   * collection. See {@link
+   * io.opencensus.trace.export.SampledSpanStore#registerSpanNamesForCollection(Collection)} for
+   * detailed behavior.
+   *
+   * @return this.
+   */
+  public abstract SpanBuilder setRegisterNameForSampledSpanStore();
+
+  /**
    * Starts a new {@link Span}.
    *
    * <p>Users <b>must</b> manually call {@link Span#end()} or {@link Span#end(EndSpanOptions)} to
@@ -250,6 +260,11 @@ public abstract class SpanBuilder {
 
     @Override
     public SpanBuilder setRecordEvents(boolean recordEvents) {
+      return this;
+    }
+
+    @Override
+    public SpanBuilder setRegisterNameForSampledSpanStore() {
       return this;
     }
 

--- a/impl_core/build.gradle
+++ b/impl_core/build.gradle
@@ -7,6 +7,7 @@ dependencies {
     compileOnly libraries.auto_value
 
     testCompile project(':opencensus-api'),
+            project(':opencensus-impl'),
             project(':opencensus-testing')
 
     signature "org.codehaus.mojo.signature:java16:+@signature"

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/SpanBuilderImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/SpanBuilderImpl.java
@@ -30,6 +30,7 @@ import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.TraceId;
 import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.Tracing;
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.config.TraceParams;
 import java.util.Collections;
@@ -48,6 +49,7 @@ final class SpanBuilderImpl extends SpanBuilder {
   private Sampler sampler;
   private List<Span> parentLinks = Collections.<Span>emptyList();
   private Boolean recordEvents;
+  private Boolean registerNameForSampledSpanStore;
 
   private SpanImpl startSpanInternal(
       @Nullable SpanContext parent,
@@ -89,6 +91,11 @@ final class SpanBuilderImpl extends SpanBuilder {
     EnumSet<Span.Options> spanOptions = EnumSet.noneOf(Span.Options.class);
     if (traceOptions.isSampled() || Boolean.TRUE.equals(recordEvents)) {
       spanOptions.add(Span.Options.RECORD_EVENTS);
+    }
+    if (Boolean.TRUE.equals(registerNameForSampledSpanStore)) {
+      Tracing.getExportComponent()
+          .getSampledSpanStore()
+          .registerSpanNamesForCollection(Collections.<String>singletonList(name));
     }
     SpanImpl span =
         SpanImpl.startSpan(
@@ -232,6 +239,12 @@ final class SpanBuilderImpl extends SpanBuilder {
   @Override
   public SpanBuilderImpl setRecordEvents(boolean recordEvents) {
     this.recordEvents = recordEvents;
+    return this;
+  }
+
+  @Override
+  public SpanBuilderImpl setRegisterNameForSampledSpanStore() {
+    this.registerNameForSampledSpanStore = true;
     return this;
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/SampledSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/SampledSpanStoreImpl.java
@@ -280,7 +280,7 @@ public final class SampledSpanStoreImpl extends SampledSpanStore {
     eventQueue.enqueue(new RegisterSpanNameEvent(this, spanNames));
   }
 
-  private void internaltRegisterSpanNamesForCollection(Collection<String> spanNames) {
+  private void internalRegisterSpanNamesForCollection(Collection<String> spanNames) {
     synchronized (samples) {
       for (String spanName : spanNames) {
         if (!samples.containsKey(spanName)) {
@@ -302,7 +302,7 @@ public final class SampledSpanStoreImpl extends SampledSpanStore {
 
     @Override
     public void process() {
-      sampledSpanStore.internaltRegisterSpanNamesForCollection(spanNames);
+      sampledSpanStore.internalRegisterSpanNamesForCollection(spanNames);
     }
   }
 


### PR DESCRIPTION
This PR addresses item#1 in this [comment](https://github.com/census-instrumentation/opencensus-java/issues/700#issuecomment-335105585).

I will work on another PR later to resolve the renaming issue.