### PR TITLE
Fix probabilitySampler_getDescription for all locales.

### DIFF
--- a/api/src/test/java/io/opencensus/trace/samplers/SamplersTest.java
+++ b/api/src/test/java/io/opencensus/trace/samplers/SamplersTest.java
@@ -271,7 +271,7 @@ public class SamplersTest {
   @Test
   public void probabilitySampler_getDescription() {
     assertThat((Samplers.probabilitySampler(0.5)).getDescription())
-        .isEqualTo("ProbabilitySampler{0.500000}");
+        .isEqualTo(String.format("ProbabilitySampler{%.6f}", 0.5));
   }
 
   @Test


### PR DESCRIPTION
PropabilitySampler#getDescription returns a string that contains the
probability formatted according to the current locale, while the test
expects a certain format.