### PR TITLE
Keep artifacts dependencyConvergence-clean

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,6 +168,19 @@ subprojects {
         ]
     }
 
+    configurations {
+        compile {
+            // Detect Maven Enforcer's dependencyConvergence failures. We only
+            // care for artifacts used as libraries by others.
+            // TODO(bdrutu): re-enable for exporters when 'com.google.cloud' artifacts become clean.
+            if (!(project.name in ['benchmarks', 'opencensus-all',
+                                   'opencensus-exporter-stats-stackdriver',
+                                   'opencensus-exporter-trace-stackdriver'])) {
+                resolutionStrategy.failOnVersionConflict()
+            }
+        }
+    }
+
     dependencies {
         if (useCheckerFramework) {
             ext.checkerFrameworkVersion = '2.3.0'

--- a/contrib/grpc_util/build.gradle
+++ b/contrib/grpc_util/build.gradle
@@ -8,8 +8,18 @@ apply plugin: 'java'
 }
 
 dependencies {
-    compile project(':opencensus-api'),
-            libraries.grpc_core
+    compile project(':opencensus-api')
+
+    compile (libraries.grpc_core) {
+        // Prefer library version.
+        exclude group: 'com.google.errorprone', module: 'error_prone_annotations'
+
+        // Prefer library version.
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+
+        // We will always be more up to date.
+        exclude group: 'io.opencensus', module: 'opencensus-api'
+    }
 
     signature "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/exporters/stats/signalfx/build.gradle
+++ b/exporters/stats/signalfx/build.gradle
@@ -8,8 +8,12 @@ description = 'OpenCensus SignalFx Stats Exporter'
 dependencies {
     compileOnly libraries.auto_value
 
-    compile project(':opencensus-api'),
-            libraries.signalfx_java
+    compile project(':opencensus-api')
+
+    compile (libraries.signalfx_java) {
+        // Prefer library version.
+        exclude group: 'com.google.guava', module: 'guava'
+    }
 
     testCompile project(':opencensus-api')
 

--- a/exporters/stats/stackdriver/build.gradle
+++ b/exporters/stats/stackdriver/build.gradle
@@ -9,8 +9,18 @@ dependencies {
     compileOnly libraries.auto_value
 
     compile project(':opencensus-api'),
-            libraries.google_auth,
-            libraries.google_cloud_monitoring
+            libraries.google_auth
+
+    compile (libraries.google_cloud_monitoring) {
+        // Prefer library version.
+        exclude group: 'com.google.guava', module: 'guava'
+
+        // Prefer library version.
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+
+        // We will always be more up to date.
+        exclude group: 'io.opencensus', module: 'opencensus-api'
+    }
 
     testCompile project(':opencensus-api')
 

--- a/exporters/trace/stackdriver/build.gradle
+++ b/exporters/trace/stackdriver/build.gradle
@@ -7,8 +7,18 @@ description = 'OpenCensus Trace Stackdriver Exporter'
 
 dependencies {
     compile project(':opencensus-api'),
-            libraries.google_auth,
-            libraries.google_cloud_trace
+            libraries.google_auth
+
+    compile (libraries.google_cloud_trace) {
+        // Prefer library version.
+        exclude group: 'com.google.guava', module: 'guava'
+
+        // Prefer library version.
+        exclude group: 'com.google.code.findbugs', module: 'jsr305'
+
+        // We will always be more up to date.
+        exclude group: 'io.opencensus', module: 'opencensus-api'
+    }
 
     testCompile project(':opencensus-api')
 


### PR DESCRIPTION
Maven Enforcer's dependencyConvergence is commonly used in Spring projects.

Currently we cannot do it for the SD exporters because of this https://github.com/GoogleCloudPlatform/google-cloud-java/issues/2803