### PR TITLE
Deprecate Window and WindowData.

### DIFF
--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -23,14 +23,9 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
-import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
-import io.opencensus.stats.View.AggregationWindow;
-import io.opencensus.stats.ViewData.AggregationWindowData;
-import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
-import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagValue;
 import java.util.Collection;
@@ -186,13 +181,8 @@ final class NoopStats {
           return ViewData.create(
               view,
               Collections.<List<TagValue>, AggregationData>emptyMap(),
-              view.getWindow()
-                  .match(
-                      Functions.<AggregationWindowData>returnConstant(
-                          CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP)),
-                      Functions.<AggregationWindowData>returnConstant(
-                          IntervalData.create(ZERO_TIMESTAMP)),
-                      Functions.<AggregationWindowData>throwAssertionError()));
+              ZERO_TIMESTAMP,
+              ZERO_TIMESTAMP);
         }
       }
     }
@@ -209,12 +199,14 @@ final class NoopStats {
     }
 
     // Returns the subset of the given views that should be exported
+    @SuppressWarnings("deprecation")
     private static Set<View> filterExportedViews(Collection<View> allViews) {
       Set<View> views = Sets.newHashSet();
       for (View view : allViews) {
-        if (view.getWindow() instanceof AggregationWindow.Cumulative) {
-          views.add(view);
+        if (view.getWindow() instanceof View.AggregationWindow.Interval) {
+          continue;
         }
+        views.add(view);
       }
       return Collections.unmodifiableSet(views);
     }

--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -23,6 +23,7 @@ import static com.google.common.base.Preconditions.checkState;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
@@ -171,6 +172,7 @@ final class NoopStats {
 
     @Override
     @Nullable
+    @SuppressWarnings("deprecation")
     public ViewData getView(View.Name name) {
       checkNotNull(name, "name");
       synchronized (registeredViews) {
@@ -181,8 +183,14 @@ final class NoopStats {
           return ViewData.create(
               view,
               Collections.<List<TagValue>, AggregationData>emptyMap(),
-              ZERO_TIMESTAMP,
-              ZERO_TIMESTAMP);
+              view.getWindow()
+                  .match(
+                      Functions.<ViewData.AggregationWindowData>returnConstant(
+                          ViewData.AggregationWindowData.CumulativeData.create(
+                              ZERO_TIMESTAMP, ZERO_TIMESTAMP)),
+                      Functions.<ViewData.AggregationWindowData>returnConstant(
+                          ViewData.AggregationWindowData.IntervalData.create(ZERO_TIMESTAMP)),
+                      Functions.<ViewData.AggregationWindowData>throwAssertionError()));
         }
       }
     }

--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -23,7 +23,6 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import io.opencensus.internal.StringUtil;
-import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.tags.TagKey;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -155,7 +154,7 @@ public abstract class View {
         measure,
         aggregation,
         Collections.unmodifiableList(new ArrayList<TagKey>(columns)),
-        Cumulative.create());
+        AggregationWindow.Cumulative.create());
   }
 
   /**

--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -40,7 +41,7 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 // Suppress Checker Framework warning about missing @Nullable in generated equals method.
 @AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
+@SuppressWarnings({"nullness", "deprecation"})
 public abstract class View {
 
   @VisibleForTesting static final int NAME_MAX_LENGTH = 255;
@@ -90,7 +91,10 @@ public abstract class View {
    *
    * @return the time {@link AggregationWindow}.
    * @since 0.8
+   * @deprecated since 0.13
    */
+  @Deprecated
+  @Nullable
   public abstract AggregationWindow getWindow();
 
   /**
@@ -105,7 +109,9 @@ public abstract class View {
    * @param window the {@link AggregationWindow} of view.
    * @return a new {@link View}.
    * @since 0.8
+   * @deprecated since 0.13
    */
