### PR TITLE
Run jaegertracing/all-in-one:1.2.0 instead of latest.

### DIFF
--- a/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
+++ b/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
@@ -71,7 +71,7 @@ public class JaegerExporterHandlerIntegrationTest {
                 "docker run --rm "
                     + "-e COLLECTOR_ZIPKIN_HTTP_PORT=9411 -p5775:5775/udp -p6831:6831/udp "
                     + "-p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 -p9411:9411 "
-                    + "jaegertracing/all-in-one:latest");
+                    + "jaegertracing/all-in-one:1.2.0");
     final long timeWaitingForJaegerToStart = 1000L;
     Thread.sleep(timeWaitingForJaegerToStart);
     final long startTime = currentTimeMillis();


### PR DESCRIPTION
This change implements option [1.b.](https://github.com/census-instrumentation/opencensus-java/issues/1066#issuecomment-375554352), in order to make the build more stable for now, while we discuss alternatives mentioned on this comment.

Fixes #1066, particularly, [this issue](https://github.com/census-instrumentation/opencensus-java/issues/1066#issuecomment-375453057) raised by @songy23.
