### PR TITLE
Auto detect GCE and GKE Stackdriver MonitoredResources.

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -81,6 +81,7 @@ final class StackdriverExportUtils {
   private static final String CUSTOM_METRIC_DOMAIN = "custom.googleapis.com";
   private static final String CUSTOM_OPENCENSUS_DOMAIN = CUSTOM_METRIC_DOMAIN + "/opencensus/";
   private static final String OPENCENSUS_TASK_VALUE_DEFAULT = generateDefaultTaskValue();
+  private static final String PROJECT_ID_LABEL_KEY = "project_id";
 
   private static String generateDefaultTaskValue() {
     // Something like '<pid>@<hostname>', at least in Oracle and OpenJdk JVMs
@@ -398,6 +399,11 @@ final class StackdriverExportUtils {
     Resource detectedResourceType = getAutoDetectedResourceType();
     String resourceType = detectedResourceType.getKey();
     MonitoredResource.Builder builder = MonitoredResource.newBuilder().setType(resourceType);
+    if (MetadataConfig.getProjectId() != null) {
+      // For default resource, always use the project id from MetadataConfig. This allows stats from
+      // other projects (e.g from GCE running in another project) to be collected.
+      builder.putLabels(PROJECT_ID_LABEL_KEY, MetadataConfig.getProjectId());
+    }
     for (Label label : RESOURCE_TYPE_WITH_LABELS.get(detectedResourceType)) {
       String value = getValue(label);
       if (value == null) {

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -380,26 +380,25 @@ final class StackdriverExportUtils {
     }
   }
 
-  private static final ImmutableMultimap<String, Label> RESOURCE_TYPE_WITH_LABELS =
-      ImmutableMultimap.<String, Label>builder()
+  private static final ImmutableMultimap<Resource, Label> RESOURCE_TYPE_WITH_LABELS =
+      ImmutableMultimap.<Resource, Label>builder()
           .putAll(
-              Resource.GkeContainer.getKey(),
+              Resource.GkeContainer,
               Label.ClusterName,
               Label.ContainerName,
               Label.NamespaceId,
               Label.InstanceId,
               Label.PodId,
               Label.Zone)
-          .putAll(Resource.GceInstance.getKey(), Label.InstanceId, Label.Zone)
+          .putAll(Resource.GceInstance, Label.InstanceId, Label.Zone)
           .build();
 
   /* Return a self-configured monitored Resource. */
-  static MonitoredResource getResource() {
+  static MonitoredResource getDefaultResource() {
     Resource detectedResourceType = getAutoDetectedResourceType();
     String resourceType = detectedResourceType.getKey();
     MonitoredResource.Builder builder = MonitoredResource.newBuilder().setType(resourceType);
-
-    for (Label label : RESOURCE_TYPE_WITH_LABELS.get(resourceType)) {
+    for (Label label : RESOURCE_TYPE_WITH_LABELS.get(detectedResourceType)) {
       String value = getValue(label);
       if (value == null) {
         value = "";

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -73,6 +73,9 @@ final class StackdriverExportUtils {
   @VisibleForTesting static final String LABEL_DESCRIPTION = "OpenCensus TagKey";
   @VisibleForTesting static final String OPENCENSUS_TASK = "opencensus_task";
   @VisibleForTesting static final String OPENCENSUS_TASK_DESCRIPTION = "Opencensus task identifier";
+  @VisibleForTesting static final String GKE_CONTAINER = "gke_container";
+  @VisibleForTesting static final String GCE_INSTANCE = "gce_instance";
+  @VisibleForTesting static final String GLOBAL = "global";
 
   private static final Logger logger = Logger.getLogger(StackdriverExportUtils.class.getName());
   private static final String CUSTOM_METRIC_DOMAIN = "custom.googleapis.com";
@@ -362,9 +365,9 @@ final class StackdriverExportUtils {
   }
 
   private enum Resource {
-    GkeContainer("gke_container"),
-    GceInstance("gce_instance"),
-    Global("global");
+    GkeContainer(GKE_CONTAINER),
+    GceInstance(GCE_INSTANCE),
+    Global(GLOBAL);
 
     private final String key;
 

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -70,8 +70,7 @@ public final class StackdriverStatsExporter {
 
   @VisibleForTesting static final Duration DEFAULT_INTERVAL = Duration.create(60, 0);
 
-  @VisibleForTesting
-  static final MonitoredResource DEFAULT_RESOURCE = StackdriverExportUtils.getResource();
+  private static final MonitoredResource DEFAULT_RESOURCE = StackdriverExportUtils.getResource();
 
   @VisibleForTesting
   StackdriverStatsExporter(

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -70,7 +70,8 @@ public final class StackdriverStatsExporter {
 
   @VisibleForTesting static final Duration DEFAULT_INTERVAL = Duration.create(60, 0);
 
-  private static final MonitoredResource DEFAULT_RESOURCE = StackdriverExportUtils.getResource();
+  private static final MonitoredResource DEFAULT_RESOURCE =
+      StackdriverExportUtils.getDefaultResource();
 
   @VisibleForTesting
   StackdriverStatsExporter(

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -71,8 +71,7 @@ public final class StackdriverStatsExporter {
   @VisibleForTesting static final Duration DEFAULT_INTERVAL = Duration.create(60, 0);
 
   @VisibleForTesting
-  static final MonitoredResource DEFAULT_RESOURCE =
-      MonitoredResource.newBuilder().setType("global").build();
+  static final MonitoredResource DEFAULT_RESOURCE = StackdriverExportUtils.getResource();
 
   @VisibleForTesting
   StackdriverStatsExporter(
@@ -154,8 +153,9 @@ public final class StackdriverStatsExporter {
    * <p>If {@code exportInterval} of the configuration is not set, the exporter will use the default
    * interval of one minute.
    *
-   * <p>If {@code monitoredResources} of the configuration is not set, the exporter will use the
-   * default resource with type global and no labels. In addition, please refer to
+   * <p>If {@code monitoredResources} of the configuration is not set, the exporter will try to
+   * create an appropriate {@code monitoredResources} based on the environment variables. In
+   * addition, please refer to
    * cloud.google.com/monitoring/custom-metrics/creating-metrics#which-resource for a list of valid
    * {@code MonitoredResource}s.
    *
@@ -192,7 +192,7 @@ public final class StackdriverStatsExporter {
    *
    * <p>This method uses the default interval of one minute.
    *
-   * <p>This method uses the default resource with type global and no labels.
+   * <p>This method uses the default resource created from the environment variables.
    *
    * @throws IllegalStateException if a Stackdriver exporter is already created.
    * @since 0.11.0

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -455,8 +455,8 @@ public class StackdriverExportUtilsTest {
   }
 
   @Test
-  public void testGetResource() {
-    MonitoredResource resource = StackdriverExportUtils.getResource();
+  public void testGetDefaultResource() {
+    MonitoredResource resource = StackdriverExportUtils.getDefaultResource();
     if (System.getenv("KUBERNETES_SERVICE_HOST") != null) {
       assertThat(resource.getType()).isEqualTo(StackdriverExportUtils.GKE_CONTAINER);
     } else if (MetadataConfig.getInstanceId() != null) {

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -26,6 +26,7 @@ import com.google.api.Metric;
 import com.google.api.MetricDescriptor;
 import com.google.api.MetricDescriptor.MetricKind;
 import com.google.api.MonitoredResource;
+import com.google.cloud.MetadataConfig;
 import com.google.common.collect.ImmutableMap;
 import com.google.monitoring.v3.Point;
 import com.google.monitoring.v3.TimeInterval;
@@ -451,5 +452,17 @@ public class StackdriverExportUtilsTest {
                 .setResource(resource)
                 .addPoints(StackdriverExportUtils.createPoint(sumData, cumulativeData, SUM))
                 .build());
+  }
+
+  @Test
+  public void testGetResource() {
+    MonitoredResource resource = StackdriverExportUtils.getResource();
+    if (System.getenv("KUBERNETES_SERVICE_HOST") != null) {
+      assertThat(resource.getType()).isEqualTo(StackdriverExportUtils.GKE_CONTAINER);
+    } else if (MetadataConfig.getInstanceId() != null) {
+      assertThat(resource.getType()).isEqualTo(StackdriverExportUtils.GCE_INSTANCE);
+    } else {
+      assertThat(resource.getType()).isEqualTo(StackdriverExportUtils.GLOBAL);
+    }
   }
 }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -18,7 +18,6 @@ package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.api.MonitoredResource;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
@@ -51,8 +50,6 @@ public class StackdriverStatsExporterTest {
   @Test
   public void testConstants() {
     assertThat(StackdriverStatsExporter.DEFAULT_INTERVAL).isEqualTo(Duration.create(60, 0));
-    assertThat(StackdriverStatsExporter.DEFAULT_RESOURCE)
-        .isEqualTo(MonitoredResource.newBuilder().setType("global").build());
   }
 
   @Test


### PR DESCRIPTION
Inspired by https://github.com/GoogleCloudPlatform/google-cloud-java/blob/master/google-cloud-logging/src/main/java/com/google/cloud/logging/MonitoredResourceUtil.java.

When creating a `StackdriverStatsExporter`, if users explicitly set a Stackdriver `MonitoredResource`, we will use the given resource for exporting; otherwise, the library will try to create an appropriate `MonitoredResource` based on current environment variables:
- If the process is running in a GKE container, a `gke_container` resource will be used;
- If the process is running on a GCE instance, a `gce_instance` resource will be used;
- Otherwise, the library will use the global resource with no labels.

In the long term, we may want to work with Veneer so that we can use some of their tools to detect the environment.

/cc @dinooliva 