### PR TITLE
Add bazel build support for `examples`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
     env: TASK=BUILD_EXAMPLES_MAVEN
     os: linux
 
+  - jdk: oraclejdk8
+    env: TASK=BUILD_EXAMPLES_BAZEL
+    os: linux
+
   - env: TASK=CHECK_GIT_HISTORY
     os: linux
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,6 +52,12 @@ before_install:
       cat gradle/errorprone/experimental_warnings  >> $HOME/.gradle/gradle.properties ;
       cat gradle/errorprone/experimental_suggestions  >> $HOME/.gradle/gradle.properties ;
     fi
+  - if \[ "$TASK" == "BUILD_EXAMPLES_BAZEL" \]; then
+      echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list ;
+      curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add - ;
+      sudo apt-get update ;
+      sudo apt-get install bazel ;
+    fi
 
 # Skip Travis' default Gradle install step. See http://stackoverflow.com/a/26575080.
 install: true

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -2,7 +2,7 @@ load("//:opencensus_workspace.bzl", "opencensus_java_libraries")
 opencensus_java_libraries()
 
 java_library(
-    name = "examples",
+    name = "opencensus_examples",
     srcs = glob(
         ["src/main/java/**/*.java"]
     ),
@@ -24,7 +24,7 @@ java_binary(
     name = "StatsRunner",
     main_class = "io.opencensus.examples.stats.StatsRunner",
     runtime_deps = [
-        ":examples",
+        ":opencensus_examples",
     ],
 )
 
@@ -32,7 +32,7 @@ java_binary(
     name = "MultiSpansTracing",
     main_class = "io.opencensus.examples.trace.MultiSpansTracing",
     runtime_deps = [
-        ":examples",
+        ":opencensus_examples",
     ],
 )
 
@@ -40,7 +40,7 @@ java_binary(
     name = "MultiSpansScopedTracing",
     main_class = "io.opencensus.examples.trace.MultiSpansScopedTracing",
     runtime_deps = [
-        ":examples",
+        ":opencensus_examples",
     ],
 )
 
@@ -48,7 +48,7 @@ java_binary(
     name = "MultiSpansContextTracing",
     main_class = "io.opencensus.examples.trace.MultiSpansContextTracing",
     runtime_deps = [
-        ":examples",
+        ":opencensus_examples",
     ],
 )
 
@@ -56,6 +56,6 @@ java_binary(
     name = "ZPagesTester",
     main_class = "io.opencensus.examples.zpages.ZPagesTester",
     runtime_deps = [
-        ":examples",
+        ":opencensus_examples",
     ],
 )

--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -1,0 +1,61 @@
+load("//:opencensus_workspace.bzl", "opencensus_java_libraries")
+opencensus_java_libraries()
+
+java_library(
+    name = "examples",
+    srcs = glob(
+        ["src/main/java/**/*.java"]
+    ),
+    deps = [
+        "@io_opencensus_opencensus_api//jar",
+        "@io_opencensus_opencensus_contrib_zpages//jar",
+        "@io_opencensus_opencensus_exporter_trace_logging//jar",
+    ],
+    runtime_deps = [
+        "@com_google_guava_guava//jar",
+        "@com_lmax_disruptor//jar",
+        "@io_grpc_grpc_context//jar",
+        "@io_opencensus_opencensus_impl//jar",
+        "@io_opencensus_opencensus_impl_core//jar",
+    ],
+)
+
+java_binary(
+    name = "StatsRunner",
+    main_class = "io.opencensus.examples.stats.StatsRunner",
+    runtime_deps = [
+        ":examples",
+    ],
+)
+
+java_binary(
+    name = "MultiSpansTracing",
+    main_class = "io.opencensus.examples.trace.MultiSpansTracing",
+    runtime_deps = [
+        ":examples",
+    ],
+)
+
+java_binary(
+    name = "MultiSpansScopedTracing",
+    main_class = "io.opencensus.examples.trace.MultiSpansScopedTracing",
+    runtime_deps = [
+        ":examples",
+    ],
+)
+
+java_binary(
+    name = "MultiSpansContextTracing",
+    main_class = "io.opencensus.examples.trace.MultiSpansContextTracing",
+    runtime_deps = [
+        ":examples",
+    ],
+)
+
+java_binary(
+    name = "ZPagesTester",
+    main_class = "io.opencensus.examples.zpages.ZPagesTester",
+    runtime_deps = [
+        ":examples",
+    ],
+)

--- a/examples/README.md
+++ b/examples/README.md
@@ -12,6 +12,11 @@ $ ./gradlew installDist
 $ mvn package appassembler:assemble
 ```
 
+### Bazel
+```
+$ bazel build :all
+```
+
 ## To run "StatsRunner" example use
 
 ### Gradle
@@ -24,6 +29,11 @@ $ ./build/install/examples/bin/StatsRunner
 $ ./target/appassembler/bin/StatsRunner
 ```
 
+### Bazel
+```
+$ ./bazel-bin/StatsRunner
+```
+
 ## To run "ZPagesTester"
 
 ### Gradle
@@ -34,6 +44,11 @@ $ ./build/install/examples/bin/ZPagesTester
 ### Maven
 ```
 $ ./target/appassembler/bin/ZPagesTester
+```
+
+### Bazel
+```
+$ ./bazel-bin/ZPagesTester
 ```
 
 Available pages:

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,0 +1,5 @@
+workspace(name = "opencensus_examples")
+
+load("//:opencensus_workspace.bzl", "opencensus_maven_jars")
+
+opencensus_maven_jars()

--- a/examples/opencensus_workspace.bzl
+++ b/examples/opencensus_workspace.bzl
@@ -1,0 +1,206 @@
+# The following dependencies were calculated from:
+#
+# generate_workspace --artifact=io.opencensus:opencensus-api:0.10.1 --artifact=io.opencensus:opencensus-contrib-zpages:0.10.1 --artifact=io.opencensus:opencensus-exporter-trace-logging:0.10.1 --artifact=io.opencensus:opencensus-impl:0.10.1 --repositories=http://repo.maven.apache.org/maven2
+
+def opencensus_maven_jars():
+  # io.opencensus:opencensus-contrib-zpages:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-impl-core:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-exporter-trace-logging:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-impl:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-api:jar:0.10.1
+  native.maven_jar(
+      name = "com_google_code_findbugs_jsr305",
+      artifact = "com.google.code.findbugs:jsr305:3.0.1",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "f7be08ec23c21485b9b5a1cf1654c2ec8c58168d",
+  )
+
+
+  # io.opencensus:opencensus-api:jar:0.10.1
+  native.maven_jar(
+      name = "io_grpc_grpc_context",
+      artifact = "io.grpc:grpc-context:1.8.0",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "7fe8214b8d1141afadbe0bcad751df2b8fe2e078",
+  )
+
+
+  native.maven_jar(
+      name = "io_opencensus_opencensus_exporter_trace_logging",
+      artifact = "io.opencensus:opencensus-exporter-trace-logging:0.10.1",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "c9d934614bb0237a39eda79d52d245626ef32d71",
+  )
+
+
+  # io.opencensus:opencensus-contrib-zpages:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-impl-core:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-exporter-trace-logging:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-impl:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-api:jar:0.10.1
+  native.maven_jar(
+      name = "com_google_errorprone_error_prone_annotations",
+      artifact = "com.google.errorprone:error_prone_annotations:2.1.2",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "6dcc08f90f678ac33e5ef78c3c752b6f59e63e0c",
+  )
+
+
+  native.maven_jar(
+      name = "io_opencensus_opencensus_contrib_zpages",
+      artifact = "io.opencensus:opencensus-contrib-zpages:0.10.1",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "4e2cf2a5f05bffb8dedbc8f183f127cd46cd4a3f",
+  )
+
+
+  # io.opencensus:opencensus-impl:jar:0.10.1
+  native.maven_jar(
+      name = "com_lmax_disruptor",
+      artifact = "com.lmax:disruptor:3.3.6",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "09bfca4ee4f691f3737b3f4f006d0c4770f178eb",
+  )
+
+
+  # io.opencensus:opencensus-contrib-zpages:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-impl-core:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-exporter-trace-logging:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-api:jar:0.10.1
+  native.maven_jar(
+      name = "com_google_guava_guava",
+      artifact = "com.google.guava:guava:19.0",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "6ce200f6b23222af3d8abb6b6459e6c44f4bb0e9",
+  )
+
+
+  # io.opencensus:opencensus-contrib-zpages:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-impl-core:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-exporter-trace-logging:jar:0.10.1 got requested version
+  # io.opencensus:opencensus-impl:jar:0.10.1 got requested version
+  native.maven_jar(
+      name = "io_opencensus_opencensus_api",
+      artifact = "io.opencensus:opencensus-api:0.10.1",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "1f5319c45aa3f4c879805f2a323d1ab6ba42e334",
+  )
+
+
+  # io.opencensus:opencensus-impl:jar:0.10.1
+  native.maven_jar(
+      name = "io_opencensus_opencensus_impl_core",
+      artifact = "io.opencensus:opencensus-impl-core:0.10.1",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "66b221c4388e3208000422954b4ba0248f7746ca",
+  )
+
+
+  native.maven_jar(
+      name = "io_opencensus_opencensus_impl",
+      artifact = "io.opencensus:opencensus-impl:0.10.1",
+      repository = "http://repo.maven.apache.org/maven2/",
+      sha1 = "6a96e07455946d43608a9bde4ed0663cd7c0fe56",
+  )
+
+def opencensus_java_libraries():
+  native.java_library(
+      name = "com_google_code_findbugs_jsr305",
+      visibility = ["//visibility:public"],
+      exports = ["@com_google_code_findbugs_jsr305//jar"],
+  )
+
+
+  native.java_library(
+      name = "io_grpc_grpc_context",
+      visibility = ["//visibility:public"],
+      exports = ["@io_grpc_grpc_context//jar"],
+  )
+
+
+  native.java_library(
+      name = "io_opencensus_opencensus_exporter_trace_logging",
+      visibility = ["//visibility:public"],
+      exports = ["@io_opencensus_opencensus_exporter_trace_logging//jar"],
+      runtime_deps = [
+          ":com_google_code_findbugs_jsr305",
+          ":com_google_errorprone_error_prone_annotations",
+          ":com_google_guava_guava",
+          ":io_opencensus_opencensus_api",
+      ],
+  )
+
+
+  native.java_library(
+      name = "com_google_errorprone_error_prone_annotations",
+      visibility = ["//visibility:public"],
+      exports = ["@com_google_errorprone_error_prone_annotations//jar"],
+  )
+
+
+  native.java_library(
+      name = "io_opencensus_opencensus_contrib_zpages",
+      visibility = ["//visibility:public"],
+      exports = ["@io_opencensus_opencensus_contrib_zpages//jar"],
+      runtime_deps = [
+          ":com_google_code_findbugs_jsr305",
+          ":com_google_errorprone_error_prone_annotations",
+          ":com_google_guava_guava",
+          ":io_opencensus_opencensus_api",
+      ],
+  )
+
+
+  native.java_library(
+      name = "com_lmax_disruptor",
+      visibility = ["//visibility:public"],
+      exports = ["@com_lmax_disruptor//jar"],
+  )
+
+
+  native.java_library(
+      name = "com_google_guava_guava",
+      visibility = ["//visibility:public"],
+      exports = ["@com_google_guava_guava//jar"],
+  )
+
+
+  native.java_library(
+      name = "io_opencensus_opencensus_api",
+      visibility = ["//visibility:public"],
+      exports = ["@io_opencensus_opencensus_api//jar"],
+      runtime_deps = [
+          ":com_google_code_findbugs_jsr305",
+          ":com_google_errorprone_error_prone_annotations",
+          ":com_google_guava_guava",
+          ":io_grpc_grpc_context",
+      ],
+  )
+
+
+  native.java_library(
+      name = "io_opencensus_opencensus_impl_core",
+      visibility = ["//visibility:public"],
+      exports = ["@io_opencensus_opencensus_impl_core//jar"],
+      runtime_deps = [
+          ":com_google_code_findbugs_jsr305",
+          ":com_google_errorprone_error_prone_annotations",
+          ":com_google_guava_guava",
+          ":io_opencensus_opencensus_api",
+      ],
+  )
+
+
+  native.java_library(
+      name = "io_opencensus_opencensus_impl",
+      visibility = ["//visibility:public"],
+      exports = ["@io_opencensus_opencensus_impl//jar"],
+      runtime_deps = [
+          ":com_google_code_findbugs_jsr305",
+          ":com_google_errorprone_error_prone_annotations",
+          ":com_google_guava_guava",
+          ":com_lmax_disruptor",
+          ":io_opencensus_opencensus_api",
+          ":io_opencensus_opencensus_impl_core",
+      ],
+  )

--- a/scripts/travis_script
+++ b/scripts/travis_script
@@ -54,6 +54,12 @@ case "$TASK" in
   "BUILD_EXAMPLES_MAVEN")
     pushd examples && mvn clean package appassembler:assemble -e && popd
     ;;
+  "BUILD_EXAMPLES_BAZEL")
+    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
+    curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
+    sudo apt-get update && sudo apt-get install bazel
+    pushd examples && bazel clean && bazel build :all && popd
+    ;;
   *)
     echo "Unknown task $TASK"
     exit 1

--- a/scripts/travis_script
+++ b/scripts/travis_script
@@ -55,9 +55,6 @@ case "$TASK" in
     pushd examples && mvn clean package appassembler:assemble -e && popd
     ;;
   "BUILD_EXAMPLES_BAZEL")
-    echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list
-    curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add -
-    sudo apt-get update && sudo apt-get install bazel
     pushd examples && bazel clean && bazel build :all && popd
     ;;
   *)


### PR DESCRIPTION
To resolve the transitive dependency, I used [migration-tooling](https://github.com/bazelbuild/migration-tooling) to auto-generate libraries definitions. Command can be found in the generated file, which might help when updating the build file in the future.

This PR is a sub-item of #855 and depends on #890 to be merged. I'll update the `README.md` later.