### PR TITLE
Fix build on platforms that are not supported by netty-tcnative.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -394,4 +394,24 @@ subprojects {
             }
         }
     }
+
+    // For projects that depend on gRPC during test execution, make sure to
+    // also configure ALPN if running on a platform (e.g. FreeBSD) that is not
+    // supported by io.netty:netty-tcnative-boringssl-static:jar. Also see:
+    // https://github.com/grpc/grpc-java/blob/master/SECURITY.md#tls-with-jdk-jetty-alpnnpn
+    if (project.name in ['opencensus-exporter-stats-stackdriver',
+                         'opencensus-exporter-trace-stackdriver']) {
+        def os = org.gradle.internal.os.OperatingSystem.current()
+        if (!os.isLinux() && !os.isWindows() && !os.isMacOsX()) {
+            configurations {
+                alpn
+            }
+            dependencies {
+                alpn 'org.mortbay.jetty.alpn:jetty-alpn-agent:2.0.7'
+            }
+            test {
+                jvmArgs "-javaagent:${configurations.alpn.asPath}"
+            }
+        }
+    }
 }


### PR DESCRIPTION
For projects that depend on gRPC during test execution, make sure to
also configure ALPN if running on a platform (e.g. FreeBSD) that is not
supported by io.netty:netty-tcnative-boringssl-static:jar. Also see:
https://github.com/grpc/grpc-java/blob/master/SECURITY.md#tls-with-jdk-jetty-alpnnpn

I think something is better than nothing here.

