### PR TITLE
Add unit test for HTTP header name validation.

### DIFF
--- a/contrib/http_util/build.gradle
+++ b/contrib/http_util/build.gradle
@@ -9,8 +9,9 @@ apply plugin: 'java'
 
 dependencies {
     compile project(':opencensus-api'),
-            project(':opencensus-testing'),
             libraries.guava
+
+    testCompile project(':opencensus-testing')
 
     signature "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/contrib/http_util/build.gradle
+++ b/contrib/http_util/build.gradle
@@ -9,6 +9,7 @@ apply plugin: 'java'
 
 dependencies {
     compile project(':opencensus-api'),
+            project(':opencensus-testing'),
             libraries.guava
 
     signature "org.codehaus.mojo.signature:java16:+@signature"

--- a/contrib/http_util/src/test/java/io/opencensus/contrib/http/util/CloudTraceFormatTest.java
+++ b/contrib/http_util/src/test/java/io/opencensus/contrib/http/util/CloudTraceFormatTest.java
@@ -286,7 +286,7 @@ public final class CloudTraceFormatTest {
   @Test
   public void fieldsShouldBeValid() {
     for (String header : cloudTraceFormat.fields()) {
-      assertThat(HttpUtils.validateHeaderName(header)).isEqualTo(true);
+      HttpUtils.assertHeaderNameIsValid(header);
     }
   }
 

--- a/contrib/http_util/src/test/java/io/opencensus/contrib/http/util/CloudTraceFormatTest.java
+++ b/contrib/http_util/src/test/java/io/opencensus/contrib/http/util/CloudTraceFormatTest.java
@@ -24,6 +24,7 @@ import static io.opencensus.contrib.http.util.CloudTraceFormat.SPAN_ID_DELIMITER
 import static io.opencensus.contrib.http.util.CloudTraceFormat.TRACE_OPTION_DELIMITER;
 
 import com.google.common.primitives.UnsignedLong;
+import io.opencensus.testing.propagation.HttpUtils;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.TraceId;
@@ -280,6 +281,13 @@ public final class CloudTraceFormatTest {
   @Test
   public void fieldsShouldMatch() {
     assertThat(cloudTraceFormat.fields()).containsExactly(HEADER_NAME);
+  }
+
+  @Test
+  public void fieldsShouldBeValid() {
+    for (String header : cloudTraceFormat.fields()) {
+      assertThat(HttpUtils.validateHeaderName(header)).isEqualTo(true);
+    }
   }
 
   @Test

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/propagation/B3FormatTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/propagation/B3FormatTest.java
@@ -23,6 +23,7 @@ import static io.opencensus.implcore.trace.propagation.B3Format.X_B3_SAMPLED;
 import static io.opencensus.implcore.trace.propagation.B3Format.X_B3_SPAN_ID;
 import static io.opencensus.implcore.trace.propagation.B3Format.X_B3_TRACE_ID;
 
+import io.opencensus.testing.propagation.HttpUtils;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.TraceId;
@@ -217,5 +218,8 @@ public class B3FormatTest {
     assertThat(b3Format.fields())
         .containsExactly(
             X_B3_TRACE_ID, X_B3_SPAN_ID, X_B3_PARENT_SPAN_ID, X_B3_SAMPLED, X_B3_FLAGS);
+    for (String header : b3Format.fields()) {
+      assertThat(HttpUtils.validateHeaderName(header)).isEqualTo(true);
+    }
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/propagation/B3FormatTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/propagation/B3FormatTest.java
@@ -219,7 +219,7 @@ public class B3FormatTest {
         .containsExactly(
             X_B3_TRACE_ID, X_B3_SPAN_ID, X_B3_PARENT_SPAN_ID, X_B3_SAMPLED, X_B3_FLAGS);
     for (String header : b3Format.fields()) {
-      assertThat(HttpUtils.validateHeaderName(header)).isEqualTo(true);
+      HttpUtils.assertHeaderNameIsValid(header);
     }
   }
 }

--- a/testing/src/main/java/io/opencensus/testing/propagation/HttpUtils.java
+++ b/testing/src/main/java/io/opencensus/testing/propagation/HttpUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.testing.propagation;
+
+/**
+ * Utilities for HTTP testing.
+ *
+ * @since 0.13
+ */
+public final class HttpUtils {
+
+  private HttpUtils() {}
+
+  /**
+   * Returns {@code false} if a header name contains invalid characters, otherwise {@code true}.
+   *
+   * <p>Specification for HTTP header name: See RFC-7230, which explicitly defines what characters
+   * are accepted. Note that RFC-2616 has different BNF rules on header name, but the derived
+   * character set is the same.
+   *
+   * <pre>
+   * field-name = token
+   * token      = 1*tchar
+   * tchar      = "!" / "#" / "$" / "%" / "&amp;" / "'" / "*" / "+" / "-" / "." / "^" / "_"
+   *            / "`" / "|" / "~" / DIGIT / ALPHA
+   * </pre>
+   *
+   * <p>This method is also inspired by
+   * https://github.com/netty/netty/blob/fc3b145cbbcad4a257f92f0640eb4ded19b44afe/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java#L381:25
+   *
+   * @param name the name of the header.
+   * @return {@code false} if a header name contains invalid characters, otherwise {@code true}.
+   */
+  public static boolean validateHeaderName(String name) {
+    for (int i = 0; i < name.length(); i++) {
+      char c = name.charAt(i);
+      switch (c) {
+        case '!':
+        case '#':
+        case '$':
+        case '%':
+        case '&':
+        case '\'':
+        case '*':
+        case '+':
+        case '-':
+        case '.':
+        case '^':
+        case '_':
+        case '`':
+        case '|':
+        case '~':
+          continue;
+        default:
+          if ((c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+            continue;
+          }
+          return false;
+      }
+    }
+    return true;
+  }
+}

--- a/testing/src/test/java/io/opencensus/testing/propagation/HttpUtilsTest.java
+++ b/testing/src/test/java/io/opencensus/testing/propagation/HttpUtilsTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.testing.propagation;
+
+import static com.google.common.truth.Truth.assertWithMessage;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests for {@link HttpUtils}.
+ *
+ * <p>Test cases comes from RFC-2616. The character set defined in this RFC is actually the same
+ * with the one in RFC-7230.
+ *
+ * <pre>
+ * token      = 1*&lt;any CHAR except CTLs or separators&gt;
+ * CTL        = &lt;any US-ASCII control character(octets 0 - 31) and DEL (127)&gt;
+ * separators = "(" | ")" | "&lt;" | "&gt;" | "{@literal @}" | "," | ";" | ":" | "\" | &lt;"&gt;
+ *            | "/" | "[" | "]" | "?" | "=" | "{" | "}" | SP | HT
+ * SP         = &lt;US-ASCII SP, space (32)&gt;
+ * HT         = &lt;US-ASCII HT, horizontal-tab (9)&gt;
+ * </pre>
+ */
+@RunWith(JUnit4.class)
+public final class HttpUtilsTest {
+
+  private final Set<Character> disallowed = new HashSet<Character>();
+
+  @Before
+  public void setUp() {
+    // non-ascii and CTLs
+    for (int i = -128; i <= 31; i++) {
+      disallowed.add((char) i);
+    }
+    disallowed.add((char) 127);
+    // separators
+    disallowed.add('(');
+    disallowed.add(')');
+    disallowed.add('<');
+    disallowed.add('>');
+    disallowed.add('@');
+    disallowed.add(',');
+    disallowed.add(';');
+    disallowed.add(':');
+    disallowed.add('\\');
+    disallowed.add('"');
+    disallowed.add('/');
+    disallowed.add('[');
+    disallowed.add(']');
+    disallowed.add('?');
+    disallowed.add('=');
+    disallowed.add('{');
+    disallowed.add('}');
+    disallowed.add(' ');
+    disallowed.add('\t');
+  }
+
+  @Test
+  public void allowedAndDisallowed() {
+    for (int i = -128; i <= 127; i++) {
+      char ch = (char) i;
+      String header = "" + ch;
+      if (disallowed.contains(ch)) {
+        assertWithMessage(String.format("ASCII %d (%s)", i, header))
+            .that(HttpUtils.validateHeaderName(header))
+            .isEqualTo(false);
+      } else {
+        assertWithMessage(String.format("ASCII %d (%s)", i, header))
+            .that(HttpUtils.validateHeaderName(header))
+            .isEqualTo(true);
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR added `HttpUtils` for `TextFormat` propagation tests. It validates the characters of header names (#1072).

The validation logic is inspired by [netty](https://github.com/netty/netty/blob/fc3b145cbbcad4a257f92f0640eb4ded19b44afe/codec-http/src/main/java/io/netty/handler/codec/http/DefaultHttpHeaders.java#L381:25), however it does not fully implement the spec.

There are two specs for the header and they are actually the same. The only difference is that [RFC-2616](https://www.w3.org/Protocols/rfc2616/rfc2616-sec2.html#sec2.1) defines the charset by excluding invalid characters, while [RFC-7230](https://tools.ietf.org/html/rfc7230#page-22) defines it by listing all allowed characters.

