### PR TITLE
Suppress Checker Framework warnings in AutoValue generated classes (fixes #917).

### DIFF
--- a/api/src/main/java/io/opencensus/common/Duration.java
+++ b/api/src/main/java/io/opencensus/common/Duration.java
@@ -34,9 +34,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class Duration implements Comparable<Duration> {
   private static final Duration ZERO = create(0, 0);
 

--- a/api/src/main/java/io/opencensus/common/Timestamp.java
+++ b/api/src/main/java/io/opencensus/common/Timestamp.java
@@ -39,9 +39,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class Timestamp implements Comparable<Timestamp> {
   private static final Timestamp EPOCH = new AutoValue_Timestamp(0, 0);
 

--- a/api/src/main/java/io/opencensus/stats/Aggregation.java
+++ b/api/src/main/java/io/opencensus/stats/Aggregation.java
@@ -64,9 +64,6 @@ public abstract class Aggregation {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Sum extends Aggregation {
 
     Sum() {}
@@ -101,9 +98,6 @@ public abstract class Aggregation {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Count extends Aggregation {
 
     Count() {}
@@ -138,9 +132,6 @@ public abstract class Aggregation {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Mean extends Aggregation {
 
     Mean() {}
@@ -176,9 +167,6 @@ public abstract class Aggregation {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Distribution extends Aggregation {
 
     Distribution() {}

--- a/api/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/api/src/main/java/io/opencensus/stats/AggregationData.java
@@ -70,9 +70,6 @@ public abstract class AggregationData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class SumDataDouble extends AggregationData {
 
     SumDataDouble() {}
@@ -115,9 +112,6 @@ public abstract class AggregationData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class SumDataLong extends AggregationData {
 
     SumDataLong() {}
@@ -160,9 +154,6 @@ public abstract class AggregationData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class CountData extends AggregationData {
 
     CountData() {}
@@ -205,9 +196,6 @@ public abstract class AggregationData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class MeanData extends AggregationData {
 
     MeanData() {}
@@ -260,9 +248,6 @@ public abstract class AggregationData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class DistributionData extends AggregationData {
 
     DistributionData() {}

--- a/api/src/main/java/io/opencensus/stats/BucketBoundaries.java
+++ b/api/src/main/java/io/opencensus/stats/BucketBoundaries.java
@@ -32,9 +32,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class BucketBoundaries {
 
   /**

--- a/api/src/main/java/io/opencensus/stats/Measure.java
+++ b/api/src/main/java/io/opencensus/stats/Measure.java
@@ -90,9 +90,6 @@ public abstract class Measure {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class MeasureDouble extends Measure {
 
     MeasureDouble() {}
@@ -140,9 +137,6 @@ public abstract class Measure {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class MeasureLong extends Measure {
 
     MeasureLong() {}

--- a/api/src/main/java/io/opencensus/stats/Measurement.java
+++ b/api/src/main/java/io/opencensus/stats/Measurement.java
@@ -57,9 +57,6 @@ public abstract class Measurement {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class MeasurementDouble extends Measurement {
     MeasurementDouble() {}
 
@@ -99,9 +96,6 @@ public abstract class Measurement {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class MeasurementLong extends Measurement {
     MeasurementLong() {}
 

--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -38,9 +38,8 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
 @AutoValue.CopyAnnotations
-@SuppressWarnings({"nullness", "deprecation"})
+@SuppressWarnings("deprecation")
 public abstract class View {
 
   @VisibleForTesting static final int NAME_MAX_LENGTH = 255;
@@ -165,9 +164,6 @@ public abstract class View {
   // This type should be used as the key when associating data with Views.
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Name {
 
     Name() {}
@@ -229,9 +225,7 @@ public abstract class View {
     @Deprecated
     @Immutable
     @AutoValue
-    // Suppress Checker Framework warning about missing @Nullable in generated equals method.
     @AutoValue.CopyAnnotations
-    @SuppressWarnings("nullness")
     public abstract static class Cumulative extends AggregationWindow {
 
       private static final Cumulative CUMULATIVE =
@@ -269,9 +263,7 @@ public abstract class View {
     @Deprecated
     @Immutable
     @AutoValue
-    // Suppress Checker Framework warning about missing @Nullable in generated equals method.
     @AutoValue.CopyAnnotations
-    @SuppressWarnings("nullness")
     public abstract static class Interval extends AggregationWindow {
 
       private static final Duration ZERO = Duration.create(0, 0);

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -54,9 +54,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
 @AutoValue.CopyAnnotations
-@SuppressWarnings({"nullness", "deprecation"})
+@SuppressWarnings("deprecation")
 public abstract class ViewData {
 
   // Prevents this class from being subclassed anywhere else.
@@ -125,9 +124,10 @@ public abstract class ViewData {
       Map<? extends List</*@Nullable*/ TagValue>, ? extends AggregationData> map,
       final AggregationWindowData windowData) {
     checkWindow(view.getWindow(), windowData);
-    final Map<List<TagValue>, AggregationData> deepCopy =
-        new HashMap<List<TagValue>, AggregationData>();
-    for (Entry<? extends List<TagValue>, ? extends AggregationData> entry : map.entrySet()) {
+    final Map<List</*@Nullable*/ TagValue>, AggregationData> deepCopy =
+        new HashMap<List</*@Nullable*/ TagValue>, AggregationData>();
+    for (Entry<? extends List</*@Nullable*/ TagValue>, ? extends AggregationData> entry :
+        map.entrySet()) {
       checkAggregation(view.getAggregation(), entry.getValue(), view.getMeasure());
       deepCopy.put(
           Collections.unmodifiableList(new ArrayList</*@Nullable*/ TagValue>(entry.getKey())),
@@ -137,7 +137,7 @@ public abstract class ViewData {
         new Function<ViewData.AggregationWindowData.CumulativeData, ViewData>() {
           @Override
           public ViewData apply(ViewData.AggregationWindowData.CumulativeData arg) {
-            return new AutoValue_ViewData(
+            return createInternal(
                 view, Collections.unmodifiableMap(deepCopy), arg, arg.getStart(), arg.getEnd());
           }
         },
@@ -145,7 +145,7 @@ public abstract class ViewData {
           @Override
           public ViewData apply(ViewData.AggregationWindowData.IntervalData arg) {
             Duration duration = ((View.AggregationWindow.Interval) view.getWindow()).getDuration();
-            return new AutoValue_ViewData(
+            return createInternal(
                 view,
                 Collections.unmodifiableMap(deepCopy),
                 arg,
@@ -174,19 +174,34 @@ public abstract class ViewData {
       Map<? extends List</*@Nullable*/ TagValue>, ? extends AggregationData> map,
       Timestamp start,
       Timestamp end) {
-    Map<List<TagValue>, AggregationData> deepCopy = new HashMap<List<TagValue>, AggregationData>();
-    for (Entry<? extends List<TagValue>, ? extends AggregationData> entry : map.entrySet()) {
+    Map<List</*@Nullable*/ TagValue>, AggregationData> deepCopy =
+        new HashMap<List</*@Nullable*/ TagValue>, AggregationData>();
+    for (Entry<? extends List</*@Nullable*/ TagValue>, ? extends AggregationData> entry :
+        map.entrySet()) {
       checkAggregation(view.getAggregation(), entry.getValue(), view.getMeasure());
       deepCopy.put(
           Collections.unmodifiableList(new ArrayList</*@Nullable*/ TagValue>(entry.getKey())),
           entry.getValue());
     }
-    return new AutoValue_ViewData(
+    return createInternal(
         view,
         Collections.unmodifiableMap(deepCopy),
         AggregationWindowData.CumulativeData.create(start, end),
         start,
         end);
+  }
+
+  // Suppresses a nullness warning about calls to the AutoValue_ViewData constructor. The generated
+  // constructor does not have the @Nullable annotation on TagValue.
+  private static ViewData createInternal(
+      View view,
+      Map<List</*@Nullable*/ TagValue>, AggregationData> aggregationMap,
+      AggregationWindowData window,
+      Timestamp start,
+      Timestamp end) {
+    @SuppressWarnings("nullness")
+    Map<List<TagValue>, AggregationData> map = aggregationMap;
+    return new AutoValue_ViewData(view, map, window, start, end);
   }
 
   private static void checkWindow(
@@ -247,7 +262,7 @@ public abstract class ViewData {
                     return null;
                   }
                 },
-                Functions.<Void>throwAssertionError());
+                Functions.</*@Nullable*/ Void>throwAssertionError());
             return null;
           }
         },
@@ -278,7 +293,7 @@ public abstract class ViewData {
             return null;
           }
         },
-        Functions.<Void>throwAssertionError());
+        Functions.</*@Nullable*/ Void>throwAssertionError());
   }
 
   private static String createErrorMessageForAggregation(
@@ -321,9 +336,7 @@ public abstract class ViewData {
     @Deprecated
     @Immutable
     @AutoValue
-    // Suppress Checker Framework warning about missing @Nullable in generated equals method.
     @AutoValue.CopyAnnotations
-    @SuppressWarnings("nullness")
     public abstract static class CumulativeData extends AggregationWindowData {
 
       CumulativeData() {}
@@ -374,9 +387,7 @@ public abstract class ViewData {
     @Deprecated
     @Immutable
     @AutoValue
-    // Suppress Checker Framework warning about missing @Nullable in generated equals method.
     @AutoValue.CopyAnnotations
-    @SuppressWarnings("nullness")
     public abstract static class IntervalData extends AggregationWindowData {
 
       IntervalData() {}

--- a/api/src/main/java/io/opencensus/tags/Tag.java
+++ b/api/src/main/java/io/opencensus/tags/Tag.java
@@ -26,9 +26,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class Tag {
 
   Tag() {}

--- a/api/src/main/java/io/opencensus/tags/TagKey.java
+++ b/api/src/main/java/io/opencensus/tags/TagKey.java
@@ -35,9 +35,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class TagKey {
   /**
    * The maximum length for a tag key name. The value is {@value #MAX_LENGTH}.

--- a/api/src/main/java/io/opencensus/tags/TagValue.java
+++ b/api/src/main/java/io/opencensus/tags/TagValue.java
@@ -31,9 +31,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class TagValue {
   /**
    * The maximum length for a tag value. The value is {@value #MAX_LENGTH}.

--- a/api/src/main/java/io/opencensus/trace/Annotation.java
+++ b/api/src/main/java/io/opencensus/trace/Annotation.java
@@ -31,9 +31,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class Annotation {
   private static final Map<String, AttributeValue> EMPTY_ATTRIBUTES =
       Collections.unmodifiableMap(Collections.<String, AttributeValue>emptyMap());

--- a/api/src/main/java/io/opencensus/trace/AttributeValue.java
+++ b/api/src/main/java/io/opencensus/trace/AttributeValue.java
@@ -88,9 +88,6 @@ public abstract class AttributeValue {
 
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   abstract static class AttributeValueString extends AttributeValue {
 
     AttributeValueString() {}
@@ -114,9 +111,6 @@ public abstract class AttributeValue {
 
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   abstract static class AttributeValueBoolean extends AttributeValue {
 
     AttributeValueBoolean() {}
@@ -140,9 +134,6 @@ public abstract class AttributeValue {
 
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   abstract static class AttributeValueLong extends AttributeValue {
 
     AttributeValueLong() {}

--- a/api/src/main/java/io/opencensus/trace/EndSpanOptions.java
+++ b/api/src/main/java/io/opencensus/trace/EndSpanOptions.java
@@ -30,9 +30,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class EndSpanOptions {
   /**
    * The default {@code EndSpanOptions}.

--- a/api/src/main/java/io/opencensus/trace/Link.java
+++ b/api/src/main/java/io/opencensus/trace/Link.java
@@ -35,9 +35,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class Link {
   private static final Map<String, AttributeValue> EMPTY_ATTRIBUTES = Collections.emptyMap();
 

--- a/api/src/main/java/io/opencensus/trace/MessageEvent.java
+++ b/api/src/main/java/io/opencensus/trace/MessageEvent.java
@@ -33,9 +33,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings({"nullness", "deprecation"})
+@SuppressWarnings("deprecation")
 public abstract class MessageEvent extends BaseMessageEvent {
   /**
    * Available types for a {@code MessageEvent}.

--- a/api/src/main/java/io/opencensus/trace/NetworkEvent.java
+++ b/api/src/main/java/io/opencensus/trace/NetworkEvent.java
@@ -33,9 +33,7 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
 @AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 @Deprecated
 public abstract class NetworkEvent extends io.opencensus.trace.BaseMessageEvent {
   /**

--- a/api/src/main/java/io/opencensus/trace/config/TraceParams.java
+++ b/api/src/main/java/io/opencensus/trace/config/TraceParams.java
@@ -34,9 +34,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @AutoValue
 @Immutable
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class TraceParams {
   // These values are the default values for all the global parameters.
   private static final double DEFAULT_PROBABILITY = 1e-4;

--- a/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
@@ -76,9 +76,6 @@ public abstract class RunningSpanStore {
    */
   @AutoValue
   @Immutable
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Summary {
 
     Summary() {}
@@ -114,9 +111,6 @@ public abstract class RunningSpanStore {
    */
   @AutoValue
   @Immutable
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class PerSpanNameSummary {
 
     PerSpanNameSummary() {}
@@ -151,9 +145,6 @@ public abstract class RunningSpanStore {
    */
   @AutoValue
   @Immutable
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Filter {
 
     Filter() {}

--- a/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
@@ -141,9 +141,6 @@ public abstract class SampledSpanStore {
    */
   @AutoValue
   @Immutable
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Summary {
 
     Summary() {}
@@ -179,9 +176,6 @@ public abstract class SampledSpanStore {
    */
   @AutoValue
   @Immutable
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class PerSpanNameSummary {
 
     PerSpanNameSummary() {}
@@ -345,9 +339,6 @@ public abstract class SampledSpanStore {
    */
   @AutoValue
   @Immutable
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class LatencyFilter {
 
     LatencyFilter() {}
@@ -418,9 +409,6 @@ public abstract class SampledSpanStore {
    */
   @AutoValue
   @Immutable
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class ErrorFilter {
 
     ErrorFilter() {}

--- a/api/src/main/java/io/opencensus/trace/export/SpanData.java
+++ b/api/src/main/java/io/opencensus/trace/export/SpanData.java
@@ -48,9 +48,6 @@ import org.checkerframework.dataflow.qual.Deterministic;
  */
 @Immutable
 @AutoValue
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class SpanData {
 
   /**
@@ -267,9 +264,6 @@ public abstract class SpanData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class TimedEvent<T> {
     /**
      * Returns a new immutable {@code TimedEvent<T>}.
@@ -312,9 +306,6 @@ public abstract class SpanData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class TimedEvents<T> {
     /**
      * Returns a new immutable {@code TimedEvents<T>}.
@@ -358,9 +349,6 @@ public abstract class SpanData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Attributes {
     /**
      * Returns a new immutable {@code Attributes}.
@@ -406,9 +394,6 @@ public abstract class SpanData {
    */
   @Immutable
   @AutoValue
-  // Suppress Checker Framework warning about missing @Nullable in generated equals method.
-  @AutoValue.CopyAnnotations
-  @SuppressWarnings("nullness")
   public abstract static class Links {
     /**
      * Returns a new immutable {@code Links}.

--- a/api/src/main/java/io/opencensus/trace/samplers/ProbabilitySampler.java
+++ b/api/src/main/java/io/opencensus/trace/samplers/ProbabilitySampler.java
@@ -37,9 +37,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @AutoValue
 @Immutable
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 abstract class ProbabilitySampler extends Sampler {
 
   ProbabilitySampler() {}

--- a/build.gradle
+++ b/build.gradle
@@ -387,7 +387,9 @@ subprojects {
             tasks.withType(JavaCompile).all { JavaCompile compile ->
                 compile.doFirst {
                     compile.options.compilerArgs += [
-                        '-Xmaxerrs', '10000', "-Xbootclasspath/p:${configurations.checkerFrameworkAnnotatedJDK.asPath}",
+                        '-Xmaxerrs', '10000',
+                        "-Xbootclasspath/p:${configurations.checkerFrameworkAnnotatedJDK.asPath}",
+                        "-AskipDefs=\\.AutoValue_"
                     ]
                     options.fork = true
                     options.forkOptions.jvmArgs += ["-Xbootclasspath/p:${configurations.checkerFrameworkJavac.asPath}"]

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsConfiguration.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsConfiguration.java
@@ -28,9 +28,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @AutoValue
 @Immutable
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class PrometheusStatsConfiguration {
 
   PrometheusStatsConfiguration() {}

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsConfiguration.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsConfiguration.java
@@ -31,9 +31,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @AutoValue
 @Immutable
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class SignalFxStatsConfiguration {
 
   /**

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
@@ -30,9 +30,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @AutoValue
 @Immutable
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class StackdriverStatsConfiguration {
 
   StackdriverStatsConfiguration() {}

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfiguration.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfiguration.java
@@ -28,9 +28,6 @@ import javax.annotation.concurrent.Immutable;
  */
 @AutoValue
 @Immutable
-// Suppress Checker Framework warning about missing @Nullable in generated equals method.
-@AutoValue.CopyAnnotations
-@SuppressWarnings("nullness")
 public abstract class StackdriverTraceConfiguration {
 
   StackdriverTraceConfiguration() {}


### PR DESCRIPTION
#### Suppress Checker Framework warnings in AutoValue generated classes (fixes #917).

#### Remove @SuppressWarnings("nullness") from all AutoValue classes.

This change allows the Checker Framework to check the classes annotated with
`@AutoValue`, even though their generated subclasses are skipped.  This commit
also fixes some previously suppressed warnings in the ViewData class.