### PR TITLE
Fix warning-throwing README.md instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ public final class QuickStart {
   private static final StatsRecorder statsRecorder = Stats.getStatsRecorder();
 
   // frontendKey allows us to break down the recorded data
-  private static final TagKey FRONTEND_KEY = TagKey.create("my.org/keys/frontend");
+  private static final TagKey FRONTEND_KEY = TagKey.create("frontend");
 
   // videoSize will measure the size of processed videos.
   private static final MeasureLong VIDEO_SIZE = MeasureLong.create(

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ public final class QuickStart {
   private static final StatsRecorder statsRecorder = Stats.getStatsRecorder();
 
   // frontendKey allows us to break down the recorded data
-  private static final TagKey FRONTEND_KEY = TagKey.create("frontend");
+  private static final TagKey FRONTEND_KEY = TagKey.create("myorg_keys_frontend");
 
   // videoSize will measure the size of processed videos.
   private static final MeasureLong VIDEO_SIZE = MeasureLong.create(


### PR DESCRIPTION
`TagKey.create("my.org/keys/frontend")` throws:

```
WARNING: ApiException thrown when creating MetricDescriptor.
com.google.api.gax.rpc.InvalidArgumentException: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Field metricDescriptor.labels[0].key had an invalid value of "my.org/keys/frontend": Label key contains invalid characters.
	at com.google.api.gax.rpc.ApiExceptionFactory.createException(ApiExceptionFactory.java:49)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:72)
	at com.google.api.gax.grpc.GrpcApiExceptionFactory.create(GrpcApiExceptionFactory.java:60)
	at com.google.api.gax.grpc.GrpcExceptionCallable$ExceptionTransformingFuture.onFailure(GrpcExceptionCallable.java:95)
	at com.google.api.core.ApiFutures$1.onFailure(ApiFutures.java:61)
	at com.google.common.util.concurrent.Futures$CallbackListener.run(Futures.java:1341)
	at com.google.common.util.concurrent.MoreExecutors$DirectExecutor.execute(MoreExecutors.java:398)
	at com.google.common.util.concurrent.AbstractFuture.executeListener(AbstractFuture.java:1027)
	at com.google.common.util.concurrent.AbstractFuture.complete(AbstractFuture.java:868)
	at com.google.common.util.concurrent.AbstractFuture.setException(AbstractFuture.java:713)
	at io.grpc.stub.ClientCalls$GrpcFuture.setException(ClientCalls.java:492)
	at io.grpc.stub.ClientCalls$UnaryStreamToFuture.onClose(ClientCalls.java:467)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:41)
	at io.grpc.internal.CensusStatsModule$StatsClientInterceptor$1$1.onClose(CensusStatsModule.java:684)
	at io.grpc.ForwardingClientCallListener.onClose(ForwardingClientCallListener.java:41)
	at io.grpc.internal.CensusTracingModule$TracingClientInterceptor$1$1.onClose(CensusTracingModule.java:392)
	at io.grpc.internal.ClientCallImpl.closeObserver(ClientCallImpl.java:475)
	at io.grpc.internal.ClientCallImpl.access$300(ClientCallImpl.java:63)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.close(ClientCallImpl.java:557)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl.access$600(ClientCallImpl.java:478)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1StreamClosed.runInContext(ClientCallImpl.java:590)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:123)
	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
	at java.util.concurrent.FutureTask.run(FutureTask.java:266)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$201(ScheduledThreadPoolExecutor.java:180)
	at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:293)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
Caused by: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: Field metricDescriptor.labels[0].key had an invalid value of "my.org/keys/frontend": Label key contains invalid characters.
	at io.grpc.Status.asRuntimeException(Status.java:526)
	... 19 more
```

All non-alphanumeric characters are not allowed.