### PR TITLE
Enable FindBugs in tests.

### DIFF
--- a/api/src/test/java/io/opencensus/trace/export/NoopSampledSpanStoreTest.java
+++ b/api/src/test/java/io/opencensus/trace/export/NoopSampledSpanStoreTest.java
@@ -23,9 +23,7 @@ import io.opencensus.trace.Status.CanonicalCode;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -33,7 +31,6 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class NoopSampledSpanStoreTest {
 
-  @Rule public final ExpectedException thrown = ExpectedException.none();
   private static final SampledSpanStore.PerSpanNameSummary EMPTY_PER_SPAN_NAME_SUMMARY =
       SampledSpanStore.PerSpanNameSummary.create(
           Collections.<SampledSpanStore.LatencyBucketBoundaries, Integer>emptyMap(),

--- a/build.gradle
+++ b/build.gradle
@@ -245,8 +245,6 @@ subprojects {
             html.enabled = true
         }
     }
-    // Disable findbugs for tests.
-    findbugsTest.enabled = false
 
     checkstyle {
         configFile = file("$rootDir/buildscripts/checkstyle.xml")

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -262,8 +262,5 @@ public final class RpcMeasureConstants {
       Measure.MeasureLong.create(
           "grpc.io/server/response_count", "Number of server RPC response messages", COUNT);
 
-  // Visible for testing.
-  RpcMeasureConstants() {
-    throw new AssertionError();
-  }
+  private RpcMeasureConstants() {}
 }

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -1061,8 +1061,5 @@ public final class RpcViewConstants {
           Arrays.asList(RPC_METHOD),
           INTERVAL_HOUR);
 
-  // Visible for testing.
-  RpcViewConstants() {
-    throw new AssertionError();
-  }
+  private RpcViewConstants() {}
 }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
@@ -56,9 +56,4 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.RPC_SERVER_STARTED_COUNT).isNotNull();
     assertThat(RpcMeasureConstants.RPC_SERVER_FINISHED_COUNT).isNotNull();
   }
-
-  @Test(expected = AssertionError.class)
-  public void testConstructor() {
-    new RpcMeasureConstants();
-  }
 }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -159,9 +159,4 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.RPC_SERVER_REQUEST_COUNT_HOUR_VIEW).isNotNull();
     assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_COUNT_HOUR_VIEW).isNotNull();
   }
-
-  @Test(expected = AssertionError.class)
-  public void testConstructor() {
-    new RpcViewConstants();
-  }
 }

