### PR TITLE
Make `XxxSpanStoreImpl` abstract and add no-op implementation. (fixes #914)

### DIFF
--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/ExportComponentImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/ExportComponentImpl.java
@@ -21,7 +21,6 @@ import io.opencensus.implcore.internal.EventQueue;
 import io.opencensus.trace.export.ExportComponent;
 import io.opencensus.trace.export.RunningSpanStore;
 import io.opencensus.trace.export.SampledSpanStore;
-import javax.annotation.Nullable;
 
 /** Implementation of the {@link ExportComponent}. */
 public final class ExportComponentImpl extends ExportComponent {
@@ -30,8 +29,8 @@ public final class ExportComponentImpl extends ExportComponent {
   private static final Duration EXPORTER_SCHEDULE_DELAY = Duration.create(5, 0);
 
   private final SpanExporterImpl spanExporter;
-  @Nullable private final RunningSpanStoreImpl runningSpanStore;
-  @Nullable private final SampledSpanStoreImpl sampledSpanStore;
+  private final RunningSpanStoreImpl runningSpanStore;
+  private final SampledSpanStoreImpl sampledSpanStore;
 
   @Override
   public SpanExporterImpl getSpanExporter() {

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/ExportComponentImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/ExportComponentImpl.java
@@ -39,17 +39,11 @@ public final class ExportComponentImpl extends ExportComponent {
   }
 
   @Override
-  // TODO(#914): This method shouldn't be nullable.
-  @SuppressWarnings("nullness")
-  @Nullable
   public RunningSpanStoreImpl getRunningSpanStore() {
     return runningSpanStore;
   }
 
   @Override
-  // TODO(#914): This method shouldn't be nullable.
-  @SuppressWarnings("nullness")
-  @Nullable
   public SampledSpanStoreImpl getSampledSpanStore() {
     return sampledSpanStore;
   }
@@ -82,7 +76,13 @@ public final class ExportComponentImpl extends ExportComponent {
    */
   private ExportComponentImpl(boolean supportInProcessStores, EventQueue eventQueue) {
     this.spanExporter = SpanExporterImpl.create(EXPORTER_BUFFER_SIZE, EXPORTER_SCHEDULE_DELAY);
-    this.runningSpanStore = supportInProcessStores ? new RunningSpanStoreImpl() : null;
-    this.sampledSpanStore = supportInProcessStores ? new SampledSpanStoreImpl(eventQueue) : null;
+    this.runningSpanStore =
+        supportInProcessStores
+            ? new InProcessRunningSpanStoreImpl()
+            : RunningSpanStoreImpl.getNoopRunningSpanStoreImpl();
+    this.sampledSpanStore =
+        supportInProcessStores
+            ? new InProcessSampledSpanStoreImpl(eventQueue)
+            : SampledSpanStoreImpl.getNoopSampledSpanStoreImpl();
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessRunningSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessRunningSpanStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, OpenCensus Authors
+ * Copyright 2018, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessRunningSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessRunningSpanStoreImpl.java
@@ -27,29 +27,21 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 
-/** Implementation of the {@link RunningSpanStore}. */
+/** In-process implementation of the {@link RunningSpanStore}. */
 @ThreadSafe
-public final class RunningSpanStoreImpl extends RunningSpanStore {
+public final class InProcessRunningSpanStoreImpl extends RunningSpanStoreImpl {
   private final ConcurrentIntrusiveList<SpanImpl> runningSpans;
 
-  public RunningSpanStoreImpl() {
+  public InProcessRunningSpanStoreImpl() {
     runningSpans = new ConcurrentIntrusiveList<SpanImpl>();
   }
 
-  /**
-   * Adds the {@code Span} into the running spans list when the {@code Span} starts.
-   *
-   * @param span the {@code Span} that started.
-   */
+  @Override
   public void onStart(SpanImpl span) {
     runningSpans.addElement(span);
   }
 
-  /**
-   * Removes the {@code Span} from the running spans list when the {@code Span} ends.
-   *
-   * @param span the {@code Span} that ended.
-   */
+  @Override
   public void onEnd(SpanImpl span) {
     runningSpans.removeElement(span);
   }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessSampledSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessSampledSpanStoreImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, OpenCensus Authors
+ * Copyright 2018, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessSampledSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessSampledSpanStoreImpl.java
@@ -37,9 +37,9 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
-/** Implementation of the {@link SampledSpanStore}. */
+/** In-process implementation of the {@link SampledSpanStore}. */
 @ThreadSafe
-public final class SampledSpanStoreImpl extends SampledSpanStore {
+public final class InProcessSampledSpanStoreImpl extends SampledSpanStoreImpl {
   private static final int NUM_SAMPLES_PER_LATENCY_BUCKET = 10;
   private static final int NUM_SAMPLES_PER_ERROR_BUCKET = 5;
   private static final long TIME_BETWEEN_SAMPLES = TimeUnit.SECONDS.toNanos(1);
@@ -235,8 +235,8 @@ public final class SampledSpanStoreImpl extends SampledSpanStore {
     }
   }
 
-  /** Constructs a new {@code SampledSpanStoreImpl}. */
-  SampledSpanStoreImpl(EventQueue eventQueue) {
+  /** Constructs a new {@code InProcessSampledSpanStoreImpl}. */
+  InProcessSampledSpanStoreImpl(EventQueue eventQueue) {
     samples = new HashMap<String, PerSpanNameSamples>();
     this.eventQueue = eventQueue;
   }
@@ -256,12 +256,7 @@ public final class SampledSpanStoreImpl extends SampledSpanStore {
     return Summary.create(ret);
   }
 
-  /**
-   * Considers to save the given spans to the stored samples. This must be called at the end of each
-   * Span with the option RECORD_EVENTS.
-   *
-   * @param span the span to be consider for storing into the store buckets.
-   */
+  @Override
   public void considerForSampling(SpanImpl span) {
     synchronized (samples) {
       String spanName = span.getName();
@@ -291,11 +286,11 @@ public final class SampledSpanStoreImpl extends SampledSpanStore {
   }
 
   private static final class RegisterSpanNameEvent implements EventQueue.Entry {
-    private final SampledSpanStoreImpl sampledSpanStore;
+    private final InProcessSampledSpanStoreImpl sampledSpanStore;
     private final Collection<String> spanNames;
 
     private RegisterSpanNameEvent(
-        SampledSpanStoreImpl sampledSpanStore, Collection<String> spanNames) {
+        InProcessSampledSpanStoreImpl sampledSpanStore, Collection<String> spanNames) {
       this.sampledSpanStore = sampledSpanStore;
       this.spanNames = new ArrayList<String>(spanNames);
     }
@@ -318,11 +313,11 @@ public final class SampledSpanStoreImpl extends SampledSpanStore {
   }
 
   private static final class UnregisterSpanNameEvent implements EventQueue.Entry {
-    private final SampledSpanStoreImpl sampledSpanStore;
+    private final InProcessSampledSpanStoreImpl sampledSpanStore;
     private final Collection<String> spanNames;
 
     private UnregisterSpanNameEvent(
-        SampledSpanStoreImpl sampledSpanStore, Collection<String> spanNames) {
+        InProcessSampledSpanStoreImpl sampledSpanStore, Collection<String> spanNames) {
       this.sampledSpanStore = sampledSpanStore;
       this.spanNames = new ArrayList<String>(spanNames);
     }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/RunningSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/RunningSpanStoreImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.trace.export;
+
+import io.opencensus.implcore.trace.SpanImpl;
+import io.opencensus.trace.export.RunningSpanStore;
+import io.opencensus.trace.export.RunningSpanStore.Filter;
+import io.opencensus.trace.export.RunningSpanStore.PerSpanNameSummary;
+import io.opencensus.trace.export.RunningSpanStore.Summary;
+import io.opencensus.trace.export.SpanData;
+import java.util.Collection;
+import java.util.Collections;
+
+/** Abstract implementation of the {@link RunningSpanStore}. */
+public abstract class RunningSpanStoreImpl extends RunningSpanStore {
+
+  private static final RunningSpanStoreImpl NOOP_RUNNING_SPAN_STORE_IMPL =
+      new NoopRunningSpanStoreImpl();
+
+  /** Returns the no-op implementation of the {@link RunningSpanStoreImpl}. */
+  static RunningSpanStoreImpl getNoopRunningSpanStoreImpl() {
+    return NOOP_RUNNING_SPAN_STORE_IMPL;
+  }
+
+  /**
+   * Adds the {@code Span} into the running spans list when the {@code Span} starts.
+   *
+   * @param span the {@code Span} that started.
+   */
+  public abstract void onStart(SpanImpl span);
+
+  /**
+   * Removes the {@code Span} from the running spans list when the {@code Span} ends.
+   *
+   * @param span the {@code Span} that ended.
+   */
+  public abstract void onEnd(SpanImpl span);
+
+  private static final class NoopRunningSpanStoreImpl extends RunningSpanStoreImpl {
+
+    private static final Summary EMPTY_SUMMARY =
+        RunningSpanStore.Summary.create(Collections.<String, PerSpanNameSummary>emptyMap());
+
+    @Override
+    public void onStart(SpanImpl span) {}
+
+    @Override
+    public void onEnd(SpanImpl span) {}
+
+    @Override
+    public Summary getSummary() {
+      return EMPTY_SUMMARY;
+    }
+
+    @Override
+    public Collection<SpanData> getRunningSpans(Filter filter) {
+      return Collections.<SpanData>emptyList();
+    }
+  }
+}

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/SampledSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/SampledSpanStoreImpl.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.trace.export;
+
+import io.opencensus.implcore.trace.SpanImpl;
+import io.opencensus.trace.export.SampledSpanStore;
+import io.opencensus.trace.export.SampledSpanStore.ErrorFilter;
+import io.opencensus.trace.export.SampledSpanStore.LatencyFilter;
+import io.opencensus.trace.export.SampledSpanStore.PerSpanNameSummary;
+import io.opencensus.trace.export.SampledSpanStore.Summary;
+import io.opencensus.trace.export.SpanData;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Set;
+
+/** Abstract implementation of the {@link SampledSpanStore}. */
+public abstract class SampledSpanStoreImpl extends SampledSpanStore {
+  private static final SampledSpanStoreImpl NOOP_SAMPLED_SPAN_STORE_IMPL =
+      new NoopSampledSpanStoreImpl();
+
+  /** Returns the new no-op implmentation of {@link SampledSpanStoreImpl}. */
+  public static SampledSpanStoreImpl getNoopSampledSpanStoreImpl() {
+    return NOOP_SAMPLED_SPAN_STORE_IMPL;
+  }
+
+  /**
+   * Considers to save the given spans to the stored samples. This must be called at the end of each
+   * Span with the option RECORD_EVENTS.
+   *
+   * @param span the span to be consider for storing into the store buckets.
+   */
+  public abstract void considerForSampling(SpanImpl span);
+
+  private static final class NoopSampledSpanStoreImpl extends SampledSpanStoreImpl {
+    private static final Summary EMPTY_SUMMARY =
+        Summary.create(Collections.<String, PerSpanNameSummary>emptyMap());
+    private static final Set<String> EMPTY_REGISTERED_SPAN_NAMES = Collections.<String>emptySet();
+    private static final Collection<SpanData> EMPTY_SPANDATA = Collections.<SpanData>emptySet();
+
+    @Override
+    public Summary getSummary() {
+      return EMPTY_SUMMARY;
+    }
+
+    @Override
+    public void considerForSampling(SpanImpl span) {}
+
+    @Override
+    public void registerSpanNamesForCollection(Collection<String> spanNames) {}
+
+    @Override
+    public void unregisterSpanNamesForCollection(Collection<String> spanNames) {}
+
+    @Override
+    public Set<String> getRegisteredSpanNamesForCollection() {
+      return EMPTY_REGISTERED_SPAN_NAMES;
+    }
+
+    @Override
+    public Collection<SpanData> getErrorSampledSpans(ErrorFilter filter) {
+      return EMPTY_SPANDATA;
+    }
+
+    @Override
+    public Collection<SpanData> getLatencySampledSpans(LatencyFilter filter) {
+      return EMPTY_SPANDATA;
+    }
+  }
+}

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/ExportComponentImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/ExportComponentImplTest.java
@@ -40,14 +40,16 @@ public class ExportComponentImplTest {
   @Test
   public void implementationOfActiveSpans() {
     assertThat(exportComponentWithInProcess.getRunningSpanStore())
-        .isInstanceOf(RunningSpanStoreImpl.class);
-    assertThat(exportComponentWithoutInProcess.getRunningSpanStore()).isNull();
+        .isInstanceOf(InProcessRunningSpanStoreImpl.class);
+    assertThat(exportComponentWithoutInProcess.getRunningSpanStore())
+        .isInstanceOf(RunningSpanStoreImpl.getNoopRunningSpanStoreImpl().getClass());
   }
 
   @Test
   public void implementationOfSampledSpanStore() {
     assertThat(exportComponentWithInProcess.getSampledSpanStore())
-        .isInstanceOf(SampledSpanStoreImpl.class);
-    assertThat(exportComponentWithoutInProcess.getSampledSpanStore()).isNull();
+        .isInstanceOf(InProcessSampledSpanStoreImpl.class);
+    assertThat(exportComponentWithoutInProcess.getSampledSpanStore())
+        .isInstanceOf(SampledSpanStoreImpl.getNoopSampledSpanStoreImpl().getClass());
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/InProcessRunningSpanStoreImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/InProcessRunningSpanStoreImplTest.java
@@ -37,16 +37,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link RunningSpanStoreImpl}. */
+/** Unit tests for {@link InProcessRunningSpanStoreImpl}. */
 @RunWith(JUnit4.class)
-public class RunningSpanStoreImplTest {
+public class InProcessRunningSpanStoreImplTest {
 
   private static final String SPAN_NAME_1 = "MySpanName/1";
   private static final String SPAN_NAME_2 = "MySpanName/2";
   private final Random random = new Random(1234);
   private final SpanExporterImpl sampledSpansServiceExporter =
       SpanExporterImpl.create(4, Duration.create(1, 0));
-  private final RunningSpanStoreImpl activeSpansExporter = new RunningSpanStoreImpl();
+  private final InProcessRunningSpanStoreImpl activeSpansExporter =
+      new InProcessRunningSpanStoreImpl();
   private final StartEndHandler startEndHandler =
       new StartEndHandlerImpl(
           sampledSpansServiceExporter, activeSpansExporter, null, new SimpleEventQueue());

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/InProcessSampledSpanStoreImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/InProcessSampledSpanStoreImplTest.java
@@ -50,9 +50,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link SampledSpanStoreImpl}. */
+/** Unit tests for {@link InProcessSampledSpanStoreImpl}. */
 @RunWith(JUnit4.class)
-public class SampledSpanStoreImplTest {
+public class InProcessSampledSpanStoreImplTest {
   private static final String REGISTERED_SPAN_NAME = "MySpanName/1";
   private static final String NOT_REGISTERED_SPAN_NAME = "MySpanName/2";
   private static final long NUM_NANOS_PER_SECOND = TimeUnit.SECONDS.toNanos(1);
@@ -68,7 +68,8 @@ public class SampledSpanStoreImplTest {
   private final SpanId parentSpanId = SpanId.generateRandomId(random);
   private final EnumSet<Options> recordSpanOptions = EnumSet.of(Options.RECORD_EVENTS);
   private final TestClock testClock = TestClock.create(Timestamp.create(12345, 54321));
-  private final SampledSpanStoreImpl sampleStore = new SampledSpanStoreImpl(new SimpleEventQueue());
+  private final InProcessSampledSpanStoreImpl sampleStore =
+      new InProcessSampledSpanStoreImpl(new SimpleEventQueue());
   private final StartEndHandler startEndHandler =
       new StartEndHandler() {
         @Override

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/NoopRunningSpanStoreImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/NoopRunningSpanStoreImplTest.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.common.Timestamp;
+import io.opencensus.implcore.internal.TimestampConverter;
+import io.opencensus.implcore.trace.SpanImpl;
+import io.opencensus.implcore.trace.SpanImpl.StartEndHandler;
+import io.opencensus.testing.common.TestClock;
+import io.opencensus.trace.Span.Options;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.config.TraceParams;
+import io.opencensus.trace.export.RunningSpanStore.Filter;
+import java.util.EnumSet;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link NoopRunningSpanStoreImpl}. */
+@RunWith(JUnit4.class)
+public class NoopRunningSpanStoreImplTest {
+
+  private static final String SPAN_NAME = "MySpanName";
+
+  private final Timestamp timestamp = Timestamp.create(1234, 5678);
+  private final Random random = new Random(1234);
+  private final SpanContext spanContext =
+      SpanContext.create(
+          TraceId.generateRandomId(random), SpanId.generateRandomId(random), TraceOptions.DEFAULT);
+  private final TestClock testClock = TestClock.create(timestamp);
+  private final TimestampConverter timestampConverter = TimestampConverter.now(testClock);
+  private final EnumSet<Options> recordSpanOptions = EnumSet.of(Options.RECORD_EVENTS);
+  @Mock private StartEndHandler startEndHandler;
+  private SpanImpl spanImpl;
+  private Filter filter = Filter.create(SPAN_NAME, 0);
+  private final RunningSpanStoreImpl runningSpanStoreImpl =
+      ExportComponentImpl.createWithoutInProcessStores(null).getRunningSpanStore();
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    SpanImpl span =
+        SpanImpl.startSpan(
+            spanContext,
+            recordSpanOptions,
+            SPAN_NAME,
+            null,
+            false,
+            TraceParams.DEFAULT,
+            startEndHandler,
+            timestampConverter,
+            testClock);
+  }
+
+  private void getMethodsReturnsEmpty() {
+    // get methods should always return empty collections.
+    assertThat(runningSpanStoreImpl.getSummary().getPerSpanNameSummary()).isEmpty();
+    assertThat(runningSpanStoreImpl.getRunningSpans(filter)).isEmpty();
+  }
+
+  @Test
+  public void noopImplementation() {
+    getMethodsReturnsEmpty();
+    // onStart() does not affect the result.
+    runningSpanStoreImpl.onStart(spanImpl);
+    getMethodsReturnsEmpty();
+    // onEnd() does not affect the result.
+    runningSpanStoreImpl.onEnd(spanImpl);
+    getMethodsReturnsEmpty();
+  }
+}

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/NoopRunningSpanStoreImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/NoopRunningSpanStoreImplTest.java
@@ -19,6 +19,8 @@ package io.opencensus.implcore.trace.export;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Timestamp;
+import io.opencensus.implcore.internal.EventQueue;
+import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.implcore.internal.TimestampConverter;
 import io.opencensus.implcore.trace.SpanImpl;
 import io.opencensus.implcore.trace.SpanImpl.StartEndHandler;
@@ -55,9 +57,11 @@ public class NoopRunningSpanStoreImplTest {
   private final EnumSet<Options> recordSpanOptions = EnumSet.of(Options.RECORD_EVENTS);
   @Mock private StartEndHandler startEndHandler;
   private SpanImpl spanImpl;
-  private Filter filter = Filter.create(SPAN_NAME, 0);
+  // maxSpansToReturn=0 means all
+  private final Filter filter = Filter.create(SPAN_NAME, 0 /* maxSpansToReturn */);
+  private final EventQueue eventQueue = new SimpleEventQueue();
   private final RunningSpanStoreImpl runningSpanStoreImpl =
-      ExportComponentImpl.createWithoutInProcessStores(null).getRunningSpanStore();
+      ExportComponentImpl.createWithoutInProcessStores(eventQueue).getRunningSpanStore();
 
   @Before
   public void setUp() {
@@ -75,7 +79,7 @@ public class NoopRunningSpanStoreImplTest {
             testClock);
   }
 
-  private void getMethodsReturnsEmpty() {
+  private void getMethodsShouldReturnEmpty() {
     // get methods should always return empty collections.
     assertThat(runningSpanStoreImpl.getSummary().getPerSpanNameSummary()).isEmpty();
     assertThat(runningSpanStoreImpl.getRunningSpans(filter)).isEmpty();
@@ -83,12 +87,12 @@ public class NoopRunningSpanStoreImplTest {
 
   @Test
   public void noopImplementation() {
-    getMethodsReturnsEmpty();
+    getMethodsShouldReturnEmpty();
     // onStart() does not affect the result.
     runningSpanStoreImpl.onStart(spanImpl);
-    getMethodsReturnsEmpty();
+    getMethodsShouldReturnEmpty();
     // onEnd() does not affect the result.
     runningSpanStoreImpl.onEnd(spanImpl);
-    getMethodsReturnsEmpty();
+    getMethodsShouldReturnEmpty();
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/NoopSampledSpanStoreImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/NoopSampledSpanStoreImplTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.trace.export;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.common.Timestamp;
+import io.opencensus.implcore.internal.TimestampConverter;
+import io.opencensus.implcore.trace.SpanImpl;
+import io.opencensus.implcore.trace.SpanImpl.StartEndHandler;
+import io.opencensus.testing.common.TestClock;
+import io.opencensus.trace.Span.Options;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.config.TraceParams;
+import io.opencensus.trace.export.SampledSpanStore.ErrorFilter;
+import io.opencensus.trace.export.SampledSpanStore.LatencyFilter;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Random;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+/** Unit tests for {@link NoopSampledSpanStoreImpl}. */
+@RunWith(JUnit4.class)
+public final class NoopSampledSpanStoreImplTest {
+
+  private static final String SPAN_NAME = "MySpanName";
+  private static final Collection<String> NAMES_FOR_COLLECTION =
+      Collections.<String>singletonList(SPAN_NAME);
+
+  private final Timestamp timestamp = Timestamp.create(1234, 5678);
+  private final Random random = new Random(1234);
+  private final SpanContext spanContext =
+      SpanContext.create(
+          TraceId.generateRandomId(random), SpanId.generateRandomId(random), TraceOptions.DEFAULT);
+  private final TestClock testClock = TestClock.create(timestamp);
+  private final TimestampConverter timestampConverter = TimestampConverter.now(testClock);
+  private final EnumSet<Options> recordSpanOptions = EnumSet.of(Options.RECORD_EVENTS);
+  @Mock private StartEndHandler startEndHandler;
+  private SpanImpl spanImpl;
+  private ErrorFilter errorFilter = ErrorFilter.create(SPAN_NAME, null, 0);
+  private LatencyFilter latencyFilter = LatencyFilter.create(SPAN_NAME, 0, 0, 0);
+  private final SampledSpanStoreImpl sampledSpanStoreImpl =
+      ExportComponentImpl.createWithoutInProcessStores(null).getSampledSpanStore();
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    SpanImpl span =
+        SpanImpl.startSpan(
+            spanContext,
+            recordSpanOptions,
+            SPAN_NAME,
+            null,
+            false,
+            TraceParams.DEFAULT,
+            startEndHandler,
+            timestampConverter,
+            testClock);
+  }
+
+  private void getMethodsReturnsEmpty() {
+    // get methods always return empty collections.
+    assertThat(sampledSpanStoreImpl.getSummary().getPerSpanNameSummary()).isEmpty();
+    assertThat(sampledSpanStoreImpl.getRegisteredSpanNamesForCollection()).isEmpty();
+    assertThat(sampledSpanStoreImpl.getErrorSampledSpans(errorFilter)).isEmpty();
+    assertThat(sampledSpanStoreImpl.getLatencySampledSpans(latencyFilter)).isEmpty();
+  }
+
+  @Test
+  public void noopImplementation() {
+    getMethodsReturnsEmpty();
+    // considerForSampling() does not affect the result.
+    sampledSpanStoreImpl.considerForSampling(spanImpl);
+    getMethodsReturnsEmpty();
+    // registerSpanNamesForCollection() does not affect the result.
+    sampledSpanStoreImpl.registerSpanNamesForCollection(NAMES_FOR_COLLECTION);
+    getMethodsReturnsEmpty();
+    // unregisterSpanNamesForCollection() does not affect the result.
+    sampledSpanStoreImpl.unregisterSpanNamesForCollection(NAMES_FOR_COLLECTION);
+    getMethodsReturnsEmpty();
+  }
+}

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/SpanExporterImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/SpanExporterImplTest.java
@@ -60,7 +60,7 @@ public class SpanExporterImplTest {
       SpanContext.create(
           TraceId.generateRandomId(random), SpanId.generateRandomId(random), TraceOptions.DEFAULT);
   private final SpanExporterImpl spanExporter = SpanExporterImpl.create(4, Duration.create(1, 0));
-  private final RunningSpanStoreImpl runningSpanStore = new RunningSpanStoreImpl();
+  private final RunningSpanStoreImpl runningSpanStore = new InProcessRunningSpanStoreImpl();
   private final StartEndHandler startEndHandler =
       new StartEndHandlerImpl(spanExporter, runningSpanStore, null, new SimpleEventQueue());
   private EnumSet<Options> recordSpanOptions = EnumSet.of(Options.RECORD_EVENTS);


### PR DESCRIPTION
Since `XxxSpanStoreImpl` have the `final` modifier, they need to be removed to `abstract` so we can add no-op implementation and pass nullness check.

This PR contains two commits. 
- The first one removes "final" modifier of the concrete implementations and rename them to `InProcessXxxSpanStoreImpl` since they serve in-process data collection purpose, it is a WIP PR and temporarily breaks the build.
- The second one rebuilds the old classes with `abstract` modifier and adds no-op implementation and related tests.
