### PR TITLE
Fixed bug in CloudTraceFormat that made it impossible to use short span id's

### DIFF
--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/util/CloudTraceFormat.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/util/CloudTraceFormat.java
@@ -107,7 +107,7 @@ final class CloudTraceFormat extends TextFormat {
       checkArgument(headerStr.charAt(TRACE_ID_SIZE) == SPAN_ID_DELIMITER, "Invalid TRACE_ID size");
 
       TraceId traceId = TraceId.fromLowerBase16(headerStr.subSequence(0, TRACE_ID_SIZE));
-      int traceOptionsPos = headerStr.indexOf(TRACE_OPTION_DELIMITER, SPAN_ID_DELIMITER);
+      int traceOptionsPos = headerStr.indexOf(TRACE_OPTION_DELIMITER, TRACE_ID_SIZE);
       CharSequence spanIdStr =
           headerStr.subSequence(
               SPAN_ID_START_POS, traceOptionsPos < 0 ? headerStr.length() : traceOptionsPos);

--- a/contrib/http_util/src/test/java/io/opencensus/contrib/http/util/CloudTraceFormatTest.java
+++ b/contrib/http_util/src/test/java/io/opencensus/contrib/http/util/CloudTraceFormatTest.java
@@ -31,6 +31,7 @@ import io.opencensus.trace.TraceOptions;
 import io.opencensus.trace.propagation.SpanContextParseException;
 import io.opencensus.trace.propagation.TextFormat.Getter;
 import io.opencensus.trace.propagation.TextFormat.Setter;
+import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -279,5 +280,16 @@ public final class CloudTraceFormatTest {
   @Test
   public void fieldsShouldMatch() {
     assertThat(cloudTraceFormat.fields()).containsExactly(HEADER_NAME);
+  }
+
+  @Test
+  public void parseWithShortSpanIdAndSamplingShouldSucceed() throws SpanContextParseException {
+    final String spanId = "1";
+    ByteBuffer buffer = ByteBuffer.allocate(SpanId.SIZE);
+    buffer.putLong(Long.valueOf(spanId));
+    SpanId expectedSpanId = SpanId.fromBytes(buffer.array());
+    parseSuccess(
+        constructHeader(TRACE_ID_BASE16, spanId, SAMPLED),
+        SpanContext.create(TRACE_ID, expectedSpanId, TRACE_OPTIONS_SAMPLED));
   }
 }


### PR DESCRIPTION
The '/' char value is used to determine from where to start searching in order to find the trace options in the trace header.
I think that using this char value is done by mistake. Because the char value for '/' is 47 making it impossible to find the trace options in a trace header with a short span id (causing it to be shorter that 47).