### PR TITLE
Support previous encoding versions.

### DIFF
--- a/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/propagation/SerializationUtils.java
@@ -103,9 +103,9 @@ final class SerializationUtils {
 
       ByteBuffer buffer = ByteBuffer.wrap(bytes).asReadOnlyBuffer();
       int versionId = buffer.get();
-      if (versionId != VERSION_ID) {
+      if (versionId > VERSION_ID || versionId < 0) {
         throw new TagContextDeserializationException(
-            "Wrong Version ID: " + versionId + ". Currently supported version is: " + VERSION_ID);
+            "Wrong Version ID: " + versionId + ". Currently supports version up to: " + VERSION_ID);
       }
       return new TagContextImpl(parseTags(buffer));
     } catch (BufferUnderflowException exn) {

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextDeserializationTest.java
@@ -296,8 +296,15 @@ public class TagContextDeserializationTest {
   @Test
   public void testDeserializeWrongVersionId() throws TagContextDeserializationException {
     thrown.expect(TagContextDeserializationException.class);
-    thrown.expectMessage("Wrong Version ID: 1. Currently supported version is: 0");
+    thrown.expectMessage("Wrong Version ID: 1. Currently supports version up to: 0");
     serializer.fromByteArray(new byte[] {(byte) (SerializationUtils.VERSION_ID + 1)});
+  }
+
+  @Test
+  public void testDeserializeNegativeVersionId() throws TagContextDeserializationException {
+    thrown.expect(TagContextDeserializationException.class);
+    thrown.expectMessage("Wrong Version ID: -1. Currently supports version up to: 0");
+    serializer.fromByteArray(new byte[] {(byte) -1});
   }
 
   //     <tag_encoding> ==


### PR DESCRIPTION
Do we want to keep backwards-compatible on encoding? I'm not sure about this but Go allows bytes in previous versions: https://github.com/census-instrumentation/opencensus-go/blob/master/tag/map_codec.go#L191