### PR TITLE
Move Travis jobs for example projects to the end of the build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,10 @@ matrix:
     env: TASK=CHECKER_FRAMEWORK
     os: linux
 
+  - env: TASK=CHECK_GIT_HISTORY
+    os: linux
+
+  # Build example projects last, since they are affected by fewer pull requests.
   - jdk: oraclejdk8
     env: TASK=BUILD_EXAMPLES_GRADLE
     os: linux
@@ -37,9 +41,6 @@ matrix:
 
   - jdk: oraclejdk8
     env: TASK=BUILD_EXAMPLES_BAZEL
-    os: linux
-
-  - env: TASK=CHECK_GIT_HISTORY
     os: linux
 
   # Work around https://github.com/travis-ci/travis-ci/issues/2317


### PR DESCRIPTION
This change allows build jobs that are affected by more pull requests to run
first, to increase the probability of failures appearing in the first set of
concurrent job runs.