### PR TITLE
Update READMEs to include Prometheus exporter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ runtime 'io.opencensus:opencensus-impl:0.11.1'
 #### Stats exporters
 * [Stackdriver][StatsExporterStackdriver]
 * [SignalFx][StatsExporterSignalFx]
+* [Prometheus][StatsExporterPrometheus]
 
 ### How to setup debugging Z-Pages?
 
@@ -137,3 +138,4 @@ see this [link](https://github.com/census-instrumentation/opencensus-java/tree/m
 [TraceExporterZipkin]: https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/trace/zipkin#quickstart
 [StatsExporterStackdriver]: https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/stackdriver#quickstart
 [StatsExporterSignalFx]: https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/signalfx#quickstart
+[StatsExporterPrometheus]: https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/prometheus#quickstart

--- a/exporters/stats/prometheus/README.md
+++ b/exporters/stats/prometheus/README.md
@@ -15,11 +15,34 @@ instructions [here](https://prometheus.io/docs/introduction/first_steps/).
 
 #### Add the dependencies to your project
 
-TODO
-
 For Maven add to your `pom.xml`:
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-api</artifactId>
+    <version>0.12.0</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-exporter-stats-prometheus</artifactId>
+    <version>0.12.0</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-impl</artifactId>
+    <version>0.12.0</version>
+    <scope>runtime</scope>
+  </dependency>
+</dependencies>
+```
 
 For Gradle add to your dependencies:
+```groovy
+compile 'io.opencensus:opencensus-api:0.12.0'
+compile 'io.opencensus:opencensus-exporter-stats-prometheus:0.12.0'
+runtime 'io.opencensus:opencensus-impl:0.12.0'
+```
 
 #### Register the exporter
  


### PR DESCRIPTION
Closes https://github.com/census-instrumentation/opencensus-java/issues/966.

This PR should be merged after Prometheus exporter is released.