### PR TITLE
Don't declare any dependencies in the generated POM because the agent JAR is self-contained.

### DIFF
--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -123,6 +123,18 @@ jar.finalizedBy shadowJar
 // The JAVA_HOMES environment variable lists the home directories of the Java installations used
 // for integration testing.
 
+// The default JAR has been replaced with a self-contained JAR by the shadowJar task. Therefore,
+// remove all declared dependencies from the generated Maven POM for said JAR.
+uploadArchives {
+  repositories {
+    mavenDeployer {
+      pom.whenConfigured {
+        dependencies = []
+      }
+    }
+  }
+}
+
 sourceSets {
   integrationTest {
     java {


### PR DESCRIPTION
The shadowJar task replaces the default JAR with a self-contained JAR, which
doesn't have any dependencies. However, when uploading the "default" JAR, the
generated POM still declares all dependencies. When depending on this artifact
from a different project, these extraneous dependencies are pulled in and may
cause conflicts, exactly what the shadowed JAR is meant to avoid.

This change fixes this issue by removing all declared dependencies from the
generated POM.