+  @Deprecated
   public static View create(
       Name name,
       String description,
@@ -122,6 +128,35 @@ public abstract class View {
         aggregation,
         Collections.unmodifiableList(new ArrayList<TagKey>(columns)),
         window);
+  }
+
+  /**
+   * Constructs a new {@link View}.
+   *
+   * @param name the {@link Name} of view. Must be unique.
+   * @param description the description of view.
+   * @param measure the {@link Measure} to be aggregated by this view.
+   * @param aggregation the basic {@link Aggregation} that this view will support.
+   * @param columns the {@link TagKey}s that this view will aggregate on. Columns should not contain
+   *     duplicates.
+   * @return a new {@link View}.
+   * @since 0.13
+   */
+  public static View create(
+      Name name,
+      String description,
+      Measure measure,
+      Aggregation aggregation,
+      List<TagKey> columns) {
+    checkArgument(new HashSet<TagKey>(columns).size() == columns.size(), "Columns have duplicate.");
+
+    return new AutoValue_View(
+        name,
+        description,
+        measure,
+        aggregation,
+        Collections.unmodifiableList(new ArrayList<TagKey>(columns)),
+        null);
   }
 
   /**
@@ -169,7 +204,9 @@ public abstract class View {
    * The time window for a {@code View}.
    *
    * @since 0.8
+   * @deprecated since 0.13
    */
+  @Deprecated
   @Immutable
   public abstract static class AggregationWindow {
 
@@ -189,7 +226,9 @@ public abstract class View {
      * Cumulative (infinite interval) time {@code AggregationWindow}.
      *
      * @since 0.8
+     * @deprecated since 0.13
      */
+    @Deprecated
     @Immutable
     @AutoValue
     // Suppress Checker Framework warning about missing @Nullable in generated equals method.
@@ -227,7 +266,9 @@ public abstract class View {
      * Interval (finite interval) time {@code AggregationWindow}.
      *
      * @since 0.8
+     * @deprecated since 0.13
      */
+    @Deprecated
     @Immutable
     @AutoValue
     // Suppress Checker Framework warning about missing @Nullable in generated equals method.

--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -23,12 +23,12 @@ import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import io.opencensus.internal.StringUtil;
+import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.tags.TagKey;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -91,10 +91,9 @@ public abstract class View {
    *
    * @return the time {@link AggregationWindow}.
    * @since 0.8
-   * @deprecated since 0.13
+   * @deprecated since 0.13. In the future all {@link View}s will be cumulative.
    */
   @Deprecated
-  @Nullable
   public abstract AggregationWindow getWindow();
 
   /**
@@ -109,7 +108,7 @@ public abstract class View {
    * @param window the {@link AggregationWindow} of view.
    * @return a new {@link View}.
    * @since 0.8
-   * @deprecated since 0.13
+   * @deprecated in favor of {@link #create(Name, String, Measure, Aggregation, List)}.
    */
   @Deprecated
   public static View create(
@@ -156,7 +155,7 @@ public abstract class View {
         measure,
         aggregation,
         Collections.unmodifiableList(new ArrayList<TagKey>(columns)),
-        null);
+        Cumulative.create());
   }
 
   /**
@@ -204,7 +203,7 @@ public abstract class View {
    * The time window for a {@code View}.
    *
    * @since 0.8
-   * @deprecated since 0.13
+   * @deprecated since 0.13. In the future all {@link View}s will be cumulative.
    */
   @Deprecated
   @Immutable
@@ -226,7 +225,7 @@ public abstract class View {
      * Cumulative (infinite interval) time {@code AggregationWindow}.
      *
      * @since 0.8
-     * @deprecated since 0.13
+     * @deprecated since 0.13. In the future all {@link View}s will be cumulative.
      */
     @Deprecated
     @Immutable
@@ -266,7 +265,7 @@ public abstract class View {
      * Interval (finite interval) time {@code AggregationWindow}.
      *
      * @since 0.8
-     * @deprecated since 0.13
+     * @deprecated since 0.13. In the future all {@link View}s will be cumulative.
      */
     @Deprecated
     @Immutable

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -35,7 +35,6 @@ import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
-import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
 import io.opencensus.tags.TagValue;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -182,7 +181,11 @@ public abstract class ViewData {
           entry.getValue());
     }
     return new AutoValue_ViewData(
-        view, Collections.unmodifiableMap(deepCopy), CumulativeData.create(start, end), start, end);
+        view,
+        Collections.unmodifiableMap(deepCopy),
+        AggregationWindowData.CumulativeData.create(start, end),
+        start,
+        end);
   }
 
   private static void checkWindow(

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -35,6 +35,7 @@ import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
 import io.opencensus.tags.TagValue;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -80,15 +81,14 @@ public abstract class ViewData {
   /**
    * Returns the {@link AggregationWindowData} associated with this {@link ViewData}.
    *
-   * <p>Always return null since 0.13.0. {@link AggregationWindowData} is deprecated, please avoid
-   * using this method. Use {@link #getStart()} and {@link #getEnd()} instead.
+   * <p>{@link AggregationWindowData} is deprecated since 0.13, please avoid using this method. Use
+   * {@link #getStart()} and {@link #getEnd()} instead.
    *
-   * @return {@code null}.
+   * @return the {@code AggregationWindowData}.
    * @since 0.8
-   * @deprecated since 0.13
+   * @deprecated in favor of {@link #getStart()} and {@link #getEnd()}.
    */
   @Deprecated
-  @javax.annotation.Nullable
   public abstract AggregationWindowData getWindowData();
 
   /**
@@ -118,7 +118,7 @@ public abstract class ViewData {
    *     AggregationData} don't match, or the types of {@code Window} and {@code WindowData} don't
    *     match.
    * @since 0.8
-   * @deprecated since 0.13
+   * @deprecated in favor of {@link #create(View, Map, Timestamp, Timestamp)}.
    */
   @Deprecated
   public static ViewData create(
@@ -154,7 +154,7 @@ public abstract class ViewData {
                 arg.getEnd());
           }
         },
-        Functions.<ViewData>throwIllegalArgumentException());
+        Functions.<ViewData>throwAssertionError());
   }
 
   /**
@@ -181,7 +181,8 @@ public abstract class ViewData {
           Collections.unmodifiableList(new ArrayList</*@Nullable*/ TagValue>(entry.getKey())),
           entry.getValue());
     }
