### PR TITLE
Add '@since' Javadoc tag to all stats and tagging APIs (issue #864).

### DIFF
--- a/api/src/main/java/io/opencensus/stats/Aggregation.java
+++ b/api/src/main/java/io/opencensus/stats/Aggregation.java
@@ -38,13 +38,19 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>When creating a {@link View}, one {@link Aggregation} needs to be specified as how to
  * aggregate {@code MeasureValue}s.
+ *
+ * @since 0.8
  */
 @Immutable
 public abstract class Aggregation {
 
   private Aggregation() {}
 
-  /** Applies the given match function to the underlying data type. */
+  /**
+   * Applies the given match function to the underlying data type.
+   *
+   * @since 0.8
+   */
   public abstract <T> T match(
       Function<? super Sum, T> p0,
       Function<? super Count, T> p1,
@@ -52,7 +58,11 @@ public abstract class Aggregation {
       Function<? super Distribution, T> p3,
       Function<? super Aggregation, T> defaultFunction);
 
-  /** Calculate sum on aggregated {@code MeasureValue}s. */
+  /**
+   * Calculate sum on aggregated {@code MeasureValue}s.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -68,6 +78,7 @@ public abstract class Aggregation {
      * Construct a {@code Sum}.
      *
      * @return a new {@code Sum}.
+     * @since 0.8
      */
     public static Sum create() {
       return INSTANCE;
@@ -84,7 +95,11 @@ public abstract class Aggregation {
     }
   }
 
-  /** Calculate count on aggregated {@code MeasureValue}s. */
+  /**
+   * Calculate count on aggregated {@code MeasureValue}s.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -100,6 +115,7 @@ public abstract class Aggregation {
      * Construct a {@code Count}.
      *
      * @return a new {@code Count}.
+     * @since 0.8
      */
     public static Count create() {
       return INSTANCE;
@@ -116,7 +132,11 @@ public abstract class Aggregation {
     }
   }
 
-  /** Calculate mean on aggregated {@code MeasureValue}s. */
+  /**
+   * Calculate mean on aggregated {@code MeasureValue}s.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -132,6 +152,7 @@ public abstract class Aggregation {
      * Construct a {@code Mean}.
      *
      * @return a new {@code Mean}.
+     * @since 0.8
      */
     public static Mean create() {
       return INSTANCE;
@@ -151,6 +172,8 @@ public abstract class Aggregation {
   /**
    * Calculate distribution stats on aggregated {@code MeasureValue}s. Distribution includes mean,
    * count, histogram, min, max and sum of squared deviations.
+   *
+   * @since 0.8
    */
   @Immutable
   @AutoValue
@@ -165,12 +188,19 @@ public abstract class Aggregation {
      * Construct a {@code Distribution}.
      *
      * @return a new {@code Distribution}.
+     * @since 0.8
      */
     public static Distribution create(BucketBoundaries bucketBoundaries) {
       checkNotNull(bucketBoundaries, "bucketBoundaries should not be null.");
       return new AutoValue_Aggregation_Distribution(bucketBoundaries);
     }
 
+    /**
+     * Returns the {@code Distribution}'s bucket boundaries.
+     *
+     * @return the {@code Distribution}'s bucket boundaries.
+     * @since 0.8
+     */
     public abstract BucketBoundaries getBucketBoundaries();
 
     @Override

--- a/api/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/api/src/main/java/io/opencensus/stats/AggregationData.java
@@ -43,13 +43,19 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>{@link ViewData} will contain one {@link AggregationData}, corresponding to its {@link
  * Aggregation} definition in {@link View}.
+ *
+ * @since 0.8
  */
 @Immutable
 public abstract class AggregationData {
 
   private AggregationData() {}
 
-  /** Applies the given match function to the underlying data type. */
+  /**
+   * Applies the given match function to the underlying data type.
+   *
+   * @since 0.8
+   */
   public abstract <T> T match(
       Function<? super SumDataDouble, T> p0,
       Function<? super SumDataLong, T> p1,
@@ -58,7 +64,11 @@ public abstract class AggregationData {
       Function<? super DistributionData, T> p4,
       Function<? super AggregationData, T> defaultFunction);
 
-  /** The sum value of aggregated {@code MeasureValueDouble}s. */
+  /**
+   * The sum value of aggregated {@code MeasureValueDouble}s.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -73,6 +83,7 @@ public abstract class AggregationData {
      *
      * @param sum the aggregated sum.
      * @return a {@code SumDataDouble}.
+     * @since 0.8
      */
     public static SumDataDouble create(double sum) {
       return new AutoValue_AggregationData_SumDataDouble(sum);
@@ -82,6 +93,7 @@ public abstract class AggregationData {
      * Returns the aggregated sum.
      *
      * @return the aggregated sum.
+     * @since 0.8
      */
     public abstract double getSum();
 
@@ -98,7 +110,11 @@ public abstract class AggregationData {
     }
   }
 
-  /** The sum value of aggregated {@code MeasureValueLong}s. */
+  /**
+   * The sum value of aggregated {@code MeasureValueLong}s.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -113,6 +129,7 @@ public abstract class AggregationData {
      *
      * @param sum the aggregated sum.
      * @return a {@code SumDataLong}.
+     * @since 0.8
      */
     public static SumDataLong create(long sum) {
       return new AutoValue_AggregationData_SumDataLong(sum);
@@ -122,6 +139,7 @@ public abstract class AggregationData {
      * Returns the aggregated sum.
      *
      * @return the aggregated sum.
+     * @since 0.8
      */
     public abstract long getSum();
 
@@ -138,7 +156,11 @@ public abstract class AggregationData {
     }
   }
 
-  /** The count value of aggregated {@code MeasureValue}s. */
+  /**
+   * The count value of aggregated {@code MeasureValue}s.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -153,6 +175,7 @@ public abstract class AggregationData {
      *
      * @param count the aggregated count.
      * @return a {@code CountData}.
+     * @since 0.8
      */
     public static CountData create(long count) {
       return new AutoValue_AggregationData_CountData(count);
@@ -162,6 +185,7 @@ public abstract class AggregationData {
      * Returns the aggregated count.
      *
      * @return the aggregated count.
+     * @since 0.8
      */
     public abstract long getCount();
 
@@ -178,7 +202,11 @@ public abstract class AggregationData {
     }
   }
 
-  /** The mean value of aggregated {@code MeasureValue}s. */
+  /**
+   * The mean value of aggregated {@code MeasureValue}s.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -194,6 +222,7 @@ public abstract class AggregationData {
      * @param mean the aggregated mean.
      * @param count the aggregated count.
      * @return a {@code MeanData}.
+     * @since 0.8
      */
     public static MeanData create(double mean, long count) {
       return new AutoValue_AggregationData_MeanData(mean, count);
@@ -203,6 +232,7 @@ public abstract class AggregationData {
      * Returns the aggregated mean.
      *
      * @return the aggregated mean.
+     * @since 0.8
      */
     public abstract double getMean();
 
@@ -210,6 +240,7 @@ public abstract class AggregationData {
      * Returns the aggregated count.
      *
      * @return the aggregated count.
+     * @since 0.8
      */
     public abstract long getCount();
 
@@ -229,6 +260,8 @@ public abstract class AggregationData {
   /**
    * The distribution stats of aggregated {@code MeasureValue}s. Distribution stats include mean,
    * count, histogram, min, max and sum of squared deviations.
+   *
+   * @since 0.8
    */
   @Immutable
   @AutoValue
@@ -249,6 +282,7 @@ public abstract class AggregationData {
      * @param sumOfSquaredDeviations sum of squared deviations.
      * @param bucketCounts histogram bucket counts.
      * @return a {@code DistributionData}.
+     * @since 0.8
      */
     public static DistributionData create(
         double mean,
@@ -275,6 +309,7 @@ public abstract class AggregationData {
      * Returns the aggregated mean.
      *
      * @return the aggregated mean.
+     * @since 0.8
      */
     public abstract double getMean();
 
@@ -282,6 +317,7 @@ public abstract class AggregationData {
      * Returns the aggregated count.
      *
      * @return the aggregated count.
+     * @since 0.8
      */
     public abstract long getCount();
 
@@ -289,6 +325,7 @@ public abstract class AggregationData {
      * Returns the minimum of the population values.
      *
      * @return the minimum of the population values.
+     * @since 0.8
      */
     public abstract double getMin();
 
@@ -296,6 +333,7 @@ public abstract class AggregationData {
      * Returns the maximum of the population values.
      *
      * @return the maximum of the population values.
+     * @since 0.8
      */
     public abstract double getMax();
 
@@ -303,6 +341,7 @@ public abstract class AggregationData {
      * Returns the aggregated sum of squared deviations.
      *
      * @return the aggregated sum of squared deviations.
+     * @since 0.8
      */
     public abstract double getSumOfSquaredDeviations();
 
@@ -311,6 +350,7 @@ public abstract class AggregationData {
      * will throw an {@code UnsupportedOperationException}.
      *
      * @return the aggregated bucket counts.
+     * @since 0.8
      */
     public abstract List<Long> getBucketCounts();
 

--- a/api/src/main/java/io/opencensus/stats/BucketBoundaries.java
+++ b/api/src/main/java/io/opencensus/stats/BucketBoundaries.java
@@ -25,7 +25,11 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
-/** The bucket boundaries for a histogram. */
+/**
+ * The bucket boundaries for a histogram.
+ *
+ * @since 0.8
+ */
 @Immutable
 @AutoValue
 // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -38,6 +42,7 @@ public abstract class BucketBoundaries {
    * @return a new {@code BucketBoundaries} with the specified boundaries.
    * @throws NullPointerException if {@code bucketBoundaries} is null.
    * @throws IllegalArgumentException if {@code bucketBoundaries} is not sorted.
+   * @since 0.8
    */
   public static final BucketBoundaries create(List<Double> bucketBoundaries) {
     checkNotNull(bucketBoundaries, "bucketBoundaries list should not be null.");
@@ -58,6 +63,7 @@ public abstract class BucketBoundaries {
    * Returns a list of histogram bucket boundaries.
    *
    * @return a list of histogram bucket boundaries.
+   * @since 0.8
    */
   public abstract List<Double> getBoundaries();
 }

--- a/api/src/main/java/io/opencensus/stats/Measure.java
+++ b/api/src/main/java/io/opencensus/stats/Measure.java
@@ -25,13 +25,21 @@ import io.opencensus.internal.CheckerFrameworkUtils;
 import io.opencensus.internal.StringUtil;
 import javax.annotation.concurrent.Immutable;
 
-/** The definition of the {@link Measurement} that is taken by OpenCensus library. */
+/**
+ * The definition of the {@link Measurement} that is taken by OpenCensus library.
+ *
+ * @since 0.8
+ */
 @Immutable
 public abstract class Measure {
 
   @VisibleForTesting static final int NAME_MAX_LENGTH = 255;
 
-  /** Applies the given match function to the underlying data type. */
+  /**
+   * Applies the given match function to the underlying data type.
+   *
+   * @since 0.8
+   */
   public abstract <T> T match(
       Function<? super MeasureDouble, T> p0,
       Function<? super MeasureLong, T> p1,
@@ -42,10 +50,16 @@ public abstract class Measure {
    * 255 characters.
    *
    * <p>Suggested format for name: {@code <web_host>/<path>}.
+   *
+   * @since 0.8
    */
   public abstract String getName();
 
-  /** Detailed description of the measure, used in documentation. */
+  /**
+   * Detailed description of the measure, used in documentation.
+   *
+   * @since 0.8
+   */
   public abstract String getDescription();
 
   /**
@@ -61,6 +75,8 @@ public abstract class Measure {
    *
    * <p>For example, string “MBy{transmitted}/ms” stands for megabytes per milliseconds, and the
    * annotation transmitted inside {} is just a comment of the unit.
+   *
+   * @since 0.8
    */
   // TODO(songya): determine whether we want to check the grammar on string unit.
   public abstract String getUnit();
@@ -68,7 +84,11 @@ public abstract class Measure {
   // Prevents this class from being subclassed anywhere else.
   private Measure() {}
 
-  /** {@link Measure} with {@code Double} typed values. */
+  /**
+   * {@link Measure} with {@code Double} typed values.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -85,6 +105,7 @@ public abstract class Measure {
      * @param description description of {@code Measure}.
      * @param unit unit of {@code Measure}.
      * @return a {@code MeasureDouble}.
+     * @since 0.8
      */
     public static MeasureDouble create(String name, String description, String unit) {
       checkArgument(
@@ -114,7 +135,11 @@ public abstract class Measure {
     public abstract String getUnit();
   }
 
-  /** {@link Measure} with {@code Long} typed values. */
+  /**
+   * {@link Measure} with {@code Long} typed values.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -131,6 +156,7 @@ public abstract class Measure {
      * @param description description of {@code Measure}.
      * @param unit unit of {@code Measure}.
      * @return a {@code MeasureLong}.
+     * @since 0.8
      */
     public static MeasureLong create(String name, String description, String unit) {
       checkArgument(

--- a/api/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/api/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -21,7 +21,11 @@ import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.tags.TagContext;
 import javax.annotation.concurrent.NotThreadSafe;
 
-/** A map from {@link Measure}s to measured values to be recorded at the same time. */
+/**
+ * A map from {@link Measure}s to measured values to be recorded at the same time.
+ *
+ * @since 0.8
+ */
 @NotThreadSafe
 public abstract class MeasureMap {
 
@@ -32,6 +36,7 @@ public abstract class MeasureMap {
    * @param measure the {@link MeasureDouble}
    * @param value the value to be associated with {@code measure}
    * @return this
+   * @since 0.8
    */
   public abstract MeasureMap put(MeasureDouble measure, double value);
 
@@ -42,6 +47,7 @@ public abstract class MeasureMap {
    * @param measure the {@link MeasureLong}
    * @param value the value to be associated with {@code measure}
    * @return this
+   * @since 0.8
    */
   public abstract MeasureMap put(MeasureLong measure, long value);
 
@@ -49,6 +55,8 @@ public abstract class MeasureMap {
    * Records all of the measures at the same time, with the current {@link TagContext}.
    *
    * <p>This method records all of the stats in the {@code MeasureMap} every time it is called.
+   *
+   * @since 0.8
    */
   public abstract void record();
 
@@ -58,6 +66,7 @@ public abstract class MeasureMap {
    * <p>This method records all of the stats in the {@code MeasureMap} every time it is called.
    *
    * @param tags the tags associated with the measurements.
+   * @since 0.8
    */
   public abstract void record(TagContext tags);
 }

--- a/api/src/main/java/io/opencensus/stats/Measurement.java
+++ b/api/src/main/java/io/opencensus/stats/Measurement.java
@@ -23,23 +23,39 @@ import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
 import javax.annotation.concurrent.Immutable;
 
-/** Immutable representation of a Measurement. */
+/**
+ * Immutable representation of a Measurement.
+ *
+ * @since 0.8
+ */
 @Immutable
 public abstract class Measurement {
 
-  /** Applies the given match function to the underlying data type. */
+  /**
+   * Applies the given match function to the underlying data type.
+   *
+   * @since 0.8
+   */
   public abstract <T> T match(
       Function<? super MeasurementDouble, T> p0,
       Function<? super MeasurementLong, T> p1,
       Function<? super Measurement, T> defaultFunction);
 
-  /** Extracts the measured {@link Measure}. */
+  /**
+   * Extracts the measured {@link Measure}.
+   *
+   * @since 0.8
+   */
   public abstract Measure getMeasure();
 
   // Prevents this class from being subclassed anywhere else.
   private Measurement() {}
 
-  /** {@code Double} typed {@link Measurement}. */
+  /**
+   * {@code Double} typed {@link Measurement}.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -48,7 +64,11 @@ public abstract class Measurement {
   public abstract static class MeasurementDouble extends Measurement {
     MeasurementDouble() {}
 
-    /** Constructs a new {@link MeasurementDouble}. */
+    /**
+     * Constructs a new {@link MeasurementDouble}.
+     *
+     * @since 0.8
+     */
     public static MeasurementDouble create(MeasureDouble measure, double value) {
       return new AutoValue_Measurement_MeasurementDouble(measure, value);
     }
@@ -56,6 +76,12 @@ public abstract class Measurement {
     @Override
     public abstract MeasureDouble getMeasure();
 
+    /**
+     * Returns the value for the measure.
+     *
+     * @return the value for the measure.
+     * @since 0.8
+     */
     public abstract double getValue();
 
     @Override
@@ -68,7 +94,11 @@ public abstract class Measurement {
     }
   }
 
-  /** {@code Long} typed {@link Measurement}. */
+  /**
+   * {@code Long} typed {@link Measurement}.
+   *
+   * @since 0.8
+   */
   @Immutable
   @AutoValue
   // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -77,7 +107,11 @@ public abstract class Measurement {
   public abstract static class MeasurementLong extends Measurement {
     MeasurementLong() {}
 
-    /** Constructs a new {@link MeasurementLong}. */
+    /**
+     * Constructs a new {@link MeasurementLong}.
+     *
+     * @since 0.8
+     */
     public static MeasurementLong create(MeasureLong measure, long value) {
       return new AutoValue_Measurement_MeasurementLong(measure, value);
     }
@@ -85,6 +119,12 @@ public abstract class Measurement {
     @Override
     public abstract MeasureLong getMeasure();
 
+    /**
+     * Returns the value for the measure.
+     *
+     * @return the value for the measure.
+     * @since 0.8
+     */
     public abstract long getValue();
 
     @Override

--- a/api/src/main/java/io/opencensus/stats/Stats.java
+++ b/api/src/main/java/io/opencensus/stats/Stats.java
@@ -22,19 +22,31 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-/** Class for accessing the default {@link StatsComponent}. */
+/**
+ * Class for accessing the default {@link StatsComponent}.
+ *
+ * @since 0.8
+ */
 public final class Stats {
   private static final Logger logger = Logger.getLogger(Stats.class.getName());
 
   private static final StatsComponent statsComponent =
       loadStatsComponent(StatsComponent.class.getClassLoader());
 
-  /** Returns the default {@link StatsRecorder}. */
+  /**
+   * Returns the default {@link StatsRecorder}.
+   *
+   * @since 0.8
+   */
   public static StatsRecorder getStatsRecorder() {
     return statsComponent.getStatsRecorder();
   }
 
-  /** Returns the default {@link ViewManager}. */
+  /**
+   * Returns the default {@link ViewManager}.
+   *
+   * @since 0.8
+   */
   public static ViewManager getViewManager() {
     return statsComponent.getViewManager();
   }
@@ -49,6 +61,7 @@ public final class Stats {
    * #setState(StatsCollectionState)} will throw an {@code IllegalStateException}.
    *
    * @return the current {@code StatsCollectionState}.
+   * @since 0.8
    */
   public static StatsCollectionState getState() {
     return statsComponent.getState();
@@ -68,6 +81,7 @@ public final class Stats {
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
    *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
    *     has been called, in order to limit changes to the result of {@code getState()}.
+   * @since 0.8
    */
   @Deprecated
   public static void setState(StatsCollectionState state) {

--- a/api/src/main/java/io/opencensus/stats/StatsCollectionState.java
+++ b/api/src/main/java/io/opencensus/stats/StatsCollectionState.java
@@ -16,13 +16,19 @@
 
 package io.opencensus.stats;
 
-/** State of the {@link StatsComponent}. */
+/**
+ * State of the {@link StatsComponent}.
+ *
+ * @since 0.8
+ */
 public enum StatsCollectionState {
 
   /**
    * State that fully enables stats collection.
    *
    * <p>The {@link StatsComponent} collects stats for registered views.
+   *
+   * @since 0.8
    */
   ENABLED,
 
@@ -31,6 +37,8 @@ public enum StatsCollectionState {
    *
    * <p>The {@link StatsComponent} does not need to collect stats for registered views and may
    * return empty {@link ViewData}s from {@link ViewManager#getView(View.Name)}.
+   *
+   * @since 0.8
    */
   DISABLED
 }

--- a/api/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/api/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -20,13 +20,23 @@ package io.opencensus.stats;
  * Class that holds the implementations for {@link ViewManager} and {@link StatsRecorder}.
  *
  * <p>All objects returned by methods on {@code StatsComponent} are cacheable.
+ *
+ * @since 0.8
  */
 public abstract class StatsComponent {
 
-  /** Returns the default {@link ViewManager}. */
+  /**
+   * Returns the default {@link ViewManager}.
+   *
+   * @since 0.8
+   */
   public abstract ViewManager getViewManager();
 
-  /** Returns the default {@link StatsRecorder}. */
+  /**
+   * Returns the default {@link StatsRecorder}.
+   *
+   * @since 0.8
+   */
   public abstract StatsRecorder getStatsRecorder();
 
   /**
@@ -39,6 +49,7 @@ public abstract class StatsComponent {
    * #setState(StatsCollectionState)} will throw an {@code IllegalStateException}.
    *
    * @return the current {@code StatsCollectionState}.
+   * @since 0.8
    */
   public abstract StatsCollectionState getState();
 
@@ -56,6 +67,7 @@ public abstract class StatsComponent {
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
    *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
    *     has been called, in order to limit changes to the result of {@code getState()}.
+   * @since 0.8
    */
   @Deprecated
   public abstract void setState(StatsCollectionState state);

--- a/api/src/main/java/io/opencensus/stats/StatsRecorder.java
+++ b/api/src/main/java/io/opencensus/stats/StatsRecorder.java
@@ -16,7 +16,11 @@
 
 package io.opencensus.stats;
 
-/** Provides methods to record stats against tags. */
+/**
+ * Provides methods to record stats against tags.
+ *
+ * @since 0.8
+ */
 public abstract class StatsRecorder {
   // TODO(sebright): Should we provide convenience methods for only recording one measure?
 
@@ -24,6 +28,7 @@ public abstract class StatsRecorder {
    * Returns an object for recording multiple measurements.
    *
    * @return an object for recording multiple measurements.
+   * @since 0.8
    */
   public abstract MeasureMap newMeasureMap();
 }

--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -34,6 +34,8 @@ import javax.annotation.concurrent.Immutable;
 /**
  * A View specifies an aggregation and a set of tag keys. The aggregation will be broken down by the
  * unique set of matching tag values for each measure.
+ *
+ * @since 0.8
  */
 @Immutable
 @AutoValue
@@ -46,16 +48,32 @@ public abstract class View {
 
   View() {}
 
-  /** Name of view. Must be unique. */
+  /**
+   * Name of view. Must be unique.
+   *
+   * @since 0.8
+   */
   public abstract Name getName();
 
-  /** More detailed description, for documentation purposes. */
+  /**
+   * More detailed description, for documentation purposes.
+   *
+   * @since 0.8
+   */
   public abstract String getDescription();
 
-  /** Measure type of this view. */
+  /**
+   * Measure type of this view.
+   *
+   * @since 0.8
+   */
   public abstract Measure getMeasure();
 
-  /** The {@link Aggregation} associated with this {@link View}. */
+  /**
+   * The {@link Aggregation} associated with this {@link View}.
+   *
+   * @since 0.8
+   */
   public abstract Aggregation getAggregation();
 
   /**
@@ -63,6 +81,8 @@ public abstract class View {
    *
    * <p>{@link Measure} will be recorded in a "greedy" way. That is, every view aggregates every
    * measure. This is similar to doing a GROUPBY on view’s columns. Columns must be unique.
+   *
+   * @since 0.8
    */
   public abstract List<TagKey> getColumns();
 
@@ -70,6 +90,7 @@ public abstract class View {
    * Returns the time {@link AggregationWindow} for this {@code View}.
    *
    * @return the time {@link AggregationWindow}.
+   * @since 0.8
    */
   public abstract AggregationWindow getWindow();
 
@@ -84,6 +105,7 @@ public abstract class View {
    *     duplicates.
    * @param window the {@link AggregationWindow} of view.
    * @return a new {@link View}.
+   * @since 0.8
    */
   public static View create(
       Name name,
@@ -103,7 +125,11 @@ public abstract class View {
         window);
   }
 
-  /** The name of a {@code View}. */
+  /**
+   * The name of a {@code View}.
+   *
+   * @since 0.8
+   */
   // This type should be used as the key when associating data with Views.
   @Immutable
   @AutoValue
@@ -118,6 +144,7 @@ public abstract class View {
      * Returns the name as a {@code String}.
      *
      * @return the name as a {@code String}.
+     * @since 0.8
      */
     public abstract String asString();
 
@@ -129,6 +156,7 @@ public abstract class View {
      *
      * @param name the name {@code String}.
      * @return a {@code View.Name} with the given name {@code String}.
+     * @since 0.8
      */
     public static Name create(String name) {
       checkArgument(
@@ -138,19 +166,31 @@ public abstract class View {
     }
   }
 
-  /** The time window for a {@code View}. */
+  /**
+   * The time window for a {@code View}.
+   *
+   * @since 0.8
+   */
   @Immutable
   public abstract static class AggregationWindow {
 
     private AggregationWindow() {}
 
-    /** Applies the given match function to the underlying data type. */
+    /**
+     * Applies the given match function to the underlying data type.
+     *
+     * @since 0.8
+     */
     public abstract <T> T match(
         Function<? super Cumulative, T> p0,
         Function<? super Interval, T> p1,
         Function<? super AggregationWindow, T> defaultFunction);
 
-    /** Cumulative (infinite interval) time {@code AggregationWindow}. */
+    /**
+     * Cumulative (infinite interval) time {@code AggregationWindow}.
+     *
+     * @since 0.8
+     */
     @Immutable
     @AutoValue
     // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -169,6 +209,7 @@ public abstract class View {
        * {@code Duration}.
        *
        * @return a cumulative {@code AggregationWindow}.
+       * @since 0.8
        */
       public static Cumulative create() {
         return CUMULATIVE;
@@ -184,7 +225,11 @@ public abstract class View {
       }
     }
 
-    /** Interval (finite interval) time {@code AggregationWindow.} */
+    /**
+     * Interval (finite interval) time {@code AggregationWindow}.
+     *
+     * @since 0.8
+     */
     @Immutable
     @AutoValue
     // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -200,6 +245,7 @@ public abstract class View {
        * Returns the {@code Duration} associated with this {@code Interval}.
        *
        * @return a {@code Duration}.
+       * @since 0.8
        */
       public abstract Duration getDuration();
 
@@ -211,6 +257,7 @@ public abstract class View {
        * cannot have smaller {@code Duration} such as microseconds or nanoseconds.
        *
        * @return an interval {@code AggregationWindow}.
+       * @since 0.8
        */
       public static Interval create(Duration duration) {
         checkArgument(duration.compareTo(ZERO) > 0, "Duration must be positive");

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -48,7 +48,11 @@ import javax.annotation.concurrent.Immutable;
 import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
-/** The aggregated data for a particular {@link View}. */
+/**
+ * The aggregated data for a particular {@link View}.
+ *
+ * @since 0.8
+ */
 @Immutable
 @AutoValue
 // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -59,12 +63,18 @@ public abstract class ViewData {
   // Prevents this class from being subclassed anywhere else.
   ViewData() {}
 
-  /** The {@link View} associated with this {@link ViewData}. */
+  /**
+   * The {@link View} associated with this {@link ViewData}.
+   *
+   * @since 0.8
+   */
   public abstract View getView();
 
   /**
    * The {@link AggregationData} grouped by combination of tag values, associated with this {@link
    * ViewData}.
+   *
+   * @since 0.8
    */
   public abstract Map<List<TagValue>, AggregationData> getAggregationMap();
 
@@ -72,6 +82,7 @@ public abstract class ViewData {
    * Returns the {@link AggregationWindowData} associated with this {@link ViewData}.
    *
    * @return the {@code AggregationWindowData}.
+   * @since 0.8
    */
   public abstract AggregationWindowData getWindowData();
 
@@ -85,6 +96,7 @@ public abstract class ViewData {
    * @throws IllegalArgumentException if the types of {@code Aggregation} and {@code
    *     AggregationData} don't match, or the types of {@code Window} and {@code WindowData} don't
    *     match.
+   * @since 0.8
    */
   public static ViewData create(
       View view,
@@ -201,19 +213,31 @@ public abstract class ViewData {
         + aggregationData;
   }
 
-  /** The {@code AggregationWindowData} for a {@link ViewData}. */
+  /**
+   * The {@code AggregationWindowData} for a {@link ViewData}.
+   *
+   * @since 0.8
+   */
   @Immutable
   public abstract static class AggregationWindowData {
 
     private AggregationWindowData() {}
 
-    /** Applies the given match function to the underlying data type. */
+    /**
+     * Applies the given match function to the underlying data type.
+     *
+     * @since 0.8
+     */
     public abstract <T> T match(
         Function<? super CumulativeData, T> p0,
         Function<? super IntervalData, T> p1,
         Function<? super AggregationWindowData, T> defaultFunction);
 
-    /** Cumulative {@code AggregationWindowData.} */
+    /**
+     * Cumulative {@code AggregationWindowData}.
+     *
+     * @since 0.8
+     */
     @Immutable
     @AutoValue
     // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -227,6 +251,7 @@ public abstract class ViewData {
        * Returns the start {@code Timestamp} for a {@link CumulativeData}.
        *
        * @return the start {@code Timestamp}.
+       * @since 0.8
        */
       public abstract Timestamp getStart();
 
@@ -234,6 +259,7 @@ public abstract class ViewData {
        * Returns the end {@code Timestamp} for a {@link CumulativeData}.
        *
        * @return the end {@code Timestamp}.
+       * @since 0.8
        */
       public abstract Timestamp getEnd();
 
@@ -246,7 +272,11 @@ public abstract class ViewData {
             .apply(this);
       }
 
-      /** Constructs a new {@link CumulativeData}. */
+      /**
+       * Constructs a new {@link CumulativeData}.
+       *
+       * @since 0.8
+       */
       public static CumulativeData create(Timestamp start, Timestamp end) {
         if (start.compareTo(end) > 0) {
           throw new IllegalArgumentException("Start time is later than end time.");
@@ -255,7 +285,11 @@ public abstract class ViewData {
       }
     }
 
-    /** Interval {@code AggregationWindowData.} */
+    /**
+     * Interval {@code AggregationWindowData}.
+     *
+     * @since 0.8
+     */
     @Immutable
     @AutoValue
     // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -269,6 +303,7 @@ public abstract class ViewData {
        * Returns the end {@code Timestamp} for an {@link IntervalData}.
        *
        * @return the end {@code Timestamp}.
+       * @since 0.8
        */
       public abstract Timestamp getEnd();
 
@@ -281,7 +316,11 @@ public abstract class ViewData {
             .apply(this);
       }
 
-      /** Constructs a new {@link IntervalData}. */
+      /**
+       * Constructs a new {@link IntervalData}.
+       *
+       * @since 0.8
+       */
       public static IntervalData create(Timestamp end) {
         return new AutoValue_ViewData_AggregationWindowData_IntervalData(end);
       }

--- a/api/src/main/java/io/opencensus/stats/ViewManager.java
+++ b/api/src/main/java/io/opencensus/stats/ViewManager.java
@@ -22,6 +22,8 @@ import javax.annotation.Nullable;
 /**
  * Provides facilities to register {@link View}s for collecting stats and retrieving stats data as a
  * {@link ViewData}.
+ *
+ * @since 0.8
  */
 public abstract class ViewManager {
   /**
@@ -29,6 +31,7 @@ public abstract class ViewManager {
    * #getView(View.Name)}.
    *
    * @param view the {@code View} to be registered.
+   * @since 0.8
    */
   public abstract void registerView(View view);
 
@@ -40,6 +43,7 @@ public abstract class ViewManager {
    * @param view the name of {@code View} for the current stats.
    * @return {@code ViewData} for the {@code View}, or {@code null} if the {@code View} is not
    *     registered.
+   * @since 0.8
    */
   @Nullable
   public abstract ViewData getView(View.Name view);

--- a/api/src/main/java/io/opencensus/tags/InternalUtils.java
+++ b/api/src/main/java/io/opencensus/tags/InternalUtils.java
@@ -18,11 +18,20 @@ package io.opencensus.tags;
 
 import java.util.Iterator;
 
-/** Internal tagging utilities. */
+/**
+ * Internal tagging utilities.
+ *
+ * @since 0.8
+ */
 @io.opencensus.common.Internal
 public final class InternalUtils {
   private InternalUtils() {}
 
+  /**
+   * Internal tag accessor.
+   *
+   * @since 0.8
+   */
   public static Iterator<Tag> getTags(TagContext tags) {
     return tags.getIterator();
   }

--- a/api/src/main/java/io/opencensus/tags/Tag.java
+++ b/api/src/main/java/io/opencensus/tags/Tag.java
@@ -19,7 +19,11 @@ package io.opencensus.tags;
 import com.google.auto.value.AutoValue;
 import javax.annotation.concurrent.Immutable;
 
-/** {@link TagKey} paired with a {@link TagValue}. */
+/**
+ * {@link TagKey} paired with a {@link TagValue}.
+ *
+ * @since 0.8
+ */
 @Immutable
 @AutoValue
 // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -35,6 +39,7 @@ public abstract class Tag {
    * @param key the tag key.
    * @param value the tag value.
    * @return a {@code Tag} with the given key and value.
+   * @since 0.8
    */
   public static Tag create(TagKey key, TagValue value) {
     return new AutoValue_Tag(key, value);
@@ -44,6 +49,7 @@ public abstract class Tag {
    * Returns the tag's key.
    *
    * @return the tag's key.
+   * @since 0.8
    */
   public abstract TagKey getKey();
 
@@ -51,6 +57,7 @@ public abstract class Tag {
    * Returns the tag's value.
    *
    * @return the tag's value.
+   * @since 0.8
    */
   public abstract TagValue getValue();
 }

--- a/api/src/main/java/io/opencensus/tags/TagContext.java
+++ b/api/src/main/java/io/opencensus/tags/TagContext.java
@@ -30,6 +30,8 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>For example, {@code TagContext}s can be used to label stats, log messages, or debugging
  * information.
+ *
+ * @since 0.8
  */
 @Immutable
 public abstract class TagContext {
@@ -38,6 +40,7 @@ public abstract class TagContext {
    * Returns an iterator over the tags in this {@code TagContext}.
    *
    * @return an iterator over the tags in this {@code TagContext}.
+   * @since 0.8
    */
   // This method is protected to prevent client code from accessing the tags of any TagContext. We
   // don't currently support efficient access to tags. However, every TagContext subclass needs to

--- a/api/src/main/java/io/opencensus/tags/TagContextBuilder.java
+++ b/api/src/main/java/io/opencensus/tags/TagContextBuilder.java
@@ -18,7 +18,11 @@ package io.opencensus.tags;
 
 import io.opencensus.common.Scope;
 
-/** Builder for the {@link TagContext} class. */
+/**
+ * Builder for the {@link TagContext} class.
+ *
+ * @since 0.8
+ */
 public abstract class TagContextBuilder {
 
   /**
@@ -27,6 +31,7 @@ public abstract class TagContextBuilder {
    * @param key the {@code TagKey} which will be set.
    * @param value the {@code TagValue} to set for the given key.
    * @return this
+   * @since 0.8
    */
   public abstract TagContextBuilder put(TagKey key, TagValue value);
 
@@ -35,6 +40,7 @@ public abstract class TagContextBuilder {
    *
    * @param key the {@code TagKey} which will be removed.
    * @return this
+   * @since 0.8
    */
   public abstract TagContextBuilder remove(TagKey key);
 
@@ -42,6 +48,7 @@ public abstract class TagContextBuilder {
    * Creates a {@code TagContext} from this builder.
    *
    * @return a {@code TagContext} with the same tags as this builder.
+   * @since 0.8
    */
   public abstract TagContext build();
 
@@ -52,6 +59,7 @@ public abstract class TagContextBuilder {
    *
    * @return an object that defines a scope where the {@code TagContext} created from this builder
    *     is set to the current context.
+   * @since 0.8
    */
   public abstract Scope buildScoped();
 }

--- a/api/src/main/java/io/opencensus/tags/TagKey.java
+++ b/api/src/main/java/io/opencensus/tags/TagKey.java
@@ -30,6 +30,8 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>{@code TagKey}s are designed to be used as constants. Declaring each key as a constant
  * prevents key names from being validated multiple times.
+ *
+ * @since 0.8
  */
 @Immutable
 @AutoValue
@@ -37,7 +39,11 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue.CopyAnnotations
 @SuppressWarnings("nullness")
 public abstract class TagKey {
-  /** The maximum length for a tag key name. The value is {@value #MAX_LENGTH}. */
+  /**
+   * The maximum length for a tag key name. The value is {@value #MAX_LENGTH}.
+   *
+   * @since 0.8
+   */
   public static final int MAX_LENGTH = 255;
 
   TagKey() {}
@@ -55,6 +61,7 @@ public abstract class TagKey {
    * @param name the name of the key.
    * @return a {@code TagKey} with the given name.
    * @throws IllegalArgumentException if the name is not valid.
+   * @since 0.8
    */
   public static TagKey create(String name) {
     checkArgument(isValid(name));
@@ -65,6 +72,7 @@ public abstract class TagKey {
    * Returns the name of the key.
    *
    * @return the name of the key.
+   * @since 0.8
    */
   public abstract String getName();
 

--- a/api/src/main/java/io/opencensus/tags/TagValue.java
+++ b/api/src/main/java/io/opencensus/tags/TagValue.java
@@ -26,6 +26,8 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>Validation ensures that the {@code String} has a maximum length of {@link #MAX_LENGTH} and
  * contains only printable ASCII characters.
+ *
+ * @since 0.8
  */
 @Immutable
 @AutoValue
@@ -33,7 +35,11 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue.CopyAnnotations
 @SuppressWarnings("nullness")
 public abstract class TagValue {
-  /** The maximum length for a tag value. The value is {@value #MAX_LENGTH}. */
+  /**
+   * The maximum length for a tag value. The value is {@value #MAX_LENGTH}.
+   *
+   * @since 0.8
+   */
   public static final int MAX_LENGTH = 255;
 
   TagValue() {}
@@ -49,6 +55,7 @@ public abstract class TagValue {
    *
    * @param value the tag value.
    * @throws IllegalArgumentException if the {@code String} is not valid.
+   * @since 0.8
    */
   public static TagValue create(String value) {
     Preconditions.checkArgument(isValid(value));
@@ -59,6 +66,7 @@ public abstract class TagValue {
    * Returns the tag value as a {@code String}.
    *
    * @return the tag value as a {@code String}.
+   * @since 0.8
    */
   public abstract String asString();
 

--- a/api/src/main/java/io/opencensus/tags/Tagger.java
+++ b/api/src/main/java/io/opencensus/tags/Tagger.java
@@ -27,6 +27,8 @@ import io.opencensus.common.Scope;
  * <p>Implementations may have different constraints and are free to convert tag contexts to their
  * own subtypes. This means callers cannot assume the {@link #getCurrentTagContext() current
  * context} is the same instance as the one {@link #withTagContext(TagContext) placed into scope}.
+ *
+ * @since 0.8
  */
 public abstract class Tagger {
 
@@ -34,6 +36,7 @@ public abstract class Tagger {
    * Returns an empty {@code TagContext}.
    *
    * @return an empty {@code TagContext}.
+   * @since 0.8
    */
   public abstract TagContext empty();
 
@@ -41,6 +44,7 @@ public abstract class Tagger {
    * Returns the current {@code TagContext}.
    *
    * @return the current {@code TagContext}.
+   * @since 0.8
    */
   public abstract TagContext getCurrentTagContext();
 
@@ -48,6 +52,7 @@ public abstract class Tagger {
    * Returns a new empty {@code Builder}.
    *
    * @return a new empty {@code Builder}.
+   * @since 0.8
    */
   public abstract TagContextBuilder emptyBuilder();
 
@@ -55,6 +60,7 @@ public abstract class Tagger {
    * Returns a builder based on this {@code TagContext}.
    *
    * @return a builder based on this {@code TagContext}.
+   * @since 0.8
    */
   public abstract TagContextBuilder toBuilder(TagContext tags);
 
@@ -62,6 +68,7 @@ public abstract class Tagger {
    * Returns a new builder created from the current {@code TagContext}.
    *
    * @return a new builder created from the current {@code TagContext}.
+   * @since 0.8
    */
   public abstract TagContextBuilder currentBuilder();
 
@@ -73,6 +80,7 @@ public abstract class Tagger {
    * @param tags the {@code TagContext} to be set to the current context.
    * @return an object that defines a scope where the given {@code TagContext} is set to the current
    *     context.
+   * @since 0.8
    */
   public abstract Scope withTagContext(TagContext tags);
 }

--- a/api/src/main/java/io/opencensus/tags/TaggingState.java
+++ b/api/src/main/java/io/opencensus/tags/TaggingState.java
@@ -16,7 +16,11 @@
 
 package io.opencensus.tags;
 
-/** State of the {@link TagsComponent}. */
+/**
+ * State of the {@link TagsComponent}.
+ *
+ * @since 0.8
+ */
 public enum TaggingState {
   // TODO(sebright): Should we add a state that propagates the tags, but doesn't allow
   // modifications?
@@ -26,6 +30,8 @@ public enum TaggingState {
    *
    * <p>The {@link TagsComponent} can add tags to {@link TagContext}s, propagate {@code TagContext}s
    * in the current context, and serialize {@code TagContext}s.
+   *
+   * @since 0.8
    */
   ENABLED,
 
@@ -34,6 +40,8 @@ public enum TaggingState {
    *
    * <p>The {@link TagsComponent} may not add tags to {@link TagContext}s, propagate {@code
    * TagContext}s in the current context, or serialize {@code TagContext}s.
+   *
+   * @since 0.8
    */
   // TODO(sebright): Document how this interacts with stats collection.
   DISABLED

--- a/api/src/main/java/io/opencensus/tags/Tags.java
+++ b/api/src/main/java/io/opencensus/tags/Tags.java
@@ -23,7 +23,11 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
-/** Class for accessing the default {@link TagsComponent}. */
+/**
+ * Class for accessing the default {@link TagsComponent}.
+ *
+ * @since 0.8
+ */
 public final class Tags {
   private static final Logger logger = Logger.getLogger(Tags.class.getName());
 
@@ -36,6 +40,7 @@ public final class Tags {
    * Returns the default {@code Tagger}.
    *
    * @return the default {@code Tagger}.
+   * @since 0.8
    */
   public static Tagger getTagger() {
     return tagsComponent.getTagger();
@@ -45,6 +50,7 @@ public final class Tags {
    * Returns the default {@code TagPropagationComponent}.
    *
    * @return the default {@code TagPropagationComponent}.
+   * @since 0.8
    */
   public static TagPropagationComponent getTagPropagationComponent() {
     return tagsComponent.getTagPropagationComponent();
@@ -60,6 +66,7 @@ public final class Tags {
    * throw an {@code IllegalStateException}.
    *
    * @return the current {@code TaggingState}.
+   * @since 0.8
    */
   public static TaggingState getState() {
     return tagsComponent.getState();
@@ -76,6 +83,7 @@ public final class Tags {
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
    *     initialization. This method throws {@link IllegalStateException} after {@link #getState()}
    *     has been called, in order to limit changes to the result of {@code getState()}.
+   * @since 0.8
    */
   @Deprecated
   public static void setState(TaggingState state) {

--- a/api/src/main/java/io/opencensus/tags/TagsComponent.java
+++ b/api/src/main/java/io/opencensus/tags/TagsComponent.java
@@ -22,13 +22,23 @@ import io.opencensus.tags.propagation.TagPropagationComponent;
  * Class that holds the implementation for {@link Tagger} and {@link TagPropagationComponent}.
  *
  * <p>All objects returned by methods on {@code TagsComponent} are cacheable.
+ *
+ * @since 0.8
  */
 public abstract class TagsComponent {
 
-  /** Returns the {@link Tagger} for this implementation. */
+  /**
+   * Returns the {@link Tagger} for this implementation.
+   *
+   * @since 0.8
+   */
   public abstract Tagger getTagger();
 
-  /** Returns the {@link TagPropagationComponent} for this implementation. */
+  /**
+   * Returns the {@link TagPropagationComponent} for this implementation.
+   *
+   * @since 0.8
+   */
   public abstract TagPropagationComponent getTagPropagationComponent();
 
   /**
@@ -41,6 +51,7 @@ public abstract class TagsComponent {
    * throw an {@code IllegalStateException}.
    *
    * @return the current {@code TaggingState}.
+   * @since 0.8
    */
   public abstract TaggingState getState();
 
@@ -55,6 +66,7 @@ public abstract class TagsComponent {
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
    *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
    *     has been called, in order to limit changes to the result of {@code getState()}.
+   * @since 0.8
    */
   @Deprecated
   public abstract void setState(TaggingState state);

--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextBinarySerializer.java
@@ -24,6 +24,8 @@ import io.opencensus.tags.TagContext;
  * <p>See <a
  * href="https://github.com/census-instrumentation/opencensus-specs/blob/master/encodings/BinaryEncoding.md#tag-context">opencensus-specs</a>
  * for the specification of the cross-language binary serialization format.
+ *
+ * @since 0.8
  */
 public abstract class TagContextBinarySerializer {
 
@@ -36,6 +38,7 @@ public abstract class TagContextBinarySerializer {
    * @return the on-the-wire representation of a {@code TagContext}.
    * @throws TagContextSerializationException if the result would be larger than the maximum allowed
    *     serialized size.
+   * @since 0.8
    */
   public abstract byte[] toByteArray(TagContext tags) throws TagContextSerializationException;
 
@@ -48,6 +51,7 @@ public abstract class TagContextBinarySerializer {
    * @return a {@code TagContext} deserialized from {@code bytes}.
    * @throws TagContextDeserializationException if there is a parse error, the input contains
    *     invalid tags, or the input is larger than the maximum allowed serialized size.
+   * @since 0.8
    */
   public abstract TagContext fromByteArray(byte[] bytes) throws TagContextDeserializationException;
 }

--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextDeserializationException.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextDeserializationException.java
@@ -18,7 +18,11 @@ package io.opencensus.tags.propagation;
 
 import io.opencensus.tags.TagContext;
 
-/** Exception thrown when a {@link TagContext} cannot be parsed. */
+/**
+ * Exception thrown when a {@link TagContext} cannot be parsed.
+ *
+ * @since 0.8
+ */
 public final class TagContextDeserializationException extends Exception {
   private static final long serialVersionUID = 0L;
 
@@ -26,6 +30,7 @@ public final class TagContextDeserializationException extends Exception {
    * Constructs a new {@code TagContextParseException} with the given message.
    *
    * @param message a message describing the error.
+   * @since 0.8
    */
   public TagContextDeserializationException(String message) {
     super(message);
@@ -36,6 +41,7 @@ public final class TagContextDeserializationException extends Exception {
    *
    * @param message a message describing the error.
    * @param cause the cause of the error.
+   * @since 0.8
    */
   public TagContextDeserializationException(String message, Throwable cause) {
     super(message, cause);

--- a/api/src/main/java/io/opencensus/tags/propagation/TagContextSerializationException.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagContextSerializationException.java
@@ -18,7 +18,11 @@ package io.opencensus.tags.propagation;
 
 import io.opencensus.tags.TagContext;
 
-/** Exception thrown when a {@link TagContext} cannot be serialized. */
+/**
+ * Exception thrown when a {@link TagContext} cannot be serialized.
+ *
+ * @since 0.8
+ */
 public final class TagContextSerializationException extends Exception {
   private static final long serialVersionUID = 0L;
 
@@ -26,6 +30,7 @@ public final class TagContextSerializationException extends Exception {
    * Constructs a new {@code TagContextSerializationException} with the given message.
    *
    * @param message a message describing the error.
+   * @since 0.8
    */
   public TagContextSerializationException(String message) {
     super(message);
@@ -36,6 +41,7 @@ public final class TagContextSerializationException extends Exception {
    *
    * @param message a message describing the error.
    * @param cause the cause of the error.
+   * @since 0.8
    */
   public TagContextSerializationException(String message, Throwable cause) {
     super(message, cause);

--- a/api/src/main/java/io/opencensus/tags/propagation/TagPropagationComponent.java
+++ b/api/src/main/java/io/opencensus/tags/propagation/TagPropagationComponent.java
@@ -18,7 +18,11 @@ package io.opencensus.tags.propagation;
 
 import io.opencensus.tags.TagContext;
 
-/** Object containing all supported {@link TagContext} propagation formats. */
+/**
+ * Object containing all supported {@link TagContext} propagation formats.
+ *
+ * @since 0.8
+ */
 // TODO(sebright): Add an HTTP serializer.
 public abstract class TagPropagationComponent {
 
@@ -26,6 +30,7 @@ public abstract class TagPropagationComponent {
    * Returns the {@link TagContextBinarySerializer} for this implementation.
    *
    * @return the {@code TagContextBinarySerializer} for this implementation.
+   * @since 0.8
    */
   public abstract TagContextBinarySerializer getBinarySerializer();
 }

--- a/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
@@ -28,6 +28,8 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>Most code should interact with the current context via the public APIs in {@link
  * io.opencensus.tags.TagContext} and avoid accessing {@link #TAG_CONTEXT_KEY} directly.
+ *
+ * @since 0.8
  */
 public final class ContextUtils {
   private static final TagContext EMPTY_TAG_CONTEXT = new EmptyTagContext();
@@ -37,6 +39,8 @@ public final class ContextUtils {
   /**
    * The {@link io.grpc.Context.Key} used to interact with the {@code TagContext} contained in the
    * {@link io.grpc.Context}.
+   *
+   * @since 0.8
    */
   public static final Context.Key<TagContext> TAG_CONTEXT_KEY =
       Context.keyWithDefault("opencensus-tag-context-key", EMPTY_TAG_CONTEXT);


### PR DESCRIPTION
The only APIs that were missing `@since` tags were from the first stats/tagging API release.