### PR TITLE
Bump version in examples/build.gradle

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -64,6 +64,7 @@ token](https://help.github.com/articles/creating-a-personal-access-token-for-the
     $ MAJOR=0 MINOR=4 PATCH=0 # Set appropriately for new release
     $ VERSION_FILES=(
       build.gradle
+      examples/build.gradle
       api/src/main/java/io/opencensus/common/OpenCensusLibraryInformation.java
       )
     $ git checkout -b v$MAJOR.$MINOR.x master

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -10,7 +10,7 @@ repositories {
 }
 
 group = "io.opencensus"
-version = "0.11.0-SNAPSHOT"
+version = "0.12.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.10.1" // LATEST_OPENCENSUS_RELEASE_VERSION
 


### PR DESCRIPTION
This also fixes the release instructions to not repeat the same thing again.