### PR TITLE
Add cumulative views for started and finished RPCs.

### DIFF
--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -44,6 +44,7 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_STATUS;
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Duration;
 import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.BucketBoundaries;
@@ -101,6 +102,7 @@ public final class RpcViewConstants {
 
   // Use Aggregation.Mean to record sum and count stats at the same time.
   @VisibleForTesting static final Aggregation MEAN = Mean.create();
+  @VisibleForTesting static final Aggregation COUNT = Count.create();
 
   @VisibleForTesting
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
@@ -258,7 +260,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/started_count/cumulative"),
           "Number of started client RPCs",
           RPC_CLIENT_STARTED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           CUMULATIVE);
 
@@ -272,7 +274,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/finished_count/cumulative"),
           "Number of finished client RPCs",
           RPC_CLIENT_FINISHED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           CUMULATIVE);
 
@@ -414,7 +416,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/started_count/cumulative"),
           "Number of started server RPCs",
           RPC_SERVER_STARTED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           CUMULATIVE);
 
@@ -428,7 +430,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/finished_count/cumulative"),
           "Number of finished server RPCs",
           RPC_SERVER_FINISHED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           CUMULATIVE);
 
@@ -544,7 +546,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/started_count/minute"),
           "Minute stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           INTERVAL_MINUTE);
 
@@ -558,7 +560,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/finished_count/minute"),
           "Minute stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           INTERVAL_MINUTE);
 
@@ -698,7 +700,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/started_count/hour"),
           "Hour stats on the number of client RPCs started",
           RPC_CLIENT_STARTED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           INTERVAL_HOUR);
 
@@ -712,7 +714,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/finished_count/hour"),
           "Hour stats on the number of client RPCs finished",
           RPC_CLIENT_FINISHED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           INTERVAL_HOUR);
 
@@ -854,7 +856,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/started_count/minute"),
           "Minute stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           INTERVAL_MINUTE);
 
@@ -868,7 +870,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/finished_count/minute"),
           "Minute stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           INTERVAL_MINUTE);
 
@@ -1008,7 +1010,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/started_count/hour"),
           "Hour stats on the number of server RPCs started",
           RPC_SERVER_STARTED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           INTERVAL_HOUR);
 
@@ -1022,7 +1024,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/finished_count/hour"),
           "Hour stats on the number of server RPCs finished",
           RPC_SERVER_FINISHED_COUNT,
-          MEAN,
+          COUNT,
           Arrays.asList(RPC_METHOD),
           INTERVAL_HOUR);
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -248,6 +248,34 @@ public final class RpcViewConstants {
           Arrays.asList(RPC_METHOD),
           CUMULATIVE);
 
+  /**
+   * Cumulative {@link View} for started client RPCs.
+   *
+   * @since 0.12
+   */
+  public static final View RPC_CLIENT_STARTED_COUNT_CUMULATIVE_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/started_count/cumulative"),
+          "Number of started client RPCs",
+          RPC_CLIENT_STARTED_COUNT,
+          MEAN,
+          Arrays.asList(RPC_METHOD),
+          CUMULATIVE);
+
+  /**
+   * Cumulative {@link View} for finished client RPCs.
+   *
+   * @since 0.12
+   */
+  public static final View RPC_CLIENT_FINISHED_COUNT_CUMULATIVE_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/finished_count/cumulative"),
+          "Number of finished client RPCs",
+          RPC_CLIENT_FINISHED_COUNT,
+          MEAN,
+          Arrays.asList(RPC_METHOD),
+          CUMULATIVE);
+
   // Rpc server cumulative views.
 
   /**
@@ -373,6 +401,34 @@ public final class RpcViewConstants {
           "Count of response messages per server RPC",
           RPC_SERVER_RESPONSE_COUNT,
           AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(RPC_METHOD),
+          CUMULATIVE);
+
+  /**
+   * Cumulative {@link View} for started server RPCs.
+   *
+   * @since 0.12
+   */
+  public static final View RPC_SERVER_STARTED_COUNT_CUMULATIVE_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/started_count/cumulative"),
+          "Number of started server RPCs",
+          RPC_SERVER_STARTED_COUNT,
+          MEAN,
+          Arrays.asList(RPC_METHOD),
+          CUMULATIVE);
+
+  /**
+   * Cumulative {@link View} for finished server RPCs.
+   *
+   * @since 0.12
+   */
+  public static final View RPC_SERVER_FINISHED_COUNT_CUMULATIVE_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/finished_count/cumulative"),
+          "Number of finished server RPCs",
+          RPC_SERVER_FINISHED_COUNT,
+          MEAN,
           Arrays.asList(RPC_METHOD),
           CUMULATIVE);
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -40,6 +40,8 @@ public final class RpcViews {
           RpcViewConstants.RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW,
           RpcViewConstants.RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW,
           RpcViewConstants.RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW,
+          RpcViewConstants.RPC_CLIENT_STARTED_COUNT_CUMULATIVE_VIEW,
+          RpcViewConstants.RPC_CLIENT_FINISHED_COUNT_CUMULATIVE_VIEW,
           RpcViewConstants.RPC_SERVER_ERROR_COUNT_VIEW,
           RpcViewConstants.RPC_SERVER_SERVER_LATENCY_VIEW,
           RpcViewConstants.RPC_SERVER_SERVER_ELAPSED_TIME_VIEW,
@@ -48,7 +50,9 @@ public final class RpcViews {
           RpcViewConstants.RPC_SERVER_REQUEST_COUNT_VIEW,
           RpcViewConstants.RPC_SERVER_RESPONSE_COUNT_VIEW,
           RpcViewConstants.RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW,
-          RpcViewConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW);
+          RpcViewConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW,
+          RpcViewConstants.RPC_SERVER_STARTED_COUNT_CUMULATIVE_VIEW,
+          RpcViewConstants.RPC_SERVER_FINISHED_COUNT_CUMULATIVE_VIEW);
 
   @VisibleForTesting
   static final ImmutableSet<View> RPC_INTERVAL_VIEWS_SET =

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -19,6 +19,7 @@ package io.opencensus.contrib.grpc.metrics;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Duration;
+import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.BucketBoundaries;
@@ -67,6 +68,7 @@ public final class RpcViewConstantsTest {
 
     // Test Aggregations
     assertThat(RpcViewConstants.MEAN).isEqualTo(Mean.create());
+    assertThat(RpcViewConstants.COUNT).isEqualTo(Count.create());
     assertThat(RpcViewConstants.AGGREGATION_WITH_BYTES_HISTOGRAM)
         .isEqualTo(
             Distribution.create(


### PR DESCRIPTION
Since we're going to remove `Interval` window in the future, we'll need cumulative views for started and finished RPCs (currently there are only minute and hour views for them, which are to be removed). 