### PR TITLE
Update occurrences of deprecated trace exporter in README.md and javadoc (except examples).

### DIFF
--- a/exporters/trace/logging/README.md
+++ b/exporters/trace/logging/README.md
@@ -43,7 +43,7 @@ runtime 'io.opencensus:opencensus-impl:0.11.0'
 ```java
 public class MyMainClass {
   public static void main(String[] args) throws Exception {
-    LoggingExporter.register();
+    LoggingTraceExporter.register();
     // ...
   }
 }

--- a/exporters/trace/stackdriver/README.md
+++ b/exporters/trace/stackdriver/README.md
@@ -64,7 +64,7 @@ This uses the default configuration for authentication and project ID.
 ```java
 public class MyMainClass {
   public static void main(String[] args) throws Exception {
-    StackdriverExporter.createAndRegister();
+    StackdriverTraceExporter.createAndRegister();
     // ...
   }
 }
@@ -77,7 +77,7 @@ for details about how to configure the authentication see [here](https://github.
 
 If you prefer to manually set the credentials use:
 ```
-StackdriverExporter.createAndRegisterWithCredentialsAndProjectId(
+StackdriverTraceExporter.createAndRegisterWithCredentialsAndProjectId(
     new GoogleCredentials(new AccessToken(accessToken, expirationTime)),
     "MyStackdriverProjectId");
 ```
@@ -89,7 +89,7 @@ for details about how to configure the project ID see [here](https://github.com/
 
 If you prefer to manually set the project ID use:
 ```
-StackdriverExporter.createAndRegisterWithProjectId("MyStackdriverProjectId");
+StackdriverTraceExporter.createAndRegisterWithProjectId("MyStackdriverProjectId");
 ```
 
 #### Java Versions

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceExporter.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceExporter.java
@@ -77,7 +77,7 @@ public final class StackdriverTraceExporter {
    * <p>This is equivalent with:
    *
    * <pre>{@code
-   * StackdriverExporter.createAndRegisterWithCredentialsAndProjectId(
+   * StackdriverTraceExporter.createAndRegisterWithCredentialsAndProjectId(
    *     GoogleCredentials.getApplicationDefault(), projectId);
    * }</pre>
    *
@@ -103,7 +103,7 @@ public final class StackdriverTraceExporter {
    * <p>This is equivalent with:
    *
    * <pre>{@code
-   * StackdriverExporter.createAndRegisterWithProjectId(ServiceOptions.getDefaultProjectId());
+   * StackdriverTraceExporter.createAndRegisterWithProjectId(ServiceOptions.getDefaultProjectId());
    * }</pre>
    *
    * @throws IllegalStateException if a Stackdriver exporter is already registered.
@@ -123,7 +123,7 @@ public final class StackdriverTraceExporter {
   }
 
   /**
-   * Registers the {@code StackdriverExporter}.
+   * Registers the {@code StackdriverTraceExporter}.
    *
    * @param spanExporter the instance of the {@code SpanExporter} where this service is registered.
    */
@@ -146,7 +146,7 @@ public final class StackdriverTraceExporter {
   }
 
   /**
-   * Unregisters the {@code StackdriverExporter}.
+   * Unregisters the {@code StackdriverTraceExporter}.
    *
    * @param spanExporter the instance of the {@code SpanExporter} from where this service is
    *     unregistered.

--- a/exporters/trace/zipkin/README.md
+++ b/exporters/trace/zipkin/README.md
@@ -64,7 +64,7 @@ This will report Zipkin v2 json format to a single server. Alternate
 ```java
 public class MyMainClass {
   public static void main(String[] args) throws Exception {
-    ZipkinExporter.createAndRegister("http://127.0.0.1:9411/api/v2/spans");
+    ZipkinTraceExporter.createAndRegister("http://127.0.0.1:9411/api/v2/spans");
     // ...
   }
 }

--- a/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinTraceExporter.java
+++ b/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinTraceExporter.java
@@ -84,7 +84,7 @@ public final class ZipkinTraceExporter {
   }
 
   /**
-   * Registers the {@code ZipkinExporter}.
+   * Registers the {@code ZipkinTraceExporter}.
    *
    * @param spanExporter the instance of the {@code SpanExporter} where this service is registered.
    */
@@ -107,7 +107,7 @@ public final class ZipkinTraceExporter {
   }
 
   /**
-   * Unregisters the {@code ZipkinExporter}.
+   * Unregisters the {@code ZipkinTraceExporter}.
    *
    * @param spanExporter the instance of the {@code SpanExporter} from where this service is
    *     unregistered.


### PR DESCRIPTION
Fixes #947. The renaming is not released yet so I will use #955 to trace the change in example code.