--- a/contrib/http_util/src/test/java/io/opencensus/contrib/http/util/CloudTraceFormatTest.java
+++ b/contrib/http_util/src/test/java/io/opencensus/contrib/http/util/CloudTraceFormatTest.java
@@ -286,7 +286,7 @@ public final class CloudTraceFormatTest {
   public void parseWithShortSpanIdAndSamplingShouldSucceed() throws SpanContextParseException {
     final String spanId = "1";
     ByteBuffer buffer = ByteBuffer.allocate(SpanId.SIZE);
-    buffer.putLong(Long.valueOf(spanId));
+    buffer.putLong(Long.parseLong(spanId));
     SpanId expectedSpanId = SpanId.fromBytes(buffer.array());
     parseSuccess(
         constructHeader(TRACE_ID_BASE16, spanId, SAMPLED),

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollectorTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollectorTest.java
@@ -40,9 +40,7 @@ import io.prometheus.client.Collector.Type;
 import java.util.Arrays;
 import java.util.Collections;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
@@ -51,8 +49,6 @@ import org.mockito.MockitoAnnotations;
 /** Unit tests for {@link PrometheusStatsCollector}. */
 @RunWith(JUnit4.class)
 public class PrometheusStatsCollectorTest {
-
-  @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private static final Cumulative CUMULATIVE = Cumulative.create();
   private static final BucketBoundaries BUCKET_BOUNDARIES =

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptorTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxSessionAdaptorTest.java
@@ -106,7 +106,7 @@ public class SignalFxSessionAdaptorTest {
             Aggregation.Sum.create(), AggregationWindow.Interval.create(ONE_SECOND)));
     assertNull(
         SignalFxSessionAdaptor.getMetricTypeForAggregation(
-            Aggregation.Distribution.create(BucketBoundaries.create(ImmutableList.of(3.14d))),
+            Aggregation.Distribution.create(BucketBoundaries.create(ImmutableList.of(3.15d))),
             AggregationWindow.Cumulative.create()));
   }
 
@@ -143,7 +143,7 @@ public class SignalFxSessionAdaptorTest {
   public void unsupportedAggregationYieldsNoDatapoints() {
     Mockito.when(view.getAggregation())
         .thenReturn(
-            Aggregation.Distribution.create(BucketBoundaries.create(ImmutableList.of(3.14d))));
+            Aggregation.Distribution.create(BucketBoundaries.create(ImmutableList.of(3.15d))));
     Mockito.when(view.getWindow()).thenReturn(AggregationWindow.Cumulative.create());
     List<DataPoint> datapoints = SignalFxSessionAdaptor.adapt(viewData);
     assertEquals(0, datapoints.size());
@@ -159,12 +159,12 @@ public class SignalFxSessionAdaptorTest {
 
   @Test
   public void createDatumFromDoubleSum() {
-    SumDataDouble data = SumDataDouble.create(3.14d);
+    SumDataDouble data = SumDataDouble.create(3.15d);
     Datum datum = SignalFxSessionAdaptor.createDatum(data);
     assertTrue(datum.hasDoubleValue());
     assertFalse(datum.hasIntValue());
     assertFalse(datum.hasStrValue());
-    assertEquals(3.14d, datum.getDoubleValue(), 0d);
+    assertEquals(3.15d, datum.getDoubleValue(), 0d);
   }
 
   @Test
@@ -189,12 +189,12 @@ public class SignalFxSessionAdaptorTest {
 
   @Test
   public void createDatumFromMean() {
-    MeanData data = MeanData.create(3.14d, 2L);
+    MeanData data = MeanData.create(3.15d, 2L);
     Datum datum = SignalFxSessionAdaptor.createDatum(data);
     assertTrue(datum.hasDoubleValue());
     assertFalse(datum.hasIntValue());
     assertFalse(datum.hasStrValue());
-    assertEquals(3.14d, datum.getDoubleValue(), 0d);
+    assertEquals(3.15d, datum.getDoubleValue(), 0d);
   }
 
   @Test

--- a/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThreadTest.java
+++ b/exporters/stats/signalfx/src/test/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThreadTest.java
@@ -126,7 +126,7 @@ public class SignalFxStatsExporterWorkerThreadTest {
     Mockito.when(viewData.getAggregationMap())
         .thenReturn(
             ImmutableMap.<List<TagValue>, AggregationData>of(
-                ImmutableList.of(TagValue.create("cat")), MeanData.create(3.14d, 1)));
+                ImmutableList.of(TagValue.create("cat")), MeanData.create(3.15d, 1)));
 
     Mockito.when(viewManager.getAllExportedViews()).thenReturn(ImmutableSet.of(view));
     Mockito.when(viewManager.getView(Mockito.eq(viewName))).thenReturn(viewData);
@@ -141,7 +141,7 @@ public class SignalFxStatsExporterWorkerThreadTest {
             .setMetric("test")
             .setMetricType(MetricType.GAUGE)
             .addDimensions(Dimension.newBuilder().setKey("animal").setValue("cat").build())
-            .setValue(Datum.newBuilder().setDoubleValue(3.14d).build())
+            .setValue(Datum.newBuilder().setDoubleValue(3.15d).build())
             .build();
     Mockito.verify(session).setDatapoint(Mockito.eq(datapoint));
     Mockito.verify(session).close();

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
@@ -55,9 +55,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.Mock;
@@ -83,8 +81,6 @@ public class StackdriverExporterWorkerTest {
   private static final Sum SUM = Sum.create();
   private static final MonitoredResource DEFAULT_RESOURCE =
       MonitoredResource.newBuilder().setType("global").build();
-
-  @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Mock private ViewManager mockViewManager;
 

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
@@ -24,17 +24,13 @@ import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import io.opencensus.common.Duration;
 import java.util.Date;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link StackdriverStatsConfiguration}. */
 @RunWith(JUnit4.class)
 public class StackdriverStatsConfigurationTest {
-
-  @Rule public final ExpectedException thrown = ExpectedException.none();
 
   private static final Credentials FAKE_CREDENTIALS =
       GoogleCredentials.newBuilder().setAccessToken(new AccessToken("fake", new Date(100))).build();

--- a/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
+++ b/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
@@ -72,7 +72,7 @@ public class JaegerExporterHandlerIntegrationTest {
                     + "-e COLLECTOR_ZIPKIN_HTTP_PORT=9411 -p5775:5775/udp -p6831:6831/udp "
                     + "-p6832:6832/udp -p5778:5778 -p16686:16686 -p14268:14268 -p9411:9411 "
                     + "jaegertracing/all-in-one:1.2.0");
-    final long timeWaitingForJaegerToStart = 1000L;
+    long timeWaitingForJaegerToStart = 1000L;
     Thread.sleep(timeWaitingForJaegerToStart);
     final long startTime = currentTimeMillis();
 
@@ -99,7 +99,7 @@ public class JaegerExporterHandlerIntegrationTest {
 
       logger.info("Wait longer than the reporting duration...");
       // Wait for a duration longer than reporting duration (5s) to ensure spans are exported.
-      final long timeWaitingForSpansToBeExported = 5100L;
+      long timeWaitingForSpansToBeExported = 5100L;
       Thread.sleep(timeWaitingForSpansToBeExported);
       JaegerTraceExporter.unregister();
       final long endTime = currentTimeMillis();

--- a/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandlerExportTest.java
+++ b/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandlerExportTest.java
@@ -20,12 +20,9 @@ import static org.mockito.Mockito.when;
 
 import com.google.cloud.trace.v2.TraceServiceClient;
 import com.google.cloud.trace.v2.stub.TraceServiceStub;
-import com.google.devtools.cloudtrace.v2.Span;
 import io.opencensus.trace.export.SpanData;
-import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -46,7 +43,7 @@ public final class StackdriverV2ExporterHandlerExportTest {
   private StackdriverV2ExporterHandler handler;
 
   @Before
-  public void setUp() throws IOException {
+  public void setUp() {
     MockitoAnnotations.initMocks(this);
     // TODO(@Hailong): TraceServiceClient.create(TraceServiceStub) is a beta API and might change
     // in the future.
@@ -59,7 +56,6 @@ public final class StackdriverV2ExporterHandlerExportTest {
     when(traceServiceStub.batchWriteSpansCallable())
         .thenThrow(new RuntimeException("TraceServiceStub called"));
     Collection<SpanData> spanDataList = Collections.<SpanData>emptyList();
-    List<Span> spanList = Collections.<Span>emptyList();
     thrown.expect(RuntimeException.class);
     thrown.expectMessage("TraceServiceStub called");
     handler.export(spanDataList);

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -23,15 +23,54 @@
     <Class name="io.opencensus.trace.internal.BaseMessageEventUtil" />
   </Match>
 
-  <!-- Suppress all FindBugs warnings about NullPointerExceptions. They are redundant with the -->
-  <!-- Checker Framework's warnings, and they sometimes conflict. -->
+  <!-- Suppress some FindBugs warnings related to performance or robustness -->
+  <!-- in test classes, where those issues are less important. -->
+  <Match>
+    <!-- Reason: Only needed for performance. -->
+    <Bug pattern="SIC_INNER_SHOULD_BE_STATIC_ANON"/>
+    <Source name="~.*Test\.java" />
+  </Match>
+  <Match>
+    <!-- Reason: Only needed for performance. -->
+    <Bug pattern="WMI_WRONG_MAP_ITERATOR"/>
+    <Source name="~.*Test\.java" />
+  </Match>
+  <Match>
+    <!-- Reason: Only needed for performance. -->
+    <Bug pattern="UM_UNNECESSARY_MATH"/>
+    <Source name="~.*Test\.java" />
+  </Match>
+  <Match>
+    <!-- Reason: This is less important in a test environment. -->
+    <Bug pattern="DP_CREATE_CLASSLOADER_INSIDE_DO_PRIVILEGED"/>
+    <Source name="~.*Test\.java" />
+  </Match>
+  <Match>
+    <!-- Reason: Many classes initialize fields in @Before methods. -->
+    <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+    <Source name="~.*Test\.java" />
+  </Match>
+
+  <!-- Suppress all FindBugs warnings about NullPointerExceptions in -->
+  <!-- non-test code. They are redundant with the Checker Framework's -->
+  <!-- warnings, and they sometimes conflict. These warnings are still -->
+  <!-- useful in test code, where we don't use the Checker Framework. -->
   <Match>
     <Bug code="NP"/>
+    <Not>
+      <Source name="~.*Test\.java" />
+    </Not>
   </Match>
   <Match>
     <Bug pattern="UR_UNINIT_READ"/>
+    <Not>
+      <Source name="~.*Test\.java" />
+    </Not>
   </Match>
   <Match>
     <Bug pattern="UWF_FIELD_NOT_INITIALIZED_IN_CONSTRUCTOR"/>
+    <Not>
+      <Source name="~.*Test\.java" />
+    </Not>
   </Match>
 </FindBugsFilter>

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsTestUtil.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsTestUtil.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import javax.annotation.Nullable;
 
 /** Stats test utilities. */
@@ -76,8 +77,9 @@ final class StatsTestUtil {
       Map<? extends List<? extends TagValue>, ? extends AggregationData> expected,
       double tolerance) {
     assertThat(actual.keySet()).containsExactlyElementsIn(expected.keySet());
-    for (List<? extends TagValue> tagValues : actual.keySet()) {
-      assertAggregationDataEquals(expected.get(tagValues), actual.get(tagValues), tolerance);
+    for (Entry<? extends List<? extends TagValue>, ? extends AggregationData> entry :
+        actual.entrySet()) {
+      assertAggregationDataEquals(expected.get(entry.getKey()), entry.getValue(), tolerance);
     }
   }
 

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/ViewManagerImplTest.java
@@ -97,7 +97,7 @@ public class ViewManagerImplTest {
   private static final Cumulative CUMULATIVE = Cumulative.create();
 
   private static final double EPSILON = 1e-7;
-  private static final int MILLIS_PER_SECOND = 1000;
+  private static final long MILLIS_PER_SECOND = 1000;
   private static final Duration TEN_SECONDS = Duration.create(10, 0);
   private static final Interval INTERVAL = Interval.create(TEN_SECONDS);
 

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/propagation/TagContextSerializationTest.java
@@ -133,7 +133,7 @@ public class TagContextSerializationTest {
         encodeString(tag.getKey().getName(), expected);
         encodeString(tag.getValue().asString(), expected);
       }
-      possibleOutputs.add(expected.toString());
+      possibleOutputs.add(new String(expected.toByteArray(), Charsets.UTF_8));
     }
 
     assertThat(possibleOutputs).contains(new String(actual, Charsets.UTF_8));

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/SpanImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/SpanImplTest.java
@@ -459,7 +459,7 @@ public class SpanImplTest {
     assertThat(spanData.getAnnotations().getEvents().size()).isEqualTo(maxNumberOfAnnotations);
     for (int i = 0; i < maxNumberOfAnnotations; i++) {
       assertThat(spanData.getAnnotations().getEvents().get(i).getTimestamp())
-          .isEqualTo(timestamp.addNanos(100 * (maxNumberOfAnnotations + i)));
+          .isEqualTo(timestamp.addNanos(100L * (maxNumberOfAnnotations + i)));
       assertThat(spanData.getAnnotations().getEvents().get(i).getEvent()).isEqualTo(annotation);
     }
     span.end();
@@ -468,7 +468,7 @@ public class SpanImplTest {
     assertThat(spanData.getAnnotations().getEvents().size()).isEqualTo(maxNumberOfAnnotations);
     for (int i = 0; i < maxNumberOfAnnotations; i++) {
       assertThat(spanData.getAnnotations().getEvents().get(i).getTimestamp())
-          .isEqualTo(timestamp.addNanos(100 * (maxNumberOfAnnotations + i)));
+          .isEqualTo(timestamp.addNanos(100L * (maxNumberOfAnnotations + i)));
       assertThat(spanData.getAnnotations().getEvents().get(i).getEvent()).isEqualTo(annotation);
     }
   }
@@ -504,7 +504,7 @@ public class SpanImplTest {
     assertThat(spanData.getNetworkEvents().getEvents().size()).isEqualTo(maxNumberOfNetworkEvents);
     for (int i = 0; i < maxNumberOfNetworkEvents; i++) {
       assertThat(spanData.getNetworkEvents().getEvents().get(i).getTimestamp())
-          .isEqualTo(timestamp.addNanos(100 * (maxNumberOfNetworkEvents + i)));
+          .isEqualTo(timestamp.addNanos(100L * (maxNumberOfNetworkEvents + i)));
       assertThat(spanData.getNetworkEvents().getEvents().get(i).getEvent()).isEqualTo(networkEvent);
     }
     span.end();
@@ -514,7 +514,7 @@ public class SpanImplTest {
     assertThat(spanData.getNetworkEvents().getEvents().size()).isEqualTo(maxNumberOfNetworkEvents);
     for (int i = 0; i < maxNumberOfNetworkEvents; i++) {
       assertThat(spanData.getNetworkEvents().getEvents().get(i).getTimestamp())
-          .isEqualTo(timestamp.addNanos(100 * (maxNumberOfNetworkEvents + i)));
+          .isEqualTo(timestamp.addNanos(100L * (maxNumberOfNetworkEvents + i)));
       assertThat(spanData.getNetworkEvents().getEvents().get(i).getEvent()).isEqualTo(networkEvent);
     }
   }


### PR DESCRIPTION
This would have caught the unused variable that was fixed by #1082.

Changes in this commit:

  - Enable FindBugs in tests in build.gradle.

  - Fix some existing minor FindBugs issues in tests.

  - Suppress some warnings in all test classes that are less important in test
    code, such as requiring nested classes to be static whenever possible.

  - Enable nullness-related FindBugs warnings in tests, since we don't run the
    Checker Framework on test code.