### PR TITLE
Simplify example Gradle build file by moving license and format checks to the Travis script.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,6 @@ matrix:
   - env: TASK=BUILD
     os: osx
 
-  # Allowing failures because not everyone has downloaded the google-java-format tool.
-  - jdk: oraclejdk8
-    env: TASK=CHECK_EXAMPLES_FORMAT
-    os: linux
-
 before_install:
   - git log --oneline --decorate --graph -30
   - if \[ "$TASK" == "BUILD" \]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ matrix:
     env: TASK=BUILD_EXAMPLES_BAZEL
     os: linux
 
+  - jdk: oraclejdk8
+    env: TASK=CHECK_EXAMPLES_FORMAT
+    os: linux
+
   # Work around https://github.com/travis-ci/travis-ci/issues/2317
   - env: TASK=BUILD
     os: osx
@@ -55,6 +59,11 @@ matrix:
   # Allowing failures because osx builds are very slow.
   - env: TASK=BUILD
     os: osx
+
+  # Allowing failures because not everyone has downloaded the google-java-format tool.
+  - jdk: oraclejdk8
+    env: TASK=CHECK_EXAMPLES_FORMAT
+    os: linux
 
 before_install:
   - git log --oneline --decorate --graph -30

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,10 @@ matrix:
 
   # Build example projects last, since they are affected by fewer pull requests.
   - jdk: oraclejdk8
+    env: TASK=CHECK_EXAMPLES_LICENSE
+    os: linux
+
+  - jdk: oraclejdk8
     env: TASK=BUILD_EXAMPLES_GRADLE
     os: linux
 

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -9,7 +9,6 @@ buildscript {
         }
     }
     dependencies {
-        classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.6"
         classpath 'com.google.protobuf:protobuf-gradle-plugin:0.8.3'
     }
 }
@@ -17,10 +16,6 @@ buildscript {
 apply plugin: 'idea'
 apply plugin: 'java'
 apply plugin: 'com.google.protobuf'
-// Plugins that require java8
-if (JavaVersion.current().isJava8Compatible()) {
-    apply plugin: 'com.github.sherter.google-java-format'
-}
 
 repositories {
     mavenCentral()
@@ -33,27 +28,6 @@ version = "0.13.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 def opencensusVersion = "0.12.2" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.9.0" // CURRENT_GRPC_VERSION
 def prometheusVersion = "0.3.0"
-
-// Google formatter works only on java8.
-if (JavaVersion.current().isJava8Compatible()) {
-    googleJavaFormat {
-        toolVersion '1.5'
-    }
-
-    afterEvaluate {  // Allow subproject to add more source sets.
-        tasks.googleJavaFormat {
-            // This skips proto generated files beucasue they are in gen_gradle/src/main/**
-            source = "src/main"
-            include '**/*.java'
-        }
-
-        tasks.verifyGoogleJavaFormat {
-            // This skips proto generated files beucasue they are in gen_gradle/src/main/**
-            source = "src/main"
-            include '**/*.java'
-        }
-    }
-}
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.8'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -14,7 +14,6 @@ buildscript {
     }
 }
 
-apply plugin: 'checkstyle'
 apply plugin: 'idea'
 apply plugin: 'java'
 apply plugin: 'com.google.protobuf'
@@ -34,21 +33,6 @@ version = "0.13.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 def opencensusVersion = "0.12.2" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.9.0" // CURRENT_GRPC_VERSION
 def prometheusVersion = "0.3.0"
-
-checkstyle {
-    configFile = file("$rootDir/../buildscripts/checkstyle.xml")
-    toolVersion = "8.0"
-    ignoreFailures = false
-    if (rootProject.hasProperty("checkstyle.ignoreFailures")) {
-        ignoreFailures = rootProject.properties["checkstyle.ignoreFailures"].toBoolean()
-    }
-    configProperties["rootDir"] = file("$rootDir/../")
-}
-
-checkstyleMain {
-    // This skips proto generated files beucasue they are in gen_gradle/src/main/**
-    source = fileTree(dir: "src/main", include: "**/*.java")
-}
 
 // Google formatter works only on java8.
 if (JavaVersion.current().isJava8Compatible()) {

--- a/scripts/travis_script
+++ b/scripts/travis_script
@@ -54,6 +54,10 @@ case "$TASK" in
   "CHECKER_FRAMEWORK")
     ./gradlew clean assemble -PcheckerFramework=true
     ;;
+  "CHECK_EXAMPLES_LICENSE")
+    curl -L -o checkstyle-8.0-all.jar https://sourceforge.net/projects/checkstyle/files/checkstyle/8.0/checkstyle-8.0-all.jar/download
+    java -DrootDir=. -jar checkstyle-8.0-all.jar -c buildscripts/checkstyle.xml examples/src/
+    ;;
   "BUILD_EXAMPLES_GRADLE")
     pushd examples && ./gradlew clean assemble --stacktrace && popd
     ;;

--- a/scripts/travis_script
+++ b/scripts/travis_script
@@ -58,6 +58,10 @@ case "$TASK" in
     curl -L -o checkstyle-8.0-all.jar https://sourceforge.net/projects/checkstyle/files/checkstyle/8.0/checkstyle-8.0-all.jar/download
     java -DrootDir=. -jar checkstyle-8.0-all.jar -c buildscripts/checkstyle.xml examples/src/
     ;;
+  "CHECK_EXAMPLES_FORMAT")
+    curl -L -o google-java-format-1.5-all-deps.jar https://github.com/google/google-java-format/releases/download/google-java-format-1.5/google-java-format-1.5-all-deps.jar
+    java -jar google-java-format-1.5-all-deps.jar --set-exit-if-changed --dry-run `find examples/src/ -name '*.java'`
+    ;;
   "BUILD_EXAMPLES_GRADLE")
     pushd examples && ./gradlew clean assemble --stacktrace && popd
     ;;


### PR DESCRIPTION
This change simplifies the example build file by removing plugins not necessary to build the project.  It adds two new build jobs, one for each check.  The google-java-format check is under allow_failures so that contributors aren't required to download and run the tool, but it is easy to see the status of the formatting.

I tested the change with license and formatting errors: https://travis-ci.org/sebright/opencensus-java/builds/356175781

A future improvement would be to move the two checks to the top-level build.gradle.