### PR TITLE
Add Aggregation.LastValue and AggregationData.LastValueData to support Gauge

### DIFF
--- a/api/src/main/java/io/opencensus/stats/Aggregation.java
+++ b/api/src/main/java/io/opencensus/stats/Aggregation.java
@@ -25,12 +25,13 @@ import javax.annotation.concurrent.Immutable;
  * {@link Aggregation} is the process of combining a certain set of {@code MeasureValue}s for a
  * given {@code Measure} into an {@link AggregationData}.
  *
- * <p>{@link Aggregation} currently supports 3 types of basic aggregation:
+ * <p>{@link Aggregation} currently supports 4 types of basic aggregation:
  *
  * <ul>
  *   <li>Sum
  *   <li>Count
  *   <li>Distribution
+ *   <li>LastValue
  * </ul>
  *
  * <p>When creating a {@link View}, one {@link Aggregation} needs to be specified as how to
@@ -47,7 +48,8 @@ public abstract class Aggregation {
    * Applies the given match function to the underlying data type.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #match(Function, Function, Function, Function)}.
+   * @deprecated in favor of {@link #match(Function, Function, Function, Function, Function,
+   *     Function)}.
    */
   @Deprecated
   public abstract <T> T match(
@@ -66,7 +68,9 @@ public abstract class Aggregation {
   public abstract <T> T match(
       Function<? super Sum, T> p0,
       Function<? super Count, T> p1,
-      Function<? super Distribution, T> p2,
+      Function<? super Mean, T> p2,
+      Function<? super Distribution, T> p3,
+      Function<? super LastValue, T> p4,
       Function<? super Aggregation, T> defaultFunction);
 
   /**
@@ -106,7 +110,9 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Distribution, T> p2,
+        Function<? super Mean, T> p2,
+        Function<? super Distribution, T> p3,
+        Function<? super LastValue, T> p4,
         Function<? super Aggregation, T> defaultFunction) {
       return p0.apply(this);
     }
@@ -149,7 +155,9 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Distribution, T> p2,
+        Function<? super Mean, T> p2,
+        Function<? super Distribution, T> p3,
+        Function<? super LastValue, T> p4,
         Function<? super Aggregation, T> defaultFunction) {
       return p1.apply(this);
     }
@@ -195,9 +203,11 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Distribution, T> p2,
+        Function<? super Mean, T> p2,
+        Function<? super Distribution, T> p3,
+        Function<? super LastValue, T> p4,
         Function<? super Aggregation, T> defaultFunction) {
-      return defaultFunction.apply(this);
+      return p2.apply(this);
     }
   }
 
@@ -246,9 +256,56 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Distribution, T> p2,
+        Function<? super Mean, T> p2,
+        Function<? super Distribution, T> p3,
+        Function<? super LastValue, T> p4,
         Function<? super Aggregation, T> defaultFunction) {
-      return p2.apply(this);
+      return p3.apply(this);
+    }
+  }
+
+  /**
+   * Calculate the last value of aggregated {@code MeasureValue}s.
+   *
+   * @since 0.13
+   */
+  @Immutable
+  @AutoValue
+  public abstract static class LastValue extends Aggregation {
+
+    LastValue() {}
+
+    private static final LastValue INSTANCE = new AutoValue_Aggregation_LastValue();
+
+    /**
+     * Construct a {@code LastValue}.
+     *
+     * @return a new {@code LastValue}.
+     * @since 0.13
+     */
+    public static LastValue create() {
+      return INSTANCE;
+    }
+
+    @Override
+    public final <T> T match(
+        Function<? super Sum, T> p0,
+        Function<? super Count, T> p1,
+        Function<? super Mean, T> p2,
+        Function<? super Distribution, T> p3,
+        Function<? super Aggregation, T> defaultFunction) {
+      return defaultFunction.apply(this);
+    }
+
+    @Override
+    public final <T> T match(
+        Function<? super Sum, T> p0,
+        Function<? super Count, T> p1,
+        Function<? super Mean, T> p2,
+        Function<? super Distribution, T> p3,
+        Function<? super LastValue, T> p4,
+        Function<? super Aggregation, T> defaultFunction) {
+      return p4.apply(this);
     }
   }
 }

--- a/api/src/main/java/io/opencensus/stats/Aggregation.java
+++ b/api/src/main/java/io/opencensus/stats/Aggregation.java
@@ -47,30 +47,13 @@ public abstract class Aggregation {
   /**
    * Applies the given match function to the underlying data type.
    *
-   * @since 0.8
-   * @deprecated in favor of {@link #match(Function, Function, Function, Function, Function,
-   *     Function)}.
-   */
-  @Deprecated
-  public abstract <T> T match(
-      Function<? super Sum, T> p0,
-      Function<? super Count, T> p1,
-      Function<? super Mean, T> p2,
-      Function<? super Distribution, T> p3,
-      Function<? super Aggregation, T> defaultFunction);
-
-  /**
-   * Applies the given match function to the underlying data type.
-   *
    * @since 0.13
    */
-  @SuppressWarnings("InconsistentOverloads")
   public abstract <T> T match(
       Function<? super Sum, T> p0,
       Function<? super Count, T> p1,
-      Function<? super Mean, T> p2,
-      Function<? super Distribution, T> p3,
-      Function<? super LastValue, T> p4,
+      Function<? super Distribution, T> p2,
+      Function<? super LastValue, T> p3,
       Function<? super Aggregation, T> defaultFunction);
 
   /**
@@ -100,19 +83,8 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
-        Function<? super Aggregation, T> defaultFunction) {
-      return p0.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super Sum, T> p0,
-        Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
-        Function<? super LastValue, T> p4,
+        Function<? super Distribution, T> p2,
+        Function<? super LastValue, T> p3,
         Function<? super Aggregation, T> defaultFunction) {
       return p0.apply(this);
     }
@@ -145,19 +117,8 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
-        Function<? super Aggregation, T> defaultFunction) {
-      return p1.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super Sum, T> p0,
-        Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
-        Function<? super LastValue, T> p4,
+        Function<? super Distribution, T> p2,
+        Function<? super LastValue, T> p3,
         Function<? super Aggregation, T> defaultFunction) {
       return p1.apply(this);
     }
@@ -193,21 +154,10 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
+        Function<? super Distribution, T> p2,
+        Function<? super LastValue, T> p3,
         Function<? super Aggregation, T> defaultFunction) {
-      return p2.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super Sum, T> p0,
-        Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
-        Function<? super LastValue, T> p4,
-        Function<? super Aggregation, T> defaultFunction) {
-      return p2.apply(this);
+      return defaultFunction.apply(this);
     }
   }
 
@@ -246,21 +196,10 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
+        Function<? super Distribution, T> p2,
+        Function<? super LastValue, T> p3,
         Function<? super Aggregation, T> defaultFunction) {
-      return p3.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super Sum, T> p0,
-        Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
-        Function<? super LastValue, T> p4,
-        Function<? super Aggregation, T> defaultFunction) {
-      return p3.apply(this);
+      return p2.apply(this);
     }
   }
 
@@ -291,21 +230,10 @@ public abstract class Aggregation {
     public final <T> T match(
         Function<? super Sum, T> p0,
         Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
+        Function<? super Distribution, T> p2,
+        Function<? super LastValue, T> p3,
         Function<? super Aggregation, T> defaultFunction) {
-      return defaultFunction.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super Sum, T> p0,
-        Function<? super Count, T> p1,
-        Function<? super Mean, T> p2,
-        Function<? super Distribution, T> p3,
-        Function<? super LastValue, T> p4,
-        Function<? super Aggregation, T> defaultFunction) {
-      return p4.apply(this);
+      return p3.apply(this);
     }
   }
 }

--- a/api/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/api/src/main/java/io/opencensus/stats/AggregationData.java
@@ -52,33 +52,15 @@ public abstract class AggregationData {
   /**
    * Applies the given match function to the underlying data type.
    *
-   * @since 0.8
-   * @deprecated in favor of {@link #match(Function, Function, Function, Function, Function,
-   *     Function, Function, Function)}.
-   */
-  @Deprecated
-  public abstract <T> T match(
-      Function<? super SumDataDouble, T> p0,
-      Function<? super SumDataLong, T> p1,
-      Function<? super CountData, T> p2,
-      Function<? super MeanData, T> p3,
-      Function<? super DistributionData, T> p4,
-      Function<? super AggregationData, T> defaultFunction);
-
-  /**
-   * Applies the given match function to the underlying data type.
-   *
    * @since 0.13
    */
-  @SuppressWarnings("InconsistentOverloads")
   public abstract <T> T match(
       Function<? super SumDataDouble, T> p0,
       Function<? super SumDataLong, T> p1,
       Function<? super CountData, T> p2,
-      Function<? super MeanData, T> p3,
-      Function<? super DistributionData, T> p4,
-      Function<? super LastValueDataDouble, T> p5,
-      Function<? super LastValueDataLong, T> p6,
+      Function<? super DistributionData, T> p3,
+      Function<? super LastValueDataDouble, T> p4,
+      Function<? super LastValueDataLong, T> p5,
       Function<? super AggregationData, T> defaultFunction);
 
   /**
@@ -116,21 +98,9 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super AggregationData, T> defaultFunction) {
-      return p0.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super SumDataDouble, T> p0,
-        Function<? super SumDataLong, T> p1,
-        Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super LastValueDataDouble, T> p5,
-        Function<? super LastValueDataLong, T> p6,
+        Function<? super DistributionData, T> p3,
+        Function<? super LastValueDataDouble, T> p4,
+        Function<? super LastValueDataLong, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
       return p0.apply(this);
     }
@@ -171,21 +141,9 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super AggregationData, T> defaultFunction) {
-      return p1.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super SumDataDouble, T> p0,
-        Function<? super SumDataLong, T> p1,
-        Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super LastValueDataDouble, T> p5,
-        Function<? super LastValueDataLong, T> p6,
+        Function<? super DistributionData, T> p3,
+        Function<? super LastValueDataDouble, T> p4,
+        Function<? super LastValueDataLong, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
       return p1.apply(this);
     }
@@ -226,21 +184,9 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super AggregationData, T> defaultFunction) {
-      return p2.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super SumDataDouble, T> p0,
-        Function<? super SumDataLong, T> p1,
-        Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super LastValueDataDouble, T> p5,
-        Function<? super LastValueDataLong, T> p6,
+        Function<? super DistributionData, T> p3,
+        Function<? super LastValueDataDouble, T> p4,
+        Function<? super LastValueDataLong, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
       return p2.apply(this);
     }
@@ -293,23 +239,11 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
+        Function<? super DistributionData, T> p3,
+        Function<? super LastValueDataDouble, T> p4,
+        Function<? super LastValueDataLong, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
-      return p3.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super SumDataDouble, T> p0,
-        Function<? super SumDataLong, T> p1,
-        Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super LastValueDataDouble, T> p5,
-        Function<? super LastValueDataLong, T> p6,
-        Function<? super AggregationData, T> defaultFunction) {
-      return p3.apply(this);
+      return defaultFunction.apply(this);
     }
   }
 
@@ -412,23 +346,11 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
+        Function<? super DistributionData, T> p3,
+        Function<? super LastValueDataDouble, T> p4,
+        Function<? super LastValueDataLong, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
-      return p4.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super SumDataDouble, T> p0,
-        Function<? super SumDataLong, T> p1,
-        Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super LastValueDataDouble, T> p5,
-        Function<? super LastValueDataLong, T> p6,
-        Function<? super AggregationData, T> defaultFunction) {
-      return p4.apply(this);
+      return p3.apply(this);
     }
   }
 
@@ -467,23 +389,11 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
+        Function<? super DistributionData, T> p3,
+        Function<? super LastValueDataDouble, T> p4,
+        Function<? super LastValueDataLong, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
-      return defaultFunction.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super SumDataDouble, T> p0,
-        Function<? super SumDataLong, T> p1,
-        Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super LastValueDataDouble, T> p5,
-        Function<? super LastValueDataLong, T> p6,
-        Function<? super AggregationData, T> defaultFunction) {
-      return p5.apply(this);
+      return p4.apply(this);
     }
   }
 
@@ -522,23 +432,11 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
+        Function<? super DistributionData, T> p3,
+        Function<? super LastValueDataDouble, T> p4,
+        Function<? super LastValueDataLong, T> p5,
         Function<? super AggregationData, T> defaultFunction) {
-      return defaultFunction.apply(this);
-    }
-
-    @Override
-    public final <T> T match(
-        Function<? super SumDataDouble, T> p0,
-        Function<? super SumDataLong, T> p1,
-        Function<? super CountData, T> p2,
-        Function<? super MeanData, T> p3,
-        Function<? super DistributionData, T> p4,
-        Function<? super LastValueDataDouble, T> p5,
-        Function<? super LastValueDataLong, T> p6,
-        Function<? super AggregationData, T> defaultFunction) {
-      return p6.apply(this);
+      return p5.apply(this);
     }
   }
 }

--- a/api/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/api/src/main/java/io/opencensus/stats/AggregationData.java
@@ -28,13 +28,15 @@ import javax.annotation.concurrent.Immutable;
  * {@link AggregationData} is the result of applying a given {@link Aggregation} to a set of {@code
  * MeasureValue}s.
  *
- * <p>{@link AggregationData} currently supports 4 types of basic aggregation values:
+ * <p>{@link AggregationData} currently supports 6 types of basic aggregation values:
  *
  * <ul>
  *   <li>SumDataDouble
  *   <li>SumDataLong
  *   <li>CountData
  *   <li>DistributionData
+ *   <li>LastValueDataDouble
+ *   <li>LastValueDataLong
  * </ul>
  *
  * <p>{@link ViewData} will contain one {@link AggregationData}, corresponding to its {@link
@@ -51,7 +53,8 @@ public abstract class AggregationData {
    * Applies the given match function to the underlying data type.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #match(Function, Function, Function, Function, Function)}.
+   * @deprecated in favor of {@link #match(Function, Function, Function, Function, Function,
+   *     Function, Function, Function)}.
    */
   @Deprecated
   public abstract <T> T match(
@@ -72,7 +75,10 @@ public abstract class AggregationData {
       Function<? super SumDataDouble, T> p0,
       Function<? super SumDataLong, T> p1,
       Function<? super CountData, T> p2,
-      Function<? super DistributionData, T> p3,
+      Function<? super MeanData, T> p3,
+      Function<? super DistributionData, T> p4,
+      Function<? super LastValueDataDouble, T> p5,
+      Function<? super LastValueDataLong, T> p6,
       Function<? super AggregationData, T> defaultFunction);
 
   /**
@@ -121,7 +127,10 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super DistributionData, T> p3,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super LastValueDataDouble, T> p5,
+        Function<? super LastValueDataLong, T> p6,
         Function<? super AggregationData, T> defaultFunction) {
       return p0.apply(this);
     }
@@ -173,7 +182,10 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super DistributionData, T> p3,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super LastValueDataDouble, T> p5,
+        Function<? super LastValueDataLong, T> p6,
         Function<? super AggregationData, T> defaultFunction) {
       return p1.apply(this);
     }
@@ -225,7 +237,10 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super DistributionData, T> p3,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super LastValueDataDouble, T> p5,
+        Function<? super LastValueDataLong, T> p6,
         Function<? super AggregationData, T> defaultFunction) {
       return p2.apply(this);
     }
@@ -289,9 +304,12 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super DistributionData, T> p3,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super LastValueDataDouble, T> p5,
+        Function<? super LastValueDataLong, T> p6,
         Function<? super AggregationData, T> defaultFunction) {
-      return defaultFunction.apply(this);
+      return p3.apply(this);
     }
   }
 
@@ -405,9 +423,122 @@ public abstract class AggregationData {
         Function<? super SumDataDouble, T> p0,
         Function<? super SumDataLong, T> p1,
         Function<? super CountData, T> p2,
-        Function<? super DistributionData, T> p3,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super LastValueDataDouble, T> p5,
+        Function<? super LastValueDataLong, T> p6,
         Function<? super AggregationData, T> defaultFunction) {
-      return p3.apply(this);
+      return p4.apply(this);
+    }
+  }
+
+  /**
+   * The last value of aggregated {@code MeasureValueDouble}s.
+   *
+   * @since 0.13
+   */
+  @Immutable
+  @AutoValue
+  public abstract static class LastValueDataDouble extends AggregationData {
+
+    LastValueDataDouble() {}
+
+    /**
+     * Creates a {@code LastValueDataDouble}.
+     *
+     * @param lastValue the last value.
+     * @return a {@code LastValueDataDouble}.
+     * @since 0.13
+     */
+    public static LastValueDataDouble create(double lastValue) {
+      return new AutoValue_AggregationData_LastValueDataDouble(lastValue);
+    }
+
+    /**
+     * Returns the last value.
+     *
+     * @return the last value.
+     * @since 0.13
+     */
+    public abstract double getLastValue();
+
+    @Override
+    public final <T> T match(
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super AggregationData, T> defaultFunction) {
+      return defaultFunction.apply(this);
+    }
+
+    @Override
+    public final <T> T match(
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super LastValueDataDouble, T> p5,
+        Function<? super LastValueDataLong, T> p6,
+        Function<? super AggregationData, T> defaultFunction) {
+      return p5.apply(this);
+    }
+  }
+
+  /**
+   * The last value of aggregated {@code MeasureValueLong}s.
+   *
+   * @since 0.13
+   */
+  @Immutable
+  @AutoValue
+  public abstract static class LastValueDataLong extends AggregationData {
+
+    LastValueDataLong() {}
+
+    /**
+     * Creates a {@code LastValueDataLong}.
+     *
+     * @param lastValue the last value.
+     * @return a {@code LastValueDataLong}.
+     * @since 0.13
+     */
+    public static LastValueDataLong create(long lastValue) {
+      return new AutoValue_AggregationData_LastValueDataLong(lastValue);
+    }
+
+    /**
+     * Returns the last value.
+     *
+     * @return the last value.
+     * @since 0.13
+     */
+    public abstract long getLastValue();
+
+    @Override
+    public final <T> T match(
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super AggregationData, T> defaultFunction) {
+      return defaultFunction.apply(this);
+    }
+
+    @Override
+    public final <T> T match(
+        Function<? super SumDataDouble, T> p0,
+        Function<? super SumDataLong, T> p1,
+        Function<? super CountData, T> p2,
+        Function<? super MeanData, T> p3,
+        Function<? super DistributionData, T> p4,
+        Function<? super LastValueDataDouble, T> p5,
+        Function<? super LastValueDataLong, T> p6,
+        Function<? super AggregationData, T> defaultFunction) {
+      return p6.apply(this);
     }
   }
 }

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -275,15 +275,6 @@ public abstract class ViewData {
             return null;
           }
         },
-        new Function<Aggregation.Mean, Void>() {
-          @Override
-          public Void apply(Aggregation.Mean arg) {
-            Utils.checkArgument(
-                aggregationData instanceof AggregationData.MeanData,
-                createErrorMessageForAggregation(aggregation, aggregationData));
-            return null;
-          }
-        },
         new Function<Distribution, Void>() {
           @Override
           public Void apply(Distribution arg) {
@@ -319,7 +310,18 @@ public abstract class ViewData {
             return null;
           }
         },
-        Functions.</*@Nullable*/ Void>throwAssertionError());
+        new Function<Aggregation, Void>() {
+          @Override
+          public Void apply(Aggregation arg) {
+            if (arg instanceof Aggregation.Mean) {
+              Utils.checkArgument(
+                  aggregationData instanceof AggregationData.MeanData,
+                  createErrorMessageForAggregation(aggregation, aggregationData));
+              return null;
+            }
+            throw new AssertionError();
+          }
+        });
   }
 
   private static String createErrorMessageForAggregation(

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -300,7 +300,7 @@ public abstract class ViewData {
                 new Function<MeasureDouble, Void>() {
                   @Override
                   public Void apply(MeasureDouble arg) {
-                    checkArgument(
+                    Utils.checkArgument(
                         aggregationData instanceof LastValueDataDouble,
                         createErrorMessageForAggregation(aggregation, aggregationData));
                     return null;
@@ -309,7 +309,7 @@ public abstract class ViewData {
                 new Function<MeasureLong, Void>() {
                   @Override
                   public Void apply(MeasureLong arg) {
-                    checkArgument(
+                    Utils.checkArgument(
                         aggregationData instanceof LastValueDataLong,
                         createErrorMessageForAggregation(aggregation, aggregationData));
                     return null;

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -24,9 +24,12 @@ import io.opencensus.common.Timestamp;
 import io.opencensus.internal.Utils;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.Aggregation.LastValue;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.LastValueDataDouble;
+import io.opencensus.stats.AggregationData.LastValueDataLong;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.Measure.MeasureDouble;
@@ -287,6 +290,32 @@ public abstract class ViewData {
             Utils.checkArgument(
                 aggregationData instanceof DistributionData,
                 createErrorMessageForAggregation(aggregation, aggregationData));
+            return null;
+          }
+        },
+        new Function<LastValue, Void>() {
+          @Override
+          public Void apply(LastValue arg) {
+            measure.match(
+                new Function<MeasureDouble, Void>() {
+                  @Override
+                  public Void apply(MeasureDouble arg) {
+                    checkArgument(
+                        aggregationData instanceof LastValueDataDouble,
+                        createErrorMessageForAggregation(aggregation, aggregationData));
+                    return null;
+                  }
+                },
+                new Function<MeasureLong, Void>() {
+                  @Override
+                  public Void apply(MeasureLong arg) {
+                    checkArgument(
+                        aggregationData instanceof LastValueDataLong,
+                        createErrorMessageForAggregation(aggregation, aggregationData));
+                    return null;
+                  }
+                },
+                Functions.</*@Nullable*/ Void>throwAssertionError());
             return null;
           }
         },

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -313,6 +313,9 @@ public abstract class ViewData {
         new Function<Aggregation, Void>() {
           @Override
           public Void apply(Aggregation arg) {
+            // TODO(songya): remove this once Mean aggregation is completely removed. Before that
+            // we need to continue supporting Mean, since it could still be used by users and some
+            // deprecated RPC views.
             if (arg instanceof Aggregation.Mean) {
               Utils.checkArgument(
                   aggregationData instanceof AggregationData.MeanData,

--- a/api/src/test/java/io/opencensus/stats/AggregationDataTest.java
+++ b/api/src/test/java/io/opencensus/stats/AggregationDataTest.java
@@ -109,7 +109,6 @@ public class AggregationDataTest {
             SumDataDouble.create(10.0),
             SumDataLong.create(100000000),
             CountData.create(40),
-            MeanData.create(5.0, 1),
             DistributionData.create(1, 1, 1, 1, 0, Arrays.asList(0L, 10L, 0L)),
             LastValueDataDouble.create(20.0),
             LastValueDataLong.create(200000000L));
@@ -138,13 +137,6 @@ public class AggregationDataTest {
               return null;
             }
           },
-          new Function<MeanData, Void>() {
-            @Override
-            public Void apply(MeanData arg) {
-              actual.add(arg.getMean());
-              return null;
-            }
-          },
           new Function<DistributionData, Void>() {
             @Override
             public Void apply(DistributionData arg) {
@@ -170,7 +162,7 @@ public class AggregationDataTest {
     }
 
     assertThat(actual)
-        .containsExactly(10.0, 100000000L, 40L, 5.0, Arrays.asList(0L, 10L, 0L), 20.0, 200000000L)
+        .containsExactly(10.0, 100000000L, 40L, Arrays.asList(0L, 10L, 0L), 20.0, 200000000L)
         .inOrder();
   }
 }

--- a/api/src/test/java/io/opencensus/stats/AggregationDataTest.java
+++ b/api/src/test/java/io/opencensus/stats/AggregationDataTest.java
@@ -23,6 +23,8 @@ import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.LastValueDataDouble;
+import io.opencensus.stats.AggregationData.LastValueDataLong;
 import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
@@ -95,6 +97,8 @@ public class AggregationDataTest {
         .addEqualityGroup(DistributionData.create(10, 10, 1, 1, 55.5, Arrays.asList(0L, 10L, 0L)))
         .addEqualityGroup(MeanData.create(5.0, 1), MeanData.create(5.0, 1))
         .addEqualityGroup(MeanData.create(-5.0, 1), MeanData.create(-5.0, 1))
+        .addEqualityGroup(LastValueDataDouble.create(20.0), LastValueDataDouble.create(20.0))
+        .addEqualityGroup(LastValueDataLong.create(20), LastValueDataLong.create(20))
         .testEquals();
   }
 
@@ -106,7 +110,9 @@ public class AggregationDataTest {
             SumDataLong.create(100000000),
             CountData.create(40),
             MeanData.create(5.0, 1),
-            DistributionData.create(1, 1, 1, 1, 0, Arrays.asList(0L, 10L, 0L)));
+            DistributionData.create(1, 1, 1, 1, 0, Arrays.asList(0L, 10L, 0L)),
+            LastValueDataDouble.create(20.0),
+            LastValueDataLong.create(200000000L));
 
     final List<Object> actual = new ArrayList<Object>();
     for (AggregationData aggregation : aggregations) {
@@ -146,10 +152,25 @@ public class AggregationDataTest {
               return null;
             }
           },
+          new Function<LastValueDataDouble, Void>() {
+            @Override
+            public Void apply(LastValueDataDouble arg) {
+              actual.add(arg.getLastValue());
+              return null;
+            }
+          },
+          new Function<LastValueDataLong, Void>() {
+            @Override
+            public Void apply(LastValueDataLong arg) {
+              actual.add(arg.getLastValue());
+              return null;
+            }
+          },
           Functions.<Void>throwIllegalArgumentException());
     }
 
     assertThat(actual)
-        .isEqualTo(Arrays.asList(10.0, 100000000L, 40L, 5.0, Arrays.asList(0L, 10L, 0L)));
+        .containsExactly(10.0, 100000000L, 40L, 5.0, Arrays.asList(0L, 10L, 0L), 20.0, 200000000L)
+        .inOrder();
   }
 }

--- a/api/src/test/java/io/opencensus/stats/AggregationTest.java
+++ b/api/src/test/java/io/opencensus/stats/AggregationTest.java
@@ -80,30 +80,18 @@ public class AggregationTest {
             Distribution.create(BucketBoundaries.create(Arrays.asList(-10.0, 1.0, 5.0))),
             LastValue.create());
 
-    List<String> actual1 = new ArrayList<String>();
-    List<String> actual2 = new ArrayList<String>();
+    List<String> actual = new ArrayList<String>();
     for (Aggregation aggregation : aggregations) {
-      actual1.add(
+      actual.add(
           aggregation.match(
               Functions.returnConstant("SUM"),
               Functions.returnConstant("COUNT"),
-              Functions.returnConstant("MEAN"),
               Functions.returnConstant("DISTRIBUTION"),
               Functions.returnConstant("LASTVALUE"),
               Functions.returnConstant("UNKNOWN")));
-
-      // Test the deprecated match() method.
-      actual2.add(
-          aggregation.match(
-              Functions.returnConstant("SUM"),
-              Functions.returnConstant("COUNT"),
-              Functions.returnConstant("MEAN"),
-              Functions.returnConstant("DISTRIBUTION"),
-              Functions.returnConstant("UNKNOWN")));
     }
 
-    assertThat(actual1)
-        .isEqualTo(Arrays.asList("SUM", "COUNT", "MEAN", "DISTRIBUTION", "LASTVALUE"));
-    assertThat(actual2).isEqualTo(Arrays.asList("SUM", "COUNT", "MEAN", "DISTRIBUTION", "UNKNOWN"));
+    assertThat(actual)
+        .isEqualTo(Arrays.asList("SUM", "COUNT", "UNKNOWN", "DISTRIBUTION", "LASTVALUE"));
   }
 }

--- a/api/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/api/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -27,10 +27,13 @@ import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.Aggregation.LastValue;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.LastValueDataDouble;
+import io.opencensus.stats.AggregationData.LastValueDataLong;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.View.AggregationWindow;
@@ -216,6 +219,22 @@ public final class ViewDataTest {
             DistributionData.create(1, 1, 1, 1, 0, Arrays.asList(0L, 1L, 0L)),
             Arrays.asList(V10, V20),
             CountData.create(100)));
+  }
+
+  @Test
+  public void preventAggregationAndAggregationDataMismatch_LastValueDouble_LastValueLong() {
+    aggregationAndAggregationDataMismatch(
+        createView(LastValue.create(), MEASURE_DOUBLE),
+        ImmutableMap.<List<TagValue>, AggregationData>of(
+            Arrays.asList(V1, V2), LastValueDataLong.create(100)));
+  }
+
+  @Test
+  public void preventAggregationAndAggregationDataMismatch_LastValueLong_LastValueDouble() {
+    aggregationAndAggregationDataMismatch(
+        createView(LastValue.create(), MEASURE_LONG),
+        ImmutableMap.<List<TagValue>, AggregationData>of(
+            Arrays.asList(V1, V2), LastValueDataDouble.create(100)));
   }
 
   private static View createView(Aggregation aggregation) {

--- a/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/StatszZPageHandler.java
+++ b/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/StatszZPageHandler.java
@@ -326,6 +326,11 @@ final class StatszZPageHandler extends ZPageHandler {
                 new Function<Aggregation, String>() {
                   @Override
                   public String apply(Aggregation arg) {
+                    // TODO(songya): remove this once Mean aggregation is completely removed. Before
+                    // that
+                    // we need to continue supporting Mean, since it could still be used by users
+                    // and some
+                    // deprecated RPC views.
                     if (arg instanceof Aggregation.Mean) {
                       return "Mean";
                     }
@@ -415,6 +420,11 @@ final class StatszZPageHandler extends ZPageHandler {
             new Function<Aggregation, Void>() {
               @Override
               public Void apply(Aggregation arg) {
+                // TODO(songya): remove this once Mean aggregation is completely removed. Before
+                // that
+                // we need to continue supporting Mean, since it could still be used by users and
+                // some
+                // deprecated RPC views.
                 if (arg instanceof Aggregation.Mean) {
                   formatter.format("<th class=\"l1\">%s, %s</th>", TABLE_HEADER_MEAN, unit);
                   formatter.format("<th class=\"l1\">%s</th>", TABLE_HEADER_COUNT);

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
@@ -211,6 +211,9 @@ final class PrometheusExportUtils {
         new Function<AggregationData, Void>() {
           @Override
           public Void apply(AggregationData arg) {
+            // TODO(songya): remove this once Mean aggregation is completely removed. Before that
+            // we need to continue supporting Mean, since it could still be used by users and some
+            // deprecated RPC views.
             if (arg instanceof AggregationData.MeanData) {
               AggregationData.MeanData meanData = (AggregationData.MeanData) arg;
               samples.add(

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
@@ -28,10 +28,13 @@ import io.opencensus.common.Duration;
 import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.Aggregation.LastValue;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.LastValueDataDouble;
+import io.opencensus.stats.AggregationData.LastValueDataLong;
 import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
@@ -71,6 +74,7 @@ public class PrometheusExportUtilsTest {
   private static final BucketBoundaries BUCKET_BOUNDARIES =
       BucketBoundaries.create(Arrays.asList(-5.0, 0.0, 5.0));
   private static final Distribution DISTRIBUTION = Distribution.create(BUCKET_BOUNDARIES);
+  private static final LastValue LAST_VALUE = LastValue.create();
   private static final View.Name VIEW_NAME_1 = View.Name.create("view1");
   private static final View.Name VIEW_NAME_2 = View.Name.create("view2");
   private static final View.Name VIEW_NAME_3 = View.Name.create("view-3");
@@ -90,6 +94,8 @@ public class PrometheusExportUtilsTest {
   private static final MeanData MEAN_DATA = MeanData.create(3.4, 22);
   private static final DistributionData DISTRIBUTION_DATA =
       DistributionData.create(4.4, 5, -3.2, 15.7, 135.22, Arrays.asList(0L, 2L, 2L, 1L));
+  private static final LastValueDataDouble LAST_VALUE_DATA_DOUBLE = LastValueDataDouble.create(7.9);
+  private static final LastValueDataLong LAST_VALUE_DATA_LONG = LastValueDataLong.create(66666666);
   private static final View VIEW1 =
       View.create(
           VIEW_NAME_1, DESCRIPTION, MEASURE_DOUBLE, COUNT, Arrays.asList(K1, K2), CUMULATIVE);
@@ -121,6 +127,7 @@ public class PrometheusExportUtilsTest {
     assertThat(PrometheusExportUtils.getType(DISTRIBUTION, CUMULATIVE)).isEqualTo(Type.HISTOGRAM);
     assertThat(PrometheusExportUtils.getType(SUM, CUMULATIVE)).isEqualTo(Type.UNTYPED);
     assertThat(PrometheusExportUtils.getType(MEAN, CUMULATIVE)).isEqualTo(Type.SUMMARY);
+    assertThat(PrometheusExportUtils.getType(LAST_VALUE, CUMULATIVE)).isEqualTo(Type.GAUGE);
   }
 
   @Test
@@ -190,6 +197,16 @@ public class PrometheusExportUtilsTest {
             new Sample(SAMPLE_NAME + "_count", Arrays.asList("k1"), Arrays.asList("v1"), 5),
             new Sample(SAMPLE_NAME + "_sum", Arrays.asList("k1"), Arrays.asList("v1"), 22.0))
         .inOrder();
+    assertThat(
+            PrometheusExportUtils.getSamples(
+                SAMPLE_NAME, Arrays.asList(K1, K2), Arrays.asList(V1, V2), LAST_VALUE_DATA_DOUBLE))
+        .containsExactly(
+            new Sample(SAMPLE_NAME, Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), 7.9));
+    assertThat(
+            PrometheusExportUtils.getSamples(
+                SAMPLE_NAME, Arrays.asList(K3), Arrays.asList(V3), LAST_VALUE_DATA_LONG))
+        .containsExactly(
+            new Sample(SAMPLE_NAME, Arrays.asList("k_3"), Arrays.asList("v-3"), 66666666));
   }
 
   @Test

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
@@ -173,6 +173,9 @@ final class SignalFxSessionAdaptor {
         new Function<AggregationData, Void>() {
           @Override
           public Void apply(AggregationData arg) {
+            // TODO(songya): remove this once Mean aggregation is completely removed. Before that
+            // we need to continue supporting Mean, since it could still be used by users and some
+            // deprecated RPC views.
             if (arg instanceof AggregationData.MeanData) {
               builder.setDoubleValue(((AggregationData.MeanData) arg).getMean());
               return null;

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptor.java
@@ -24,11 +24,12 @@ import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Datum;
 import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.Dimension;
 import com.signalfx.metrics.protobuf.SignalFxProtocolBuffers.MetricType;
 import io.opencensus.common.Function;
-import io.opencensus.common.Functions;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.AggregationData;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.LastValueDataDouble;
+import io.opencensus.stats.AggregationData.LastValueDataLong;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
 import io.opencensus.stats.View;
@@ -88,7 +89,7 @@ final class SignalFxSessionAdaptor {
   @javax.annotation.Nullable
   static MetricType getMetricTypeForAggregation(
       Aggregation aggregation, View.AggregationWindow window) {
-    if (aggregation instanceof Aggregation.Mean) {
+    if (aggregation instanceof Aggregation.Mean || aggregation instanceof Aggregation.LastValue) {
       return MetricType.GAUGE;
     } else if (aggregation instanceof Aggregation.Count || aggregation instanceof Aggregation.Sum) {
       if (window instanceof View.AggregationWindow.Cumulative) {
@@ -148,13 +149,6 @@ final class SignalFxSessionAdaptor {
             return null;
           }
         },
-        new Function<AggregationData.MeanData, Void>() {
-          @Override
-          public Void apply(AggregationData.MeanData arg) {
-            builder.setDoubleValue(arg.getMean());
-            return null;
-          }
-        },
         new Function<DistributionData, Void>() {
           @Override
           public Void apply(DistributionData arg) {
@@ -162,7 +156,30 @@ final class SignalFxSessionAdaptor {
             throw new IllegalArgumentException("Distribution aggregations are not supported");
           }
         },
-        Functions.</*@Nullable*/ Void>throwIllegalArgumentException());
+        new Function<LastValueDataDouble, Void>() {
+          @Override
+          public Void apply(LastValueDataDouble arg) {
+            builder.setDoubleValue(arg.getLastValue());
+            return null;
+          }
+        },
+        new Function<LastValueDataLong, Void>() {
+          @Override
+          public Void apply(LastValueDataLong arg) {
+            builder.setIntValue(arg.getLastValue());
+            return null;
+          }
+        },
+        new Function<AggregationData, Void>() {
+          @Override
+          public Void apply(AggregationData arg) {
+            if (arg instanceof AggregationData.MeanData) {
+              builder.setDoubleValue(((AggregationData.MeanData) arg).getMean());
+              return null;
+            }
+            throw new IllegalArgumentException("Unknown Aggregation.");
+          }
+        });
     return builder.build();
   }
 }

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -198,6 +198,9 @@ final class StackdriverExportUtils {
         new Function<Aggregation, MetricDescriptor.ValueType>() {
           @Override
           public MetricDescriptor.ValueType apply(Aggregation arg) {
+            // TODO(songya): remove this once Mean aggregation is completely removed. Before that
+            // we need to continue supporting Mean, since it could still be used by users and some
+            // deprecated RPC views.
             if (arg instanceof Aggregation.Mean) {
               return MetricDescriptor.ValueType.DOUBLE;
             }
@@ -348,6 +351,9 @@ final class StackdriverExportUtils {
         new Function<AggregationData, Void>() {
           @Override
           public Void apply(AggregationData arg) {
+            // TODO(songya): remove this once Mean aggregation is completely removed. Before that
+            // we need to continue supporting Mean, since it could still be used by users and some
+            // deprecated RPC views.
             if (arg instanceof AggregationData.MeanData) {
               builder.setDoubleValue(((AggregationData.MeanData) arg).getMean());
               return null;

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -35,10 +35,13 @@ import io.opencensus.common.Duration;
 import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.Aggregation.LastValue;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.LastValueDataDouble;
+import io.opencensus.stats.AggregationData.LastValueDataLong;
 import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
@@ -92,6 +95,7 @@ public class StackdriverExportUtilsTest {
   private static final Count COUNT = Count.create();
   private static final Mean MEAN = Mean.create();
   private static final Distribution DISTRIBUTION = Distribution.create(BUCKET_BOUNDARIES);
+  private static final LastValue LAST_VALUE = LastValue.create();
   private static final String PROJECT_ID = "id";
   private static final MonitoredResource DEFAULT_RESOURCE =
       MonitoredResource.newBuilder().setType("global").build();
@@ -116,10 +120,14 @@ public class StackdriverExportUtilsTest {
 
   @Test
   public void createMetricKind() {
-    assertThat(StackdriverExportUtils.createMetricKind(CUMULATIVE))
+    assertThat(StackdriverExportUtils.createMetricKind(CUMULATIVE, SUM))
         .isEqualTo(MetricKind.CUMULATIVE);
-    assertThat(StackdriverExportUtils.createMetricKind(INTERVAL))
+    assertThat(StackdriverExportUtils.createMetricKind(INTERVAL, COUNT))
         .isEqualTo(MetricKind.UNRECOGNIZED);
+    assertThat(StackdriverExportUtils.createMetricKind(CUMULATIVE, LAST_VALUE))
+        .isEqualTo(MetricKind.GAUGE);
+    assertThat(StackdriverExportUtils.createMetricKind(INTERVAL, LAST_VALUE))
+        .isEqualTo(MetricKind.GAUGE);
   }
 
   @Test
@@ -140,6 +148,10 @@ public class StackdriverExportUtilsTest {
         .isEqualTo(MetricDescriptor.ValueType.DISTRIBUTION);
     assertThat(StackdriverExportUtils.createValueType(DISTRIBUTION, MEASURE_LONG))
         .isEqualTo(MetricDescriptor.ValueType.DISTRIBUTION);
+    assertThat(StackdriverExportUtils.createValueType(LAST_VALUE, MEASURE_DOUBLE))
+        .isEqualTo(MetricDescriptor.ValueType.DOUBLE);
+    assertThat(StackdriverExportUtils.createValueType(LAST_VALUE, MEASURE_LONG))
+        .isEqualTo(MetricDescriptor.ValueType.INT64);
   }
 
   @Test
@@ -148,6 +160,8 @@ public class StackdriverExportUtilsTest {
     assertThat(StackdriverExportUtils.createUnit(COUNT, MEASURE_DOUBLE)).isEqualTo("1");
     assertThat(StackdriverExportUtils.createUnit(MEAN, MEASURE_DOUBLE)).isEqualTo(MEASURE_UNIT);
     assertThat(StackdriverExportUtils.createUnit(DISTRIBUTION, MEASURE_DOUBLE))
+        .isEqualTo(MEASURE_UNIT);
+    assertThat(StackdriverExportUtils.createUnit(LAST_VALUE, MEASURE_DOUBLE))
         .isEqualTo(MEASURE_UNIT);
   }
 
@@ -288,6 +302,10 @@ public class StackdriverExportUtilsTest {
                 .setDistributionValue(
                     StackdriverExportUtils.createDistribution(distributionData, BUCKET_BOUNDARIES))
                 .build());
+    assertThat(StackdriverExportUtils.createTypedValue(LAST_VALUE, LastValueDataDouble.create(9.9)))
+        .isEqualTo(TypedValue.newBuilder().setDoubleValue(9.9).build());
+    assertThat(StackdriverExportUtils.createTypedValue(LAST_VALUE, LastValueDataLong.create(90000)))
+        .isEqualTo(TypedValue.newBuilder().setInt64Value(90000).build());
   }
 
   @Test

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -498,6 +498,9 @@ abstract class MutableViewData {
     private static final CreateMutableCount INSTANCE = new CreateMutableCount();
   }
 
+  // TODO(songya): remove this once Mean aggregation is completely removed. Before that
+  // we need to continue supporting Mean, since it could still be used by users and some
+  // deprecated RPC views.
   private static final class AggregationDefaultFunction
       implements Function<Aggregation, MutableAggregation> {
     @Override

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -161,10 +161,9 @@ abstract class MutableViewData {
     return aggregation.match(
         CreateMutableSum.INSTANCE,
         CreateMutableCount.INSTANCE,
-        CreateMutableMean.INSTANCE,
         CreateMutableDistribution.INSTANCE,
         CreateMutableLastValue.INSTANCE,
-        Functions.<MutableAggregation>throwIllegalArgumentException());
+        AggregationDefaultFunction.INSTANCE);
   }
 
   /**
@@ -499,14 +498,17 @@ abstract class MutableViewData {
     private static final CreateMutableCount INSTANCE = new CreateMutableCount();
   }
 
-  private static final class CreateMutableMean
-      implements Function<Aggregation.Mean, MutableAggregation> {
+  private static final class AggregationDefaultFunction
+      implements Function<Aggregation, MutableAggregation> {
     @Override
-    public MutableAggregation apply(Aggregation.Mean arg) {
-      return MutableMean.create();
+    public MutableAggregation apply(Aggregation arg) {
+      if (arg instanceof Aggregation.Mean) {
+        return MutableMean.create();
+      }
+      throw new IllegalArgumentException("Unknown Aggregation.");
     }
 
-    private static final CreateMutableMean INSTANCE = new CreateMutableMean();
+    private static final AggregationDefaultFunction INSTANCE = new AggregationDefaultFunction();
   }
 
   private static final class CreateMutableDistribution

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsTestUtil.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsTestUtil.java
@@ -26,6 +26,8 @@ import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.AggregationData;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
+import io.opencensus.stats.AggregationData.LastValueDataDouble;
+import io.opencensus.stats.AggregationData.LastValueDataLong;
 import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
@@ -130,6 +132,24 @@ final class StatsTestUtil {
           public Void apply(DistributionData arg) {
             assertThat(actual).isInstanceOf(DistributionData.class);
             assertDistributionDataEquals(arg, (DistributionData) actual, tolerance);
+            return null;
+          }
+        },
+        new Function<LastValueDataDouble, Void>() {
+          @Override
+          public Void apply(LastValueDataDouble arg) {
+            assertThat(actual).isInstanceOf(LastValueDataDouble.class);
+            assertThat(((LastValueDataDouble) actual).getLastValue())
+                .isWithin(tolerance)
+                .of(arg.getLastValue());
+            return null;
+          }
+        },
+        new Function<LastValueDataLong, Void>() {
+          @Override
+          public Void apply(LastValueDataLong arg) {
+            assertThat(actual).isInstanceOf(LastValueDataLong.class);
+            assertThat(((LastValueDataLong) actual).getLastValue()).isEqualTo(arg.getLastValue());
             return null;
           }
         },

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsTestUtil.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsTestUtil.java
@@ -119,14 +119,6 @@ final class StatsTestUtil {
             return null;
           }
         },
-        new Function<MeanData, Void>() {
-          @Override
-          public Void apply(MeanData arg) {
-            assertThat(actual).isInstanceOf(MeanData.class);
-            assertThat(((MeanData) actual).getMean()).isWithin(tolerance).of(arg.getMean());
-            return null;
-          }
-        },
         new Function<DistributionData, Void>() {
           @Override
           public Void apply(DistributionData arg) {
@@ -153,7 +145,19 @@ final class StatsTestUtil {
             return null;
           }
         },
-        Functions.<Void>throwIllegalArgumentException());
+        new Function<AggregationData, Void>() {
+          @Override
+          public Void apply(AggregationData arg) {
+            if (arg instanceof MeanData) {
+              assertThat(actual).isInstanceOf(MeanData.class);
+              assertThat(((MeanData) actual).getMean())
+                  .isWithin(tolerance)
+                  .of(((MeanData) arg).getMean());
+              return null;
+            }
+            throw new IllegalArgumentException("Unknown Aggregation.");
+          }
+        });
   }
 
   // Create an empty ViewData with the given View.

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -28,9 +28,12 @@ import io.opencensus.implcore.internal.SimpleEventQueue;
 import io.opencensus.implcore.tags.TagsComponentImplBase;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.Aggregation.LastValue;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.AggregationData;
+import io.opencensus.stats.AggregationData.LastValueDataDouble;
+import io.opencensus.stats.AggregationData.LastValueDataLong;
 import io.opencensus.stats.AggregationData.MeanData;
 import io.opencensus.stats.AggregationData.SumDataDouble;
 import io.opencensus.stats.AggregationData.SumDataLong;
@@ -109,6 +112,7 @@ public class ViewManagerImplTest {
   private static final Sum SUM = Sum.create();
   private static final Mean MEAN = Mean.create();
   private static final Distribution DISTRIBUTION = Distribution.create(BUCKET_BOUNDARIES);
+  private static final LastValue LAST_VALUE = LastValue.create();
 
   private final TestClock clock = TestClock.create();
 
@@ -284,6 +288,16 @@ public class ViewManagerImplTest {
     testRecordCumulative(MEASURE_LONG, SUM, 1000, 2000, 3000, 4000);
   }
 
+  @Test
+  public void testRecordDouble_lastvalue_cumulative() {
+    testRecordCumulative(MEASURE_DOUBLE, LAST_VALUE, 11.1, 22.2, 33.3, 44.4);
+  }
+
+  @Test
+  public void testRecordLong_lastvalue_cumulative() {
+    testRecordCumulative(MEASURE_LONG, LAST_VALUE, 1000, 2000, 3000, 4000);
+  }
+
   private void testRecordCumulative(Measure measure, Aggregation aggregation, double... values) {
     View view = createCumulativeView(VIEW_NAME, measure, aggregation, Arrays.asList(KEY));
     clock.setTime(Timestamp.create(1, 2));
@@ -355,6 +369,32 @@ public class ViewManagerImplTest {
         SumDataLong.create(Math.round(3000 * 0.6 + 12000)),
         SumDataLong.create(-4000),
         SumDataLong.create(30));
+  }
+
+  @Test
+  public void testRecordDouble_lastvalue_interval() {
+    testRecordInterval(
+        MEASURE_DOUBLE,
+        LAST_VALUE,
+        new double[] {20.0, -1.0, 1.0, -5.0, 5.0},
+        9.0,
+        30.0,
+        LastValueDataDouble.create(5.0),
+        LastValueDataDouble.create(9.0),
+        LastValueDataDouble.create(30.0));
+  }
+
+  @Test
+  public void testRecordLong_lastvalue_interval() {
+    testRecordInterval(
+        MEASURE_LONG,
+        LAST_VALUE,
+        new double[] {1000, 2000, 3000, 4000, 5000},
+        -5000,
+        30,
+        LastValueDataLong.create(5000),
+        LastValueDataLong.create(-5000),
+        LastValueDataLong.create(30));
   }
 
   private void testRecordInterval(


### PR DESCRIPTION
Closes https://github.com/census-instrumentation/opencensus-java/issues/1047.

Add Aggregation.LastValue and AggregationData.LastValueData to support Gauge, according to the design doc and [OpenCensus-specs](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/DataAggregation.md#aggregation).

Might be easier to review by each commit. ~~I'll post a follow-up PR to support LastValue/LastValueData for zpage and exporters.~~

/cc @bogdandrutu 