### PR TITLE
Add a configuration class to help to create StackdriverTraceExporter. (closes #949)

### DIFF
--- a/exporters/trace/stackdriver/build.gradle
+++ b/exporters/trace/stackdriver/build.gradle
@@ -6,6 +6,8 @@ description = 'OpenCensus Trace Stackdriver Exporter'
 }
 
 dependencies {
+    compileOnly libraries.auto_value
+
     compile project(':opencensus-api'),
             libraries.google_auth
 

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverExporter.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverExporter.java
@@ -54,7 +54,11 @@ public final class StackdriverExporter {
    */
   public static void createAndRegisterWithCredentialsAndProjectId(
       Credentials credentials, String projectId) throws IOException {
-    StackdriverTraceExporter.createAndRegisterWithCredentialsAndProjectId(credentials, projectId);
+    StackdriverTraceExporter.createAndRegister(
+        StackdriverTraceConfiguration.builder()
+            .setCredentials(credentials)
+            .setProjectId(projectId)
+            .build());
   }
 
   /**
@@ -76,7 +80,11 @@ public final class StackdriverExporter {
    * @since 0.6
    */
   public static void createAndRegisterWithProjectId(String projectId) throws IOException {
-    StackdriverTraceExporter.createAndRegisterWithProjectId(projectId);
+    StackdriverTraceExporter.createAndRegister(
+        StackdriverTraceConfiguration.builder()
+            .setCredentials(GoogleCredentials.getApplicationDefault())
+            .setProjectId(projectId)
+            .build());
   }
 
   /**
@@ -98,7 +106,11 @@ public final class StackdriverExporter {
    * @since 0.6
    */
   public static void createAndRegister() throws IOException {
-    StackdriverTraceExporter.createAndRegister();
+    StackdriverTraceExporter.createAndRegister(
+        StackdriverTraceConfiguration.builder()
+            .setCredentials(GoogleCredentials.getApplicationDefault())
+            .setProjectId(ServiceOptions.getDefaultProjectId())
+            .build());
   }
 
   /**

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfiguration.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfiguration.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.stackdriver;
+
+import com.google.auth.Credentials;
+import com.google.auto.value.AutoValue;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Configurations for {@link StackdriverTraceExporter}.
+ *
+ * @since 0.12
+ */
+@AutoValue
+@Immutable
+// Suppress Checker Framework warning about missing @Nullable in generated equals method.
+@AutoValue.CopyAnnotations
+@SuppressWarnings("nullness")
+public abstract class StackdriverTraceConfiguration {
+
+  StackdriverTraceConfiguration() {}
+
+  /**
+   * Returns the {@link Credentials}.
+   *
+   * @return the {@code Credentials}.
+   * @since 0.12
+   */
+  @Nullable
+  public abstract Credentials getCredentials();
+
+  /**
+   * Returns the cloud project id.
+   *
+   * @return the cloud project id.
+   * @since 0.12
+   */
+  @Nullable
+  public abstract String getProjectId();
+
+  /**
+   * Returns a new {@link Builder}.
+   *
+   * @return a {@code Builder}.
+   * @since 0.12
+   */
+  public static Builder builder() {
+    return new AutoValue_StackdriverTraceConfiguration.Builder();
+  }
+
+  /**
+   * Builder for {@link StackdriverTraceConfiguration}.
+   *
+   * @since 0.12
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    Builder() {}
+
+    /**
+     * Sets the {@link Credentials} used to authenticate API calls.
+     *
+     * @param credentials the {@code Credentials}.
+     * @return this.
+     * @since 0.12
+     */
+    public abstract Builder setCredentials(Credentials credentials);
+
+    /**
+     * Sets the cloud project id.
+     *
+     * @param projectId the cloud project id.
+     * @return this.
+     * @since 0.12
+     */
+    public abstract Builder setProjectId(String projectId);
+
+    /**
+     * Builds a {@link StackdriverTraceConfiguration}.
+     *
+     * @return a {@code StackdriverTraceConfiguration}.
+     * @since 0.12
+     */
+    public abstract StackdriverTraceConfiguration build();
+  }
+}

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceExporter.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceExporter.java
@@ -22,7 +22,6 @@ import com.google.auth.Credentials;
 import com.google.auth.oauth2.GoogleCredentials;
 import com.google.cloud.ServiceOptions;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.MoreObjects;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.export.SpanExporter;
 import io.opencensus.trace.export.SpanExporter.Handler;
@@ -75,13 +74,12 @@ public final class StackdriverTraceExporter {
       throws IOException {
     synchronized (monitor) {
       checkState(handler == null, "Stackdriver exporter is already registered.");
-      Credentials credentials =
-          MoreObjects.<Credentials>firstNonNull(
-              configuration.getCredentials(), GoogleCredentials.getApplicationDefault());
-      String projectId =
-          MoreObjects.<String>firstNonNull(
-              configuration.getProjectId(), ServiceOptions.getDefaultProjectId());
-      registerInternal(StackdriverV2ExporterHandler.createWithCredentials(credentials, projectId));
+      Credentials credentials = configuration.getCredentials();
+      String projectId = configuration.getProjectId();
+      registerInternal(
+          StackdriverV2ExporterHandler.createWithCredentials(
+              credentials != null ? credentials : GoogleCredentials.getApplicationDefault(),
+              projectId != null ? projectId : ServiceOptions.getDefaultProjectId()));
     }
   }
 

--- a/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfigurationTest.java
+++ b/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfigurationTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.stackdriver;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.auth.Credentials;
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.util.Date;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link StackdriverTraceConfiguration}. */
+@RunWith(JUnit4.class)
+public class StackdriverTraceConfigurationTest {
+
+  private static final Credentials FAKE_CREDENTIALS =
+      GoogleCredentials.newBuilder().setAccessToken(new AccessToken("fake", new Date(100))).build();
+  private static final String PROJECT_ID = "project";
+
+  @Test
+  public void defaultConfiguration() {
+    StackdriverTraceConfiguration configuration = StackdriverTraceConfiguration.builder().build();
+    assertThat(configuration.getCredentials()).isNull();
+    assertThat(configuration.getProjectId()).isNull();
+  }
+
+  @Test
+  public void updateAll() {
+    StackdriverTraceConfiguration configuration =
+        StackdriverTraceConfiguration.builder()
+            .setCredentials(FAKE_CREDENTIALS)
+            .setProjectId(PROJECT_ID)
+            .build();
+    assertThat(configuration.getCredentials()).isEqualTo(FAKE_CREDENTIALS);
+    assertThat(configuration.getProjectId()).isEqualTo(PROJECT_ID);
+  }
+}


### PR DESCRIPTION
Similar to [StackdriverStatsConfiguration](https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java).

Since we've just deprecated `StackdriverExporter` and rename it to `StackdriverTraceExporter` and it is not yet released, I simply removed those factory methods in the new class instead of deprecating them again.