### PR TITLE
Fix broken command in examples readme.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -21,7 +21,7 @@ $ bazel build :all
 
 ### Gradle
 ```
-$ ./build/install/examples/bin/StatsRunner
+$ ./build/install/opencensus-examples/bin/StatsRunner
 ```
 
 ### Maven
@@ -38,7 +38,7 @@ $ ./bazel-bin/StatsRunner
 
 ### Gradle
 ```
-$ ./build/install/examples/bin/ZPagesTester
+$ ./build/install/opencensus-examples/bin/ZPagesTester
 ```
 
 ### Maven


### PR DESCRIPTION
In this [PR](https://github.com/census-instrumentation/opencensus-java/commit/c0be5b44ec9d787e0834dc418381f0a5b87fca85#diff-61bed45ac875f146b81f38ad4f26140c) we changed the name of the project and the generated path in the command should be updated accordingly.