### PR TITLE
Allow users to use custom metric name prefix for Stackdriver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@
   on recording exemplars.
 - Reduce the default limit on `Link`s per `Span` to 32 (was 128 before).
 - Add Spring support for `@Traced` annotation and java.sql.PreparedStatements 
-  tracing  
+  tracing
+- Allow custom prefix for Stackdriver metrics in `StackdriverStatsConfiguration`.
 
 ## 0.15.0 - 2018-06-20
 - Expose the factory methods of MonitoredResource.

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -221,10 +221,7 @@ final class StackdriverExportUtils {
     builder.setName(String.format("projects/%s/metricDescriptors/%s", projectId, type));
     builder.setType(type);
     builder.setDescription(view.getDescription());
-    String displayName =
-        metricNamePrefix == null
-            ? DEFAULT_DISPLAY_NAME_PREFIX + '/' + viewName
-            : metricNamePrefix + '/' + viewName;
+    String displayName = createDisplayName(viewName, metricNamePrefix);
     builder.setDisplayName(displayName);
     for (TagKey tagKey : view.getColumns()) {
       builder.addLabels(createLabelDescriptor(tagKey));
@@ -255,6 +252,18 @@ final class StackdriverExportUtils {
       }
     }
     return domain + viewName;
+  }
+
+  private static String createDisplayName(
+      String viewName, @javax.annotation.Nullable String metricNamePrefix) {
+    if (metricNamePrefix == null) {
+      return DEFAULT_DISPLAY_NAME_PREFIX + '/' + viewName;
+    } else {
+      if (!metricNamePrefix.endsWith("/")) {
+        metricNamePrefix += '/';
+      }
+      return metricNamePrefix + viewName;
+    }
   }
 
   // Construct a LabelDescriptor from a TagKey

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -89,6 +89,7 @@ final class StackdriverExportUtils {
 
   private static final Logger logger = Logger.getLogger(StackdriverExportUtils.class.getName());
   private static final String CUSTOM_METRIC_DOMAIN = "custom.googleapis.com";
+  private static final String EXTERNAL_METRIC_DOMAIN = "external.googleapis.com";
   private static final String CUSTOM_OPENCENSUS_DOMAIN = CUSTOM_METRIC_DOMAIN + "/opencensus/";
   private static final String OPENCENSUS_TASK_VALUE_DEFAULT = generateDefaultTaskValue();
   private static final String PROJECT_ID_LABEL_KEY = "project_id";
@@ -242,10 +243,17 @@ final class StackdriverExportUtils {
 
   private static String generateType(
       String viewName, @javax.annotation.Nullable String metricNamePrefix) {
-    String domain =
-        metricNamePrefix == null
-            ? CUSTOM_OPENCENSUS_DOMAIN
-            : CUSTOM_METRIC_DOMAIN + '/' + metricNamePrefix + '/';
+    String domain;
+    if (metricNamePrefix == null) {
+      domain = CUSTOM_OPENCENSUS_DOMAIN;
+    } else {
+      if (metricNamePrefix.startsWith(CUSTOM_METRIC_DOMAIN)
+          || metricNamePrefix.startsWith(EXTERNAL_METRIC_DOMAIN)) {
+        domain = metricNamePrefix;
+      } else {
+        domain = String.format("%s/%s/", CUSTOM_METRIC_DOMAIN, metricNamePrefix);
+      }
+    }
     return domain + viewName;
   }
 

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -204,7 +204,8 @@ final class StackdriverExportUtils {
 
   // Construct a MetricDescriptor using a View.
   @javax.annotation.Nullable
-  static MetricDescriptor createMetricDescriptor(View view, String projectId) {
+  static MetricDescriptor createMetricDescriptor(
+      View view, String projectId, String displayNamePrefix) {
     if (!(view.getWindow() instanceof View.AggregationWindow.Cumulative)) {
       // TODO(songya): Only Cumulative view will be exported to Stackdriver in this version.
       return null;
@@ -218,7 +219,7 @@ final class StackdriverExportUtils {
     builder.setName(String.format("projects/%s/metricDescriptors/%s", projectId, type));
     builder.setType(type);
     builder.setDescription(view.getDescription());
-    builder.setDisplayName("OpenCensus/" + viewName);
+    builder.setDisplayName(displayNamePrefix + '/' + viewName);
     for (TagKey tagKey : view.getColumns()) {
       builder.addLabels(createLabelDescriptor(tagKey));
     }

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
@@ -71,6 +71,7 @@ final class StackdriverExporterWorker implements Runnable {
   private final MetricServiceClient metricServiceClient;
   private final ViewManager viewManager;
   private final MonitoredResource monitoredResource;
+  private final String displayNamePrefix;
   private final Map<View.Name, View> registeredViews = new HashMap<View.Name, View>();
 
   private static final Tracer tracer = Tracing.getTracer();
@@ -81,13 +82,15 @@ final class StackdriverExporterWorker implements Runnable {
       MetricServiceClient metricServiceClient,
       Duration exportInterval,
       ViewManager viewManager,
-      MonitoredResource monitoredResource) {
+      MonitoredResource monitoredResource,
+      String displayNamePrefix) {
     this.scheduleDelayMillis = exportInterval.toMillis();
     this.projectId = projectId;
     projectName = ProjectName.newBuilder().setProject(projectId).build();
     this.metricServiceClient = metricServiceClient;
     this.viewManager = viewManager;
     this.monitoredResource = monitoredResource;
+    this.displayNamePrefix = displayNamePrefix;
 
     Tracing.getExportComponent()
         .getSampledSpanStore()
@@ -122,7 +125,7 @@ final class StackdriverExporterWorker implements Runnable {
       // canonical metrics. Registration is required only for custom view definitions. Canonical
       // views should be pre-registered.
       MetricDescriptor metricDescriptor =
-          StackdriverExportUtils.createMetricDescriptor(view, projectId);
+          StackdriverExportUtils.createMetricDescriptor(view, projectId, displayNamePrefix);
       if (metricDescriptor == null) {
         // Don't register interval views in this version.
         return false;

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
@@ -43,7 +43,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /*>>>
@@ -72,7 +71,7 @@ final class StackdriverExporterWorker implements Runnable {
   private final MetricServiceClient metricServiceClient;
   private final ViewManager viewManager;
   private final MonitoredResource monitoredResource;
-  @Nullable private final String metricNamePrefix;
+  @javax.annotation.Nullable private final String metricNamePrefix;
   private final Map<View.Name, View> registeredViews = new HashMap<View.Name, View>();
 
   private static final Tracer tracer = Tracing.getTracer();
@@ -84,7 +83,7 @@ final class StackdriverExporterWorker implements Runnable {
       Duration exportInterval,
       ViewManager viewManager,
       MonitoredResource monitoredResource,
-      @Nullable String metricNamePrefix) {
+      @javax.annotation.Nullable String metricNamePrefix) {
     this.scheduleDelayMillis = exportInterval.toMillis();
     this.projectId = projectId;
     projectName = ProjectName.newBuilder().setProject(projectId).build();

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
@@ -71,6 +71,15 @@ public abstract class StackdriverStatsConfiguration {
   public abstract MonitoredResource getMonitoredResource();
 
   /**
+   * Returns the name prefix when displaying Stackdriver metrics.
+   *
+   * @return the display name prefix.
+   * @since 0.13
+   */
+  @Nullable
+  public abstract String getDisplayNamePrefix();
+
+  /**
    * Returns a new {@link Builder}.
    *
    * @return a {@code Builder}.
@@ -125,6 +134,15 @@ public abstract class StackdriverStatsConfiguration {
      * @since 0.11
      */
     public abstract Builder setMonitoredResource(MonitoredResource monitoredResource);
+
+    /**
+     * Sets the the name prefix when displaying Stackdriver metrics.
+     *
+     * @param prefix the display name prefix.
+     * @return this.
+     * @since 0.13
+     */
+    public abstract Builder setDisplayNamePrefix(String prefix);
 
     /**
      * Builds a new {@link StackdriverStatsConfiguration} with current settings.

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
@@ -74,7 +74,7 @@ public abstract class StackdriverStatsConfiguration {
    * Returns the name prefix for Stackdriver metrics.
    *
    * @return the metric name prefix.
-   * @since 0.13
+   * @since 0.16
    */
   @Nullable
   public abstract String getMetricNamePrefix();
@@ -138,9 +138,13 @@ public abstract class StackdriverStatsConfiguration {
     /**
      * Sets the the name prefix for Stackdriver metrics.
      *
+     * <p>It is suggested to use prefix with custom or external domain name, for example
+     * "custom.googleapis.com/myorg/" or "external.googleapis.com/prometheus/". If the given prefix
+     * doesn't start with a valid domain, we will add "custom.googleapis.com/" before the prefix.
+     *
      * @param prefix the metric name prefix.
      * @return this.
-     * @since 0.13
+     * @since 0.16
      */
     public abstract Builder setMetricNamePrefix(String prefix);
 

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
@@ -71,13 +71,13 @@ public abstract class StackdriverStatsConfiguration {
   public abstract MonitoredResource getMonitoredResource();
 
   /**
-   * Returns the name prefix when displaying Stackdriver metrics.
+   * Returns the name prefix for Stackdriver metrics.
    *
-   * @return the display name prefix.
+   * @return the metric name prefix.
    * @since 0.13
    */
   @Nullable
-  public abstract String getDisplayNamePrefix();
+  public abstract String getMetricNamePrefix();
 
   /**
    * Returns a new {@link Builder}.
@@ -136,13 +136,13 @@ public abstract class StackdriverStatsConfiguration {
     public abstract Builder setMonitoredResource(MonitoredResource monitoredResource);
 
     /**
-     * Sets the the name prefix when displaying Stackdriver metrics.
+     * Sets the the name prefix for Stackdriver metrics.
      *
-     * @param prefix the display name prefix.
+     * @param prefix the metric name prefix.
      * @return this.
      * @since 0.13
      */
-    public abstract Builder setDisplayNamePrefix(String prefix);
+    public abstract Builder setMetricNamePrefix(String prefix);
 
     /**
      * Builds a new {@link StackdriverStatsConfiguration} with current settings.

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -17,7 +17,6 @@
 package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.DEFAULT_DISPLAY_NAME_PREFIX;
 
 import com.google.api.Distribution.BucketOptions;
 import com.google.api.Distribution.BucketOptions.Explicit;
@@ -106,6 +105,7 @@ public class StackdriverExportUtilsTest {
   @Test
   public void testConstant() {
     assertThat(StackdriverExportUtils.LABEL_DESCRIPTION).isEqualTo("OpenCensus TagKey");
+    assertThat(StackdriverExportUtils.DEFAULT_DISPLAY_NAME_PREFIX).isEqualTo("OpenCensus  ");
   }
 
   @Test
@@ -176,7 +176,7 @@ public class StackdriverExportUtilsTest {
             DISTRIBUTION,
             Arrays.asList(KEY),
             CUMULATIVE);
-    assertThat(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1)))
+    assertThat(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1), null))
         .isEqualTo(
             Metric.newBuilder()
                 .setType("custom.googleapis.com/opencensus/" + VIEW_NAME)
@@ -195,7 +195,8 @@ public class StackdriverExportUtilsTest {
             DISTRIBUTION,
             Arrays.asList(KEY, KEY_2, KEY_3),
             CUMULATIVE);
-    assertThat(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1, null, VALUE_2)))
+    assertThat(
+            StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1, null, VALUE_2), null))
         .isEqualTo(
             Metric.newBuilder()
                 .setType("custom.googleapis.com/opencensus/" + VIEW_NAME)
@@ -218,7 +219,7 @@ public class StackdriverExportUtilsTest {
     List<TagValue> tagValues = Arrays.asList(VALUE_1, null);
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("TagKeys and TagValues don't have same size.");
-    StackdriverExportUtils.createMetric(view, tagValues);
+    StackdriverExportUtils.createMetric(view, tagValues, null);
   }
 
   @Test
@@ -428,10 +429,7 @@ public class StackdriverExportUtilsTest {
             DISTRIBUTION,
             Arrays.asList(KEY),
             INTERVAL);
-    assertThat(
-            StackdriverExportUtils.createMetricDescriptor(
-                view, PROJECT_ID, DEFAULT_DISPLAY_NAME_PREFIX))
-        .isNull();
+    assertThat(StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID, null)).isNull();
   }
 
   @Test
@@ -455,13 +453,13 @@ public class StackdriverExportUtilsTest {
         CumulativeData.create(Timestamp.fromMillis(1000), Timestamp.fromMillis(2000));
     ViewData viewData = ViewData.create(view, aggregationMap, cumulativeData);
     List<TimeSeries> timeSeriesList =
-        StackdriverExportUtils.createTimeSeriesList(viewData, DEFAULT_RESOURCE);
+        StackdriverExportUtils.createTimeSeriesList(viewData, DEFAULT_RESOURCE, null);
     assertThat(timeSeriesList).hasSize(2);
     TimeSeries expected1 =
         TimeSeries.newBuilder()
             .setMetricKind(MetricKind.CUMULATIVE)
             .setValueType(MetricDescriptor.ValueType.DISTRIBUTION)
-            .setMetric(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1)))
+            .setMetric(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1), null))
             .setResource(MonitoredResource.newBuilder().setType("global"))
             .addPoints(
                 StackdriverExportUtils.createPoint(distributionData1, cumulativeData, DISTRIBUTION))
@@ -470,7 +468,7 @@ public class StackdriverExportUtilsTest {
         TimeSeries.newBuilder()
             .setMetricKind(MetricKind.CUMULATIVE)
             .setValueType(MetricDescriptor.ValueType.DISTRIBUTION)
-            .setMetric(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_2)))
+            .setMetric(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_2), null))
             .setResource(MonitoredResource.newBuilder().setType("global"))
             .addPoints(
                 StackdriverExportUtils.createPoint(distributionData2, cumulativeData, DISTRIBUTION))
@@ -496,7 +494,8 @@ public class StackdriverExportUtilsTest {
             DistributionData.create(-1, 1, -1, -1, 0, Arrays.asList(1L, 0L, 0L, 0L, 0L)));
     ViewData viewData =
         ViewData.create(view, aggregationMap, IntervalData.create(Timestamp.fromMillis(2000)));
-    assertThat(StackdriverExportUtils.createTimeSeriesList(viewData, DEFAULT_RESOURCE)).isEmpty();
+    assertThat(StackdriverExportUtils.createTimeSeriesList(viewData, DEFAULT_RESOURCE, null))
+        .isEmpty();
   }
 
   @Test
@@ -518,13 +517,13 @@ public class StackdriverExportUtilsTest {
         CumulativeData.create(Timestamp.fromMillis(1000), Timestamp.fromMillis(2000));
     ViewData viewData = ViewData.create(view, aggregationMap, cumulativeData);
     List<TimeSeries> timeSeriesList =
-        StackdriverExportUtils.createTimeSeriesList(viewData, resource);
+        StackdriverExportUtils.createTimeSeriesList(viewData, resource, null);
     assertThat(timeSeriesList)
         .containsExactly(
             TimeSeries.newBuilder()
                 .setMetricKind(MetricKind.CUMULATIVE)
                 .setValueType(MetricDescriptor.ValueType.DOUBLE)
-                .setMetric(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1)))
+                .setMetric(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1), null))
                 .setResource(resource)
                 .addPoints(StackdriverExportUtils.createPoint(sumData, cumulativeData, SUM))
                 .build());

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.DEFAULT_DISPLAY_NAME_PREFIX;
 
 import com.google.api.Distribution.BucketOptions;
 import com.google.api.Distribution.BucketOptions.Explicit;
@@ -350,7 +351,7 @@ public class StackdriverExportUtilsTest {
             Arrays.asList(KEY),
             CUMULATIVE);
     MetricDescriptor metricDescriptor =
-        StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID);
+        StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID, "myorg");
     assertThat(metricDescriptor.getName())
         .isEqualTo(
             "projects/"
@@ -358,7 +359,7 @@ public class StackdriverExportUtilsTest {
                 + "/metricDescriptors/custom.googleapis.com/opencensus/"
                 + VIEW_NAME);
     assertThat(metricDescriptor.getDescription()).isEqualTo(VIEW_DESCRIPTION);
-    assertThat(metricDescriptor.getDisplayName()).isEqualTo("OpenCensus/" + VIEW_NAME);
+    assertThat(metricDescriptor.getDisplayName()).isEqualTo("myorg/" + VIEW_NAME);
     assertThat(metricDescriptor.getType())
         .isEqualTo("custom.googleapis.com/opencensus/" + VIEW_NAME);
     assertThat(metricDescriptor.getUnit()).isEqualTo(MEASURE_UNIT);
@@ -427,7 +428,10 @@ public class StackdriverExportUtilsTest {
             DISTRIBUTION,
             Arrays.asList(KEY),
             INTERVAL);
-    assertThat(StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID)).isNull();
+    assertThat(
+            StackdriverExportUtils.createMetricDescriptor(
+                view, PROJECT_ID, DEFAULT_DISPLAY_NAME_PREFIX))
+        .isNull();
   }
 
   @Test

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -105,7 +105,7 @@ public class StackdriverExportUtilsTest {
   @Test
   public void testConstant() {
     assertThat(StackdriverExportUtils.LABEL_DESCRIPTION).isEqualTo("OpenCensus TagKey");
-    assertThat(StackdriverExportUtils.DEFAULT_DISPLAY_NAME_PREFIX).isEqualTo("OpenCensus  ");
+    assertThat(StackdriverExportUtils.DEFAULT_DISPLAY_NAME_PREFIX).isEqualTo("OpenCensus");
   }
 
   @Test
@@ -180,6 +180,26 @@ public class StackdriverExportUtilsTest {
         .isEqualTo(
             Metric.newBuilder()
                 .setType("custom.googleapis.com/opencensus/" + VIEW_NAME)
+                .putLabels("KEY", "VALUE1")
+                .putLabels(StackdriverExportUtils.OPENCENSUS_TASK, DEFAULT_TASK_VALUE)
+                .build());
+  }
+
+  @Test
+  public void createMetric_WithExternalMetricDomain() {
+    View view =
+        View.create(
+            Name.create(VIEW_NAME),
+            VIEW_DESCRIPTION,
+            MEASURE_DOUBLE,
+            DISTRIBUTION,
+            Arrays.asList(KEY),
+            CUMULATIVE);
+    String prometheusDomain = "external.googleapis.com/prometheus/";
+    assertThat(StackdriverExportUtils.createMetric(view, Arrays.asList(VALUE_1), prometheusDomain))
+        .isEqualTo(
+            Metric.newBuilder()
+                .setType(prometheusDomain + VIEW_NAME)
                 .putLabels("KEY", "VALUE1")
                 .putLabels(StackdriverExportUtils.OPENCENSUS_TASK, DEFAULT_TASK_VALUE)
                 .build());
@@ -357,12 +377,11 @@ public class StackdriverExportUtilsTest {
         .isEqualTo(
             "projects/"
                 + PROJECT_ID
-                + "/metricDescriptors/custom.googleapis.com/opencensus/"
+                + "/metricDescriptors/custom.googleapis.com/myorg/"
                 + VIEW_NAME);
     assertThat(metricDescriptor.getDescription()).isEqualTo(VIEW_DESCRIPTION);
     assertThat(metricDescriptor.getDisplayName()).isEqualTo("myorg/" + VIEW_NAME);
-    assertThat(metricDescriptor.getType())
-        .isEqualTo("custom.googleapis.com/opencensus/" + VIEW_NAME);
+    assertThat(metricDescriptor.getType()).isEqualTo("custom.googleapis.com/myorg/" + VIEW_NAME);
     assertThat(metricDescriptor.getUnit()).isEqualTo(MEASURE_UNIT);
     assertThat(metricDescriptor.getMetricKind()).isEqualTo(MetricKind.CUMULATIVE);
     assertThat(metricDescriptor.getValueType()).isEqualTo(MetricDescriptor.ValueType.DISTRIBUTION);
@@ -391,7 +410,7 @@ public class StackdriverExportUtilsTest {
             Arrays.asList(KEY),
             CUMULATIVE);
     MetricDescriptor metricDescriptor =
-        StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID, "OpenCensus");
+        StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID, null);
     assertThat(metricDescriptor.getName())
         .isEqualTo(
             "projects/"

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -390,7 +390,7 @@ public class StackdriverExportUtilsTest {
             Arrays.asList(KEY),
             CUMULATIVE);
     MetricDescriptor metricDescriptor =
-        StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID);
+        StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID, "OpenCensus");
     assertThat(metricDescriptor.getName())
         .isEqualTo(
             "projects/"

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.DEFAULT_DISPLAY_NAME_PREFIX;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -127,13 +128,16 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            DEFAULT_DISPLAY_NAME_PREFIX);
     worker.export();
 
     verify(mockStub, times(1)).createMetricDescriptorCallable();
     verify(mockStub, times(1)).createTimeSeriesCallable();
 
-    MetricDescriptor descriptor = StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID);
+    MetricDescriptor descriptor =
+        StackdriverExportUtils.createMetricDescriptor(
+            view, PROJECT_ID, DEFAULT_DISPLAY_NAME_PREFIX);
     List<TimeSeries> timeSeries =
         StackdriverExportUtils.createTimeSeriesList(viewData, DEFAULT_RESOURCE);
     verify(mockCreateMetricDescriptorCallable, times(1))
@@ -170,7 +174,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            DEFAULT_DISPLAY_NAME_PREFIX);
 
     worker.export();
     verify(mockStub, times(1)).createMetricDescriptorCallable();
@@ -189,7 +194,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            DEFAULT_DISPLAY_NAME_PREFIX);
 
     assertThat(worker.registerView(view)).isFalse();
     worker.export();
@@ -205,7 +211,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            DEFAULT_DISPLAY_NAME_PREFIX);
     View view1 =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
     assertThat(worker.registerView(view1)).isTrue();
@@ -231,7 +238,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            DEFAULT_DISPLAY_NAME_PREFIX);
     View view =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
     assertThat(worker.registerView(view)).isTrue();
@@ -249,7 +257,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            DEFAULT_DISPLAY_NAME_PREFIX);
     View view =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), INTERVAL);
     assertThat(worker.registerView(view)).isFalse();

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
@@ -17,6 +17,8 @@
 package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.exporter.stats.stackdriver.StackdriverExporterWorker.CUSTOM_OPENCENSUS_DOMAIN;
+import static io.opencensus.exporter.stats.stackdriver.StackdriverExporterWorker.DEFAULT_DISPLAY_NAME_PREFIX;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -107,6 +109,12 @@ public class StackdriverExporterWorkerTest {
   @Test
   public void testConstants() {
     assertThat(StackdriverExporterWorker.MAX_BATCH_EXPORT_SIZE).isEqualTo(200);
+    assertThat(StackdriverExporterWorker.CUSTOM_METRIC_DOMAIN).isEqualTo("custom.googleapis.com/");
+    assertThat(StackdriverExporterWorker.EXTERNAL_METRIC_DOMAIN)
+        .isEqualTo("external.googleapis.com/");
+    assertThat(StackdriverExporterWorker.CUSTOM_OPENCENSUS_DOMAIN)
+        .isEqualTo("custom.googleapis.com/opencensus/");
+    assertThat(StackdriverExporterWorker.DEFAULT_DISPLAY_NAME_PREFIX).isEqualTo("OpenCensus/");
   }
 
   @Test
@@ -135,9 +143,11 @@ public class StackdriverExporterWorkerTest {
     verify(mockStub, times(1)).createTimeSeriesCallable();
 
     MetricDescriptor descriptor =
-        StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID, null);
+        StackdriverExportUtils.createMetricDescriptor(
+            view, PROJECT_ID, CUSTOM_OPENCENSUS_DOMAIN, DEFAULT_DISPLAY_NAME_PREFIX);
     List<TimeSeries> timeSeries =
-        StackdriverExportUtils.createTimeSeriesList(viewData, DEFAULT_RESOURCE, null);
+        StackdriverExportUtils.createTimeSeriesList(
+            viewData, DEFAULT_RESOURCE, CUSTOM_OPENCENSUS_DOMAIN);
     verify(mockCreateMetricDescriptorCallable, times(1))
         .call(
             eq(
@@ -261,6 +271,32 @@ public class StackdriverExporterWorkerTest {
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), INTERVAL);
     assertThat(worker.registerView(view)).isFalse();
     verify(mockStub, times(0)).createMetricDescriptorCallable();
+  }
+
+  @Test
+  public void getDomain() {
+    assertThat(StackdriverExporterWorker.getDomain(null))
+        .isEqualTo("custom.googleapis.com/opencensus/");
+    assertThat(StackdriverExporterWorker.getDomain(""))
+        .isEqualTo("custom.googleapis.com/opencensus/");
+    assertThat(StackdriverExporterWorker.getDomain("custom.googleapis.com/myorg/"))
+        .isEqualTo("custom.googleapis.com/myorg/");
+    assertThat(StackdriverExporterWorker.getDomain("external.googleapis.com/prometheus/"))
+        .isEqualTo("external.googleapis.com/prometheus/");
+    assertThat(StackdriverExporterWorker.getDomain("myorg"))
+        .isEqualTo("custom.googleapis.com/myorg/");
+  }
+
+  @Test
+  public void getDisplayNamePrefix() {
+    assertThat(StackdriverExporterWorker.getDisplayNamePrefix(null)).isEqualTo("OpenCensus/");
+    assertThat(StackdriverExporterWorker.getDisplayNamePrefix("")).isEqualTo("");
+    assertThat(StackdriverExporterWorker.getDisplayNamePrefix("custom.googleapis.com/myorg/"))
+        .isEqualTo("custom.googleapis.com/myorg/");
+    assertThat(
+            StackdriverExporterWorker.getDisplayNamePrefix("external.googleapis.com/prometheus/"))
+        .isEqualTo("external.googleapis.com/prometheus/");
+    assertThat(StackdriverExporterWorker.getDisplayNamePrefix("myorg")).isEqualTo("myorg/");
   }
 
   /*

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
@@ -17,7 +17,6 @@
 package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.opencensus.exporter.stats.stackdriver.StackdriverStatsExporter.DEFAULT_DISPLAY_NAME_PREFIX;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -129,17 +128,16 @@ public class StackdriverExporterWorkerTest {
             ONE_SECOND,
             mockViewManager,
             DEFAULT_RESOURCE,
-            DEFAULT_DISPLAY_NAME_PREFIX);
+            null);
     worker.export();
 
     verify(mockStub, times(1)).createMetricDescriptorCallable();
     verify(mockStub, times(1)).createTimeSeriesCallable();
 
     MetricDescriptor descriptor =
-        StackdriverExportUtils.createMetricDescriptor(
-            view, PROJECT_ID, DEFAULT_DISPLAY_NAME_PREFIX);
+        StackdriverExportUtils.createMetricDescriptor(view, PROJECT_ID, null);
     List<TimeSeries> timeSeries =
-        StackdriverExportUtils.createTimeSeriesList(viewData, DEFAULT_RESOURCE);
+        StackdriverExportUtils.createTimeSeriesList(viewData, DEFAULT_RESOURCE, null);
     verify(mockCreateMetricDescriptorCallable, times(1))
         .call(
             eq(
@@ -175,7 +173,7 @@ public class StackdriverExporterWorkerTest {
             ONE_SECOND,
             mockViewManager,
             DEFAULT_RESOURCE,
-            DEFAULT_DISPLAY_NAME_PREFIX);
+            null);
 
     worker.export();
     verify(mockStub, times(1)).createMetricDescriptorCallable();
@@ -195,7 +193,7 @@ public class StackdriverExporterWorkerTest {
             ONE_SECOND,
             mockViewManager,
             DEFAULT_RESOURCE,
-            DEFAULT_DISPLAY_NAME_PREFIX);
+            null);
 
     assertThat(worker.registerView(view)).isFalse();
     worker.export();
@@ -212,7 +210,7 @@ public class StackdriverExporterWorkerTest {
             ONE_SECOND,
             mockViewManager,
             DEFAULT_RESOURCE,
-            DEFAULT_DISPLAY_NAME_PREFIX);
+            null);
     View view1 =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
     assertThat(worker.registerView(view1)).isTrue();
@@ -239,7 +237,7 @@ public class StackdriverExporterWorkerTest {
             ONE_SECOND,
             mockViewManager,
             DEFAULT_RESOURCE,
-            DEFAULT_DISPLAY_NAME_PREFIX);
+            null);
     View view =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
     assertThat(worker.registerView(view)).isTrue();
@@ -258,7 +256,7 @@ public class StackdriverExporterWorkerTest {
             ONE_SECOND,
             mockViewManager,
             DEFAULT_RESOURCE,
-            DEFAULT_DISPLAY_NAME_PREFIX);
+            null);
     View view =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), INTERVAL);
     assertThat(worker.registerView(view)).isFalse();

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
@@ -51,13 +51,13 @@ public class StackdriverStatsConfigurationTest {
             .setProjectId(PROJECT_ID)
             .setExportInterval(DURATION)
             .setMonitoredResource(RESOURCE)
-            .setDisplayNamePrefix(CUSTOM_PREFIX)
+            .setMetricNamePrefix(CUSTOM_PREFIX)
             .build();
     assertThat(configuration.getCredentials()).isEqualTo(FAKE_CREDENTIALS);
     assertThat(configuration.getProjectId()).isEqualTo(PROJECT_ID);
     assertThat(configuration.getExportInterval()).isEqualTo(DURATION);
     assertThat(configuration.getMonitoredResource()).isEqualTo(RESOURCE);
-    assertThat(configuration.getDisplayNamePrefix()).isEqualTo(CUSTOM_PREFIX);
+    assertThat(configuration.getMetricNamePrefix()).isEqualTo(CUSTOM_PREFIX);
   }
 
   @Test
@@ -67,6 +67,6 @@ public class StackdriverStatsConfigurationTest {
     assertThat(configuration.getProjectId()).isNull();
     assertThat(configuration.getExportInterval()).isNull();
     assertThat(configuration.getMonitoredResource()).isNull();
-    assertThat(configuration.getDisplayNamePrefix()).isNull();
+    assertThat(configuration.getMetricNamePrefix()).isNull();
   }
 }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
@@ -41,6 +41,7 @@ public class StackdriverStatsConfigurationTest {
           .setType("gce-instance")
           .putLabels("instance-id", "instance")
           .build();
+  private static final String CUSTOM_PREFIX = "myorg";
 
   @Test
   public void testBuild() {
@@ -50,11 +51,13 @@ public class StackdriverStatsConfigurationTest {
             .setProjectId(PROJECT_ID)
             .setExportInterval(DURATION)
             .setMonitoredResource(RESOURCE)
+            .setDisplayNamePrefix(CUSTOM_PREFIX)
             .build();
     assertThat(configuration.getCredentials()).isEqualTo(FAKE_CREDENTIALS);
     assertThat(configuration.getProjectId()).isEqualTo(PROJECT_ID);
     assertThat(configuration.getExportInterval()).isEqualTo(DURATION);
     assertThat(configuration.getMonitoredResource()).isEqualTo(RESOURCE);
+    assertThat(configuration.getDisplayNamePrefix()).isEqualTo(CUSTOM_PREFIX);
   }
 
   @Test
@@ -64,5 +67,6 @@ public class StackdriverStatsConfigurationTest {
     assertThat(configuration.getProjectId()).isNull();
     assertThat(configuration.getExportInterval()).isNull();
     assertThat(configuration.getMonitoredResource()).isNull();
+    assertThat(configuration.getDisplayNamePrefix()).isNull();
   }
 }


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1350

Equivalent to https://github.com/census-instrumentation/opencensus-go/pull/583.