This fixes the build issue on FreeBSD:
```
> Task :opencensus-exporter-stats-stackdriver:test 

io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporterTest > createWithNegativeDuration FAILED
    java.lang.AssertionError: 
    Expected: (an instance of java.lang.IllegalArgumentException and exception with message a string containing "Duration must be positive")
         but: exception with message a string containing "Duration must be positive" message was "ALPN is not configured properly. See https://github.com/grpc/grpc-java/blob/master/SECURITY.md#troubleshooting for more information."
    Stacktrace was: java.lang.IllegalArgumentException: ALPN is not configured properly. See https://github.com/grpc/grpc-java/blob/master/SECURITY.md#troubleshooting for more information.
        at io.grpc.netty.GrpcSslContexts.selectApplicationProtocolConfig(GrpcSslContexts.java:163)
        at io.grpc.netty.GrpcSslContexts.configure(GrpcSslContexts.java:136)
        at io.grpc.netty.GrpcSslContexts.configure(GrpcSslContexts.java:124)
        at io.grpc.netty.GrpcSslContexts.forClient(GrpcSslContexts.java:94)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory$DefaultNettyTransportCreationParamsFilterFactory.<init>(NettyChannelBuilder.java:546)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory$DefaultNettyTransportCreationParamsFilterFactory.<init>(NettyChannelBuilder.java:539)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory.<init>(NettyChannelBuilder.java:477)
        at io.grpc.netty.NettyChannelBuilder.buildTransportFactory(NettyChannelBuilder.java:325)
        at io.grpc.internal.AbstractManagedChannelImplBuilder.build(AbstractManagedChannelImplBuilder.java:342)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createSingleChannel(InstantiatingGrpcChannelProvider.java:185)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createChannel(InstantiatingGrpcChannelProvider.java:142)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.getTransportChannel(InstantiatingGrpcChannelProvider.java:134)
        at com.google.api.gax.rpc.ClientContext.create(ClientContext.java:137)
        at com.google.cloud.monitoring.v3.stub.GrpcMetricServiceStub.create(GrpcMetricServiceStub.java:171)
        at com.google.cloud.monitoring.v3.stub.MetricServiceStubSettings.createStub(MetricServiceStubSettings.java:184)
        at com.google.cloud.monitoring.v3.MetricServiceClient.<init>(MetricServiceClient.java:155)
        at com.google.cloud.monitoring.v3.MetricServiceClient.create(MetricServiceClient.java:136)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.createInternal(StackdriverStatsExporter.java:305)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.createAndRegisterWithCredentialsAndProjectId(StackdriverStatsExporter.java:110)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporterTest.createWithNegativeDuration(StackdriverStatsExporterTest.java:109)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.runTestClass(JUnitTestClassExecuter.java:114)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.execute(JUnitTestClassExecuter.java:57)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassProcessor.processTestClass(JUnitTestClassProcessor.java:66)
        at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
        at com.sun.proxy.$Proxy1.processTestClass(Unknown Source)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:108)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:146)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:128)
        at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
        at java.lang.Thread.run(Thread.java:748)
    Caused by: java.lang.ClassNotFoundException: org/eclipse/jetty/alpn/ALPN
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:348)
        at io.grpc.netty.JettyTlsUtil.isJettyAlpnConfigured(JettyTlsUtil.java:34)
        at io.grpc.netty.GrpcSslContexts.selectApplicationProtocolConfig(GrpcSslContexts.java:153)
        ... 67 more

io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporterTest > createExporterTwice FAILED
    java.lang.IllegalArgumentException: ALPN is not configured properly. See https://github.com/grpc/grpc-java/blob/master/SECURITY.md#troubleshooting for more information.
        at io.grpc.netty.GrpcSslContexts.selectApplicationProtocolConfig(GrpcSslContexts.java:163)
        at io.grpc.netty.GrpcSslContexts.configure(GrpcSslContexts.java:136)
        at io.grpc.netty.GrpcSslContexts.configure(GrpcSslContexts.java:124)
        at io.grpc.netty.GrpcSslContexts.forClient(GrpcSslContexts.java:94)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory$DefaultNettyTransportCreationParamsFilterFactory.<init>(NettyChannelBuilder.java:546)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory$DefaultNettyTransportCreationParamsFilterFactory.<init>(NettyChannelBuilder.java:539)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory.<init>(NettyChannelBuilder.java:477)
        at io.grpc.netty.NettyChannelBuilder.buildTransportFactory(NettyChannelBuilder.java:325)
        at io.grpc.internal.AbstractManagedChannelImplBuilder.build(AbstractManagedChannelImplBuilder.java:342)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createSingleChannel(InstantiatingGrpcChannelProvider.java:185)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createChannel(InstantiatingGrpcChannelProvider.java:142)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.getTransportChannel(InstantiatingGrpcChannelProvider.java:134)
        at com.google.api.gax.rpc.ClientContext.create(ClientContext.java:137)
        at com.google.cloud.monitoring.v3.stub.GrpcMetricServiceStub.create(GrpcMetricServiceStub.java:171)
        at com.google.cloud.monitoring.v3.stub.MetricServiceStubSettings.createStub(MetricServiceStubSettings.java:184)
        at com.google.cloud.monitoring.v3.MetricServiceClient.<init>(MetricServiceClient.java:155)
        at com.google.cloud.monitoring.v3.MetricServiceClient.create(MetricServiceClient.java:136)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.createInternal(StackdriverStatsExporter.java:305)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.createAndRegister(StackdriverStatsExporter.java:169)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporterTest.createExporterTwice(StackdriverStatsExporterTest.java:115)

        Caused by:
        java.lang.ClassNotFoundException: org/eclipse/jetty/alpn/ALPN
            at java.lang.Class.forName0(Native Method)
            at java.lang.Class.forName(Class.java:348)
            at io.grpc.netty.JettyTlsUtil.isJettyAlpnConfigured(JettyTlsUtil.java:34)
            at io.grpc.netty.GrpcSslContexts.selectApplicationProtocolConfig(GrpcSslContexts.java:153)
            ... 19 more

io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporterTest > createWithNegativeDuration_WithConfiguration FAILED
    java.lang.AssertionError: 
    Expected: (an instance of java.lang.IllegalArgumentException and exception with message a string containing "Duration must be positive")
         but: exception with message a string containing "Duration must be positive" message was "ALPN is not configured properly. See https://github.com/grpc/grpc-java/blob/master/SECURITY.md#troubleshooting for more information."
    Stacktrace was: java.lang.IllegalArgumentException: ALPN is not configured properly. See https://github.com/grpc/grpc-java/blob/master/SECURITY.md#troubleshooting for more information.
        at io.grpc.netty.GrpcSslContexts.selectApplicationProtocolConfig(GrpcSslContexts.java:163)
        at io.grpc.netty.GrpcSslContexts.configure(GrpcSslContexts.java:136)
        at io.grpc.netty.GrpcSslContexts.configure(GrpcSslContexts.java:124)
        at io.grpc.netty.GrpcSslContexts.forClient(GrpcSslContexts.java:94)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory$DefaultNettyTransportCreationParamsFilterFactory.<init>(NettyChannelBuilder.java:546)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory$DefaultNettyTransportCreationParamsFilterFactory.<init>(NettyChannelBuilder.java:539)
        at io.grpc.netty.NettyChannelBuilder$NettyTransportFactory.<init>(NettyChannelBuilder.java:477)
        at io.grpc.netty.NettyChannelBuilder.buildTransportFactory(NettyChannelBuilder.java:325)
        at io.grpc.internal.AbstractManagedChannelImplBuilder.build(AbstractManagedChannelImplBuilder.java:342)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createSingleChannel(InstantiatingGrpcChannelProvider.java:185)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.createChannel(InstantiatingGrpcChannelProvider.java:142)
        at com.google.api.gax.grpc.InstantiatingGrpcChannelProvider.getTransportChannel(InstantiatingGrpcChannelProvider.java:134)
        at com.google.api.gax.rpc.ClientContext.create(ClientContext.java:137)
        at com.google.cloud.monitoring.v3.stub.GrpcMetricServiceStub.create(GrpcMetricServiceStub.java:171)
        at com.google.cloud.monitoring.v3.stub.MetricServiceStubSettings.createStub(MetricServiceStubSettings.java:184)
        at com.google.cloud.monitoring.v3.MetricServiceClient.<init>(MetricServiceClient.java:155)
        at com.google.cloud.monitoring.v3.MetricServiceClient.create(MetricServiceClient.java:136)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.createInternal(StackdriverStatsExporter.java:305)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.createAndRegister(StackdriverStatsExporter.java:169)
        at io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporterTest.createWithNegativeDuration_WithConfiguration(StackdriverStatsExporterTest.java:74)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:50)
        at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
        at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:47)
        at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
        at org.junit.rules.ExpectedException$ExpectedExceptionStatement.evaluate(ExpectedException.java:239)
        at org.junit.rules.RunRules.evaluate(RunRules.java:20)
        at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:325)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:78)
        at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:57)
        at org.junit.runners.ParentRunner$3.run(ParentRunner.java:290)
        at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:71)
        at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:288)
        at org.junit.runners.ParentRunner.access$000(ParentRunner.java:58)
        at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:268)
        at org.junit.runners.ParentRunner.run(ParentRunner.java:363)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.runTestClass(JUnitTestClassExecuter.java:114)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassExecuter.execute(JUnitTestClassExecuter.java:57)
        at org.gradle.api.internal.tasks.testing.junit.JUnitTestClassProcessor.processTestClass(JUnitTestClassProcessor.java:66)
        at org.gradle.api.internal.tasks.testing.SuiteTestClassProcessor.processTestClass(SuiteTestClassProcessor.java:51)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.dispatch.ContextClassLoaderDispatch.dispatch(ContextClassLoaderDispatch.java:32)
        at org.gradle.internal.dispatch.ProxyDispatchAdapter$DispatchingInvocationHandler.invoke(ProxyDispatchAdapter.java:93)
        at com.sun.proxy.$Proxy1.processTestClass(Unknown Source)
        at org.gradle.api.internal.tasks.testing.worker.TestWorker.processTestClass(TestWorker.java:108)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:35)
        at org.gradle.internal.dispatch.ReflectionDispatch.dispatch(ReflectionDispatch.java:24)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:146)
        at org.gradle.internal.remote.internal.hub.MessageHubBackedObjectConnection$DispatchWrapper.dispatch(MessageHubBackedObjectConnection.java:128)
        at org.gradle.internal.remote.internal.hub.MessageHub$Handler.run(MessageHub.java:404)
        at org.gradle.internal.concurrent.ExecutorPolicy$CatchAndRecordFailures.onExecute(ExecutorPolicy.java:63)
        at org.gradle.internal.concurrent.ManagedExecutorImpl$1.run(ManagedExecutorImpl.java:46)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at org.gradle.internal.concurrent.ThreadFactoryImpl$ManagedThreadRunnable.run(ThreadFactoryImpl.java:55)
        at java.lang.Thread.run(Thread.java:748)
    Caused by: java.lang.ClassNotFoundException: org/eclipse/jetty/alpn/ALPN
        at java.lang.Class.forName0(Native Method)
        at java.lang.Class.forName(Class.java:348)
        at io.grpc.netty.JettyTlsUtil.isJettyAlpnConfigured(JettyTlsUtil.java:34)
        at io.grpc.netty.GrpcSslContexts.selectApplicationProtocolConfig(GrpcSslContexts.java:153)
        ... 67 more

38 tests completed, 3 failed


FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':opencensus-exporter-stats-stackdriver:test'.
> There were failing tests. See the report at: file:///home/sts/proj/instrumentation-java/exporters/stats/stackdriver/build/reports/tests/test/index.html

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

* Get more help at https://help.gradle.org

BUILD FAILED in 3m 50s
181 actionable tasks: 160 executed, 21 up-to-date
```