### PR TITLE
Silently skip NO_ERROR Goaway

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
@@ -182,9 +182,10 @@ final class StackdriverExporterWorker implements Runnable {
         metricServiceClient.createTimeSeries(request);
         span.addAnnotation("Finish exporting TimeSeries.");
       } catch (com.google.api.gax.rpc.UnavailableException e) {
-        if (e.getLocalizedMessage()
-            .startsWith(
-                "io.grpc.StatusRuntimeException: UNAVAILABLE: HTTP/2 error code: NO_ERROR")) {
+        if (e.getLocalizedMessage() != null
+            && e.getLocalizedMessage()
+                .startsWith(
+                    "io.grpc.StatusRuntimeException: UNAVAILABLE: HTTP/2 error code: NO_ERROR")) {
           continue; // Silently skip NO_ERROR Goaway
         } else {
           logAndSetSpanStatusForApiException(e, span);

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, OpenCensus Authors
+ * Copyright 2018, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
@@ -182,11 +182,15 @@ final class StackdriverExporterWorker implements Runnable {
         metricServiceClient.createTimeSeries(request);
         span.addAnnotation("Finish exporting TimeSeries.");
       } catch (com.google.api.gax.rpc.UnavailableException e) {
-        if (e.getLocalizedMessage() != null
-            && e.getLocalizedMessage()
-                .startsWith(
-                    "io.grpc.StatusRuntimeException: UNAVAILABLE: HTTP/2 error code: NO_ERROR")) {
-          continue; // Silently skip NO_ERROR Goaway
+        if (e.getLocalizedMessage() != null) {
+          String message = e.getLocalizedMessage();
+          if (message == null) {
+            throw new AssertionError(); // To pass null check
+          }
+          if (message.startsWith(
+              "io.grpc.StatusRuntimeException: UNAVAILABLE: HTTP/2 error code: NO_ERROR")) {
+            continue; // Silently skip NO_ERROR Goaway
+          }
         } else {
           logAndSetSpanStatusForApiException(e, span);
         }

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
@@ -181,6 +181,12 @@ final class StackdriverExporterWorker implements Runnable {
                 .build();
         metricServiceClient.createTimeSeries(request);
         span.addAnnotation("Finish exporting TimeSeries.");
+      } catch (com.google.api.gax.rpc.UnavailableException e) {
+        if (e.getLocalizedMessage()
+            .startsWith(
+                "io.grpc.StatusRuntimeException: UNAVAILABLE: HTTP/2 error code: NO_ERROR")) {
+          continue; // Silently skip NO_ERROR Goaway
+        }
       } catch (ApiException e) {
         logger.log(Level.WARNING, "ApiException thrown when exporting TimeSeries.", e);
         span.setStatus(


### PR DESCRIPTION
Closes https://github.com/census-instrumentation/opencensus-java/issues/869.

Based on the discussion in https://github.com/census-instrumentation/opencensus-java/issues/869, I think it's safe to silently skip status UNAVAILABLE with error code NO_ERROR.