-    return new AutoValue_ViewData(view, Collections.unmodifiableMap(deepCopy), null, start, end);
+    return new AutoValue_ViewData(
+        view, Collections.unmodifiableMap(deepCopy), CumulativeData.create(start, end), start, end);
   }
 
   private static void checkWindow(
@@ -205,7 +206,7 @@ public abstract class ViewData {
             return null;
           }
         },
-        Functions.</*@Nullable*/ Void>throwIllegalArgumentException());
+        Functions.</*@Nullable*/ Void>throwAssertionError());
   }
 
   private static String createErrorMessageForWindow(
@@ -289,7 +290,7 @@ public abstract class ViewData {
    * The {@code AggregationWindowData} for a {@link ViewData}.
    *
    * @since 0.8
-   * @deprecated since 0.13
+   * @deprecated since 0.13, please use start and end {@link Timestamp} instead.
    */
   @Deprecated
   @Immutable
@@ -311,7 +312,7 @@ public abstract class ViewData {
      * Cumulative {@code AggregationWindowData}.
      *
      * @since 0.8
-     * @deprecated since 0.13
+     * @deprecated since 0.13, please use start and end {@link Timestamp} instead.
      */
     @Deprecated
     @Immutable
@@ -364,7 +365,7 @@ public abstract class ViewData {
      * Interval {@code AggregationWindowData}.
      *
      * @since 0.8
-     * @deprecated since 0.13
+     * @deprecated since 0.13, please use start and end {@link Timestamp} instead.
      */
     @Deprecated
     @Immutable

--- a/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
@@ -19,14 +19,11 @@ package io.opencensus.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Duration;
-import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
 import io.opencensus.stats.View.Name;
-import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
-import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
 import io.opencensus.tags.TagKey;
 import java.util.Arrays;
 import java.util.Set;
@@ -105,8 +102,6 @@ public final class NoopViewManagerTest {
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
-    assertThat(viewData.getWindowData())
-        .isEqualTo(CumulativeData.create(Timestamp.create(0, 0), Timestamp.create(0, 0)));
   }
 
   @Test
@@ -120,7 +115,6 @@ public final class NoopViewManagerTest {
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
-    assertThat(viewData.getWindowData()).isEqualTo(IntervalData.create(Timestamp.create(0, 0)));
   }
 
   @Test
@@ -171,23 +165,13 @@ public final class NoopViewManagerTest {
     ViewManager viewManager = NoopStats.newNoopViewManager();
     View view1 =
         View.create(
-            View.Name.create("View 1"),
-            VIEW_DESCRIPTION,
-            MEASURE,
-            AGGREGATION,
-            Arrays.asList(KEY),
-            CUMULATIVE);
+            View.Name.create("View 1"), VIEW_DESCRIPTION, MEASURE, AGGREGATION, Arrays.asList(KEY));
     viewManager.registerView(view1);
     Set<View> exported = viewManager.getAllExportedViews();
 
     View view2 =
         View.create(
-            View.Name.create("View 2"),
-            VIEW_DESCRIPTION,
-            MEASURE,
-            AGGREGATION,
-            Arrays.asList(KEY),
-            CUMULATIVE);
+            View.Name.create("View 2"), VIEW_DESCRIPTION, MEASURE, AGGREGATION, Arrays.asList(KEY));
     thrown.expect(UnsupportedOperationException.class);
     exported.add(view2);
   }

--- a/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
@@ -19,11 +19,14 @@ package io.opencensus.stats;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.common.Duration;
+import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
 import io.opencensus.stats.View.Name;
+import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
+import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
 import io.opencensus.tags.TagKey;
 import java.util.Arrays;
 import java.util.Set;
@@ -102,6 +105,8 @@ public final class NoopViewManagerTest {
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
+    assertThat(viewData.getWindowData())
+        .isEqualTo(CumulativeData.create(Timestamp.create(0, 0), Timestamp.create(0, 0)));
   }
 
   @Test
@@ -115,6 +120,7 @@ public final class NoopViewManagerTest {
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
+    assertThat(viewData.getWindowData()).isEqualTo(IntervalData.create(Timestamp.create(0, 0)));
   }
 
   @Test

--- a/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
@@ -26,7 +26,6 @@ import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
 import io.opencensus.stats.View.Name;
 import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
-import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
 import io.opencensus.tags.TagKey;
 import java.util.Arrays;
 import java.util.Set;
@@ -105,6 +104,8 @@ public final class NoopViewManagerTest {
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
+    assertThat(viewData.getStart()).isEqualTo(Timestamp.create(0, 0));
+    assertThat(viewData.getEnd()).isEqualTo(Timestamp.create(0, 0));
     assertThat(viewData.getWindowData())
         .isEqualTo(CumulativeData.create(Timestamp.create(0, 0), Timestamp.create(0, 0)));
   }
@@ -120,7 +121,8 @@ public final class NoopViewManagerTest {
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
-    assertThat(viewData.getWindowData()).isEqualTo(IntervalData.create(Timestamp.create(0, 0)));
+    assertThat(viewData.getStart()).isEqualTo(Timestamp.create(0, 0));
+    assertThat(viewData.getEnd()).isEqualTo(Timestamp.create(0, 0));
   }
 
   @Test

--- a/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopViewManagerTest.java
@@ -26,6 +26,7 @@ import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.View.AggregationWindow.Interval;
 import io.opencensus.stats.View.Name;
 import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
+import io.opencensus.stats.ViewData.AggregationWindowData.IntervalData;
 import io.opencensus.tags.TagKey;
 import java.util.Arrays;
 import java.util.Set;
@@ -121,8 +122,7 @@ public final class NoopViewManagerTest {
     ViewData viewData = viewManager.getView(VIEW_NAME);
     assertThat(viewData.getView()).isEqualTo(view);
     assertThat(viewData.getAggregationMap()).isEmpty();
-    assertThat(viewData.getStart()).isEqualTo(Timestamp.create(0, 0));
-    assertThat(viewData.getEnd()).isEqualTo(Timestamp.create(0, 0));
+    assertThat(viewData.getWindowData()).isEqualTo(IntervalData.create(Timestamp.create(0, 0)));
   }
 
   @Test

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -49,9 +49,6 @@ import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.BucketBoundaries;
 import io.opencensus.stats.View;
-import io.opencensus.stats.View.AggregationWindow;
-import io.opencensus.stats.View.AggregationWindow.Cumulative;
-import io.opencensus.stats.View.AggregationWindow.Interval;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -61,6 +58,7 @@ import java.util.List;
  *
  * @since 0.8
  */
+@SuppressWarnings("deprecation")
 public final class RpcViewConstants {
 
   // Common histogram bucket boundaries for bytes received/sets Views.
@@ -118,9 +116,16 @@ public final class RpcViewConstants {
 
   @VisibleForTesting static final Duration MINUTE = Duration.create(60, 0);
   @VisibleForTesting static final Duration HOUR = Duration.create(60 * 60, 0);
-  @VisibleForTesting static final AggregationWindow CUMULATIVE = Cumulative.create();
-  @VisibleForTesting static final AggregationWindow INTERVAL_MINUTE = Interval.create(MINUTE);
-  @VisibleForTesting static final AggregationWindow INTERVAL_HOUR = Interval.create(HOUR);
+
+  @VisibleForTesting
+  static final View.AggregationWindow CUMULATIVE = View.AggregationWindow.Cumulative.create();
+
+  @VisibleForTesting
+  static final View.AggregationWindow INTERVAL_MINUTE =
+      View.AggregationWindow.Interval.create(MINUTE);
+
+  @VisibleForTesting
+  static final View.AggregationWindow INTERVAL_HOUR = View.AggregationWindow.Interval.create(HOUR);
 
   // Rpc client cumulative views.
 

--- a/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/StatszZPageHandler.java
+++ b/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/StatszZPageHandler.java
@@ -41,8 +41,6 @@ import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.View;
 import io.opencensus.stats.ViewData;
-import io.opencensus.stats.ViewData.AggregationWindowData;
-import io.opencensus.stats.ViewData.AggregationWindowData.CumulativeData;
 import io.opencensus.stats.ViewManager;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
@@ -66,6 +64,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
 /** HTML page formatter for all exported {@link View}s. */
+@SuppressWarnings("deprecation")
 final class StatszZPageHandler extends ZPageHandler {
 
   private static final Object monitor = new Object();
@@ -305,7 +304,7 @@ final class StatszZPageHandler extends ZPageHandler {
   }
 
   private static void emitViewInfo(
-      View view, AggregationWindowData windowData, PrintWriter out, Formatter formatter) {
+      View view, ViewData.AggregationWindowData windowData, PrintWriter out, Formatter formatter) {
     formatter.format("<table width=100%% %s>", TABLE_BORDER);
     emitViewInfoHeader(out, formatter);
 
@@ -324,9 +323,9 @@ final class StatszZPageHandler extends ZPageHandler {
                 Functions.<String>throwAssertionError());
     formatter.format("<td>%s</td>", aggregationType);
     windowData.match(
-        new Function<CumulativeData, Void>() {
+        new Function<ViewData.AggregationWindowData.CumulativeData, Void>() {
           @Override
-          public Void apply(CumulativeData arg) {
+          public Void apply(ViewData.AggregationWindowData.CumulativeData arg) {
             formatter.format("<td>%s</td>", toDate(arg.getStart()));
             formatter.format("<td>%s</td>", toDate(arg.getEnd()));
             return null;

--- a/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/ZPageHandlers.java
+++ b/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/ZPageHandlers.java
@@ -22,7 +22,6 @@ import com.sun.net.httpserver.HttpServer;
 import io.opencensus.stats.Measure;
 import io.opencensus.stats.Stats;
 import io.opencensus.stats.View;
-import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.trace.Tracing;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -128,7 +127,7 @@ public final class ZPageHandlers {
   /**
    * Returns a {@code ZPageHandler} for all registered {@link View}s and {@link Measure}s.
    *
-   * <p>Only {@link Cumulative} views are exported. {@link View}s are grouped by directories.
+   * <p>Only {@code Cumulative} views are exported. {@link View}s are grouped by directories.
    *
    * @return a {@code ZPageHandler} for all registered {@code View}s and {@code Measure}s.
    * @since 0.12.0

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
@@ -33,8 +33,6 @@ import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.View;
-import io.opencensus.stats.View.AggregationWindow;
-import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.ViewData;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
@@ -55,7 +53,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Util methods to convert OpenCensus Stats data models to Prometheus data models.
  *
  * <p>Each OpenCensus {@link View} will be converted to a Prometheus {@link MetricFamilySamples}
- * with no {@link Sample}s, and is used for registering Prometheus {@code Metric}s. Only {@link
+ * with no {@link Sample}s, and is used for registering Prometheus {@code Metric}s. Only {@code
  * Cumulative} views are supported. All views are under namespace "opencensus".
  *
  * <p>{@link Aggregation} will be converted to a corresponding Prometheus {@link Type}. {@link Sum}
@@ -78,6 +76,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>Please note that Prometheus Metric and Label name can only have alphanumeric characters and
  * underscore. All other characters will be sanitized by underscores.
  */
+@SuppressWarnings("deprecation")
 final class PrometheusExportUtils {
 
   @VisibleForTesting static final String OPENCENSUS_NAMESPACE = "opencensus";
@@ -112,8 +111,8 @@ final class PrometheusExportUtils {
   }
 
   @VisibleForTesting
-  static Type getType(Aggregation aggregation, AggregationWindow window) {
-    if (!(window instanceof Cumulative)) {
+  static Type getType(Aggregation aggregation, View.AggregationWindow window) {
+    if (!(window instanceof View.AggregationWindow.Cumulative)) {
       return Type.UNTYPED;
     }
     return aggregation.match(

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
@@ -33,7 +33,6 @@ import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.View;
-import io.opencensus.stats.View.AggregationWindow;
 import io.opencensus.stats.ViewData;
 import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
@@ -48,6 +47,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
 /** Adapter for a {@code ViewData}'s contents into SignalFx datapoints. */
+@SuppressWarnings("deprecation")
 final class SignalFxSessionAdaptor {
 
   private SignalFxSessionAdaptor() {}
@@ -87,11 +87,12 @@ final class SignalFxSessionAdaptor {
 
   @VisibleForTesting
   @javax.annotation.Nullable
-  static MetricType getMetricTypeForAggregation(Aggregation aggregation, AggregationWindow window) {
+  static MetricType getMetricTypeForAggregation(
+      Aggregation aggregation, View.AggregationWindow window) {
     if (aggregation instanceof Aggregation.Mean) {
       return MetricType.GAUGE;
     } else if (aggregation instanceof Aggregation.Count || aggregation instanceof Aggregation.Sum) {
-      if (window instanceof AggregationWindow.Cumulative) {
+      if (window instanceof View.AggregationWindow.Cumulative) {
         return MetricType.CUMULATIVE_COUNTER;
       }
       // TODO(mpetazzoni): support incremental counters when AggregationWindow.Interval is ready

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -30,7 +30,6 @@ import io.opencensus.stats.Measurement.MeasurementDouble;
 import io.opencensus.stats.Measurement.MeasurementLong;
 import io.opencensus.stats.StatsCollectionState;
 import io.opencensus.stats.View;
-import io.opencensus.stats.View.AggregationWindow;
 import io.opencensus.stats.ViewData;
 import io.opencensus.tags.TagContext;
 import java.util.Collection;
@@ -47,6 +46,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
 /** A class that stores a singleton map from {@code MeasureName}s to {@link MutableViewData}s. */
+@SuppressWarnings("deprecation")
 final class MeasureToViewMap {
 
   /*
@@ -89,7 +89,7 @@ final class MeasureToViewMap {
   private static Set<View> filterExportedViews(Collection<View> allViews) {
     Set<View> views = Sets.newHashSet();
     for (View view : allViews) {
-      if (view.getWindow() instanceof AggregationWindow.Cumulative) {
+      if (view.getWindow() instanceof View.AggregationWindow.Cumulative) {
         views.add(view);
       }
     }


### PR DESCRIPTION
Closes https://github.com/census-instrumentation/opencensus-java/issues/995. Might be easier to review by each commit.

- Deprecate Window and WindowData type in Stats API, and deprecate the factory method that takes Window or WindowData. Also add start and end timestamp to ViewData to replace WindowData.
- Implementation will continue to support Window (including interval stats). 
- ~~Remove usage of Window and WindowData from zpages and exporters except RpcZ, since most of them only need cumulative stats.~~

/cc @dinooliva @ramonza 