### PR TITLE
Fix bugs, fix warnings and update disruptor.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ subprojects {
                 auto_service: 'com.google.auto.service:auto-service:1.0-rc3',
                 byte_buddy: 'net.bytebuddy:byte-buddy:1.7.10',
                 config: 'com.typesafe:config:1.2.1',
-                disruptor: 'com.lmax:disruptor:3.3.6',
+                disruptor: 'com.lmax:disruptor:3.3.8',
                 errorprone: "com.google.errorprone:error_prone_annotations:${errorProneVersion}",
                 findbugs_annotations: "com.google.code.findbugs:annotations:${findBugsVersion}",
                 google_auth: "com.google.auth:google-auth-library-credentials:${googleAuthVersion}",

--- a/impl/src/main/java/io/opencensus/impl/internal/DisruptorEventQueue.java
+++ b/impl/src/main/java/io/opencensus/impl/internal/DisruptorEventQueue.java
@@ -24,8 +24,6 @@ import com.lmax.disruptor.dsl.Disruptor;
 import com.lmax.disruptor.dsl.ProducerType;
 import io.opencensus.implcore.internal.DaemonThreadFactory;
 import io.opencensus.implcore.internal.EventQueue;
-import java.util.concurrent.Executors;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
@@ -101,19 +99,20 @@ public final class DisruptorEventQueue implements EventQueue {
   private final RingBuffer<DisruptorEvent> ringBuffer;
 
   // Creates a new EventQueue. Private to prevent creation of non-singleton instance.
-  // Suppress warnings for disruptor.handleEventsWith and Disruptor constructor
-  @SuppressWarnings({"deprecation", "unchecked", "varargs"})
+  // Suppress warnings for disruptor.handleEventsWith.
+  @SuppressWarnings({"unchecked"})
   private DisruptorEventQueue() {
-    // Create new Disruptor for processing. Note that this uses a single thread for processing; this
-    // ensures that the event handler can take unsynchronized actions whenever possible.
+    // Create new Disruptor for processing. Note that Disruptor creates a single thread per
+    // consumer (see https://github.com/LMAX-Exchange/disruptor/issues/121 for details);
+    // this ensures that the event handler can take unsynchronized actions whenever possible.
     disruptor =
-        new Disruptor<DisruptorEvent>(
-            new DisruptorEventFactory(),
+        new Disruptor<>(
+            DisruptorEventFactory.INSTANCE,
             DISRUPTOR_BUFFER_SIZE,
-            Executors.newSingleThreadExecutor(new DaemonThreadFactory("OpenCensus.Disruptor")),
+            new DaemonThreadFactory("OpenCensus.Disruptor"),
             ProducerType.MULTI,
             new SleepingWaitStrategy());
-    disruptor.handleEventsWith(new DisruptorEventHandler());
+    disruptor.handleEventsWith(DisruptorEventHandler.INSTANCE);
     disruptor.start();
     ringBuffer = disruptor.getRingBuffer();
   }
@@ -145,7 +144,7 @@ public final class DisruptorEventQueue implements EventQueue {
 
   // An event in the {@link EventQueue}. Just holds a reference to an EventQueue.Entry.
   private static final class DisruptorEvent {
-    @Nullable private Entry entry;
+    private Entry entry = EventQueue.NoopEntry.INSTANCE;
 
     // Sets the EventQueueEntry associated with this DisruptorEvent.
     void setEntry(Entry entry) {
@@ -153,14 +152,15 @@ public final class DisruptorEventQueue implements EventQueue {
     }
 
     // Returns the EventQueueEntry associated with this DisruptorEvent.
-    @Nullable
     Entry getEntry() {
       return entry;
     }
   }
 
   // Factory for DisruptorEvent.
-  private static final class DisruptorEventFactory implements EventFactory<DisruptorEvent> {
+  private enum DisruptorEventFactory implements EventFactory<DisruptorEvent> {
+    INSTANCE;
+
     @Override
     public DisruptorEvent newInstance() {
       return new DisruptorEvent();
@@ -171,10 +171,10 @@ public final class DisruptorEventQueue implements EventQueue {
    * Every event that gets added to {@link EventQueue} will get processed here. Just calls the
    * underlying process() method.
    */
-  private static final class DisruptorEventHandler implements EventHandler<DisruptorEvent> {
+  private enum DisruptorEventHandler implements EventHandler<DisruptorEvent> {
+    INSTANCE;
+
     @Override
-    // TODO(sebright): Fix the Checker Framework warning.
-    @SuppressWarnings("nullness")
     public void onEvent(DisruptorEvent event, long sequence, boolean endOfBatch) {
       event.getEntry().process();
     }

--- a/impl_core/src/main/java/io/opencensus/implcore/internal/EventQueue.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/EventQueue.java
@@ -31,4 +31,12 @@ public interface EventQueue {
      */
     void process();
   }
+
+  /** No-op implementation of the {@link EventQueue.Entry}. */
+  enum NoopEntry implements Entry {
+    INSTANCE;
+
+    @Override
+    public void process() {}
+  }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/internal/EventQueue.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/EventQueue.java
@@ -31,12 +31,4 @@ public interface EventQueue {
      */
     void process();
   }
-
-  /** No-op implementation of the {@link EventQueue.Entry}. */
-  enum NoopEntry implements Entry {
-    INSTANCE;
-
-    @Override
-    public void process() {}
-  }
 }


### PR DESCRIPTION
There are 2 bugs fixed in this PR:
1) The memory of SpanImpl, TagContext, MeasureMap was hold for all the objects in disruptor. Disruptor is configured with 8K objects so the memory for the past 8K recorded objects was hold.
2) The objects that are shared between threads via disruptor were not synchronized. Because the event is shared between producer and consumer thread all instances must be volatile.