### PR TITLE
Increase batch export size of StackdriverStatsExporter to 200

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
@@ -60,7 +60,8 @@ final class StackdriverExporterWorker implements Runnable {
 
   private static final Logger logger = Logger.getLogger(StackdriverExporterWorker.class.getName());
 
-  @VisibleForTesting static final int MAX_BATCH_EXPORT_SIZE = 3;
+  // Stackdriver Monitoring v3 only accepts up to 200 TimeSeries per CreateTimeSeries call.
+  @VisibleForTesting static final int MAX_BATCH_EXPORT_SIZE = 200;
 
   private final long scheduleDelayMillis;
   private final String projectId;
@@ -173,7 +174,6 @@ final class StackdriverExporterWorker implements Runnable {
       Span span = tracer.getCurrentSpan();
       span.addAnnotation("Export Stackdriver TimeSeries.");
       try (Scope scope = tracer.withSpan(span)) {
-        // Batch export 3 TimeSeries at one call, to avoid exceeding RPC header size limit.
         CreateTimeSeriesRequest request =
             CreateTimeSeriesRequest.newBuilder()
                 .setName(projectName.toString())

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
@@ -110,7 +110,7 @@ public class StackdriverExporterWorkerTest {
 
   @Test
   public void testConstants() {
-    assertThat(StackdriverExporterWorker.MAX_BATCH_EXPORT_SIZE).isEqualTo(3);
+    assertThat(StackdriverExporterWorker.MAX_BATCH_EXPORT_SIZE).isEqualTo(200);
   }
 
   @Test


### PR DESCRIPTION
Previously we found an issue that if we batch too many `TimeSeries` in one call, Stackdriver metric service client might throw a `Http2Exception: Header size exceeded max allowed size (10240)` (https://github.com/census-instrumentation/opencensus-java/issues/840). I posted https://github.com/census-instrumentation/opencensus-java/pull/836 to fix this, which limit the batch size to 3. After running some E2E tests recently, I think this issue in Stackdriver client has been fixed, and it's safe to remove the batch limit.

Update the batch limit to 200, which is the maximum size allowed by Stackdriver client v3 (https://github.com/census-instrumentation/opencensus-go/issues/170).

/cc @jcd2