### PR TITLE
Add shutdown hook to trace exporter.

### DIFF
--- a/impl_core/src/main/java/io/opencensus/implcore/internal/ShutdownHookManager.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/ShutdownHookManager.java
@@ -30,19 +30,25 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * A utility class to help with registering shutdown {@link Hook}s to the runtime.
+ * A utility class to help with registering shutdown {@link Hook}s to the runtime, influenced by
+ * Apache Hadoop's <a
+ * href="https://github.com/apache/hadoop/blob/trunk/hadoop-common-project/hadoop-common/src/main/java/org/apache/hadoop/util/ShutdownHookManager.java">ShutdownHookManager</a>.
+ * It is used for OpenCensus to clean things up in a deterministic order. Possible usages are: 1.
+ * close running spans. 2. Dump unexported spans for stat/tracing. 3. Allow users to have their own
+ * shutdown hooks (not supported yet, still in discussion).
  *
  * <p>A {@link Hook} can have its own name and priority. The execution order among registered hooks
  * will be determined by their priorities first (descending order) and then registration time
  * (ascending order). That is to say, higher priority {@code Hook} will be executed first, and
  * earlier registered {@code Hook} will be executed first given the same priority.
  *
- * <p>Caveat: 1. GAE Java 7 environment is not supported for now. 2. User can still use other method
- * to register a shutdown hook, e.g. the native {@link Runtime#addShutdownHook}. The execution order
- * of registered {@link Hook}s and other hooks depends on the JVM implementation and thus can not be
- * guaranteed, which might sometimes leads to unwanted behaviors. An example is that {@code
- * java.util.logging.Logger} has its own shutdown hook to reset all handlers, and once invoked, it
- * will prevent all future logging in other shutdown hooks.
+ * <p>Caveat: 1. GAE Java 7 environment is not supported for now. 2. This manager only manages
+ * OpenCensus related shutdown hooks. User can still use other methods to register a shutdown hook,
+ * e.g. the native {@link Runtime#addShutdownHook}, or the Hadoop's {@code ShutdownHookManager}. The
+ * execution order of registered {@link Hook}s and hooks registered by other systems depends on the
+ * JVM implementation and thus can not be guaranteed, which might sometimes leads to unwanted
+ * behaviors. An example is that {@code java.util.logging.Logger} has its own shutdown hook to reset
+ * all handlers, and once invoked, it will prevent all future logging in other shutdown hooks.
  */
 @ThreadSafe
 public final class ShutdownHookManager {

--- a/impl_core/src/main/java/io/opencensus/implcore/internal/ShutdownHookManager.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/ShutdownHookManager.java
@@ -30,7 +30,7 @@ import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
 
 /**
- * An utility class to help with registering shutdown {@link Hook}s to the runtime.
+ * A utility class to help with registering shutdown {@link Hook}s to the runtime.
  *
  * <p>A {@link Hook} can have its own name and priority. The execution order among registered hooks
  * will be determined by their priorities first (descending order) and then registration time
@@ -54,7 +54,7 @@ public final class ShutdownHookManager {
 
   private final Object monitor = new Object();
 
-  // A list to store registered {@link Hook}s.
+  // A list to store registered hooks.
   @GuardedBy("monitor")
   private final List<Hook> hooks = new ArrayList<Hook>();
 
@@ -194,7 +194,7 @@ public final class ShutdownHookManager {
    * @param hook the {@code Hook}
    */
   public void addShutdownHook(Hook hook) {
-    checkNotNull(hook);
+    checkNotNull(hook, "hook");
     synchronized (monitor) {
       if (!isShuttingDown) {
         hooks.add(hook);

--- a/impl_core/src/main/java/io/opencensus/implcore/internal/ShutdownHookManager.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/ShutdownHookManager.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.internal;
+
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Objects;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * An utility class to help with registering shutdown {@link Hook}s to the runtime.
+ *
+ * <p>A {@link Hook} can have its own name and priority. The execution order among registered hooks
+ * will be determined by their priorities first (descending order) and then registration time
+ * (ascending order). That is to say, higher priority {@code Hook} will be executed first, and
+ * earlier registered {@code Hook} will be executed first given the same priority.
+ *
+ * <p>Caveat: 1. GAE Java 7 environment is not supported for now. 2. User can still use other method
+ * to register a shutdown hook, e.g. the native {@link Runtime#addShutdownHook}. The execution order
+ * of registered {@link Hook}s and other hooks depends on the JVM implementation and thus can not be
+ * guaranteed, which might sometimes leads to unwanted behaviors. An example is that {@code
+ * java.util.logging.Logger} has its own shutdown hook to reset all handlers, and once invoked, it
+ * will prevent all future logging in other shutdown hooks.
+ */
+@ThreadSafe
+public final class ShutdownHookManager {
+
+  private static final Logger logger = Logger.getLogger(ShutdownHookManager.class.getName());
+
+  // The singlelon instance.
+  private static final ShutdownHookManager instance = new ShutdownHookManager();
+
+  private final Object monitor = new Object();
+
+  // A list to store registered {@link Hook}s.
+  @GuardedBy("monitor")
+  private final List<Hook> hooks = new ArrayList<Hook>();
+
+  @GuardedBy("monitor")
+  private boolean isShuttingDown = false;
+
+  /** A shutdown hook with name and priority. */
+  public abstract static class Hook implements Comparable<Hook> {
+
+    // Default priority. It is public for user to know the default priority.
+    public static final int DEFAULT_PRIORITY = 100;
+
+    private final String name;
+    private final int priority;
+
+    /**
+     * Creates a hook with given name and default priority.
+     *
+     * @param name the name of the hook
+     */
+    // Suppress false postive warning, see https://github.com/google/error-prone/issues/655 and
+    // https://github.com/google/error-prone/pull/789
+    @SuppressWarnings("ConstructorLeaksThis")
+    public Hook(String name) {
+      this(name, DEFAULT_PRIORITY);
+    }
+
+    /**
+     * Creates a hook with given name and priority.
+     *
+     * @param name the name of the hook.
+     * @param priority the priority of the hook. Use a priority higher than {@link DEFAULT_PRIORITY}
+     *     if the hook needs to be executed earlier than default ones. Use a priority lower than
+     *     that if the hook needs to be executed later.
+     */
+    public Hook(String name, int priority) {
+      this.name = name;
+      this.priority = priority;
+    }
+
+    /**
+     * Returns the name of this hook.
+     *
+     * @return the name of this hook.
+     */
+    public final String getName() {
+      return this.name;
+    }
+
+    /**
+     * Returns the priority of this hook.
+     *
+     * @return the priority of this hook.
+     */
+    public final int getPriority() {
+      return this.priority;
+    }
+
+    @Override
+    public int compareTo(@Nullable Hook hook) {
+      return hook == null ? -1 : hook.priority - this.priority;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(name, priority);
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+      if (other == this) {
+        return true;
+      }
+      if (other instanceof Hook) {
+        Hook that = (Hook) other;
+        return priority == that.priority && Objects.equal(name, that.name);
+      }
+      return false;
+    }
+
+    /**
+     * Things that will be done before shutdown.
+     *
+     * <p>There is no guarentee of the completion of this method.
+     */
+    public abstract void run();
+  }
+
+  private static final class ShutdownHandler implements Runnable {
+    @Override
+    public void run() {
+      ShutdownHookManager.getInstance().invokeShutdownHooks();
+    }
+  }
+
+  /**
+   * Returns the singleton instance of this class.
+   *
+   * @return the singleton instance of this class.
+   */
+  public static ShutdownHookManager getInstance() {
+    return instance;
+  }
+
+  @VisibleForTesting
+  void sortHooks(List<Hook> hooks) {
+    // This is a stable sort and will maintain the original order when priorities are equal.
+    Collections.sort(hooks);
+  }
+
+  @VisibleForTesting
+  void invokeShutdownHooks() {
+    synchronized (monitor) {
+      isShuttingDown = true;
+      sortHooks(hooks);
+      for (Hook hook : hooks) {
+        try {
+          hook.run();
+        } catch (Throwable e) {
+          String message = e.getMessage();
+          if (message == null) {
+            message = e.getClass().getSimpleName();
+          }
+          logger.log(
+              Level.WARNING,
+              String.format(
+                  "Error occurred during execution of shutdown hook %s, message is `%s`.",
+                  hook.getName(), message));
+        }
+      }
+    }
+  }
+
+  /**
+   * Adds a {@link Hook} to the manager.
+   *
+   * @param hook the {@code Hook}
+   */
+  public void addShutdownHook(Hook hook) {
+    checkNotNull(hook);
+    synchronized (monitor) {
+      if (!isShuttingDown) {
+        hooks.add(hook);
+      }
+    }
+  }
+
+  private ShutdownHookManager() {
+    // TODO(hailongwen@): Consider using `LifecycleManager.setShutdownHook` to support GAE Java 7
+    // environment.
+    if (!DaemonThreadFactory.IS_RESTRICTED_APPENGINE) {
+      Runtime.getRuntime()
+          .addShutdownHook(
+              new DaemonThreadFactory("OpenCensus.ShutdownHookManager")
+                  .newThread(new ShutdownHandler()));
+    }
+  }
+}

--- a/impl_core/src/test/java/io/opencensus/implcore/internal/ShutdownHookManagerTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/internal/ShutdownHookManagerTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.mockito.Mockito.verify;
+
+import com.google.common.collect.Lists;
+import io.opencensus.implcore.internal.ShutdownHookManager.Hook;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.Mockito;
+
+/** Unit tests for {@link ShutdownHookManager}. */
+@RunWith(JUnit4.class)
+public class ShutdownHookManagerTest {
+
+  private static class NoopHook extends Hook {
+    public NoopHook(String name, int priority) {
+      super(name, priority);
+    }
+
+    public NoopHook(String name) {
+      super(name);
+    }
+
+    @Override
+    public void run() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void addShutdownHookDisallowNull() {
+    thrown.expect(NullPointerException.class);
+    ShutdownHookManager.getInstance().addShutdownHook(null);
+  }
+
+  @Test
+  public void sortHooksOrder() {
+    Hook hook1 = new NoopHook("hook1", 200);
+    Hook hook2 = new NoopHook("hook2", 100);
+    Hook hook3 = new NoopHook("hook3", 200);
+    Hook hook4 = new NoopHook("hook4", 300);
+    List<Hook> hooks = Lists.newArrayList(hook1, hook2, hook3, hook4);
+    ShutdownHookManager.getInstance().sortHooks(hooks);
+    assertThat(hooks).containsExactly(hook4, hook1, hook3, hook2);
+  }
+
+  @Test
+  public void invokeShutdownHooksShouldIgnoreHookError() {
+    Hook exceptionHook = new NoopHook("exceptionHook");
+    Hook mockHook = Mockito.spy(new NoopHook("mockHook"));
+    ShutdownHookManager.getInstance().addShutdownHook(exceptionHook);
+    ShutdownHookManager.getInstance().addShutdownHook(mockHook);
+    ShutdownHookManager.getInstance().invokeShutdownHooks();
+    // exception of a previous hook does not affect others.
+    verify(mockHook).run();
+  }
+
+  @Test
+  public void hookCreationAndGetter() {
+    Hook hook1 = new NoopHook("Test1");
+    Hook hook2 = new NoopHook("Test2", 300);
+    assertThat(hook1.getName()).isEqualTo("Test1");
+    assertThat(hook1.getPriority()).isEqualTo(Hook.DEFAULT_PRIORITY);
+    assertThat(hook2.getName()).isEqualTo("Test2");
+    assertThat(hook2.getPriority()).isEqualTo(300);
+  }
+}


### PR DESCRIPTION
This PR adds a class `ShutdownHookManager` to manage registering the shutdown hooks, and use it in `SpanExporterImpl` to flush unexported data before exit. 

GAE Java 7 is not supported for now. Although tests shows that using `LifecycleManager` did help resolve the compatibility issue, the added appengine-api-sdk-1.0 is a big artifact, and it implicitly updates the version of the errorprone plugin which requires some extra code change. So for now I prefer not to include that change and leave it as a TODO in the future. For GAE Java 8, the compatibility is tested using grpc-interop-testing. (we should add our own interop-testing in the future.)

This PR might potentially resolve https://github.com/census-instrumentation/opencensus-java/issues/1015 so no sleep will not be necessary. However, a test is needed to verify that. 

A known issue is that this PR does not resolve the unexported data in `LoggingTraceExporter`, as reported in https://github.com/census-instrumentation/opencensus-java/pull/1039#discussion_r171713621 and https://github.com/census-instrumentation/opencensus-java/issues/842. The `java.util.logging` component registers its own shutdown hook, which closes all handlers upon shutdown signal and this hook could be executed before our registered one. Other logging system might not suffer this (I've tested log4j and it worked well). The same applies to all other user-registered shutdown hook, which is mentioned in the javadoc.