### PR TITLE
Disable Jaeger integration test by default. (closes #1066)

### DIFF
--- a/exporters/trace/jaeger/build.gradle
+++ b/exporters/trace/jaeger/build.gradle
@@ -16,3 +16,7 @@ dependencies {
 
     signature "org.codehaus.mojo.signature:java16:+@signature"
 }
+
+test {
+  systemProperty "enable.jaeger.integration.test", System.getProperty("enable.jaeger.integration.test")
+}

--- a/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
+++ b/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
@@ -67,6 +67,7 @@ public class JaegerExporterHandlerIntegrationTest {
 
   @Test(timeout = 30000)
   public void exportToJaeger() throws InterruptedException, IOException {
+    assumeThat("enable jaeger integration test", enableJaegerIntegrationTest(), is(true));
     assumeThat("docker is installed and executable", dockerIsInstalledAndExecutable(), is(true));
 
     final Process jaeger =
@@ -202,6 +203,10 @@ public class JaegerExporterHandlerIntegrationTest {
     } finally {
       jaeger.destroy();
     }
+  }
+
+  private static boolean enableJaegerIntegrationTest() {
+    return "true".equals(System.getProperty("enable.jaeger.integration.test"));
   }
 
   private static boolean dockerIsInstalledAndExecutable() {


### PR DESCRIPTION
The integration test will try to lookup "docker" in the "PATH" and this operation might timeout and fail the windows build.

This PR add a system property "enable.jaeger.integration.test" to make it option.
Users can use "gradlew -Denable.jaeger.integration.test=true" to execute the integration test.