### PR TITLE
Remove stackdriver dependencyConvergence failure list because they are not clean.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -175,7 +175,9 @@ subprojects {
         compile {
             // Detect Maven Enforcer's dependencyConvergence failures. We only
             // care for artifacts used as libraries by others.
-            if (!(project.name in ['benchmarks', 'opencensus-all'])) {
+            if (!(project.name in ['benchmarks', 'opencensus-all',
+                                   'opencensus-exporter-stats-stackdriver',
+                                   'opencensus-exporter-trace-stackdriver'])) {
                 resolutionStrategy.failOnVersionConflict()
             }
         }


### PR DESCRIPTION
They bring multiple dependencies for protobuf.