### PR TITLE
Add more null annotations (issue #359).

### DIFF
--- a/api/src/main/java/io/opencensus/tags/TagContext.java
+++ b/api/src/main/java/io/opencensus/tags/TagContext.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMultiset;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multiset;
 import java.util.Iterator;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -59,7 +60,7 @@ public abstract class TagContext {
    * performance.
    */
   @Override
-  public boolean equals(Object other) {
+  public boolean equals(@Nullable Object other) {
     if (!(other instanceof TagContext)) {
       return false;
     }

--- a/api/src/main/java/io/opencensus/trace/SpanContext.java
+++ b/api/src/main/java/io/opencensus/trace/SpanContext.java
@@ -18,6 +18,7 @@ package io.opencensus.trace;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -85,7 +86,7 @@ public final class SpanContext {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     }

--- a/api/src/main/java/io/opencensus/trace/SpanId.java
+++ b/api/src/main/java/io/opencensus/trace/SpanId.java
@@ -23,6 +23,7 @@ import com.google.common.base.MoreObjects;
 import com.google.common.io.BaseEncoding;
 import java.util.Arrays;
 import java.util.Random;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -162,7 +163,7 @@ public final class SpanId implements Comparable<SpanId> {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     }

--- a/api/src/main/java/io/opencensus/trace/Status.java
+++ b/api/src/main/java/io/opencensus/trace/Status.java
@@ -249,8 +249,9 @@ public final class Status {
 
   // The canonical code of this message.
   private final CanonicalCode canonicalCode;
+
   // An additional error message.
-  private final String description;
+  @Nullable private final String description;
 
   private Status(CanonicalCode canonicalCode, @Nullable String description) {
     this.canonicalCode = checkNotNull(canonicalCode, "canonicalCode");
@@ -304,7 +305,7 @@ public final class Status {
    * additional fields may be added to Status in the future.
    */
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     }

--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -24,6 +24,7 @@ import com.google.common.io.BaseEncoding;
 import io.opencensus.common.Internal;
 import java.util.Arrays;
 import java.util.Random;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -184,7 +185,7 @@ public final class TraceId implements Comparable<TraceId> {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     }

--- a/api/src/main/java/io/opencensus/trace/TraceOptions.java
+++ b/api/src/main/java/io/opencensus/trace/TraceOptions.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -150,7 +151,7 @@ public final class TraceOptions {
   }
 
   @Override
-  public boolean equals(Object obj) {
+  public boolean equals(@Nullable Object obj) {
     if (obj == this) {
       return true;
     }

--- a/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/ZPageHandlers.java
+++ b/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/ZPageHandlers.java
@@ -23,6 +23,7 @@ import io.opencensus.trace.Tracing;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.logging.Logger;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
@@ -71,6 +72,7 @@ public final class ZPageHandlers {
   private static final Object monitor = new Object();
 
   @GuardedBy("monitor")
+  @Nullable
   private static HttpServer server;
 
   /**

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -61,6 +61,7 @@ public final class StackdriverStatsExporter {
   private final Thread workerThread;
 
   @GuardedBy("monitor")
+  @Nullable
   private static StackdriverStatsExporter exporter = null;
 
   private static final Duration ZERO = Duration.create(0, 0);

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverExporter.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverExporter.java
@@ -26,6 +26,7 @@ import io.opencensus.trace.Tracing;
 import io.opencensus.trace.export.SpanExporter;
 import io.opencensus.trace.export.SpanExporter.Handler;
 import java.io.IOException;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
 /**
@@ -46,6 +47,7 @@ public final class StackdriverExporter {
   private static final Object monitor = new Object();
 
   @GuardedBy("monitor")
+  @Nullable
   private static Handler handler = null;
 
   /**

--- a/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinExporter.java
+++ b/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinExporter.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.export.SpanExporter;
 import io.opencensus.trace.export.SpanExporter.Handler;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import zipkin2.Span;
 import zipkin2.codec.SpanBytesEncoder;
@@ -46,6 +47,7 @@ public final class ZipkinExporter {
   private static final Object monitor = new Object();
 
   @GuardedBy("monitor")
+  @Nullable
   private static Handler handler = null;
 
   private ZipkinExporter() {}

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -17,5 +17,9 @@
     <Class name="io.opencensus.common.Duration" />
     <Method name="compareTo" />
   </Match>
+  <Match>
+    <!-- Reason: It conflicts with Checker Framework null analysis. -->
+    <Bug pattern="NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION"/>
+  </Match>
 
 </FindBugsFilter>

--- a/gradle/errorprone/experimental_suggestions
+++ b/gradle/errorprone/experimental_suggestions
@@ -1,6 +1,9 @@
 # FieldMissingNullable is turned off due to
 # https://github.com/google/error-prone/issues/823.
 
+# ReturnMissingNullable is turned off because it
+# conflicts with Checker Framework null analysis.
+
 errorProneExperimentalSuggestions = \
 -Xep:ConstantField:ERROR,\
 -Xep:EmptySetMultibindingContributions:ERROR,\
@@ -16,7 +19,7 @@ errorProneExperimentalSuggestions = \
 -Xep:PrivateConstructorForNoninstantiableModuleTest:ERROR,\
 -Xep:PrivateConstructorForUtilityClass:ERROR,\
 -Xep:RemoveUnusedImports:ERROR,\
--Xep:ReturnMissingNullable:ERROR,\
+-Xep:ReturnMissingNullable:OFF,\
 -Xep:ThrowsUncheckedException:ERROR,\
 -Xep:UngroupedOverloads:ERROR,\
 -Xep:UnnecessarySetDefault:ERROR,\

--- a/impl/src/main/java/io/opencensus/impl/internal/DisruptorEventQueue.java
+++ b/impl/src/main/java/io/opencensus/impl/internal/DisruptorEventQueue.java
@@ -25,6 +25,7 @@ import com.lmax.disruptor.dsl.ProducerType;
 import io.opencensus.implcore.internal.DaemonThreadFactory;
 import io.opencensus.implcore.internal.EventQueue;
 import java.util.concurrent.Executors;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -144,7 +145,7 @@ public final class DisruptorEventQueue implements EventQueue {
 
   // An event in the {@link EventQueue}. Just holds a reference to an EventQueue.Entry.
   private static final class DisruptorEvent {
-    private Entry entry = null;
+    @Nullable private Entry entry;
 
     // Sets the EventQueueEntry associated with this DisruptorEvent.
     void setEntry(Entry entry) {
@@ -152,6 +153,7 @@ public final class DisruptorEventQueue implements EventQueue {
     }
 
     // Returns the EventQueueEntry associated with this DisruptorEvent.
+    @Nullable
     Entry getEntry() {
       return entry;
     }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -62,6 +62,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.annotation.Nullable;
 
 /** A mutable version of {@link ViewData}, used for recording stats and start/end time. */
 abstract class MutableViewData {
@@ -69,7 +70,8 @@ abstract class MutableViewData {
   private static final long MILLIS_PER_SECOND = 1000L;
   private static final long NANOS_PER_MILLI = 1000 * 1000;
 
-  @VisibleForTesting static final TagValue UNKNOWN_TAG_VALUE = null;
+  @Nullable @VisibleForTesting static final TagValue UNKNOWN_TAG_VALUE = null;
+
   @VisibleForTesting static final Timestamp ZERO_TIMESTAMP = Timestamp.create(0, 0);
 
   private final View view;

--- a/impl_core/src/main/java/io/opencensus/implcore/tags/CurrentTagContextUtils.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/CurrentTagContextUtils.java
@@ -20,7 +20,6 @@ import io.grpc.Context;
 import io.opencensus.common.Scope;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.unsafe.ContextUtils;
-import javax.annotation.Nullable;
 
 /**
  * Utility methods for accessing the {@link TagContext} contained in the {@link io.grpc.Context}.
@@ -34,7 +33,6 @@ final class CurrentTagContextUtils {
    *
    * @return the {@code TagContext} from the current context.
    */
-  @Nullable
   static TagContext getCurrentTagContext() {
     return ContextUtils.TAG_CONTEXT_KEY.get();
   }

--- a/impl_core/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/TagContextImpl.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 @Immutable
@@ -50,7 +51,7 @@ public final class TagContextImpl extends TagContext {
   }
 
   @Override
-  public boolean equals(Object other) {
+  public boolean equals(@Nullable Object other) {
     // Directly compare the tags when both objects are TagContextImpls, for efficiency.
     if (other instanceof TagContextImpl) {
       return getTags().equals(((TagContextImpl) other).getTags());

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/SpanBuilderImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/SpanBuilderImpl.java
@@ -43,19 +43,19 @@ final class SpanBuilderImpl extends SpanBuilder {
   private final Options options;
 
   private final String name;
-  private final Span parent;
-  private final SpanContext remoteParentSpanContext;
-  private Sampler sampler;
+  @Nullable private final Span parent;
+  @Nullable private final SpanContext remoteParentSpanContext;
+  @Nullable private Sampler sampler;
   private List<Span> parentLinks = Collections.<Span>emptyList();
-  private Boolean recordEvents;
+  @Nullable private Boolean recordEvents;
 
   private SpanImpl startSpanInternal(
       @Nullable SpanContext parent,
       @Nullable Boolean hasRemoteParent,
       String name,
-      Sampler sampler,
+      @Nullable Sampler sampler,
       List<Span> parentLinks,
-      Boolean recordEvents,
+      @Nullable Boolean recordEvents,
       @Nullable TimestampConverter timestampConverter) {
     TraceParams activeTraceParams = options.traceConfig.getActiveTraceParams();
     Random random = options.randomHandler.current();

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/SpanImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/SpanImpl.java
@@ -55,9 +55,9 @@ public final class SpanImpl extends Span implements Element<SpanImpl> {
   private static final Logger logger = Logger.getLogger(Tracer.class.getName());
 
   // The parent SpanId of this span. Null if this is a root span.
-  private final SpanId parentSpanId;
+  @Nullable private final SpanId parentSpanId;
   // True if the parent is on a different process.
-  private final Boolean hasRemoteParent;
+  @Nullable private final Boolean hasRemoteParent;
   // Active trace params when the Span was created.
   private final TraceParams traceParams;
   // Handler called when the span starts and ends.
@@ -68,24 +68,29 @@ public final class SpanImpl extends Span implements Element<SpanImpl> {
   private final Clock clock;
   // The time converter used to convert nano time to Timestamp. This is needed because Java has
   // millisecond granularity for Timestamp and tracing events are recorded more often.
-  private final TimestampConverter timestampConverter;
+  @Nullable private final TimestampConverter timestampConverter;
   // The start time of the span. Set when the span is created iff the RECORD_EVENTS options is
   // set, otherwise 0.
   private final long startNanoTime;
   // Set of recorded attributes. DO NOT CALL any other method that changes the ordering of events.
   @GuardedBy("this")
+  @Nullable
   private AttributesWithCapacity attributes;
   // List of recorded annotations.
   @GuardedBy("this")
+  @Nullable
   private TraceEvents<EventWithNanoTime<Annotation>> annotations;
   // List of recorded network events.
   @GuardedBy("this")
+  @Nullable
   private TraceEvents<EventWithNanoTime<NetworkEvent>> networkEvents;
   // List of recorded links to parent and child spans.
   @GuardedBy("this")
+  @Nullable
   private TraceEvents<Link> links;
   // The status of the span. Set when the span is ended iff the RECORD_EVENTS options is set.
   @GuardedBy("this")
+  @Nullable
   private Status status;
   // The end time of the span. Set when the span is ended iff the RECORD_EVENTS options is set,
   // otherwise 0.
@@ -99,8 +104,8 @@ public final class SpanImpl extends Span implements Element<SpanImpl> {
   private boolean sampleToLocalSpanStore;
 
   // Pointers for the ConcurrentIntrusiveList$Element. Guarded by the ConcurrentIntrusiveList.
-  private SpanImpl next = null;
-  private SpanImpl prev = null;
+  @Nullable private SpanImpl next = null;
+  @Nullable private SpanImpl prev = null;
 
   /**
    * Creates and starts a span with the given configuration.
@@ -424,7 +429,7 @@ public final class SpanImpl extends Span implements Element<SpanImpl> {
   }
 
   private static <T> SpanData.TimedEvents<T> createTimedEvents(
-      TraceEvents<EventWithNanoTime<T>> events, TimestampConverter timestampConverter) {
+      TraceEvents<EventWithNanoTime<T>> events, @Nullable TimestampConverter timestampConverter) {
     if (events == null) {
       return SpanData.TimedEvents.create(Collections.<TimedEvent<T>>emptyList(), 0);
     }
@@ -436,22 +441,24 @@ public final class SpanImpl extends Span implements Element<SpanImpl> {
   }
 
   @Override
+  @Nullable
   public SpanImpl getNext() {
     return next;
   }
 
   @Override
-  public void setNext(SpanImpl element) {
+  public void setNext(@Nullable SpanImpl element) {
     next = element;
   }
 
   @Override
+  @Nullable
   public SpanImpl getPrev() {
     return prev;
   }
 
   @Override
-  public void setPrev(SpanImpl element) {
+  public void setPrev(@Nullable SpanImpl element) {
     prev = element;
   }
 

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/StartEndHandlerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/StartEndHandlerImpl.java
@@ -33,8 +33,8 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class StartEndHandlerImpl implements StartEndHandler {
   private final SpanExporterImpl spanExporter;
-  private final RunningSpanStoreImpl runningSpanStore;
-  private final SampledSpanStoreImpl sampledSpanStore;
+  @Nullable private final RunningSpanStoreImpl runningSpanStore;
+  @Nullable private final SampledSpanStoreImpl sampledSpanStore;
   private final EventQueue eventQueue;
   // true if any of (runningSpanStore OR sampledSpanStore) are different than null, which
   // means the spans with RECORD_EVENTS should be enqueued in the queue.
@@ -78,7 +78,7 @@ public final class StartEndHandlerImpl implements StartEndHandler {
   // An EventQueue entry that records the start of the span event.
   private static final class SpanStartEvent implements EventQueue.Entry {
     private final SpanImpl span;
-    private final RunningSpanStoreImpl activeSpansExporter;
+    @Nullable private final RunningSpanStoreImpl activeSpansExporter;
 
     SpanStartEvent(SpanImpl span, @Nullable RunningSpanStoreImpl activeSpansExporter) {
       this.span = span;
@@ -96,9 +96,9 @@ public final class StartEndHandlerImpl implements StartEndHandler {
   // An EventQueue entry that records the end of the span event.
   private static final class SpanEndEvent implements EventQueue.Entry {
     private final SpanImpl span;
-    private final RunningSpanStoreImpl runningSpanStore;
+    @Nullable private final RunningSpanStoreImpl runningSpanStore;
     private final SpanExporterImpl spanExporter;
-    private final SampledSpanStoreImpl sampledSpanStore;
+    @Nullable private final SampledSpanStoreImpl sampledSpanStore;
 
     SpanEndEvent(
         SpanImpl span,

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/ExportComponentImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/ExportComponentImpl.java
@@ -30,8 +30,8 @@ public final class ExportComponentImpl extends ExportComponent {
   private static final Duration EXPORTER_SCHEDULE_DELAY = Duration.create(5, 0);
 
   private final SpanExporterImpl spanExporter;
-  private final RunningSpanStoreImpl runningSpanStore;
-  private final SampledSpanStoreImpl sampledSpanStore;
+  @Nullable private final RunningSpanStoreImpl runningSpanStore;
+  @Nullable private final SampledSpanStoreImpl sampledSpanStore;
 
   @Override
   public SpanExporterImpl getSpanExporter() {

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/SampledSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/SampledSpanStoreImpl.java
@@ -208,7 +208,7 @@ public final class SampledSpanStoreImpl extends SampledSpanStore {
       return errorBucketSummaries;
     }
 
-    private List<SpanImpl> getErrorSamples(CanonicalCode code, int maxSpansToReturn) {
+    private List<SpanImpl> getErrorSamples(@Nullable CanonicalCode code, int maxSpansToReturn) {
       ArrayList<SpanImpl> output = new ArrayList<SpanImpl>(maxSpansToReturn);
       if (code != null) {
         getErrorBucket(code).getSamples(maxSpansToReturn, output);

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/internal/ConcurrentIntrusiveList.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/internal/ConcurrentIntrusiveList.java
@@ -22,6 +22,7 @@ import io.opencensus.implcore.trace.internal.ConcurrentIntrusiveList.Element;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -60,7 +61,7 @@ import javax.annotation.concurrent.ThreadSafe;
 @ThreadSafe
 public final class ConcurrentIntrusiveList<T extends Element<T>> {
   private int size = 0;
-  private T head = null;
+  @Nullable private T head = null;
 
   public ConcurrentIntrusiveList() {}
 
@@ -151,6 +152,7 @@ public final class ConcurrentIntrusiveList<T extends Element<T>> {
      *
      * @return a reference to the next element in the list.
      */
+    @Nullable
     T getNext();
 
     /**
@@ -158,13 +160,14 @@ public final class ConcurrentIntrusiveList<T extends Element<T>> {
      *
      * @param element the reference to the next element in the list.
      */
-    void setNext(T element);
+    void setNext(@Nullable T element);
 
     /**
      * Returns a reference to the previous element in the list.
      *
      * @return a reference to the previous element in the list.
      */
+    @Nullable
     T getPrev();
 
     /**
@@ -172,6 +175,6 @@ public final class ConcurrentIntrusiveList<T extends Element<T>> {
      *
      * @param element the reference to the previous element in the list.
      */
-    void setPrev(T element);
+    void setPrev(@Nullable T element);
   }
 }


### PR DESCRIPTION
This commit adds some Nullable annotations that are required by the Checker
Framework, but it doesn't change any other code.  It also suppresses some Error
Prone and FindBugs warnings that conflict with the Checker Framework, since the
three tools use different algorithms.