### PR TITLE
Run docker version to find whether Jaeger integration test can be performed.

### DIFF
--- a/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
+++ b/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
@@ -201,7 +201,7 @@ public class JaegerExporterHandlerIntegrationTest {
   }
 
   private static boolean isDockerInstalledAndRunning() {
-    final String command = "docker -v";
+    final String command = "docker version";
     try {
       return Runtime.getRuntime().exec(command).waitFor() == 0;
     } catch (IOException e) {


### PR DESCRIPTION
Running `docker -v`, as done before this change, succeeds even when the Docker daemon is down, which means integration tests are attempted even though we cannot start Jaeger's container.

Running `docker version`, as done after this change, checks both the version of the CLI and the daemon, which fails when the daemon is down, and is what we really want here.

Fixes #1066. Improves on #1077. 