### PR TITLE
Upgrade disruptor to include the fix for SleepingWaitStrategy causing 100% CPU usage

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -149,7 +149,7 @@ subprojects {
                 auto_service: 'com.google.auto.service:auto-service:1.0-rc3',
                 byte_buddy: 'net.bytebuddy:byte-buddy:1.7.10',
                 config: 'com.typesafe:config:1.2.1',
-                disruptor: 'com.lmax:disruptor:3.3.8',
+                disruptor: 'com.lmax:disruptor:3.3.9',
                 errorprone: "com.google.errorprone:error_prone_annotations:${errorProneVersion}",
                 findbugs_annotations: "com.google.code.findbugs:annotations:${findBugsVersion}",
                 google_auth: "com.google.auth:google-auth-library-credentials:${googleAuthVersion}",


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/801

This is a conservative upgrade because we want to cherry-pick this into 0.12.2. We will later upgrade to disruptor 3.4.0 but that release contains other changes as well so for the purpose of cherry-pick and minor release for OpenCensus is better to only upgrade to 3.3.9.