### PR TITLE
SignalFx stats exporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ runtime 'io.opencensus:opencensus-impl:0.10.1'
 
 #### Stats exporters
 * [Stackdriver][StatsExporterStackdriver]
+* [SignalFx][StatsExporterSignalFx]
 
 ### How to setup debugging Z-Pages?
 
@@ -133,3 +134,4 @@ see this [link](https://github.com/census-instrumentation/opencensus-java/tree/m
 [TraceExporterStackdriver]: https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/trace/stackdriver#quickstart
 [TraceExporterZipkin]: https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/trace/zipkin#quickstart
 [StatsExporterStackdriver]: https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/stackdriver#quickstart
+[StatsExporterSignalFx]: https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/signalfx#quickstart

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -24,6 +24,7 @@ def subprojects = [
         project(':opencensus-exporter-trace-logging'),
         project(':opencensus-exporter-trace-stackdriver'),
         project(':opencensus-exporter-trace-zipkin'),
+        project(':opencensus-exporter-stats-signalfx'),
         project(':opencensus-exporter-stats-stackdriver'),
 ]
 
@@ -38,6 +39,7 @@ def subprojects_javadoc = [
         project(':opencensus-exporter-trace-logging'),
         project(':opencensus-exporter-trace-stackdriver'),
         project(':opencensus-exporter-trace-zipkin'),
+        project(':opencensus-exporter-stats-signalfx'),
         project(':opencensus-exporter-stats-stackdriver'),
 ]
 

--- a/build.gradle
+++ b/build.gradle
@@ -136,6 +136,7 @@ subprojects {
         guavaVersion = '19.0'
         googleAuthVersion = '0.9.0'
         googleCloudVersion = '0.30.0-beta'
+        signalfxVersion = '0.0.39'
         zipkinReporterVersion = '2.0.0'
 
         libraries = [
@@ -155,6 +156,7 @@ subprojects {
                 grpc_core: "io.grpc:grpc-core:${grpcVersion}",
                 guava: "com.google.guava:guava:${guavaVersion}",
                 jsr305: "com.google.code.findbugs:jsr305:${findBugsVersion}",
+                signalfx_java: "com.signalfx.public:signalfx-java:${signalfxVersion}",
 
                 // Test dependencies.
                 guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
@@ -317,6 +319,7 @@ subprojects {
                  'opencensus-contrib-grpc-metrics',
                  'opencensus-contrib-grpc-util',
                  'opencensus-contrib-zpages',
+                 'opencensus-exporter-stats-signalfx',
                  'opencensus-exporter-stats-stackdriver',
                  'opencensus-exporter-trace-logging',
                  'opencensus-exporter-trace-stackdriver',

--- a/exporters/stats/signalfx/README.md
+++ b/exporters/stats/signalfx/README.md
@@ -1,0 +1,75 @@
+# OpenCensus SignalFx Stats Exporter
+
+The _OpenCensus SignalFx Stats Exporter_ is a stats exporter that
+exports data to [SignalFx](https://signalfx.com), a real-time monitoring
+solution for cloud and distributed applications. SignalFx ingests that
+data and offers various visualizations on charts, dashboards and service
+maps, as well as real-time anomaly detection.
+
+## Quickstart
+
+### Prerequisites
+
+To use this exporter, you must have a [SignalFx](https://signalfx.com)
+account and corresponding [data ingest
+token](https://docs.signalfx.com/en/latest/admin-guide/tokens.html).
+
+#### Java versions
+
+This exporter requires Java 7 or above.
+
+### Add the dependencies to your project
+
+For Maven add to your `pom.xml`:
+
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-api</artifactId>
+    <version>0.10.1</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-impl</artifactId>
+    <version>0.10.1</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-exporter-stats-signalfx</artifactId>
+    <version>0.10.1</version>
+    <scope>runtime</scope>
+  </dependency>
+</dependencies>
+```
+
+For Gradle add to your dependencies:
+
+```
+compile 'io.opencensus:opencensus-api:0.10.1'
+compile 'io.opencensus:opencensus-impl:0.10.1'
+runtime 'io.opencensus:opencensus-exporter-stats-signalfx:0.10.1'
+```
+
+### Register the exporter
+
+```java
+public class MyMainClass {
+  public static void main(String[] args) {
+    // SignalFx token is read from Java system properties.
+    // Stats will be reported every second by default.
+    SignalFxStatsExporter.create();
+  }
+}
+```
+
+If you want to pass in the token yourself, or set a different reporting
+interval, use:
+
+```java
+// Use token "your_signalfx_token" and report every 5 seconds.
+SignalFxStatsExporter.create(
+    SignalFxStatsExporter.DEFAULT_SIGNALFX_ENDPOINT,
+    "your_signalfx_token",
+    Duration.create(5, 0));
+```

--- a/exporters/stats/signalfx/README.md
+++ b/exporters/stats/signalfx/README.md
@@ -31,12 +31,12 @@ For Maven add to your `pom.xml`:
   </dependency>
   <dependency>
     <groupId>io.opencensus</groupId>
-    <artifactId>opencensus-impl</artifactId>
+    <artifactId>opencensus-exporter-stats-signalfx</artifactId>
     <version>0.10.1</version>
   </dependency>
   <dependency>
     <groupId>io.opencensus</groupId>
-    <artifactId>opencensus-exporter-stats-signalfx</artifactId>
+    <artifactId>opencensus-impl</artifactId>
     <version>0.10.1</version>
     <scope>runtime</scope>
   </dependency>

--- a/exporters/stats/signalfx/README.md
+++ b/exporters/stats/signalfx/README.md
@@ -47,8 +47,8 @@ For Gradle add to your dependencies:
 
 ```
 compile 'io.opencensus:opencensus-api:0.10.1'
-compile 'io.opencensus:opencensus-impl:0.10.1'
-runtime 'io.opencensus:opencensus-exporter-stats-signalfx:0.10.1'
+compile 'io.opencensus:opencensus-exporter-stats-signalfx:0.10.1'
+runtime 'io.opencensus:opencensus-impl:0.10.1'
 ```
 
 ### Register the exporter

--- a/exporters/stats/signalfx/build.gradle
+++ b/exporters/stats/signalfx/build.gradle
@@ -1,0 +1,15 @@
+description = 'OpenCensus SignalFx Stats Exporter'
+
+[compileJava, compileTestJava].each() {
+    it.sourceCompatibility = 1.7
+    it.targetCompatibility = 1.7
+}
+
+dependencies {
+    compile project(':opencensus-api'),
+            libraries.signalfx_java
+
+    testCompile project(':opencensus-api')
+
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+}

--- a/exporters/stats/signalfx/build.gradle
+++ b/exporters/stats/signalfx/build.gradle
@@ -6,6 +6,8 @@ description = 'OpenCensus SignalFx Stats Exporter'
 }
 
 dependencies {
+    compileOnly libraries.auto_value
+
     compile project(':opencensus-api'),
             libraries.signalfx_java
 

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxMetricsSenderFactory.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxMetricsSenderFactory.java
@@ -22,7 +22,7 @@ import com.signalfx.metrics.connection.HttpDataPointProtobufReceiverFactory;
 import com.signalfx.metrics.connection.HttpEventProtobufReceiverFactory;
 import com.signalfx.metrics.errorhandler.OnSendErrorHandler;
 import com.signalfx.metrics.flush.AggregateMetricSender;
-import java.net.URL;
+import java.net.URI;
 import java.util.Collections;
 
 /** Interface for creators of {@link AggregateMetricSender}. */
@@ -31,26 +31,26 @@ interface SignalFxMetricsSenderFactory {
   /**
    * Creates a new SignalFx metrics sender instance.
    *
-   * @param url The SignalFx ingest endpoint URL.
+   * @param endpoint The SignalFx ingest endpoint URL.
    * @param token The SignalFx ingest token.
    * @param errorHandler An {@link OnSendErrorHandler} through which errors when sending data to
    *     SignalFx will be communicated.
    * @return The created {@link AggregateMetricSender} instance.
    */
-  AggregateMetricSender create(URL url, String token, OnSendErrorHandler errorHandler);
+  AggregateMetricSender create(URI endpoint, String token, OnSendErrorHandler errorHandler);
 
   /** The default, concrete implementation of this interface. */
   SignalFxMetricsSenderFactory DEFAULT =
       new SignalFxMetricsSenderFactory() {
         @Override
         public AggregateMetricSender create(
-            URL url, String token, OnSendErrorHandler errorHandler) {
-          SignalFxEndpoint endpoint =
-              new SignalFxEndpoint(url.getProtocol(), url.getHost(), url.getPort());
+            URI endpoint, String token, OnSendErrorHandler errorHandler) {
+          SignalFxEndpoint sfx =
+              new SignalFxEndpoint(endpoint.getScheme(), endpoint.getHost(), endpoint.getPort());
           return new AggregateMetricSender(
               null,
-              new HttpDataPointProtobufReceiverFactory(endpoint).setVersion(2),
-              new HttpEventProtobufReceiverFactory(endpoint),
+              new HttpDataPointProtobufReceiverFactory(sfx).setVersion(2),
+              new HttpEventProtobufReceiverFactory(sfx),
               new StaticAuthToken(token),
               Collections.singleton(errorHandler));
         }

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxMetricsSenderFactory.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxMetricsSenderFactory.java
@@ -43,6 +43,7 @@ interface SignalFxMetricsSenderFactory {
   SignalFxMetricsSenderFactory DEFAULT =
       new SignalFxMetricsSenderFactory() {
         @Override
+        @SuppressWarnings("nullness")
         public AggregateMetricSender create(
             URI endpoint, String token, OnSendErrorHandler errorHandler) {
           SignalFxEndpoint sfx =

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxMetricsSenderFactory.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxMetricsSenderFactory.java
@@ -26,7 +26,7 @@ import java.net.URL;
 import java.util.Collections;
 
 /** Interface for creators of {@link AggregateMetricSender}. */
-public interface SignalFxMetricsSenderFactory {
+interface SignalFxMetricsSenderFactory {
 
   /**
    * Creates a new SignalFx metrics sender instance.

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxMetricsSenderFactory.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxMetricsSenderFactory.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import com.signalfx.endpoint.SignalFxEndpoint;
+import com.signalfx.metrics.auth.StaticAuthToken;
+import com.signalfx.metrics.connection.HttpDataPointProtobufReceiverFactory;
+import com.signalfx.metrics.connection.HttpEventProtobufReceiverFactory;
+import com.signalfx.metrics.errorhandler.OnSendErrorHandler;
+import com.signalfx.metrics.flush.AggregateMetricSender;
+import java.net.URL;
+import java.util.Collections;
+
+/** Interface for creators of {@link AggregateMetricSender}. */
+public interface SignalFxMetricsSenderFactory {
+
+  /**
+   * Creates a new SignalFx metrics sender instance.
+   *
+   * @param url The SignalFx ingest endpoint URL.
+   * @param token The SignalFx ingest token.
+   * @param errorHandler An {@link OnSendErrorHandler} through which errors when sending data to
+   *     SignalFx will be communicated.
+   * @return The created {@link AggregateMetricSender} instance.
+   */
+  AggregateMetricSender create(URL url, String token, OnSendErrorHandler errorHandler);
+
+  /** The default, concrete implementation of this interface. */
+  SignalFxMetricsSenderFactory DEFAULT =
+      new SignalFxMetricsSenderFactory() {
+        @Override
+        public AggregateMetricSender create(
+            URL url, String token, OnSendErrorHandler errorHandler) {
+          SignalFxEndpoint endpoint =
+              new SignalFxEndpoint(url.getProtocol(), url.getHost(), url.getPort());
+          return new AggregateMetricSender(
+              null,
+              new HttpDataPointProtobufReceiverFactory(endpoint).setVersion(2),
+              new HttpEventProtobufReceiverFactory(endpoint),
+              new StaticAuthToken(token),
+              Collections.singleton(errorHandler));
+        }
+      };
+}

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
@@ -42,7 +42,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import javax.annotation.Nonnull;
 
 /*>>>
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -63,7 +62,7 @@ final class SignalFxSessionAdaptor {
    *     values.
    * @return A list of datapoints for the corresponding metric timeseries of this view's metric.
    */
-  static List<DataPoint> adapt(@Nonnull ViewData data) {
+  static List<DataPoint> adapt(ViewData data) {
     View view = data.getView();
     List<TagKey> keys = view.getColumns();
 

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
@@ -1,0 +1,169 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.DataPoint;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Datum;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Dimension;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.MetricType;
+import io.opencensus.common.Function;
+import io.opencensus.common.Functions;
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.AggregationData;
+import io.opencensus.stats.AggregationData.CountData;
+import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.MeanData;
+import io.opencensus.stats.AggregationData.SumDataDouble;
+import io.opencensus.stats.AggregationData.SumDataLong;
+import io.opencensus.stats.View;
+import io.opencensus.stats.View.AggregationWindow;
+import io.opencensus.stats.ViewData;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+
+/** Adapter for a {@code ViewData}'s contents into SignalFx datapoints. */
+final class SignalFxSessionAdaptor {
+
+  private SignalFxSessionAdaptor() {}
+
+  /**
+   * Converts the given view data into datapoints that can be sent to SignalFx.
+   *
+   * <p>The view name is used as the metric name, and the aggregation type and aggregation window
+   * type determine the metric type.
+   *
+   * @param data The {@link ViewData} containing the aggregation data of each combination of tag
+   *     values.
+   * @return A list of datapoints for the corresponding metric timeseries of this view's metric.
+   */
+  static List<DataPoint> adapt(ViewData data) {
+    View view = data.getView();
+    List<TagKey> keys = view.getColumns();
+
+    MetricType metricType = getMetricTypeForAggregation(view.getAggregation(), view.getWindow());
+    if (metricType == null) {
+      return Collections.emptyList();
+    }
+
+    List<DataPoint> datapoints = new ArrayList<>(data.getAggregationMap().size());
+    for (Map.Entry<List<TagValue>, AggregationData> entry : data.getAggregationMap().entrySet()) {
+      datapoints.add(
+          DataPoint.newBuilder()
+              .setMetric(view.getName().asString())
+              .setMetricType(metricType)
+              .addAllDimensions(createDimensions(keys, entry.getKey()))
+              .setValue(createDatum(entry.getValue()))
+              .build());
+    }
+    return datapoints;
+  }
+
+  @VisibleForTesting
+  @Nullable
+  static MetricType getMetricTypeForAggregation(Aggregation aggregation, AggregationWindow window) {
+    if (aggregation instanceof Aggregation.Mean) {
+      return MetricType.GAUGE;
+    } else if (aggregation instanceof Aggregation.Count || aggregation instanceof Aggregation.Sum) {
+      if (window instanceof AggregationWindow.Interval) {
+        return MetricType.COUNTER;
+      } else if (window instanceof AggregationWindow.Cumulative) {
+        return MetricType.CUMULATIVE_COUNTER;
+      }
+    }
+
+    // TODO(mpetazzoni): add support for histograms (Aggregation.Distribution).
+    return null;
+  }
+
+  @VisibleForTesting
+  static Iterable<Dimension> createDimensions(List<TagKey> keys, List<TagValue> values) {
+    Preconditions.checkArgument(
+        keys.size() == values.size(), "TagKeys and TagValues don't have the same size.");
+    List<Dimension> dimensions = new ArrayList<>(keys.size());
+    for (ListIterator<TagKey> it = keys.listIterator(); it.hasNext(); ) {
+      TagKey key = it.next();
+      TagValue value = values.get(it.previousIndex());
+      if (value == null || Strings.isNullOrEmpty(value.asString())) {
+        continue;
+      }
+      dimensions.add(createDimension(key, value));
+    }
+    return dimensions;
+  }
+
+  @VisibleForTesting
+  static Dimension createDimension(TagKey key, TagValue value) {
+    return Dimension.newBuilder().setKey(key.getName()).setValue(value.asString()).build();
+  }
+
+  @VisibleForTesting
+  static Datum createDatum(AggregationData data) {
+    final Datum.Builder builder = Datum.newBuilder();
+    data.match(
+        new Function<SumDataDouble, Object>() {
+          @Override
+          @Nullable
+          public Object apply(SumDataDouble arg) {
+            builder.setDoubleValue(arg.getSum());
+            return null;
+          }
+        },
+        new Function<SumDataLong, Object>() {
+          @Override
+          @Nullable
+          public Object apply(SumDataLong arg) {
+            builder.setIntValue(arg.getSum());
+            return null;
+          }
+        },
+        new Function<CountData, Object>() {
+          @Override
+          @Nullable
+          public Object apply(CountData arg) {
+            builder.setIntValue(arg.getCount());
+            return null;
+          }
+        },
+        new Function<MeanData, Object>() {
+          @Override
+          @Nullable
+          public Object apply(MeanData arg) {
+            builder.setDoubleValue(arg.getMean());
+            return null;
+          }
+        },
+        new Function<DistributionData, Object>() {
+          @Override
+          @Nullable
+          public Object apply(DistributionData arg) {
+            // TODO(mpetazzoni): add histogram support.
+            throw new IllegalArgumentException("Distribution aggregations are not supported");
+          }
+        },
+        Functions.throwIllegalArgumentException());
+    return builder.build();
+  }
+}

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
@@ -90,11 +90,10 @@ final class SignalFxSessionAdaptor {
     if (aggregation instanceof Aggregation.Mean) {
       return MetricType.GAUGE;
     } else if (aggregation instanceof Aggregation.Count || aggregation instanceof Aggregation.Sum) {
-      if (window instanceof AggregationWindow.Interval) {
-        return MetricType.COUNTER;
-      } else if (window instanceof AggregationWindow.Cumulative) {
+      if (window instanceof AggregationWindow.Cumulative) {
         return MetricType.CUMULATIVE_COUNTER;
       }
+      // TODO(mpetazzoni): support incremental counters when AggregationWindow.Interval is ready
     }
 
     // TODO(mpetazzoni): add support for histograms (Aggregation.Distribution).

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
@@ -42,7 +42,11 @@ import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import javax.annotation.Nullable;
+import javax.annotation.Nonnull;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
 
 /** Adapter for a {@code ViewData}'s contents into SignalFx datapoints. */
 final class SignalFxSessionAdaptor {
@@ -59,7 +63,7 @@ final class SignalFxSessionAdaptor {
    *     values.
    * @return A list of datapoints for the corresponding metric timeseries of this view's metric.
    */
-  static List<DataPoint> adapt(ViewData data) {
+  static List<DataPoint> adapt(@Nonnull ViewData data) {
     View view = data.getView();
     List<TagKey> keys = view.getColumns();
 
@@ -82,7 +86,7 @@ final class SignalFxSessionAdaptor {
   }
 
   @VisibleForTesting
-  @Nullable
+  @javax.annotation.Nullable
   static MetricType getMetricTypeForAggregation(Aggregation aggregation, AggregationWindow window) {
     if (aggregation instanceof Aggregation.Mean) {
       return MetricType.GAUGE;
@@ -123,47 +127,42 @@ final class SignalFxSessionAdaptor {
   static Datum createDatum(AggregationData data) {
     final Datum.Builder builder = Datum.newBuilder();
     data.match(
-        new Function<SumDataDouble, Object>() {
+        new Function<SumDataDouble, Void>() {
           @Override
-          @Nullable
-          public Object apply(SumDataDouble arg) {
+          public Void apply(SumDataDouble arg) {
             builder.setDoubleValue(arg.getSum());
             return null;
           }
         },
-        new Function<SumDataLong, Object>() {
+        new Function<SumDataLong, Void>() {
           @Override
-          @Nullable
-          public Object apply(SumDataLong arg) {
+          public Void apply(SumDataLong arg) {
             builder.setIntValue(arg.getSum());
             return null;
           }
         },
-        new Function<CountData, Object>() {
+        new Function<CountData, Void>() {
           @Override
-          @Nullable
-          public Object apply(CountData arg) {
+          public Void apply(CountData arg) {
             builder.setIntValue(arg.getCount());
             return null;
           }
         },
-        new Function<MeanData, Object>() {
+        new Function<MeanData, Void>() {
           @Override
-          @Nullable
-          public Object apply(MeanData arg) {
+          public Void apply(MeanData arg) {
             builder.setDoubleValue(arg.getMean());
             return null;
           }
         },
-        new Function<DistributionData, Object>() {
+        new Function<DistributionData, Void>() {
           @Override
-          @Nullable
-          public Object apply(DistributionData arg) {
+          public Void apply(DistributionData arg) {
             // TODO(mpetazzoni): add histogram support.
             throw new IllegalArgumentException("Distribution aggregations are not supported");
           }
         },
-        Functions.throwIllegalArgumentException());
+        Functions.</*@Nullable*/ Void>throwIllegalArgumentException());
     return builder.build();
   }
 }

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsConfiguration.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsConfiguration.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.Duration;
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.annotation.concurrent.Immutable;
+
+/** Configurations for {@link SignalFxStatsExporter}. */
+@AutoValue
+@Immutable
+// Suppress Checker Framework warning about missing @Nullable in generated equals method.
+@AutoValue.CopyAnnotations
+@SuppressWarnings("nullness")
+public abstract class SignalFxStatsConfiguration {
+
+  /** The default SignalFx ingest API URL. */
+  public static final String DEFAULT_SIGNALFX_ENDPOINT = "https://ingest.signalfx.com";
+
+  /** The default stats export interval. */
+  public static final Duration DEFAULT_EXPORT_INTERVAL = Duration.create(1, 0);
+
+  SignalFxStatsConfiguration() {}
+
+  /**
+   * Returns the SignalFx ingest API URL.
+   *
+   * @return the SignalFx ingest API URL.
+   */
+  public abstract URI getIngestEndpoint();
+
+  /**
+   * Returns the authentication token.
+   *
+   * @return the authentication token.
+   */
+  public abstract String getToken();
+
+  /**
+   * Returns the export interval between pushes to SignalFx.
+   *
+   * @return the export interval.
+   */
+  public abstract Duration getExportInterval();
+
+  /**
+   * Returns a new {@link Builder}.
+   *
+   * @return a {@code Builder}.
+   */
+  public static Builder builder() {
+    try {
+      return new AutoValue_SignalFxStatsConfiguration.Builder()
+          .setIngestEndpoint(new URI(DEFAULT_SIGNALFX_ENDPOINT))
+          .setExportInterval(DEFAULT_EXPORT_INTERVAL);
+    } catch (URISyntaxException e) {
+      // This shouldn't happen if DEFAULT_SIGNALFX_ENDPOINT was typed in correctly.
+      throw new IllegalArgumentException(e);
+    }
+  }
+
+  /** Builder for {@link SignalFxStatsConfiguration}. */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    Builder() {}
+
+    /**
+     * Sets the given SignalFx ingest API URL.
+     *
+     * @param url the SignalFx ingest API URL.
+     * @return this.
+     */
+    public abstract Builder setIngestEndpoint(URI url);
+
+    /**
+     * Sets the given authentication token.
+     *
+     * @param token the authentication token.
+     * @return this.
+     */
+    public abstract Builder setToken(String token);
+
+    /**
+     * Sets the export interval.
+     *
+     * @param exportInterval the export interval between pushes to SignalFx.
+     * @return this.
+     */
+    public abstract Builder setExportInterval(Duration exportInterval);
+
+    /**
+     * Builds a new {@link SignalFxStatsConfiguration} with current settings.
+     *
+     * @return a {@code SignalFxStatsConfiguration}.
+     */
+    public abstract SignalFxStatsConfiguration build();
+  }
+}

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporter.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporter.java
@@ -56,7 +56,8 @@ public final class SignalFxStatsExporter {
 
   private SignalFxStatsExporter(URL url, String token, Duration interval, ViewManager viewManager) {
     Preconditions.checkArgument(!Strings.isNullOrEmpty(token), "Invalid SignalFx token");
-    Preconditions.checkArgument(interval.compareTo(ZERO) > 0, "Duration must be positive");
+    Preconditions.checkNotNull(interval, "Interval must not be null");
+    Preconditions.checkArgument(interval.compareTo(ZERO) > 0, "Interval duration must be positive");
     this.workerThread =
         new SignalFxStatsExporterWorkerThread(
             SignalFxMetricsSenderFactory.DEFAULT, url, token, interval, viewManager);
@@ -85,6 +86,7 @@ public final class SignalFxStatsExporter {
    * @throws IllegalStateException if a SignalFx exporter already exists.
    */
   public static void create(Properties properties) {
+    Preconditions.checkNotNull(properties, "Given properties shouldn't be null");
     String host = properties.getProperty(SIGNALFX_HOST_PROPERTY, DEFAULT_SIGNALFX_ENDPOINT);
     String token = properties.getProperty(SIGNALFX_TOKEN_PROPERTY);
     create(host, token, DEFAULT_INTERVAL);

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporter.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporter.java
@@ -18,11 +18,8 @@ package io.opencensus.exporter.stats.signalfx;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
-import io.opencensus.common.Duration;
 import io.opencensus.stats.Stats;
 import io.opencensus.stats.ViewManager;
-import java.net.URI;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -40,7 +37,6 @@ import javax.annotation.concurrent.GuardedBy;
  */
 public final class SignalFxStatsExporter {
 
-  private static final Duration ZERO = Duration.create(0, 0);
   private static final Object monitor = new Object();
 
   private final SignalFxStatsConfiguration configuration;
@@ -53,17 +49,13 @@ public final class SignalFxStatsExporter {
   private SignalFxStatsExporter(SignalFxStatsConfiguration configuration, ViewManager viewManager) {
     Preconditions.checkNotNull(configuration, "SignalFx stats exporter configuration");
     this.configuration = configuration;
-
-    String token = configuration.getToken();
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(token), "Invalid SignalFx token");
-
-    Duration interval = configuration.getExportInterval();
-    Preconditions.checkArgument(interval.compareTo(ZERO) > 0, "Interval duration must be positive");
-
-    URI endpoint = configuration.getIngestEndpoint();
     this.workerThread =
         new SignalFxStatsExporterWorkerThread(
-            SignalFxMetricsSenderFactory.DEFAULT, endpoint, token, interval, viewManager);
+            SignalFxMetricsSenderFactory.DEFAULT,
+            configuration.getIngestEndpoint(),
+            configuration.getToken(),
+            configuration.getExportInterval(),
+            viewManager);
   }
 
   /**

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporter.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporter.java
@@ -41,8 +41,14 @@ import javax.annotation.concurrent.GuardedBy;
  */
 public final class SignalFxStatsExporter {
 
+  /**
+   * The name of the Java property that specifies the SignalFx authentication token to use when
+   * reporting metrics.
+   */
   public static final String SIGNALFX_TOKEN_PROPERTY = "signalfx.auth.token";
+  /** The name of the Java property that specifies the SignalFx ingest API URL (without path). */
   public static final String SIGNALFX_HOST_PROPERTY = "signalfx.ingest.url";
+  /** The default SignalFx ingest API URL. */
   public static final String DEFAULT_SIGNALFX_ENDPOINT = "https://ingest.signalfx.com";
 
   private static final Duration ZERO = Duration.create(0, 0);

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporter.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporter.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import io.opencensus.common.Duration;
+import io.opencensus.stats.Stats;
+import io.opencensus.stats.ViewManager;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Properties;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * Exporter to SignalFx.
+ *
+ * <p>Example of usage:
+ *
+ * <pre><code>
+ * public static void main(String[] args) {
+ *   SignalFxStatsExporter.create();
+ *   ... // Do work.
+ * }
+ * </code></pre>
+ */
+public final class SignalFxStatsExporter {
+
+  public static final String SIGNALFX_TOKEN_PROPERTY = "signalfx.auth.token";
+  public static final String SIGNALFX_HOST_PROPERTY = "signalfx.ingest.url";
+  public static final String DEFAULT_SIGNALFX_ENDPOINT = "https://ingest.signalfx.com";
+
+  private static final Duration ZERO = Duration.create(0, 0);
+  private static final Duration DEFAULT_INTERVAL = Duration.create(1, 0);
+  private static final Object monitor = new Object();
+
+  private final SignalFxStatsExporterWorkerThread workerThread;
+
+  @GuardedBy("monitor")
+  private static SignalFxStatsExporter exporter = null;
+
+  private SignalFxStatsExporter(URL url, String token, Duration interval, ViewManager viewManager) {
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(token), "Invalid SignalFx token");
+    Preconditions.checkArgument(interval.compareTo(ZERO) > 0, "Duration must be positive");
+    this.workerThread =
+        new SignalFxStatsExporterWorkerThread(
+            SignalFxMetricsSenderFactory.DEFAULT, url, token, interval, viewManager);
+  }
+
+  /**
+   * Creates a SignalFx Stats exporter that gets its authentication token and the SignalFx ingest
+   * URL from system properties and uses the default reporting interval.
+   *
+   * <p>Only one SignalFx Stats exporter can be created.
+   *
+   * @throws IllegalStateException if a SignalFx exporter already exists.
+   */
+  public static void create() {
+    create(System.getProperties());
+  }
+
+  /**
+   * Creates a SignalFx Stats exporter that gets its authentication token and the SignalFx ingest
+   * URL from the given Java properties and uses the default reporting interval.
+   *
+   * <p>Only one SignalFx Stats exporter can be created.
+   *
+   * @param properties a {@code Properties} object containing the {@link #SIGNALFX_TOKEN_PROPERTY}
+   *     and {@link #SIGNALFX_HOST_PROPERTY}.
+   * @throws IllegalStateException if a SignalFx exporter already exists.
+   */
+  public static void create(Properties properties) {
+    String host = properties.getProperty(SIGNALFX_HOST_PROPERTY, DEFAULT_SIGNALFX_ENDPOINT);
+    String token = properties.getProperty(SIGNALFX_TOKEN_PROPERTY);
+    create(host, token, DEFAULT_INTERVAL);
+  }
+
+  /**
+   * Creates a SignalFx Stats exporter with an explicit authentication token and reporting interval.
+   *
+   * <p>Only one SignalFx Stats exporter can be created.
+   *
+   * @param host the SignalFx ingest URL.
+   * @param token a SignalFx ingest token.
+   * @param interval the interval at which stats are reported to SignalFx.
+   * @throws IllegalStateException if a SignalFx exporter already exists.
+   */
+  public static void create(String host, String token, Duration interval) {
+    URL url;
+    try {
+      url = new URL(host);
+    } catch (MalformedURLException e) {
+      throw new IllegalArgumentException("Invalid SignalFx endpoint URL", e);
+    }
+
+    synchronized (monitor) {
+      Preconditions.checkState(exporter == null, "SignalFx stats exporter is already created.");
+      exporter = new SignalFxStatsExporter(url, token, interval, Stats.getViewManager());
+      exporter.workerThread.start();
+    }
+  }
+
+  @VisibleForTesting
+  static void unsafeResetExporter() {
+    synchronized (monitor) {
+      if (exporter != null) {
+        try {
+          exporter.workerThread.interrupt();
+          exporter.workerThread.join();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        } finally {
+          exporter = null;
+        }
+      }
+    }
+  }
+}

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThread.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThread.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.signalfx.metrics.errorhandler.MetricError;
+import com.signalfx.metrics.errorhandler.OnSendErrorHandler;
+import com.signalfx.metrics.flush.AggregateMetricSender;
+import com.signalfx.metrics.flush.AggregateMetricSender.Session;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.DataPoint;
+import io.opencensus.common.Duration;
+import io.opencensus.stats.View;
+import io.opencensus.stats.ViewData;
+import io.opencensus.stats.ViewManager;
+import java.io.IOException;
+import java.net.URL;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+/**
+ * Worker {@code Thread} that polls ViewData from the Stats's ViewManager and exports to SignalFx.
+ *
+ * <p>{@code SignalFxStatsExporterWorkerThread} is a daemon {@code Thread}
+ */
+final class SignalFxStatsExporterWorkerThread extends Thread {
+
+  private static final Logger logger =
+      Logger.getLogger(SignalFxStatsExporterWorkerThread.class.getName());
+
+  private static final OnSendErrorHandler ERROR_HANDLER =
+      new OnSendErrorHandler() {
+        @Override
+        public void handleError(MetricError error) {
+          logger.log(Level.WARNING, "Unable to send metrics to SignalFx: {0}", error.getMessage());
+        }
+      };
+
+  private final long intervalMs;
+  private final ViewManager views;
+  private final AggregateMetricSender sender;
+
+  SignalFxStatsExporterWorkerThread(
+      SignalFxMetricsSenderFactory factory,
+      URL url,
+      String token,
+      Duration interval,
+      ViewManager views) {
+    this.intervalMs =
+        TimeUnit.SECONDS.toMillis(interval.getSeconds())
+            + TimeUnit.NANOSECONDS.toMillis(interval.getNanos());
+    this.views = views;
+    this.sender = factory.create(url, token, ERROR_HANDLER);
+
+    setDaemon(true);
+    setName(getClass().getSimpleName());
+    logger.log(Level.FINE, "Initialized SignalFx exporter to {0}.", url);
+  }
+
+  @VisibleForTesting
+  void export() {
+    try (Session session = sender.createSession()) {
+      for (View view : views.getAllExportedViews()) {
+        ViewData data = views.getView(view.getName());
+        for (DataPoint datapoint : SignalFxSessionAdaptor.adapt(data)) {
+          session.setDatapoint(datapoint);
+        }
+      }
+    } catch (IOException e) {
+      // Does not happen, flush/close errors are communicated through the sender's error handlers.
+    }
+  }
+
+  @Override
+  public void run() {
+    while (true) {
+      try {
+        export();
+        Thread.sleep(intervalMs);
+      } catch (InterruptedException ie) {
+        Thread.currentThread().interrupt();
+        break;
+      } catch (Throwable e) {
+        logger.log(Level.WARNING, "Exception thrown by the SignalFx stats exporter", e);
+      }
+    }
+    logger.log(Level.INFO, "SignalFx stats exporter stopped.");
+  }
+}

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThread.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThread.java
@@ -27,7 +27,7 @@ import io.opencensus.stats.View;
 import io.opencensus.stats.ViewData;
 import io.opencensus.stats.ViewManager;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -56,7 +56,7 @@ final class SignalFxStatsExporterWorkerThread extends Thread {
 
   SignalFxStatsExporterWorkerThread(
       SignalFxMetricsSenderFactory factory,
-      URL url,
+      URI endpoint,
       String token,
       Duration interval,
       ViewManager views) {
@@ -64,11 +64,11 @@ final class SignalFxStatsExporterWorkerThread extends Thread {
         TimeUnit.SECONDS.toMillis(interval.getSeconds())
             + TimeUnit.NANOSECONDS.toMillis(interval.getNanos());
     this.views = views;
-    this.sender = factory.create(url, token, ERROR_HANDLER);
+    this.sender = factory.create(endpoint, token, ERROR_HANDLER);
 
     setDaemon(true);
     setName(getClass().getSimpleName());
-    logger.log(Level.FINE, "Initialized SignalFx exporter to {0}.", url);
+    logger.log(Level.FINE, "Initialized SignalFx exporter to {0}.", endpoint);
   }
 
   @VisibleForTesting

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThread.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThread.java
@@ -76,6 +76,10 @@ final class SignalFxStatsExporterWorkerThread extends Thread {
     try (Session session = sender.createSession()) {
       for (View view : views.getAllExportedViews()) {
         ViewData data = views.getView(view.getName());
+        if (data == null) {
+          continue;
+        }
+
         for (DataPoint datapoint : SignalFxSessionAdaptor.adapt(data)) {
           session.setDatapoint(datapoint);
         }

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptorTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptorTest.java
@@ -92,20 +92,18 @@ public class SignalFxSessionAdaptorTest {
         SignalFxSessionAdaptor.getMetricTypeForAggregation(
             Aggregation.Count.create(), AggregationWindow.Cumulative.create()));
     assertEquals(
-        MetricType.COUNTER,
-        SignalFxSessionAdaptor.getMetricTypeForAggregation(
-            Aggregation.Count.create(), AggregationWindow.Interval.create(ONE_SECOND)));
-    assertEquals(
         MetricType.CUMULATIVE_COUNTER,
         SignalFxSessionAdaptor.getMetricTypeForAggregation(
             Aggregation.Sum.create(), AggregationWindow.Cumulative.create()));
-    assertEquals(
-        MetricType.COUNTER,
-        SignalFxSessionAdaptor.getMetricTypeForAggregation(
-            Aggregation.Sum.create(), AggregationWindow.Interval.create(ONE_SECOND)));
     assertNull(
         SignalFxSessionAdaptor.getMetricTypeForAggregation(Aggregation.Count.create(), null));
     assertNull(SignalFxSessionAdaptor.getMetricTypeForAggregation(Aggregation.Sum.create(), null));
+    assertNull(
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Count.create(), AggregationWindow.Interval.create(ONE_SECOND)));
+    assertNull(
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Sum.create(), AggregationWindow.Interval.create(ONE_SECOND)));
     assertNull(
         SignalFxSessionAdaptor.getMetricTypeForAggregation(
             Aggregation.Distribution.create(BucketBoundaries.create(ImmutableList.of(3.14d))),

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptorTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptorTest.java
@@ -1,0 +1,250 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.DataPoint;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Datum;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Dimension;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.MetricType;
+import io.opencensus.common.Duration;
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.AggregationData;
+import io.opencensus.stats.AggregationData.CountData;
+import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.MeanData;
+import io.opencensus.stats.AggregationData.SumDataDouble;
+import io.opencensus.stats.AggregationData.SumDataLong;
+import io.opencensus.stats.BucketBoundaries;
+import io.opencensus.stats.View;
+import io.opencensus.stats.View.AggregationWindow;
+import io.opencensus.stats.View.Name;
+import io.opencensus.stats.ViewData;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SignalFxSessionAdaptorTest {
+
+  private static final Duration ONE_SECOND = Duration.create(1, 0);
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Mock private View view;
+
+  @Mock private ViewData viewData;
+
+  @Before
+  public void setUp() {
+    Mockito.when(view.getName()).thenReturn(Name.create("view-name"));
+    Mockito.when(view.getColumns()).thenReturn(ImmutableList.of(TagKey.create("animal")));
+    Mockito.when(viewData.getView()).thenReturn(view);
+  }
+
+  @Test
+  public void checkMetricTypeFromAggregation() {
+    assertNull(SignalFxSessionAdaptor.getMetricTypeForAggregation(null, null));
+    assertNull(
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            null, AggregationWindow.Cumulative.create()));
+    assertEquals(
+        MetricType.GAUGE,
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Mean.create(), AggregationWindow.Cumulative.create()));
+    assertEquals(
+        MetricType.GAUGE,
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Mean.create(), AggregationWindow.Interval.create(ONE_SECOND)));
+    assertEquals(
+        MetricType.CUMULATIVE_COUNTER,
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Count.create(), AggregationWindow.Cumulative.create()));
+    assertEquals(
+        MetricType.COUNTER,
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Count.create(), AggregationWindow.Interval.create(ONE_SECOND)));
+    assertEquals(
+        MetricType.CUMULATIVE_COUNTER,
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Sum.create(), AggregationWindow.Cumulative.create()));
+    assertEquals(
+        MetricType.COUNTER,
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Sum.create(), AggregationWindow.Interval.create(ONE_SECOND)));
+    assertNull(
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(Aggregation.Count.create(), null));
+    assertNull(SignalFxSessionAdaptor.getMetricTypeForAggregation(Aggregation.Sum.create(), null));
+    assertNull(
+        SignalFxSessionAdaptor.getMetricTypeForAggregation(
+            Aggregation.Distribution.create(BucketBoundaries.create(ImmutableList.of(3.14d))),
+            AggregationWindow.Cumulative.create()));
+  }
+
+  @Test
+  public void createDimensionsWithNonMatchingListSizes() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("don't have the same size");
+    SignalFxSessionAdaptor.createDimensions(
+        ImmutableList.of(TagKey.create("animal"), TagKey.create("color")),
+        ImmutableList.of(TagValue.create("dog")));
+  }
+
+  @Test
+  public void createDimensionsIgnoresEmptyValues() {
+    List<Dimension> dimensions =
+        Lists.newArrayList(
+            SignalFxSessionAdaptor.createDimensions(
+                ImmutableList.of(TagKey.create("animal"), TagKey.create("color")),
+                ImmutableList.of(TagValue.create("dog"), TagValue.create(""))));
+    assertEquals(1, dimensions.size());
+    assertEquals("animal", dimensions.get(0).getKey());
+    assertEquals("dog", dimensions.get(0).getValue());
+  }
+
+  @Test
+  public void createDimension() {
+    Dimension dimension =
+        SignalFxSessionAdaptor.createDimension(TagKey.create("animal"), TagValue.create("dog"));
+    assertEquals("animal", dimension.getKey());
+    assertEquals("dog", dimension.getValue());
+  }
+
+  @Test
+  public void unsupportedAggregationYieldsNoDatapoints() {
+    Mockito.when(view.getAggregation())
+        .thenReturn(
+            Aggregation.Distribution.create(BucketBoundaries.create(ImmutableList.of(3.14d))));
+    Mockito.when(view.getWindow()).thenReturn(AggregationWindow.Cumulative.create());
+    List<DataPoint> datapoints = SignalFxSessionAdaptor.adapt(viewData);
+    assertEquals(0, datapoints.size());
+  }
+
+  @Test
+  public void noAggregationDataYieldsNoDatapoints() {
+    Mockito.when(view.getAggregation()).thenReturn(Aggregation.Count.create());
+    Mockito.when(view.getWindow()).thenReturn(AggregationWindow.Cumulative.create());
+    List<DataPoint> datapoints = SignalFxSessionAdaptor.adapt(viewData);
+    assertEquals(0, datapoints.size());
+  }
+
+  @Test
+  public void createDatumFromDoubleSum() {
+    SumDataDouble data = SumDataDouble.create(3.14d);
+    Datum datum = SignalFxSessionAdaptor.createDatum(data);
+    assertTrue(datum.hasDoubleValue());
+    assertFalse(datum.hasIntValue());
+    assertFalse(datum.hasStrValue());
+    assertEquals(3.14d, datum.getDoubleValue(), 0d);
+  }
+
+  @Test
+  public void createDatumFromLongSum() {
+    SumDataLong data = SumDataLong.create(42L);
+    Datum datum = SignalFxSessionAdaptor.createDatum(data);
+    assertFalse(datum.hasDoubleValue());
+    assertTrue(datum.hasIntValue());
+    assertFalse(datum.hasStrValue());
+    assertEquals(42L, datum.getIntValue());
+  }
+
+  @Test
+  public void createDatumFromCount() {
+    CountData data = CountData.create(42L);
+    Datum datum = SignalFxSessionAdaptor.createDatum(data);
+    assertFalse(datum.hasDoubleValue());
+    assertTrue(datum.hasIntValue());
+    assertFalse(datum.hasStrValue());
+    assertEquals(42L, datum.getIntValue());
+  }
+
+  @Test
+  public void createDatumFromMean() {
+    MeanData data = MeanData.create(3.14d, 2L);
+    Datum datum = SignalFxSessionAdaptor.createDatum(data);
+    assertTrue(datum.hasDoubleValue());
+    assertFalse(datum.hasIntValue());
+    assertFalse(datum.hasStrValue());
+    assertEquals(3.14d, datum.getDoubleValue(), 0d);
+  }
+
+  @Test
+  public void createDatumFromDistributionThrows() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Distribution aggregations are not supported");
+    SignalFxSessionAdaptor.createDatum(
+        DistributionData.create(5, 2, 0, 10, 40, ImmutableList.of(1L)));
+  }
+
+  @Test
+  public void adaptViewIntoDatapoints() {
+    Map<List<TagValue>, AggregationData> map =
+        ImmutableMap.<List<TagValue>, AggregationData>of(
+            ImmutableList.of(TagValue.create("dog")),
+            SumDataLong.create(2L),
+            ImmutableList.of(TagValue.create("cat")),
+            SumDataLong.create(3L));
+    Mockito.when(viewData.getAggregationMap()).thenReturn(map);
+    Mockito.when(view.getAggregation()).thenReturn(Aggregation.Count.create());
+    Mockito.when(view.getWindow()).thenReturn(AggregationWindow.Cumulative.create());
+
+    List<DataPoint> datapoints = SignalFxSessionAdaptor.adapt(viewData);
+    assertEquals(2, datapoints.size());
+    for (DataPoint dp : datapoints) {
+      assertEquals("view-name", dp.getMetric());
+      assertEquals(MetricType.CUMULATIVE_COUNTER, dp.getMetricType());
+      assertEquals(1, dp.getDimensionsCount());
+      assertTrue(dp.hasValue());
+      assertFalse(dp.hasSource());
+
+      Datum datum = dp.getValue();
+      assertTrue(datum.hasIntValue());
+      assertFalse(datum.hasDoubleValue());
+      assertFalse(datum.hasStrValue());
+
+      Dimension dimension = dp.getDimensions(0);
+      assertEquals("animal", dimension.getKey());
+      switch (dimension.getValue()) {
+        case "dog":
+          assertEquals(2L, datum.getIntValue());
+          break;
+        case "cat":
+          assertEquals(3L, datum.getIntValue());
+          break;
+        default:
+          fail("unexpected dimension value");
+      }
+    }
+  }
+}

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsConfigurationTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsConfigurationTest.java
@@ -21,7 +21,9 @@ import static org.junit.Assert.assertEquals;
 import io.opencensus.common.Duration;
 import java.net.URI;
 import java.net.URISyntaxException;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -31,20 +33,21 @@ public class SignalFxStatsConfigurationTest {
 
   private static final String TEST_TOKEN = "token";
 
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
   @Test
-  public void testBuildDefaults() {
+  public void buildWithDefaults() {
     SignalFxStatsConfiguration configuration =
         SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build();
     assertEquals(TEST_TOKEN, configuration.getToken());
     assertEquals(
-        SignalFxStatsConfiguration.DEFAULT_SIGNALFX_ENDPOINT,
-        configuration.getIngestEndpoint().toString());
+        SignalFxStatsConfiguration.DEFAULT_SIGNALFX_ENDPOINT, configuration.getIngestEndpoint());
     assertEquals(
         SignalFxStatsConfiguration.DEFAULT_EXPORT_INTERVAL, configuration.getExportInterval());
   }
 
   @Test
-  public void testBuildFields() throws URISyntaxException {
+  public void buildWithFields() throws URISyntaxException {
     URI url = new URI("http://example.com");
     Duration duration = Duration.create(5, 0);
     SignalFxStatsConfiguration configuration =
@@ -59,12 +62,29 @@ public class SignalFxStatsConfigurationTest {
   }
 
   @Test
-  public void testSameConfigurationsAreEqual() {
+  public void sameConfigurationsAreEqual() {
     SignalFxStatsConfiguration config1 =
         SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build();
     SignalFxStatsConfiguration config2 =
         SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build();
     assertEquals(config1, config2);
     assertEquals(config1.hashCode(), config2.hashCode());
+  }
+
+  @Test
+  public void buildWithEmptyToken() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid SignalFx token");
+    SignalFxStatsConfiguration.builder().setToken("").build();
+  }
+
+  @Test
+  public void buildWithNegativeDuration() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Interval duration must be positive");
+    SignalFxStatsConfiguration.builder()
+        .setToken(TEST_TOKEN)
+        .setExportInterval(Duration.create(-1, 0))
+        .build();
   }
 }

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsConfigurationTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsConfigurationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import static org.junit.Assert.assertEquals;
+
+import io.opencensus.common.Duration;
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link SignalFxStatsConfiguration}. */
+@RunWith(JUnit4.class)
+public class SignalFxStatsConfigurationTest {
+
+  private static final String TEST_TOKEN = "token";
+
+  @Test
+  public void testBuildDefaults() {
+    SignalFxStatsConfiguration configuration =
+        SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build();
+    assertEquals(TEST_TOKEN, configuration.getToken());
+    assertEquals(
+        SignalFxStatsConfiguration.DEFAULT_SIGNALFX_ENDPOINT,
+        configuration.getIngestEndpoint().toString());
+    assertEquals(
+        SignalFxStatsConfiguration.DEFAULT_EXPORT_INTERVAL, configuration.getExportInterval());
+  }
+
+  @Test
+  public void testBuildFields() throws URISyntaxException {
+    URI url = new URI("http://example.com");
+    Duration duration = Duration.create(5, 0);
+    SignalFxStatsConfiguration configuration =
+        SignalFxStatsConfiguration.builder()
+            .setToken(TEST_TOKEN)
+            .setIngestEndpoint(url)
+            .setExportInterval(duration)
+            .build();
+    assertEquals(TEST_TOKEN, configuration.getToken());
+    assertEquals(url, configuration.getIngestEndpoint());
+    assertEquals(duration, configuration.getExportInterval());
+  }
+
+  @Test
+  public void testSameConfigurationsAreEqual() {
+    SignalFxStatsConfiguration config1 =
+        SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build();
+    SignalFxStatsConfiguration config2 =
+        SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build();
+    assertEquals(config1, config2);
+    assertEquals(config1.hashCode(), config2.hashCode());
+  }
+}

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterTest.java
@@ -51,17 +51,10 @@ public class SignalFxStatsExporterTest {
   }
 
   @Test
-  public void createWithEmptyToken() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid SignalFx token");
-    SignalFxStatsExporter.create(SignalFxStatsConfiguration.builder().setToken("").build());
-  }
-
-  @Test
-  public void createWithNullHostUsesDefault() throws URISyntaxException {
+  public void createWithNullHostUsesDefault() {
     SignalFxStatsExporter.create(SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build());
     assertEquals(
-        new URI(SignalFxStatsConfiguration.DEFAULT_SIGNALFX_ENDPOINT),
+        SignalFxStatsConfiguration.DEFAULT_SIGNALFX_ENDPOINT,
         SignalFxStatsExporter.unsafeGetConfig().getIngestEndpoint());
   }
 
@@ -71,17 +64,6 @@ public class SignalFxStatsExporterTest {
     assertEquals(
         SignalFxStatsConfiguration.DEFAULT_EXPORT_INTERVAL,
         SignalFxStatsExporter.unsafeGetConfig().getExportInterval());
-  }
-
-  @Test
-  public void createWithNegativeDuration() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Interval duration must be positive");
-    SignalFxStatsExporter.create(
-        SignalFxStatsConfiguration.builder()
-            .setToken(TEST_TOKEN)
-            .setExportInterval(Duration.create(-1, 0))
-            .build());
   }
 
   @Test

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import io.opencensus.common.Duration;
+import java.util.Properties;
+import org.junit.After;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link SignalFxStatsExporter}. */
+@RunWith(JUnit4.class)
+public class SignalFxStatsExporterTest {
+
+  private static final String TEST_TOKEN = "token";
+  private static final String TEST_ENDPOINT = "https://example.com";
+  private static final Duration ONE_SECOND = Duration.create(1, 0);
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @After
+  public void tearDown() {
+    System.getProperties().remove(SignalFxStatsExporter.SIGNALFX_HOST_PROPERTY);
+    System.getProperties().remove(SignalFxStatsExporter.SIGNALFX_TOKEN_PROPERTY);
+    SignalFxStatsExporter.unsafeResetExporter();
+  }
+
+  @Test
+  public void createWithNullTokenFromSystemProperties() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid SignalFx token");
+    SignalFxStatsExporter.create();
+  }
+
+  @Test
+  public void createWithNullTokenFromGivenProperties() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid SignalFx token");
+    SignalFxStatsExporter.create(new Properties());
+  }
+
+  @Test
+  public void createWithTokenFromSystemProperties() {
+    System.setProperty(SignalFxStatsExporter.SIGNALFX_TOKEN_PROPERTY, TEST_TOKEN);
+    SignalFxStatsExporter.create();
+  }
+
+  @Test
+  public void createWithTokenFromGivenProperties() {
+    Properties props = new Properties();
+    props.put(SignalFxStatsExporter.SIGNALFX_TOKEN_PROPERTY, TEST_TOKEN);
+    SignalFxStatsExporter.create(props);
+  }
+
+  @Test
+  public void createWithNullToken() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid SignalFx token");
+    SignalFxStatsExporter.create(TEST_ENDPOINT, null, ONE_SECOND);
+  }
+
+  @Test
+  public void createWithNullHost() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid SignalFx endpoint URL");
+    SignalFxStatsExporter.create(null, TEST_TOKEN, ONE_SECOND);
+  }
+
+  @Test
+  public void createWithNegativeDuration() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Duration must be positive");
+    SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, Duration.create(-1, 0));
+  }
+
+  @Test
+  public void createExporterTwice() {
+    SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, ONE_SECOND);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("SignalFx stats exporter is already created.");
+    SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, ONE_SECOND);
+  }
+}

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterTest.java
@@ -16,8 +16,11 @@
 
 package io.opencensus.exporter.stats.signalfx;
 
+import static org.junit.Assert.assertEquals;
+
 import io.opencensus.common.Duration;
-import java.util.Properties;
+import java.net.URI;
+import java.net.URISyntaxException;
 import org.junit.After;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,78 +40,72 @@ public class SignalFxStatsExporterTest {
 
   @After
   public void tearDown() {
-    System.getProperties().remove(SignalFxStatsExporter.SIGNALFX_HOST_PROPERTY);
-    System.getProperties().remove(SignalFxStatsExporter.SIGNALFX_TOKEN_PROPERTY);
     SignalFxStatsExporter.unsafeResetExporter();
   }
 
   @Test
-  public void createWithNullTokenFromSystemProperties() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid SignalFx token");
-    SignalFxStatsExporter.create();
-  }
-
-  @Test
-  public void createWithNullProperties() {
+  public void createWithNullConfiguration() {
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("Given properties shouldn't be null");
+    thrown.expectMessage("configuration");
     SignalFxStatsExporter.create(null);
   }
 
   @Test
-  public void createWithNullTokenFromGivenProperties() {
+  public void createWithEmptyToken() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid SignalFx token");
-    SignalFxStatsExporter.create(new Properties());
+    SignalFxStatsExporter.create(SignalFxStatsConfiguration.builder().setToken("").build());
   }
 
   @Test
-  public void createWithTokenFromSystemProperties() {
-    System.setProperty(SignalFxStatsExporter.SIGNALFX_TOKEN_PROPERTY, TEST_TOKEN);
-    SignalFxStatsExporter.create();
+  public void createWithNullHostUsesDefault() throws URISyntaxException {
+    SignalFxStatsExporter.create(SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build());
+    assertEquals(
+        new URI(SignalFxStatsConfiguration.DEFAULT_SIGNALFX_ENDPOINT),
+        SignalFxStatsExporter.unsafeGetConfig().getIngestEndpoint());
   }
 
   @Test
-  public void createWithTokenFromGivenProperties() {
-    Properties props = new Properties();
-    props.put(SignalFxStatsExporter.SIGNALFX_TOKEN_PROPERTY, TEST_TOKEN);
-    SignalFxStatsExporter.create(props);
-  }
-
-  @Test
-  public void createWithNullToken() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid SignalFx token");
-    SignalFxStatsExporter.create(TEST_ENDPOINT, null, ONE_SECOND);
-  }
-
-  @Test
-  public void createWithNullHost() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Invalid SignalFx endpoint URL");
-    SignalFxStatsExporter.create(null, TEST_TOKEN, ONE_SECOND);
-  }
-
-  @Test
-  public void createWithNullInterval() {
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("Interval must not be null");
-    SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, null);
+  public void createWithNullIntervalUsesDefault() {
+    SignalFxStatsExporter.create(SignalFxStatsConfiguration.builder().setToken(TEST_TOKEN).build());
+    assertEquals(
+        SignalFxStatsConfiguration.DEFAULT_EXPORT_INTERVAL,
+        SignalFxStatsExporter.unsafeGetConfig().getExportInterval());
   }
 
   @Test
   public void createWithNegativeDuration() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Interval duration must be positive");
-    SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, Duration.create(-1, 0));
+    SignalFxStatsExporter.create(
+        SignalFxStatsConfiguration.builder()
+            .setToken(TEST_TOKEN)
+            .setExportInterval(Duration.create(-1, 0))
+            .build());
   }
 
   @Test
   public void createExporterTwice() {
-    SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, ONE_SECOND);
+    SignalFxStatsConfiguration config =
+        SignalFxStatsConfiguration.builder()
+            .setToken(TEST_TOKEN)
+            .setExportInterval(ONE_SECOND)
+            .build();
+    SignalFxStatsExporter.create(config);
     thrown.expect(IllegalStateException.class);
     thrown.expectMessage("SignalFx stats exporter is already created.");
-    SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, ONE_SECOND);
+    SignalFxStatsExporter.create(config);
+  }
+
+  @Test
+  public void createWithConfiguration() throws URISyntaxException {
+    SignalFxStatsConfiguration config =
+        SignalFxStatsConfiguration.builder()
+            .setToken(TEST_TOKEN)
+            .setIngestEndpoint(new URI(TEST_ENDPOINT))
+            .setExportInterval(ONE_SECOND)
+            .build();
+    SignalFxStatsExporter.create(config);
+    assertEquals(config, SignalFxStatsExporter.unsafeGetConfig());
   }
 }

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterTest.java
@@ -50,6 +50,13 @@ public class SignalFxStatsExporterTest {
   }
 
   @Test
+  public void createWithNullProperties() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("Given properties shouldn't be null");
+    SignalFxStatsExporter.create(null);
+  }
+
+  @Test
   public void createWithNullTokenFromGivenProperties() {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid SignalFx token");
@@ -84,9 +91,16 @@ public class SignalFxStatsExporterTest {
   }
 
   @Test
+  public void createWithNullInterval() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("Interval must not be null");
+    SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, null);
+  }
+
+  @Test
   public void createWithNegativeDuration() {
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Duration must be positive");
+    thrown.expectMessage("Interval duration must be positive");
     SignalFxStatsExporter.create(TEST_ENDPOINT, TEST_TOKEN, Duration.create(-1, 0));
   }
 

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThreadTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThreadTest.java
@@ -42,7 +42,7 @@ import io.opencensus.stats.ViewManager;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import java.io.IOException;
-import java.net.URL;
+import java.net.URI;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
@@ -65,15 +65,15 @@ public class SignalFxStatsExporterWorkerThreadTest {
 
   @Mock private SignalFxMetricsSenderFactory factory;
 
-  private URL endpoint;
+  private URI endpoint;
 
   @Before
   public void setUp() throws Exception {
-    endpoint = new URL("http://example.com");
+    endpoint = new URI("http://example.com");
 
     Mockito.when(
             factory.create(
-                Mockito.any(URL.class), Mockito.anyString(), Mockito.any(OnSendErrorHandler.class)))
+                Mockito.any(URI.class), Mockito.anyString(), Mockito.any(OnSendErrorHandler.class)))
         .thenAnswer(
             new Answer<AggregateMetricSender>() {
               @Override
@@ -81,7 +81,7 @@ public class SignalFxStatsExporterWorkerThreadTest {
                 Object[] args = invocation.getArguments();
                 AggregateMetricSender sender =
                     SignalFxMetricsSenderFactory.DEFAULT.create(
-                        (URL) args[0], (String) args[1], (OnSendErrorHandler) args[2]);
+                        (URI) args[0], (String) args[1], (OnSendErrorHandler) args[2]);
                 AggregateMetricSender spy = Mockito.spy(sender);
                 Mockito.doReturn(session).when(spy).createSession();
                 return spy;

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThreadTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThreadTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.signalfx;
+
+import static org.hamcrest.CoreMatchers.startsWith;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.signalfx.metrics.errorhandler.OnSendErrorHandler;
+import com.signalfx.metrics.flush.AggregateMetricSender;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.DataPoint;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Datum;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Dimension;
+import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.MetricType;
+import io.opencensus.common.Duration;
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.AggregationData;
+import io.opencensus.stats.AggregationData.SumDataDouble;
+import io.opencensus.stats.View;
+import io.opencensus.stats.View.AggregationWindow;
+import io.opencensus.stats.View.Name;
+import io.opencensus.stats.ViewData;
+import io.opencensus.stats.ViewManager;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
+import java.io.IOException;
+import java.net.URL;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.runners.MockitoJUnitRunner;
+import org.mockito.stubbing.Answer;
+
+@RunWith(MockitoJUnitRunner.class)
+public class SignalFxStatsExporterWorkerThreadTest {
+
+  private static final String TEST_TOKEN = "token";
+  private static final Duration ONE_SECOND = Duration.create(1, 0);
+
+  @Mock private AggregateMetricSender.Session session;
+
+  @Mock private ViewManager viewManager;
+
+  @Mock private SignalFxMetricsSenderFactory factory;
+
+  private URL endpoint;
+
+  @Before
+  public void setUp() throws Exception {
+    endpoint = new URL("http://example.com");
+
+    Mockito.when(
+            factory.create(
+                Mockito.any(URL.class), Mockito.anyString(), Mockito.any(OnSendErrorHandler.class)))
+        .thenAnswer(
+            new Answer<AggregateMetricSender>() {
+              @Override
+              public AggregateMetricSender answer(InvocationOnMock invocation) {
+                Object[] args = invocation.getArguments();
+                AggregateMetricSender sender =
+                    SignalFxMetricsSenderFactory.DEFAULT.create(
+                        (URL) args[0], (String) args[1], (OnSendErrorHandler) args[2]);
+                AggregateMetricSender spy = Mockito.spy(sender);
+                Mockito.doReturn(session).when(spy).createSession();
+                return spy;
+              }
+            });
+  }
+
+  @Test
+  public void createThread() {
+    SignalFxStatsExporterWorkerThread thread =
+        new SignalFxStatsExporterWorkerThread(
+            factory, endpoint, TEST_TOKEN, ONE_SECOND, viewManager);
+    assertTrue(thread.isDaemon());
+    assertThat(thread.getName(), startsWith("SignalFx"));
+  }
+
+  @Test
+  public void senderThreadInterruptStopsLoop() throws InterruptedException {
+    Mockito.when(session.setDatapoint(Mockito.any(DataPoint.class))).thenReturn(session);
+    Mockito.when(viewManager.getAllExportedViews()).thenReturn(ImmutableSet.<View>of());
+
+    SignalFxStatsExporterWorkerThread thread =
+        new SignalFxStatsExporterWorkerThread(
+            factory, endpoint, TEST_TOKEN, ONE_SECOND, viewManager);
+    thread.start();
+    thread.interrupt();
+    thread.join();
+    assertFalse("Worker thread should have stopped", thread.isAlive());
+  }
+
+  @Test
+  public void setsDatapointsFromViewOnSession() throws IOException {
+    View view = Mockito.mock(View.class);
+    Name viewName = Name.create("test");
+    Mockito.when(view.getName()).thenReturn(viewName);
+    Mockito.when(view.getAggregation()).thenReturn(Aggregation.Mean.create());
+    Mockito.when(view.getWindow()).thenReturn(AggregationWindow.Cumulative.create());
+    Mockito.when(view.getColumns()).thenReturn(ImmutableList.of(TagKey.create("animal")));
+
+    ViewData viewData = Mockito.mock(ViewData.class);
+    Mockito.when(viewData.getView()).thenReturn(view);
+    Mockito.when(viewData.getAggregationMap())
+        .thenReturn(
+            ImmutableMap.<List<TagValue>, AggregationData>of(
+                ImmutableList.of(TagValue.create("cat")), SumDataDouble.create(3.14d)));
+
+    Mockito.when(viewManager.getAllExportedViews()).thenReturn(ImmutableSet.of(view));
+    Mockito.when(viewManager.getView(Mockito.eq(viewName))).thenReturn(viewData);
+
+    SignalFxStatsExporterWorkerThread thread =
+        new SignalFxStatsExporterWorkerThread(
+            factory, endpoint, TEST_TOKEN, ONE_SECOND, viewManager);
+    thread.export();
+
+    DataPoint datapoint =
+        DataPoint.newBuilder()
+            .setMetric("test")
+            .setMetricType(MetricType.GAUGE)
+            .addDimensions(Dimension.newBuilder().setKey("animal").setValue("cat").build())
+            .setValue(Datum.newBuilder().setDoubleValue(3.14d).build())
+            .build();
+    Mockito.verify(session).setDatapoint(Mockito.eq(datapoint));
+    Mockito.verify(session).close();
+  }
+}

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThreadTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThreadTest.java
@@ -33,7 +33,7 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.MetricType;
 import io.opencensus.common.Duration;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.AggregationData;
-import io.opencensus.stats.AggregationData.SumDataDouble;
+import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.View;
 import io.opencensus.stats.View.AggregationWindow;
 import io.opencensus.stats.View.Name;
@@ -108,7 +108,7 @@ public class SignalFxStatsExporterWorkerThreadTest {
             factory, endpoint, TEST_TOKEN, ONE_SECOND, viewManager);
     thread.start();
     thread.interrupt();
-    thread.join();
+    thread.join(5000, 0);
     assertFalse("Worker thread should have stopped", thread.isAlive());
   }
 
@@ -126,7 +126,7 @@ public class SignalFxStatsExporterWorkerThreadTest {
     Mockito.when(viewData.getAggregationMap())
         .thenReturn(
             ImmutableMap.<List<TagValue>, AggregationData>of(
-                ImmutableList.of(TagValue.create("cat")), SumDataDouble.create(3.14d)));
+                ImmutableList.of(TagValue.create("cat")), MeanData.create(3.14d, 1)));
 
     Mockito.when(viewManager.getAllExportedViews()).thenReturn(ImmutableSet.of(view));
     Mockito.when(viewManager.getView(Mockito.eq(viewName))).thenReturn(viewData);

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,7 @@ include ":opencensus-testing"
 include ":opencensus-exporter-trace-logging"
 include ":opencensus-exporter-trace-stackdriver"
 include ":opencensus-exporter-trace-zipkin"
+include ":opencensus-exporter-stats-signalfx"
 include ":opencensus-exporter-stats-stackdriver"
 include ":opencensus-contrib-agent"
 include ":opencensus-contrib-grpc-metrics"
@@ -26,6 +27,7 @@ project(':opencensus-exporter-trace-logging').projectDir =
 project(':opencensus-exporter-trace-stackdriver').projectDir =
         "$rootDir/exporters/trace/stackdriver" as File
 project(':opencensus-exporter-trace-zipkin').projectDir = "$rootDir/exporters/trace/zipkin" as File
+project(':opencensus-exporter-stats-signalfx').projectDir = "$rootDir/exporters/stats/signalfx" as File
 project(':opencensus-exporter-stats-stackdriver').projectDir = "$rootDir/exporters/stats/stackdriver" as File
 
 // Java8 projects only


### PR DESCRIPTION
A stats exporter to report stats as SignalFx metric timeseries.

Note that SignalFx doesn't have native histogram support yet, so those views can't be reported to SignalFx and are ignored for now.