### PR TITLE
Add a PrometheusStatsConfiguration class.

### DIFF
--- a/exporters/stats/prometheus/build.gradle
+++ b/exporters/stats/prometheus/build.gradle
@@ -6,6 +6,8 @@ description = 'OpenCensus Stats Prometheus Exporter'
 }
 
 dependencies {
+    compileOnly libraries.auto_value
+
     compile project(':opencensus-api'),
             libraries.prometheus_simpleclient
 

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollector.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollector.java
@@ -50,12 +50,37 @@ public final class PrometheusStatsCollector extends Collector implements Collect
    * Creates a {@link PrometheusStatsCollector} and registers it to Prometheus {@link
    * CollectorRegistry#defaultRegistry}.
    *
+   * <p>This is equivalent with:
+   *
+   * <pre>{@code
+   * PrometheusStatsCollector.createAndRegister(PrometheusStatsConfiguration.builder().build());
+   * }</pre>
+   *
    * @throws IllegalArgumentException if a {@code PrometheusStatsCollector} has already been created
    *     and registered.
    * @since 0.12
    */
   public static void createAndRegister() {
     new PrometheusStatsCollector(Stats.getViewManager()).register();
+  }
+
+  /**
+   * Creates a {@link PrometheusStatsCollector} and registers it to the given Prometheus {@link
+   * CollectorRegistry} in the {@link PrometheusStatsConfiguration}.
+   *
+   * <p>If {@code CollectorRegistry} of the configuration is not set, the collector will use {@link
+   * CollectorRegistry#defaultRegistry}.
+   *
+   * @throws IllegalArgumentException if a {@code PrometheusStatsCollector} has already been created
+   *     and registered.
+   * @since 0.13
+   */
+  public static void createAndRegister(PrometheusStatsConfiguration configuration) {
+    CollectorRegistry registry =
+        configuration.getRegistry() == null
+            ? CollectorRegistry.defaultRegistry
+            : configuration.getRegistry();
+    new PrometheusStatsCollector(Stats.getViewManager()).register(registry);
   }
 
   @Override

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollector.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollector.java
@@ -76,10 +76,10 @@ public final class PrometheusStatsCollector extends Collector implements Collect
    * @since 0.13
    */
   public static void createAndRegister(PrometheusStatsConfiguration configuration) {
-    CollectorRegistry registry =
-        configuration.getRegistry() == null
-            ? CollectorRegistry.defaultRegistry
-            : configuration.getRegistry();
+    CollectorRegistry registry = configuration.getRegistry();
+    if (registry == null) {
+      registry = CollectorRegistry.defaultRegistry;
+    }
     new PrometheusStatsCollector(Stats.getViewManager()).register(registry);
   }
 

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsConfiguration.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, OpenCensus Authors
+ * Copyright 2018, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsConfiguration.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsConfiguration.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.stats.prometheus;
+
+import com.google.auto.value.AutoValue;
+import io.prometheus.client.CollectorRegistry;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Configurations for {@link PrometheusStatsCollector}.
+ *
+ * @since 0.13
+ */
+@AutoValue
+@Immutable
+// Suppress Checker Framework warning about missing @Nullable in generated equals method.
+@AutoValue.CopyAnnotations
+@SuppressWarnings("nullness")
+public abstract class PrometheusStatsConfiguration {
+
+  PrometheusStatsConfiguration() {}
+
+  /**
+   * Returns the Prometheus {@link CollectorRegistry}.
+   *
+   * @return the Prometheus {@code CollectorRegistry}.
+   * @since 0.13
+   */
+  @Nullable
+  public abstract CollectorRegistry getRegistry();
+
+  /**
+   * Returns a new {@link Builder}.
+   *
+   * @return a {@code Builder}.
+   * @since 0.13
+   */
+  public static Builder builder() {
+    return new AutoValue_PrometheusStatsConfiguration.Builder();
+  }
+
+  /**
+   * Builder for {@link PrometheusStatsConfiguration}.
+   *
+   * @since 0.13
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    Builder() {}
+
+    /**
+     * Sets the given Prometheus {@link CollectorRegistry}.
+     *
+     * @param registry the Prometheus {@code CollectorRegistry}.
+     * @return this.
+     * @since 0.13
+     */
+    public abstract Builder setRegistry(CollectorRegistry registry);
+
+    /**
+     * Builds a new {@link PrometheusStatsConfiguration} with current settings.
+     *
+     * @return a {@code PrometheusStatsConfiguration}.
+     * @since 0.13
+     */
+    public abstract PrometheusStatsConfiguration build();
+  }
+}


### PR DESCRIPTION
Add a PrometheusStatsConfiguration class, so that users can use a custom Prometheus registry for exporting metrics.

Equivalent to https://github.com/census-instrumentation/opencensus-go/pull/533.