### PR TITLE
Remove usages of guava collections in api/

### DIFF
--- a/api/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/api/src/main/java/io/opencensus/stats/AggregationData.java
@@ -20,8 +20,8 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.Lists;
 import io.opencensus.common.Function;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
@@ -291,7 +291,7 @@ public abstract class AggregationData {
       }
 
       checkNotNull(bucketCounts, "bucket counts should not be null.");
-      List<Long> bucketCountsCopy = Collections.unmodifiableList(Lists.newArrayList(bucketCounts));
+      List<Long> bucketCountsCopy = Collections.unmodifiableList(new ArrayList<Long>(bucketCounts));
       for (Long bucket : bucketCountsCopy) {
         checkNotNull(bucket, "bucket should not be null.");
       }

--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -21,8 +21,6 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
 import io.opencensus.stats.Measure.MeasureDouble;
@@ -31,6 +29,8 @@ import io.opencensus.tags.TagContext;
 import io.opencensus.tags.TagValue;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -149,7 +149,7 @@ final class NoopStats {
     private static final Timestamp ZERO_TIMESTAMP = Timestamp.create(0, 0);
 
     @GuardedBy("registeredViews")
-    private final Map<View.Name, View> registeredViews = Maps.newHashMap();
+    private final Map<View.Name, View> registeredViews = new HashMap<View.Name, View>();
 
     // Cached set of exported views. It must be set to null whenever a view is registered or
     // unregistered.
@@ -209,7 +209,7 @@ final class NoopStats {
     // Returns the subset of the given views that should be exported
     @SuppressWarnings("deprecation")
     private static Set<View> filterExportedViews(Collection<View> allViews) {
-      Set<View> views = Sets.newHashSet();
+      Set<View> views = new HashSet<View>();
       for (View view : allViews) {
         if (view.getWindow() instanceof View.AggregationWindow.Interval) {
           continue;

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -19,7 +19,6 @@ package io.opencensus.stats;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.Maps;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
@@ -38,6 +37,7 @@ import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.tags.TagValue;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -125,7 +125,8 @@ public abstract class ViewData {
       Map<? extends List</*@Nullable*/ TagValue>, ? extends AggregationData> map,
       final AggregationWindowData windowData) {
     checkWindow(view.getWindow(), windowData);
-    final Map<List<TagValue>, AggregationData> deepCopy = Maps.newHashMap();
+    final Map<List<TagValue>, AggregationData> deepCopy =
+        new HashMap<List<TagValue>, AggregationData>();
     for (Entry<? extends List<TagValue>, ? extends AggregationData> entry : map.entrySet()) {
       checkAggregation(view.getAggregation(), entry.getValue(), view.getMeasure());
       deepCopy.put(
@@ -173,7 +174,7 @@ public abstract class ViewData {
       Map<? extends List</*@Nullable*/ TagValue>, ? extends AggregationData> map,
       Timestamp start,
       Timestamp end) {
-    Map<List<TagValue>, AggregationData> deepCopy = Maps.newHashMap();
+    Map<List<TagValue>, AggregationData> deepCopy = new HashMap<List<TagValue>, AggregationData>();
     for (Entry<? extends List<TagValue>, ? extends AggregationData> entry : map.entrySet()) {
       checkAggregation(view.getAggregation(), entry.getValue(), view.getMeasure());
       deepCopy.put(

--- a/api/src/main/java/io/opencensus/tags/TagContext.java
+++ b/api/src/main/java/io/opencensus/tags/TagContext.java
@@ -16,10 +16,7 @@
 
 package io.opencensus.tags;
 
-import com.google.common.collect.HashMultiset;
-import com.google.common.collect.ImmutableMultiset;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Multiset;
+import java.util.HashMap;
 import java.util.Iterator;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -70,15 +67,28 @@ public abstract class TagContext {
     TagContext otherTags = (TagContext) other;
     Iterator<Tag> iter1 = getIterator();
     Iterator<Tag> iter2 = otherTags.getIterator();
-    Multiset<Tag> tags1 =
-        iter1 == null
-            ? ImmutableMultiset.<Tag>of()
-            : HashMultiset.create(Lists.<Tag>newArrayList(iter1));
-    Multiset<Tag> tags2 =
-        iter2 == null
-            ? ImmutableMultiset.<Tag>of()
-            : HashMultiset.create(Lists.<Tag>newArrayList(iter2));
-    return tags1.equals(tags2);
+    HashMap<Tag, Integer> tags = new HashMap<Tag, Integer>();
+    while (iter1 != null && iter1.hasNext()) {
+      Tag tag = iter1.next();
+      if (tags.containsKey(tag)) {
+        tags.put(tag, tags.get(tag) + 1);
+      } else {
+        tags.put(tag, 1);
+      }
+    }
+    while (iter2 != null && iter2.hasNext()) {
+      Tag tag = iter2.next();
+      if (!tags.containsKey(tag)) {
+        return false;
+      }
+      int count = tags.get(tag);
+      if (count > 1) {
+        tags.put(tag, count - 1);
+      } else {
+        tags.remove(tag);
+      }
+    }
+    return tags.isEmpty();
   }
 
   @Override

--- a/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
@@ -21,14 +21,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Status.CanonicalCode;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -487,11 +486,11 @@ public abstract class SampledSpanStore {
             Collections.<CanonicalCode, Integer>emptyMap());
 
     @GuardedBy("registeredSpanNames")
-    private final Set<String> registeredSpanNames = Sets.newHashSet();
+    private final Set<String> registeredSpanNames = new HashSet<String>();
 
     @Override
     public Summary getSummary() {
-      Map<String, PerSpanNameSummary> result = Maps.newHashMap();
+      Map<String, PerSpanNameSummary> result = new HashMap<String, PerSpanNameSummary>();
       synchronized (registeredSpanNames) {
         for (String registeredSpanName : registeredSpanNames) {
           result.put(registeredSpanName, EMPTY_PER_SPAN_NAME_SUMMARY);
@@ -531,7 +530,7 @@ public abstract class SampledSpanStore {
     @Override
     public Set<String> getRegisteredSpanNamesForCollection() {
       synchronized (registeredSpanNames) {
-        return Collections.<String>unmodifiableSet(Sets.newHashSet(registeredSpanNames));
+        return Collections.<String>unmodifiableSet(new HashSet<String>(registeredSpanNames));
       }
     }
   }

--- a/api/src/main/java/io/opencensus/trace/export/SpanData.java
+++ b/api/src/main/java/io/opencensus/trace/export/SpanData.java
@@ -19,7 +19,6 @@ package io.opencensus.trace.export;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.collect.Lists;
 import io.opencensus.common.Timestamp;
 import io.opencensus.internal.BaseMessageEventUtil;
 import io.opencensus.trace.Annotation;
@@ -94,7 +93,7 @@ public abstract class SpanData {
     if (messageOrNetworkEvents == null) {
       throw new NullPointerException("Null messageOrNetworkEvents");
     }
-    List<TimedEvent<MessageEvent>> messageEventsList = Lists.newArrayList();
+    List<TimedEvent<MessageEvent>> messageEventsList = new ArrayList<TimedEvent<MessageEvent>>();
     for (TimedEvent<? extends io.opencensus.trace.BaseMessageEvent> timedEvent :
         messageOrNetworkEvents.getEvents()) {
       io.opencensus.trace.BaseMessageEvent event = timedEvent.getEvent();
@@ -198,7 +197,8 @@ public abstract class SpanData {
   @SuppressWarnings({"deprecation"})
   public TimedEvents<io.opencensus.trace.NetworkEvent> getNetworkEvents() {
     TimedEvents<MessageEvent> timedEvents = getMessageEvents();
-    List<TimedEvent<io.opencensus.trace.NetworkEvent>> networkEventsList = Lists.newArrayList();
+    List<TimedEvent<io.opencensus.trace.NetworkEvent>> networkEventsList =
+        new ArrayList<TimedEvent<io.opencensus.trace.NetworkEvent>>();
     for (TimedEvent<MessageEvent> timedEvent : timedEvents.getEvents()) {
       networkEventsList.add(
           TimedEvent.<io.opencensus.trace.NetworkEvent>create(


### PR DESCRIPTION
This allows proguard to strip out the com.google.common.collect.* classes on Android, and is aimed at resolving https://github.com/census-instrumentation/opencensus-java/issues/1068

On Android, making this change saves 325 method references and 7.8KB in the APK size. I don't have numbers for an app that directly depends on OpenCensus, but for gRPC (grpc-core depends on opencensus-api) this is a 6.5% decrease in method references and a 3% decrease in APK size (percentages based on the increase an app will see from adding a dependency on gRPC Java and Protobuf Lite).

Dropping `Multiset` from `TagContext#equals` is the only change that looks potentially significant. But, if I understand correctly, `TagContextImpl` instances are used where the equality check may need to be fast. If this means that the comparison is always between two `TagContextImpl` objects, then the implementation of `equals` in the super class isn't invoked, and the changes here shouldn't incur any penalties in actual use of OpenCensus.
