### PR TITLE
Remove more usages of Guava from opencensus-api (issue #1081).

### DIFF
--- a/api/src/main/java/io/opencensus/common/Duration.java
+++ b/api/src/main/java/io/opencensus/common/Duration.java
@@ -16,10 +16,10 @@
 
 package io.opencensus.common;
 
-import static io.opencensus.common.TimeUtil.MAX_NANOS;
-import static io.opencensus.common.TimeUtil.MAX_SECONDS;
-import static io.opencensus.common.TimeUtil.MILLIS_PER_SECOND;
-import static io.opencensus.common.TimeUtil.NANOS_PER_MILLI;
+import static io.opencensus.common.TimeUtils.MAX_NANOS;
+import static io.opencensus.common.TimeUtils.MAX_SECONDS;
+import static io.opencensus.common.TimeUtils.MILLIS_PER_SECOND;
+import static io.opencensus.common.TimeUtils.NANOS_PER_MILLI;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.primitives.Longs;

--- a/api/src/main/java/io/opencensus/common/Duration.java
+++ b/api/src/main/java/io/opencensus/common/Duration.java
@@ -22,7 +22,7 @@ import static io.opencensus.common.TimeUtils.MILLIS_PER_SECOND;
 import static io.opencensus.common.TimeUtils.NANOS_PER_MILLI;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.primitives.Longs;
+import io.opencensus.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -104,11 +104,11 @@ public abstract class Duration implements Comparable<Duration> {
    */
   @Override
   public int compareTo(Duration otherDuration) {
-    int cmp = Longs.compare(getSeconds(), otherDuration.getSeconds());
+    int cmp = Utils.compareLongs(getSeconds(), otherDuration.getSeconds());
     if (cmp != 0) {
       return cmp;
     }
-    return Longs.compare(getNanos(), otherDuration.getNanos());
+    return Utils.compareLongs(getNanos(), otherDuration.getNanos());
   }
 
   Duration() {}

--- a/api/src/main/java/io/opencensus/common/TimeUtils.java
+++ b/api/src/main/java/io/opencensus/common/TimeUtils.java
@@ -17,12 +17,12 @@
 package io.opencensus.common;
 
 /** Util class for {@link Timestamp} and {@link Duration}. */
-final class TimeUtil {
+final class TimeUtils {
   static final long MAX_SECONDS = 315576000000L;
   static final int MAX_NANOS = 999999999;
   static final long MILLIS_PER_SECOND = 1000L;
   static final long NANOS_PER_MILLI = 1000 * 1000;
   static final long NANOS_PER_SECOND = NANOS_PER_MILLI * MILLIS_PER_SECOND;
 
-  private TimeUtil() {}
+  private TimeUtils() {}
 }

--- a/api/src/main/java/io/opencensus/common/Timestamp.java
+++ b/api/src/main/java/io/opencensus/common/Timestamp.java
@@ -16,11 +16,11 @@
 
 package io.opencensus.common;
 
-import static io.opencensus.common.TimeUtil.MAX_NANOS;
-import static io.opencensus.common.TimeUtil.MAX_SECONDS;
-import static io.opencensus.common.TimeUtil.MILLIS_PER_SECOND;
-import static io.opencensus.common.TimeUtil.NANOS_PER_MILLI;
-import static io.opencensus.common.TimeUtil.NANOS_PER_SECOND;
+import static io.opencensus.common.TimeUtils.MAX_NANOS;
+import static io.opencensus.common.TimeUtils.MAX_SECONDS;
+import static io.opencensus.common.TimeUtils.MILLIS_PER_SECOND;
+import static io.opencensus.common.TimeUtils.NANOS_PER_MILLI;
+import static io.opencensus.common.TimeUtils.NANOS_PER_SECOND;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.math.LongMath;

--- a/api/src/main/java/io/opencensus/internal/DefaultVisibilityForTesting.java
+++ b/api/src/main/java/io/opencensus/internal/DefaultVisibilityForTesting.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that an element is package-private instead of private only for the purpose of testing.
+ * This annotation is only meant to be used as documentation in the source code.
+ */
+@Retention(RetentionPolicy.SOURCE)
+@Target({
+  ElementType.ANNOTATION_TYPE,
+  ElementType.CONSTRUCTOR,
+  ElementType.FIELD,
+  ElementType.METHOD,
+  ElementType.PACKAGE,
+  ElementType.TYPE
+})
+public @interface DefaultVisibilityForTesting {}

--- a/api/src/main/java/io/opencensus/internal/PublicForTesting.java
+++ b/api/src/main/java/io/opencensus/internal/PublicForTesting.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.internal;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Indicates that an element is public instead of package-private only for the purpose of testing.
+ * This annotation is only meant to be used as documentation in the source code.
+ */
+// TODO(#977): All uses of this annotation should be removed or replaced with @Internal.
+@Retention(RetentionPolicy.SOURCE)
+@Target({
+  ElementType.ANNOTATION_TYPE,
+  ElementType.CONSTRUCTOR,
+  ElementType.FIELD,
+  ElementType.METHOD,
+  ElementType.PACKAGE,
+  ElementType.TYPE
+})
+public @interface PublicForTesting {}

--- a/api/src/main/java/io/opencensus/internal/StringUtils.java
+++ b/api/src/main/java/io/opencensus/internal/StringUtils.java
@@ -17,7 +17,7 @@
 package io.opencensus.internal;
 
 /** Internal utility methods for working with tag keys, tag values, and metric names. */
-public final class StringUtil {
+public final class StringUtils {
 
   /**
    * Determines whether the {@code String} contains only printable characters.
@@ -38,5 +38,5 @@ public final class StringUtil {
     return ch >= ' ' && ch <= '~';
   }
 
-  private StringUtil() {}
+  private StringUtils() {}
 }

--- a/api/src/main/java/io/opencensus/internal/Utils.java
+++ b/api/src/main/java/io/opencensus/internal/Utils.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.internal;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.NonNull;
+*/
+
+/** General internal utility methods. */
+public final class Utils {
+
+  private Utils() {}
+
+  /**
+   * Throws an {@link IllegalArgumentException} if the argument is false. This method is similar to
+   * {@code Preconditions.checkArgument(boolean, Object)} from Guava.
+   *
+   * @param isValid whether the argument check passed.
+   * @param message the message to use for the exception.
+   */
+  public static void checkArgument(boolean isValid, String message) {
+    if (!isValid) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  /**
+   * Throws an {@link IllegalStateException} if the argument is false. This method is similar to
+   * {@code Preconditions.checkState(boolean, Object)} from Guava.
+   *
+   * @param isValid whether the state check passed.
+   * @param message the message to use for the exception.
+   */
+  public static void checkState(boolean isValid, String message) {
+    if (!isValid) {
+      throw new IllegalStateException(message);
+    }
+  }
+
+  /**
+   * Validates an index in an array or other container. This method throws an {@link
+   * IllegalArgumentException} if the size is negative and throws an {@link
+   * IndexOutOfBoundsException} if the index is negative or greater than or equal to the size. This
+   * method is similar to {@code Preconditions.checkElementIndex(int, int)} from Guava.
+   *
+   * @param index the index to validate.
+   * @param size the size of the array or container.
+   */
+  public static void checkIndex(int index, int size) {
+    if (size < 0) {
+      throw new IllegalArgumentException("Negative size: " + size);
+    }
+    if (index < 0 || index >= size) {
+      throw new IndexOutOfBoundsException("Index out of bounds: size=" + size + ", index=" + index);
+    }
+  }
+
+  /**
+   * Throws a {@link NullPointerException} if the argument is null. This method is similar to {@code
+   * Preconditions.checkNotNull(Object, Object)} from Guava.
+   *
+   * @param arg the argument to check for null.
+   * @param message the message to use for the exception.
+   * @return the argument, if it passes the null check.
+   */
+  public static <T /*>>> extends @NonNull Object*/> T checkNotNull(T arg, String message) {
+    if (arg == null) {
+      throw new NullPointerException(message);
+    }
+    return arg;
+  }
+}

--- a/api/src/main/java/io/opencensus/internal/Utils.java
+++ b/api/src/main/java/io/opencensus/internal/Utils.java
@@ -17,6 +17,7 @@
 package io.opencensus.internal;
 
 import java.math.BigInteger;
+import javax.annotation.Nullable;
 
 /*>>>
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -84,6 +85,14 @@ public final class Utils {
       throw new NullPointerException(message);
     }
     return arg;
+  }
+
+  /**
+   * Compares two Objects for equality. This functionality is provided by {@code
+   * Objects.equal(Object, Object)} in Java 7.
+   */
+  public static boolean equalsObjects(@Nullable Object x, @Nullable Object y) {
+    return x == null ? y == null : x.equals(y);
   }
 
   /**

--- a/api/src/main/java/io/opencensus/internal/Utils.java
+++ b/api/src/main/java/io/opencensus/internal/Utils.java
@@ -16,6 +16,8 @@
 
 package io.opencensus.internal;
 
+import java.math.BigInteger;
+
 /*>>>
 import org.checkerframework.checker.nullness.qual.NonNull;
 */
@@ -82,5 +84,34 @@ public final class Utils {
       throw new NullPointerException(message);
     }
     return arg;
+  }
+
+  /**
+   * Compares two longs. This functionality is provided by {@code Long.compare(long, long)} in Java
+   * 7.
+   */
+  public static int compareLongs(long x, long y) {
+    if (x < y) {
+      return -1;
+    } else if (x == y) {
+      return 0;
+    } else {
+      return 1;
+    }
+  }
+
+  private static final BigInteger MAX_LONG_VALUE = BigInteger.valueOf(Long.MAX_VALUE);
+  private static final BigInteger MIN_LONG_VALUE = BigInteger.valueOf(Long.MIN_VALUE);
+
+  /**
+   * Adds two longs and throws an {@link ArithmeticException} if the result overflows. This
+   * functionality is provided by {@code Math.addExact(long, long)} in Java 8.
+   */
+  public static long checkedAdd(long x, long y) {
+    BigInteger sum = BigInteger.valueOf(x).add(BigInteger.valueOf(y));
+    if (sum.compareTo(MAX_LONG_VALUE) > 0 || sum.compareTo(MIN_LONG_VALUE) < 0) {
+      throw new ArithmeticException("Long sum overflow: x=" + x + ", y=" + y);
+    }
+    return x + y;
   }
 }

--- a/api/src/main/java/io/opencensus/stats/Aggregation.java
+++ b/api/src/main/java/io/opencensus/stats/Aggregation.java
@@ -16,10 +16,9 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Function;
+import io.opencensus.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -221,7 +220,7 @@ public abstract class Aggregation {
      * @since 0.8
      */
     public static Distribution create(BucketBoundaries bucketBoundaries) {
-      checkNotNull(bucketBoundaries, "bucketBoundaries should not be null.");
+      Utils.checkNotNull(bucketBoundaries, "bucketBoundaries should not be null.");
       return new AutoValue_Aggregation_Distribution(bucketBoundaries);
     }
 

--- a/api/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/api/src/main/java/io/opencensus/stats/AggregationData.java
@@ -16,11 +16,9 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Function;
+import io.opencensus.internal.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -329,13 +327,13 @@ public abstract class AggregationData {
         double sumOfSquaredDeviations,
         List<Long> bucketCounts) {
       if (min != Double.POSITIVE_INFINITY || max != Double.NEGATIVE_INFINITY) {
-        checkArgument(min <= max, "max should be greater or equal to min.");
+        Utils.checkArgument(min <= max, "max should be greater or equal to min.");
       }
 
-      checkNotNull(bucketCounts, "bucket counts should not be null.");
+      Utils.checkNotNull(bucketCounts, "bucket counts should not be null.");
       List<Long> bucketCountsCopy = Collections.unmodifiableList(new ArrayList<Long>(bucketCounts));
       for (Long bucket : bucketCountsCopy) {
-        checkNotNull(bucket, "bucket should not be null.");
+        Utils.checkNotNull(bucket, "bucket should not be null.");
       }
 
       return new AutoValue_AggregationData_DistributionData(

--- a/api/src/main/java/io/opencensus/stats/BucketBoundaries.java
+++ b/api/src/main/java/io/opencensus/stats/BucketBoundaries.java
@@ -16,10 +16,8 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
+import io.opencensus.internal.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -42,14 +40,14 @@ public abstract class BucketBoundaries {
    * @since 0.8
    */
   public static final BucketBoundaries create(List<Double> bucketBoundaries) {
-    checkNotNull(bucketBoundaries, "bucketBoundaries list should not be null.");
+    Utils.checkNotNull(bucketBoundaries, "bucketBoundaries list should not be null.");
     List<Double> bucketBoundariesCopy = new ArrayList<Double>(bucketBoundaries); // Deep copy.
     // Check if sorted.
     if (bucketBoundariesCopy.size() > 1) {
       double lower = bucketBoundariesCopy.get(0);
       for (int i = 1; i < bucketBoundariesCopy.size(); i++) {
         double next = bucketBoundariesCopy.get(i);
-        checkArgument(lower < next, "Bucket boundaries not sorted.");
+        Utils.checkArgument(lower < next, "Bucket boundaries not sorted.");
         lower = next;
       }
     }

--- a/api/src/main/java/io/opencensus/stats/Measure.java
+++ b/api/src/main/java/io/opencensus/stats/Measure.java
@@ -16,12 +16,11 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Function;
 import io.opencensus.internal.StringUtils;
+import io.opencensus.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -104,7 +103,7 @@ public abstract class Measure {
      * @since 0.8
      */
     public static MeasureDouble create(String name, String description, String unit) {
-      checkArgument(
+      Utils.checkArgument(
           StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
           "Name should be a ASCII string with a length no greater than "
               + NAME_MAX_LENGTH
@@ -151,7 +150,7 @@ public abstract class Measure {
      * @since 0.8
      */
     public static MeasureLong create(String name, String description, String unit) {
-      checkArgument(
+      Utils.checkArgument(
           StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
           "Name should be a ASCII string with a length no greater than "
               + NAME_MAX_LENGTH

--- a/api/src/main/java/io/opencensus/stats/Measure.java
+++ b/api/src/main/java/io/opencensus/stats/Measure.java
@@ -21,7 +21,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Function;
-import io.opencensus.internal.StringUtil;
+import io.opencensus.internal.StringUtils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -105,7 +105,7 @@ public abstract class Measure {
      */
     public static MeasureDouble create(String name, String description, String unit) {
       checkArgument(
-          StringUtil.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
+          StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
           "Name should be a ASCII string with a length no greater than "
               + NAME_MAX_LENGTH
               + " characters.");
@@ -152,7 +152,7 @@ public abstract class Measure {
      */
     public static MeasureLong create(String name, String description, String unit) {
       checkArgument(
-          StringUtil.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
+          StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
           "Name should be a ASCII string with a length no greater than "
               + NAME_MAX_LENGTH
               + " characters.");

--- a/api/src/main/java/io/opencensus/stats/Measure.java
+++ b/api/src/main/java/io/opencensus/stats/Measure.java
@@ -17,8 +17,8 @@
 package io.opencensus.stats;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Function;
+import io.opencensus.internal.DefaultVisibilityForTesting;
 import io.opencensus.internal.StringUtils;
 import io.opencensus.internal.Utils;
 import javax.annotation.concurrent.Immutable;
@@ -31,7 +31,7 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public abstract class Measure {
 
-  @VisibleForTesting static final int NAME_MAX_LENGTH = 255;
+  @DefaultVisibilityForTesting static final int NAME_MAX_LENGTH = 255;
 
   /**
    * Applies the given match function to the underlying data type.

--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -16,13 +16,9 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-import static com.google.common.base.Preconditions.checkState;
-
-import com.google.common.base.Preconditions;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
+import io.opencensus.internal.Utils;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.tags.TagContext;
@@ -106,8 +102,8 @@ final class NoopStats {
     @Override
     @Deprecated
     public void setState(StatsCollectionState state) {
-      Preconditions.checkNotNull(state, "state");
-      checkState(!isRead, "State was already read, cannot set state.");
+      Utils.checkNotNull(state, "state");
+      Utils.checkState(!isRead, "State was already read, cannot set state.");
     }
   }
 
@@ -140,7 +136,7 @@ final class NoopStats {
 
     @Override
     public void record(TagContext tags) {
-      checkNotNull(tags, "tags");
+      Utils.checkNotNull(tags, "tags");
     }
   }
 
@@ -157,11 +153,11 @@ final class NoopStats {
 
     @Override
     public void registerView(View newView) {
-      checkNotNull(newView, "newView");
+      Utils.checkNotNull(newView, "newView");
       synchronized (registeredViews) {
         exportedViews = null;
         View existing = registeredViews.get(newView.getName());
-        checkArgument(
+        Utils.checkArgument(
             existing == null || newView.equals(existing),
             "A different view with the same name already exists.");
         if (existing == null) {
@@ -174,7 +170,7 @@ final class NoopStats {
     @Nullable
     @SuppressWarnings("deprecation")
     public ViewData getView(View.Name name) {
-      checkNotNull(name, "name");
+      Utils.checkNotNull(name, "name");
       synchronized (registeredViews) {
         View view = registeredViews.get(name);
         if (view == null) {

--- a/api/src/main/java/io/opencensus/stats/Stats.java
+++ b/api/src/main/java/io/opencensus/stats/Stats.java
@@ -16,7 +16,7 @@
 
 package io.opencensus.stats;
 
-import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.internal.DefaultVisibilityForTesting;
 import io.opencensus.internal.Provider;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -89,7 +89,7 @@ public final class Stats {
   }
 
   // Any provider that may be used for StatsComponent can be added here.
-  @VisibleForTesting
+  @DefaultVisibilityForTesting
   static StatsComponent loadStatsComponent(@Nullable ClassLoader classLoader) {
     try {
       // Call Class.forName with literal string name of the class to help shading tools.

--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -16,13 +16,12 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import io.opencensus.internal.StringUtils;
+import io.opencensus.internal.Utils;
 import io.opencensus.tags.TagKey;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -125,7 +124,8 @@ public abstract class View {
       Aggregation aggregation,
       List<TagKey> columns,
       AggregationWindow window) {
-    checkArgument(new HashSet<TagKey>(columns).size() == columns.size(), "Columns have duplicate.");
+    Utils.checkArgument(
+        new HashSet<TagKey>(columns).size() == columns.size(), "Columns have duplicate.");
 
     List<TagKey> tagKeys = new ArrayList<TagKey>(columns);
     Collections.sort(tagKeys, TAG_KEY_COMPARATOR);
@@ -151,7 +151,8 @@ public abstract class View {
       Measure measure,
       Aggregation aggregation,
       List<TagKey> columns) {
-    checkArgument(new HashSet<TagKey>(columns).size() == columns.size(), "Columns have duplicate.");
+    Utils.checkArgument(
+        new HashSet<TagKey>(columns).size() == columns.size(), "Columns have duplicate.");
     return create(
         name, description, measure, aggregation, columns, AggregationWindow.Cumulative.create());
   }
@@ -187,7 +188,7 @@ public abstract class View {
      * @since 0.8
      */
     public static Name create(String name) {
-      checkArgument(
+      Utils.checkArgument(
           StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
           "Name should be a ASCII string with a length no greater than 255 characters.");
       return new AutoValue_View_Name(name);
@@ -289,7 +290,7 @@ public abstract class View {
        * @since 0.8
        */
       public static Interval create(Duration duration) {
-        checkArgument(duration.compareTo(ZERO) > 0, "Duration must be positive");
+        Utils.checkArgument(duration.compareTo(ZERO) > 0, "Duration must be positive");
         return new AutoValue_View_AggregationWindow_Interval(duration);
       }
 

--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -17,9 +17,9 @@
 package io.opencensus.stats;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
+import io.opencensus.internal.DefaultVisibilityForTesting;
 import io.opencensus.internal.StringUtils;
 import io.opencensus.internal.Utils;
 import io.opencensus.tags.TagKey;
@@ -42,7 +42,7 @@ import javax.annotation.concurrent.Immutable;
 @SuppressWarnings("deprecation")
 public abstract class View {
 
-  @VisibleForTesting static final int NAME_MAX_LENGTH = 255;
+  @DefaultVisibilityForTesting static final int NAME_MAX_LENGTH = 255;
 
   private static final Comparator<TagKey> TAG_KEY_COMPARATOR =
       new Comparator<TagKey>() {

--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -22,7 +22,7 @@ import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
-import io.opencensus.internal.StringUtil;
+import io.opencensus.internal.StringUtils;
 import io.opencensus.tags.TagKey;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -188,7 +188,7 @@ public abstract class View {
      */
     public static Name create(String name) {
       checkArgument(
-          StringUtil.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
+          StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
           "Name should be a ASCII string with a length no greater than 255 characters.");
       return new AutoValue_View_Name(name);
     }

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -16,13 +16,12 @@
 
 package io.opencensus.stats;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Duration;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
+import io.opencensus.internal.Utils;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.Aggregation.Sum;
@@ -208,7 +207,7 @@ public abstract class ViewData {
         new Function<View.AggregationWindow.Cumulative, Void>() {
           @Override
           public Void apply(View.AggregationWindow.Cumulative arg) {
-            checkArgument(
+            Utils.checkArgument(
                 windowData instanceof AggregationWindowData.CumulativeData,
                 createErrorMessageForWindow(arg, windowData));
             return null;
@@ -217,7 +216,7 @@ public abstract class ViewData {
         new Function<View.AggregationWindow.Interval, Void>() {
           @Override
           public Void apply(View.AggregationWindow.Interval arg) {
-            checkArgument(
+            Utils.checkArgument(
                 windowData instanceof AggregationWindowData.IntervalData,
                 createErrorMessageForWindow(arg, windowData));
             return null;
@@ -245,7 +244,7 @@ public abstract class ViewData {
                 new Function<MeasureDouble, Void>() {
                   @Override
                   public Void apply(MeasureDouble arg) {
-                    checkArgument(
+                    Utils.checkArgument(
                         aggregationData instanceof SumDataDouble,
                         createErrorMessageForAggregation(aggregation, aggregationData));
                     return null;
@@ -254,7 +253,7 @@ public abstract class ViewData {
                 new Function<MeasureLong, Void>() {
                   @Override
                   public Void apply(MeasureLong arg) {
-                    checkArgument(
+                    Utils.checkArgument(
                         aggregationData instanceof SumDataLong,
                         createErrorMessageForAggregation(aggregation, aggregationData));
                     return null;
@@ -267,7 +266,7 @@ public abstract class ViewData {
         new Function<Count, Void>() {
           @Override
           public Void apply(Count arg) {
-            checkArgument(
+            Utils.checkArgument(
                 aggregationData instanceof CountData,
                 createErrorMessageForAggregation(aggregation, aggregationData));
             return null;
@@ -276,7 +275,7 @@ public abstract class ViewData {
         new Function<Aggregation.Mean, Void>() {
           @Override
           public Void apply(Aggregation.Mean arg) {
-            checkArgument(
+            Utils.checkArgument(
                 aggregationData instanceof AggregationData.MeanData,
                 createErrorMessageForAggregation(aggregation, aggregationData));
             return null;
@@ -285,7 +284,7 @@ public abstract class ViewData {
         new Function<Distribution, Void>() {
           @Override
           public Void apply(Distribution arg) {
-            checkArgument(
+            Utils.checkArgument(
                 aggregationData instanceof DistributionData,
                 createErrorMessageForAggregation(aggregation, aggregationData));
             return null;

--- a/api/src/main/java/io/opencensus/tags/NoopTags.java
+++ b/api/src/main/java/io/opencensus/tags/NoopTags.java
@@ -16,11 +16,9 @@
 
 package io.opencensus.tags;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
-import com.google.common.base.Preconditions;
 import io.opencensus.common.Scope;
 import io.opencensus.internal.NoopScope;
+import io.opencensus.internal.Utils;
 import io.opencensus.tags.propagation.TagContextBinarySerializer;
 import io.opencensus.tags.propagation.TagPropagationComponent;
 import java.util.Collections;
@@ -105,8 +103,8 @@ final class NoopTags {
     @Override
     @Deprecated
     public void setState(TaggingState state) {
-      Preconditions.checkNotNull(state, "state");
-      Preconditions.checkState(!isRead, "State was already read, cannot set state.");
+      Utils.checkNotNull(state, "state");
+      Utils.checkState(!isRead, "State was already read, cannot set state.");
     }
   }
 
@@ -131,7 +129,7 @@ final class NoopTags {
 
     @Override
     public TagContextBuilder toBuilder(TagContext tags) {
-      checkNotNull(tags, "tags");
+      Utils.checkNotNull(tags, "tags");
       return getNoopTagContextBuilder();
     }
 
@@ -142,7 +140,7 @@ final class NoopTags {
 
     @Override
     public Scope withTagContext(TagContext tags) {
-      checkNotNull(tags, "tags");
+      Utils.checkNotNull(tags, "tags");
       return NoopScope.getInstance();
     }
   }
@@ -153,14 +151,14 @@ final class NoopTags {
 
     @Override
     public TagContextBuilder put(TagKey key, TagValue value) {
-      checkNotNull(key, "key");
-      checkNotNull(value, "value");
+      Utils.checkNotNull(key, "key");
+      Utils.checkNotNull(value, "value");
       return this;
     }
 
     @Override
     public TagContextBuilder remove(TagKey key) {
-      checkNotNull(key, "key");
+      Utils.checkNotNull(key, "key");
       return this;
     }
 
@@ -203,13 +201,13 @@ final class NoopTags {
 
     @Override
     public byte[] toByteArray(TagContext tags) {
-      checkNotNull(tags, "tags");
+      Utils.checkNotNull(tags, "tags");
       return EMPTY_BYTE_ARRAY;
     }
 
     @Override
     public TagContext fromByteArray(byte[] bytes) {
-      checkNotNull(bytes, "bytes");
+      Utils.checkNotNull(bytes, "bytes");
       return getNoopTagContext();
     }
   }

--- a/api/src/main/java/io/opencensus/tags/TagKey.java
+++ b/api/src/main/java/io/opencensus/tags/TagKey.java
@@ -19,7 +19,7 @@ package io.opencensus.tags;
 import static com.google.common.base.Preconditions.checkArgument;
 
 import com.google.auto.value.AutoValue;
-import io.opencensus.internal.StringUtil;
+import io.opencensus.internal.StringUtils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -80,6 +80,6 @@ public abstract class TagKey {
    * @return whether the name is valid.
    */
   private static boolean isValid(String name) {
-    return !name.isEmpty() && name.length() <= MAX_LENGTH && StringUtil.isPrintableString(name);
+    return !name.isEmpty() && name.length() <= MAX_LENGTH && StringUtils.isPrintableString(name);
   }
 }

--- a/api/src/main/java/io/opencensus/tags/TagKey.java
+++ b/api/src/main/java/io/opencensus/tags/TagKey.java
@@ -16,10 +16,9 @@
 
 package io.opencensus.tags;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.auto.value.AutoValue;
 import io.opencensus.internal.StringUtils;
+import io.opencensus.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -61,7 +60,7 @@ public abstract class TagKey {
    * @since 0.8
    */
   public static TagKey create(String name) {
-    checkArgument(isValid(name));
+    Utils.checkArgument(isValid(name), "Invalid TagKey name: " + name);
     return new AutoValue_TagKey(name);
   }
 

--- a/api/src/main/java/io/opencensus/tags/TagValue.java
+++ b/api/src/main/java/io/opencensus/tags/TagValue.java
@@ -17,8 +17,8 @@
 package io.opencensus.tags;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.base.Preconditions;
 import io.opencensus.internal.StringUtils;
+import io.opencensus.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -55,7 +55,7 @@ public abstract class TagValue {
    * @since 0.8
    */
   public static TagValue create(String value) {
-    Preconditions.checkArgument(isValid(value));
+    Utils.checkArgument(isValid(value), "Invalid TagValue: " + value);
     return new AutoValue_TagValue(value);
   }
 

--- a/api/src/main/java/io/opencensus/tags/TagValue.java
+++ b/api/src/main/java/io/opencensus/tags/TagValue.java
@@ -18,7 +18,7 @@ package io.opencensus.tags;
 
 import com.google.auto.value.AutoValue;
 import com.google.common.base.Preconditions;
-import io.opencensus.internal.StringUtil;
+import io.opencensus.internal.StringUtils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -74,6 +74,6 @@ public abstract class TagValue {
    * @return whether the value is valid.
    */
   private static boolean isValid(String value) {
-    return value.length() <= MAX_LENGTH && StringUtil.isPrintableString(value);
+    return value.length() <= MAX_LENGTH && StringUtils.isPrintableString(value);
   }
 }

--- a/api/src/main/java/io/opencensus/tags/Tags.java
+++ b/api/src/main/java/io/opencensus/tags/Tags.java
@@ -16,7 +16,7 @@
 
 package io.opencensus.tags;
 
-import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.internal.DefaultVisibilityForTesting;
 import io.opencensus.internal.Provider;
 import io.opencensus.tags.propagation.TagPropagationComponent;
 import java.util.logging.Level;
@@ -91,7 +91,7 @@ public final class Tags {
   }
 
   // Any provider that may be used for TagsComponent can be added here.
-  @VisibleForTesting
+  @DefaultVisibilityForTesting
   static TagsComponent loadTagsComponent(@Nullable ClassLoader classLoader) {
     try {
       // Call Class.forName with literal string name of the class to help shading tools.

--- a/api/src/main/java/io/opencensus/trace/Annotation.java
+++ b/api/src/main/java/io/opencensus/trace/Annotation.java
@@ -16,9 +16,8 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
+import io.opencensus.internal.Utils;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -61,7 +60,7 @@ public abstract class Annotation {
     return new AutoValue_Annotation(
         description,
         Collections.unmodifiableMap(
-            new HashMap<String, AttributeValue>(checkNotNull(attributes, "attributes"))));
+            new HashMap<String, AttributeValue>(Utils.checkNotNull(attributes, "attributes"))));
   }
 
   /**

--- a/api/src/main/java/io/opencensus/trace/AttributeValue.java
+++ b/api/src/main/java/io/opencensus/trace/AttributeValue.java
@@ -16,10 +16,9 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Function;
+import io.opencensus.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -94,7 +93,7 @@ public abstract class AttributeValue {
 
     static AttributeValue create(String stringValue) {
       return new AutoValue_AttributeValue_AttributeValueString(
-          checkNotNull(stringValue, "stringValue"));
+          Utils.checkNotNull(stringValue, "stringValue"));
     }
 
     @Override
@@ -117,7 +116,7 @@ public abstract class AttributeValue {
 
     static AttributeValue create(Boolean stringValue) {
       return new AutoValue_AttributeValue_AttributeValueBoolean(
-          checkNotNull(stringValue, "stringValue"));
+          Utils.checkNotNull(stringValue, "stringValue"));
     }
 
     @Override
@@ -140,7 +139,7 @@ public abstract class AttributeValue {
 
     static AttributeValue create(Long stringValue) {
       return new AutoValue_AttributeValue_AttributeValueLong(
-          checkNotNull(stringValue, "stringValue"));
+          Utils.checkNotNull(stringValue, "stringValue"));
     }
 
     @Override

--- a/api/src/main/java/io/opencensus/trace/CurrentSpanUtils.java
+++ b/api/src/main/java/io/opencensus/trace/CurrentSpanUtils.java
@@ -16,7 +16,6 @@
 
 package io.opencensus.trace;
 
-import com.google.common.base.Throwables;
 import io.grpc.Context;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.unsafe.ContextUtils;
@@ -121,7 +120,11 @@ final class CurrentSpanUtils {
         runnable.run();
       } catch (Throwable t) {
         setErrorStatus(span, t);
-        Throwables.throwIfUnchecked(t);
+        if (t instanceof RuntimeException) {
+          throw (RuntimeException) t;
+        } else if (t instanceof Error) {
+          throw (Error) t;
+        }
         throw new RuntimeException("unexpected", t);
       } finally {
         Context.current().detach(origContext);
@@ -154,7 +157,9 @@ final class CurrentSpanUtils {
         throw e;
       } catch (Throwable t) {
         setErrorStatus(span, t);
-        Throwables.throwIfUnchecked(t);
+        if (t instanceof Error) {
+          throw (Error) t;
+        }
         throw new RuntimeException("unexpected", t);
       } finally {
         Context.current().detach(origContext);

--- a/api/src/main/java/io/opencensus/trace/MessageEvent.java
+++ b/api/src/main/java/io/opencensus/trace/MessageEvent.java
@@ -16,9 +16,8 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
+import io.opencensus.internal.Utils;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -66,7 +65,7 @@ public abstract class MessageEvent extends BaseMessageEvent {
    */
   public static Builder builder(Type type, long messageId) {
     return new AutoValue_MessageEvent.Builder()
-        .setType(checkNotNull(type, "type"))
+        .setType(Utils.checkNotNull(type, "type"))
         .setMessageId(messageId)
         // We need to set a value for the message size because the autovalue requires all
         // primitives to be initialized.

--- a/api/src/main/java/io/opencensus/trace/NetworkEvent.java
+++ b/api/src/main/java/io/opencensus/trace/NetworkEvent.java
@@ -16,10 +16,9 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Timestamp;
+import io.opencensus.internal.Utils;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -67,7 +66,7 @@ public abstract class NetworkEvent extends io.opencensus.trace.BaseMessageEvent 
    */
   public static Builder builder(Type type, long messageId) {
     return new AutoValue_NetworkEvent.Builder()
-        .setType(checkNotNull(type, "type"))
+        .setType(Utils.checkNotNull(type, "type"))
         .setMessageId(messageId)
         // We need to set a value for the message size because the autovalue requires all
         // primitives to be initialized.

--- a/api/src/main/java/io/opencensus/trace/Span.java
+++ b/api/src/main/java/io/opencensus/trace/Span.java
@@ -19,7 +19,7 @@ package io.opencensus.trace;
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
-import io.opencensus.trace.internal.BaseMessageEventUtil;
+import io.opencensus.trace.internal.BaseMessageEventUtils;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
@@ -165,7 +165,7 @@ public abstract class Span {
    */
   @Deprecated
   public void addNetworkEvent(NetworkEvent networkEvent) {
-    addMessageEvent(BaseMessageEventUtil.asMessageEvent(networkEvent));
+    addMessageEvent(BaseMessageEventUtils.asMessageEvent(networkEvent));
   }
 
   /**
@@ -182,7 +182,7 @@ public abstract class Span {
   public void addMessageEvent(MessageEvent messageEvent) {
     // Default implementation by invoking addNetworkEvent() so that any existing derived classes,
     // including implementation and the mocked ones, do not need to override this method explicitly.
-    addNetworkEvent(BaseMessageEventUtil.asNetworkEvent(messageEvent));
+    addNetworkEvent(BaseMessageEventUtils.asNetworkEvent(messageEvent));
   }
 
   /**

--- a/api/src/main/java/io/opencensus/trace/Span.java
+++ b/api/src/main/java/io/opencensus/trace/Span.java
@@ -16,9 +16,7 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.internal.BaseMessageEventUtils;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -76,12 +74,12 @@ public abstract class Span {
    * @since 0.5
    */
   protected Span(SpanContext context, @Nullable EnumSet<Options> options) {
-    this.context = checkNotNull(context, "context");
+    this.context = Utils.checkNotNull(context, "context");
     this.options =
         options == null
             ? DEFAULT_OPTIONS
             : Collections.<Options>unmodifiableSet(EnumSet.copyOf(options));
-    checkArgument(
+    Utils.checkArgument(
         !context.getTraceOptions().isSampled() || (this.options.contains(Options.RECORD_EVENTS)),
         "Span is sampled, but does not have RECORD_EVENTS set.");
   }

--- a/api/src/main/java/io/opencensus/trace/SpanBuilder.java
+++ b/api/src/main/java/io/opencensus/trace/SpanBuilder.java
@@ -16,10 +16,9 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.errorprone.annotations.MustBeClosed;
 import io.opencensus.common.Scope;
+import io.opencensus.internal.Utils;
 import java.util.List;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
@@ -324,7 +323,7 @@ public abstract class SpanBuilder {
     }
 
     private NoopSpanBuilder(String name) {
-      checkNotNull(name, "name");
+      Utils.checkNotNull(name, "name");
     }
   }
 }

--- a/api/src/main/java/io/opencensus/trace/SpanContext.java
+++ b/api/src/main/java/io/opencensus/trace/SpanContext.java
@@ -16,8 +16,7 @@
 
 package io.opencensus.trace;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
+import java.util.Arrays;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -114,16 +113,18 @@ public final class SpanContext {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(traceId, spanId, traceOptions);
+    return Arrays.hashCode(new Object[] {traceId, spanId, traceOptions});
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("traceId", traceId)
-        .add("spanId", spanId)
-        .add("traceOptions", traceOptions)
-        .toString();
+    return "SpanContext{traceId="
+        + traceId
+        + ", spanId="
+        + spanId
+        + ", traceOptions="
+        + traceOptions
+        + "}";
   }
 
   private SpanContext(TraceId traceId, SpanId spanId, TraceOptions traceOptions) {

--- a/api/src/main/java/io/opencensus/trace/SpanId.java
+++ b/api/src/main/java/io/opencensus/trace/SpanId.java
@@ -16,7 +16,6 @@
 
 package io.opencensus.trace;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.io.BaseEncoding;
 import io.opencensus.internal.Utils;
 import java.util.Arrays;
@@ -178,6 +177,10 @@ public final class SpanId implements Comparable<SpanId> {
    * @since 0.11
    */
   public String toLowerBase16() {
+    return toLowerBase16(bytes);
+  }
+
+  private static String toLowerBase16(byte[] bytes) {
     return BaseEncoding.base16().lowerCase().encode(bytes);
   }
 
@@ -202,9 +205,7 @@ public final class SpanId implements Comparable<SpanId> {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("spanId", BaseEncoding.base16().lowerCase().encode(bytes))
-        .toString();
+    return "SpanId{spanId=" + toLowerBase16(bytes) + "}";
   }
 
   @Override

--- a/api/src/main/java/io/opencensus/trace/SpanId.java
+++ b/api/src/main/java/io/opencensus/trace/SpanId.java
@@ -16,11 +16,9 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.io.BaseEncoding;
+import io.opencensus.internal.Utils;
 import java.util.Arrays;
 import java.util.Random;
 import javax.annotation.Nullable;
@@ -71,8 +69,10 @@ public final class SpanId implements Comparable<SpanId> {
    * @since 0.5
    */
   public static SpanId fromBytes(byte[] buffer) {
-    checkNotNull(buffer, "buffer");
-    checkArgument(buffer.length == SIZE, "Invalid size: expected %s, got %s", SIZE, buffer.length);
+    Utils.checkNotNull(buffer, "buffer");
+    Utils.checkArgument(
+        buffer.length == SIZE,
+        String.format("Invalid size: expected %s, got %s", SIZE, buffer.length));
     byte[] bytesCopied = Arrays.copyOf(buffer, SIZE);
     return new SpanId(bytesCopied);
   }
@@ -107,8 +107,9 @@ public final class SpanId implements Comparable<SpanId> {
    * @since 0.11
    */
   public static SpanId fromLowerBase16(CharSequence src) {
-    checkArgument(
-        src.length() == 2 * SIZE, "Invalid size: expected %s, got %s", 2 * SIZE, src.length());
+    Utils.checkArgument(
+        src.length() == 2 * SIZE,
+        String.format("Invalid size: expected %s, got %s", 2 * SIZE, src.length()));
     byte[] bytes = BaseEncoding.base16().lowerCase().decode(src);
     return new SpanId(bytes);
   }

--- a/api/src/main/java/io/opencensus/trace/Status.java
+++ b/api/src/main/java/io/opencensus/trace/Status.java
@@ -16,11 +16,10 @@
 
 package io.opencensus.trace;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import io.opencensus.internal.PublicForTesting;
 import io.opencensus.internal.Utils;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.TreeMap;
@@ -397,7 +396,7 @@ public final class Status {
    * @since 0.5
    */
   public Status withDescription(String description) {
-    if (Objects.equal(this.description, description)) {
+    if (Utils.equalsObjects(this.description, description)) {
       return this;
     }
     return new Status(this.canonicalCode, description);
@@ -451,7 +450,8 @@ public final class Status {
     }
 
     Status that = (Status) obj;
-    return canonicalCode == that.canonicalCode && Objects.equal(description, that.description);
+    return canonicalCode == that.canonicalCode
+        && Utils.equalsObjects(description, that.description);
   }
 
   /**
@@ -461,14 +461,11 @@ public final class Status {
    */
   @Override
   public int hashCode() {
-    return Objects.hashCode(canonicalCode, description);
+    return Arrays.hashCode(new Object[] {canonicalCode, description});
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("canonicalCode", canonicalCode)
-        .add("description", description)
-        .toString();
+    return "Status{canonicalCode=" + canonicalCode + ", description=" + description + "}";
   }
 }

--- a/api/src/main/java/io/opencensus/trace/Status.java
+++ b/api/src/main/java/io/opencensus/trace/Status.java
@@ -16,9 +16,9 @@
 
 package io.opencensus.trace;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.opencensus.internal.PublicForTesting;
 import io.opencensus.internal.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -229,7 +229,7 @@ public final class Status {
      * @return the status that has the current {@code CanonicalCode}.
      * @since 0.5
      */
-    @VisibleForTesting
+    @PublicForTesting
     public Status toStatus() {
       return STATUS_LIST.get(value);
     }

--- a/api/src/main/java/io/opencensus/trace/Status.java
+++ b/api/src/main/java/io/opencensus/trace/Status.java
@@ -16,11 +16,10 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.opencensus.internal.Utils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -386,7 +385,7 @@ public final class Status {
   @Nullable private final String description;
 
   private Status(CanonicalCode canonicalCode, @Nullable String description) {
-    this.canonicalCode = checkNotNull(canonicalCode, "canonicalCode");
+    this.canonicalCode = Utils.checkNotNull(canonicalCode, "canonicalCode");
     this.description = description;
   }
 

--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -16,12 +16,10 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.base.MoreObjects;
 import com.google.common.io.BaseEncoding;
 import io.opencensus.common.Internal;
+import io.opencensus.internal.Utils;
 import java.util.Arrays;
 import java.util.Random;
 import javax.annotation.Nullable;
@@ -72,8 +70,10 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.5
    */
   public static TraceId fromBytes(byte[] buffer) {
-    checkNotNull(buffer, "buffer");
-    checkArgument(buffer.length == SIZE, "Invalid size: expected %s, got %s", SIZE, buffer.length);
+    Utils.checkNotNull(buffer, "buffer");
+    Utils.checkArgument(
+        buffer.length == SIZE,
+        String.format("Invalid size: expected %s, got %s", SIZE, buffer.length));
     byte[] bytesCopied = Arrays.copyOf(buffer, SIZE);
     return new TraceId(bytesCopied);
   }
@@ -108,8 +108,9 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.11
    */
   public static TraceId fromLowerBase16(CharSequence src) {
-    checkArgument(
-        src.length() == 2 * SIZE, "Invalid size: expected %s, got %s", 2 * SIZE, src.length());
+    Utils.checkArgument(
+        src.length() == 2 * SIZE,
+        String.format("Invalid size: expected %s, got %s", 2 * SIZE, src.length()));
     byte[] bytes = BaseEncoding.base16().lowerCase().decode(src);
     return new TraceId(bytes);
   }

--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -16,7 +16,6 @@
 
 package io.opencensus.trace;
 
-import com.google.common.base.MoreObjects;
 import com.google.common.io.BaseEncoding;
 import io.opencensus.common.Internal;
 import io.opencensus.internal.Utils;
@@ -179,6 +178,10 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.11
    */
   public String toLowerBase16() {
+    return toLowerBase16(bytes);
+  }
+
+  private static String toLowerBase16(byte[] bytes) {
     return BaseEncoding.base16().lowerCase().encode(bytes);
   }
 
@@ -224,9 +227,7 @@ public final class TraceId implements Comparable<TraceId> {
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this)
-        .add("traceId", BaseEncoding.base16().lowerCase().encode(bytes))
-        .toString();
+    return "TraceId{traceId=" + toLowerBase16(bytes) + "}";
   }
 
   @Override

--- a/api/src/main/java/io/opencensus/trace/TraceOptions.java
+++ b/api/src/main/java/io/opencensus/trace/TraceOptions.java
@@ -16,9 +16,9 @@
 
 package io.opencensus.trace;
 
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.opencensus.internal.DefaultVisibilityForTesting;
 import io.opencensus.internal.Utils;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -241,7 +241,7 @@ public final class TraceOptions {
   }
 
   // Returns the current set of options bitmask.
-  @VisibleForTesting
+  @DefaultVisibilityForTesting
   byte getOptions() {
     return options;
   }

--- a/api/src/main/java/io/opencensus/trace/TraceOptions.java
+++ b/api/src/main/java/io/opencensus/trace/TraceOptions.java
@@ -16,13 +16,10 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkElementIndex;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.MoreObjects;
 import com.google.common.base.Objects;
+import io.opencensus.internal.Utils;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -78,8 +75,10 @@ public final class TraceOptions {
    * @since 0.5
    */
   public static TraceOptions fromBytes(byte[] buffer) {
-    checkNotNull(buffer, "buffer");
-    checkArgument(buffer.length == SIZE, "Invalid size: expected %s, got %s", SIZE, buffer.length);
+    Utils.checkNotNull(buffer, "buffer");
+    Utils.checkArgument(
+        buffer.length == SIZE,
+        String.format("Invalid size: expected %s, got %s", SIZE, buffer.length));
     return new TraceOptions(buffer[0]);
   }
 
@@ -97,7 +96,7 @@ public final class TraceOptions {
    * @since 0.5
    */
   public static TraceOptions fromBytes(byte[] src, int srcOffset) {
-    checkElementIndex(srcOffset, src.length);
+    Utils.checkIndex(srcOffset, src.length);
     return new TraceOptions(src[srcOffset]);
   }
 
@@ -131,7 +130,7 @@ public final class TraceOptions {
    * @since 0.5
    */
   public void copyBytesTo(byte[] dest, int destOffset) {
-    checkElementIndex(destOffset, dest.length);
+    Utils.checkIndex(destOffset, dest.length);
     dest[destOffset] = options;
   }
 

--- a/api/src/main/java/io/opencensus/trace/TraceOptions.java
+++ b/api/src/main/java/io/opencensus/trace/TraceOptions.java
@@ -16,10 +16,9 @@
 
 package io.opencensus.trace;
 
-import com.google.common.base.MoreObjects;
-import com.google.common.base.Objects;
 import io.opencensus.internal.DefaultVisibilityForTesting;
 import io.opencensus.internal.Utils;
+import java.util.Arrays;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -182,12 +181,12 @@ public final class TraceOptions {
 
   @Override
   public int hashCode() {
-    return Objects.hashCode(options);
+    return Arrays.hashCode(new byte[] {options});
   }
 
   @Override
   public String toString() {
-    return MoreObjects.toStringHelper(this).add("sampled", isSampled()).toString();
+    return "TraceOptions{sampled=" + isSampled() + "}";
   }
 
   /**

--- a/api/src/main/java/io/opencensus/trace/Tracer.java
+++ b/api/src/main/java/io/opencensus/trace/Tracer.java
@@ -16,10 +16,9 @@
 
 package io.opencensus.trace;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.errorprone.annotations.MustBeClosed;
 import io.opencensus.common.Scope;
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.SpanBuilder.NoopSpanBuilder;
 import java.util.concurrent.Callable;
 import javax.annotation.Nullable;
@@ -152,7 +151,7 @@ public abstract class Tracer {
    */
   @MustBeClosed
   public final Scope withSpan(Span span) {
-    return CurrentSpanUtils.withSpan(checkNotNull(span, "span"), /* endSpan= */ false);
+    return CurrentSpanUtils.withSpan(Utils.checkNotNull(span, "span"), /* endSpan= */ false);
   }
 
   /**

--- a/api/src/main/java/io/opencensus/trace/Tracing.java
+++ b/api/src/main/java/io/opencensus/trace/Tracing.java
@@ -16,8 +16,8 @@
 
 package io.opencensus.trace;
 
-import com.google.common.annotations.VisibleForTesting;
 import io.opencensus.common.Clock;
+import io.opencensus.internal.DefaultVisibilityForTesting;
 import io.opencensus.internal.Provider;
 import io.opencensus.trace.config.TraceConfig;
 import io.opencensus.trace.export.ExportComponent;
@@ -87,7 +87,7 @@ public final class Tracing {
   }
 
   // Any provider that may be used for TraceComponent can be added here.
-  @VisibleForTesting
+  @DefaultVisibilityForTesting
   static TraceComponent loadTraceComponent(@Nullable ClassLoader classLoader) {
     try {
       // Call Class.forName with literal string name of the class to help shading tools.

--- a/api/src/main/java/io/opencensus/trace/config/TraceParams.java
+++ b/api/src/main/java/io/opencensus/trace/config/TraceParams.java
@@ -16,9 +16,8 @@
 
 package io.opencensus.trace.config;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.auto.value.AutoValue;
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.Link;
 import io.opencensus.trace.MessageEvent;
@@ -209,10 +208,11 @@ public abstract class TraceParams {
      */
     public TraceParams build() {
       TraceParams traceParams = autoBuild();
-      checkArgument(traceParams.getMaxNumberOfAttributes() > 0, "maxNumberOfAttributes");
-      checkArgument(traceParams.getMaxNumberOfAnnotations() > 0, "maxNumberOfAnnotations");
-      checkArgument(traceParams.getMaxNumberOfMessageEvents() > 0, "maxNumberOfMessageEvents");
-      checkArgument(traceParams.getMaxNumberOfLinks() > 0, "maxNumberOfLinks");
+      Utils.checkArgument(traceParams.getMaxNumberOfAttributes() > 0, "maxNumberOfAttributes");
+      Utils.checkArgument(traceParams.getMaxNumberOfAnnotations() > 0, "maxNumberOfAnnotations");
+      Utils.checkArgument(
+          traceParams.getMaxNumberOfMessageEvents() > 0, "maxNumberOfMessageEvents");
+      Utils.checkArgument(traceParams.getMaxNumberOfLinks() > 0, "maxNumberOfLinks");
       return traceParams;
     }
   }

--- a/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/RunningSpanStore.java
@@ -16,10 +16,8 @@
 
 package io.opencensus.trace.export;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
+import io.opencensus.internal.Utils;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -92,7 +90,7 @@ public abstract class RunningSpanStore {
       return new AutoValue_RunningSpanStore_Summary(
           Collections.unmodifiableMap(
               new HashMap<String, PerSpanNameSummary>(
-                  checkNotNull(perSpanNameSummary, "perSpanNameSummary"))));
+                  Utils.checkNotNull(perSpanNameSummary, "perSpanNameSummary"))));
     }
 
     /**
@@ -124,7 +122,7 @@ public abstract class RunningSpanStore {
      * @since 0.5
      */
     public static PerSpanNameSummary create(int numRunningSpans) {
-      checkArgument(numRunningSpans >= 0, "Negative numRunningSpans.");
+      Utils.checkArgument(numRunningSpans >= 0, "Negative numRunningSpans.");
       return new AutoValue_RunningSpanStore_PerSpanNameSummary(numRunningSpans);
     }
 
@@ -163,7 +161,7 @@ public abstract class RunningSpanStore {
      * @since 0.5
      */
     public static Filter create(String spanName, int maxSpansToReturn) {
-      checkArgument(maxSpansToReturn >= 0, "Negative maxSpansToReturn.");
+      Utils.checkArgument(maxSpansToReturn >= 0, "Negative maxSpansToReturn.");
       return new AutoValue_RunningSpanStore_Filter(spanName, maxSpansToReturn);
     }
 
@@ -196,7 +194,7 @@ public abstract class RunningSpanStore {
 
     @Override
     public Collection<SpanData> getRunningSpans(Filter filter) {
-      checkNotNull(filter, "filter");
+      Utils.checkNotNull(filter, "filter");
       return Collections.<SpanData>emptyList();
     }
   }

--- a/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
@@ -17,7 +17,7 @@
 package io.opencensus.trace.export;
 
 import com.google.auto.value.AutoValue;
-import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.internal.PublicForTesting;
 import io.opencensus.internal.Utils;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
@@ -129,7 +129,7 @@ public abstract class SampledSpanStore {
    * @return the set of unique span names registered to the library.
    * @since 0.7
    */
-  @VisibleForTesting
+  @PublicForTesting
   public abstract Set<String> getRegisteredSpanNamesForCollection();
 
   /**

--- a/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
@@ -16,11 +16,9 @@
 
 package io.opencensus.trace.export;
 
-import static com.google.common.base.Preconditions.checkArgument;
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Status.CanonicalCode;
@@ -157,7 +155,7 @@ public abstract class SampledSpanStore {
       return new AutoValue_SampledSpanStore_Summary(
           Collections.unmodifiableMap(
               new HashMap<String, PerSpanNameSummary>(
-                  checkNotNull(perSpanNameSummary, "perSpanNameSummary"))));
+                  Utils.checkNotNull(perSpanNameSummary, "perSpanNameSummary"))));
     }
 
     /**
@@ -196,10 +194,11 @@ public abstract class SampledSpanStore {
       return new AutoValue_SampledSpanStore_PerSpanNameSummary(
           Collections.unmodifiableMap(
               new HashMap<LatencyBucketBoundaries, Integer>(
-                  checkNotNull(numbersOfLatencySampledSpans, "numbersOfLatencySampledSpans"))),
+                  Utils.checkNotNull(
+                      numbersOfLatencySampledSpans, "numbersOfLatencySampledSpans"))),
           Collections.unmodifiableMap(
               new HashMap<CanonicalCode, Integer>(
-                  checkNotNull(numbersOfErrorSampledSpans, "numbersOfErrorSampledSpans"))));
+                  Utils.checkNotNull(numbersOfErrorSampledSpans, "numbersOfErrorSampledSpans"))));
     }
 
     /**
@@ -361,9 +360,9 @@ public abstract class SampledSpanStore {
      */
     public static LatencyFilter create(
         String spanName, long latencyLowerNs, long latencyUpperNs, int maxSpansToReturn) {
-      checkArgument(maxSpansToReturn >= 0, "Negative maxSpansToReturn.");
-      checkArgument(latencyLowerNs >= 0, "Negative latencyLowerNs");
-      checkArgument(latencyUpperNs >= 0, "Negative latencyUpperNs");
+      Utils.checkArgument(maxSpansToReturn >= 0, "Negative maxSpansToReturn.");
+      Utils.checkArgument(latencyLowerNs >= 0, "Negative latencyLowerNs");
+      Utils.checkArgument(latencyUpperNs >= 0, "Negative latencyUpperNs");
       return new AutoValue_SampledSpanStore_LatencyFilter(
           spanName, latencyLowerNs, latencyUpperNs, maxSpansToReturn);
     }
@@ -432,9 +431,9 @@ public abstract class SampledSpanStore {
     public static ErrorFilter create(
         String spanName, @Nullable CanonicalCode canonicalCode, int maxSpansToReturn) {
       if (canonicalCode != null) {
-        checkArgument(canonicalCode != CanonicalCode.OK, "Invalid canonical code.");
+        Utils.checkArgument(canonicalCode != CanonicalCode.OK, "Invalid canonical code.");
       }
-      checkArgument(maxSpansToReturn >= 0, "Negative maxSpansToReturn.");
+      Utils.checkArgument(maxSpansToReturn >= 0, "Negative maxSpansToReturn.");
       return new AutoValue_SampledSpanStore_ErrorFilter(spanName, canonicalCode, maxSpansToReturn);
     }
 
@@ -489,19 +488,19 @@ public abstract class SampledSpanStore {
 
     @Override
     public Collection<SpanData> getLatencySampledSpans(LatencyFilter filter) {
-      checkNotNull(filter, "latencyFilter");
+      Utils.checkNotNull(filter, "latencyFilter");
       return Collections.<SpanData>emptyList();
     }
 
     @Override
     public Collection<SpanData> getErrorSampledSpans(ErrorFilter filter) {
-      checkNotNull(filter, "errorFilter");
+      Utils.checkNotNull(filter, "errorFilter");
       return Collections.<SpanData>emptyList();
     }
 
     @Override
     public void registerSpanNamesForCollection(Collection<String> spanNames) {
-      checkNotNull(spanNames, "spanNames");
+      Utils.checkNotNull(spanNames, "spanNames");
       synchronized (registeredSpanNames) {
         registeredSpanNames.addAll(spanNames);
       }
@@ -509,7 +508,7 @@ public abstract class SampledSpanStore {
 
     @Override
     public void unregisterSpanNamesForCollection(Collection<String> spanNames) {
-      checkNotNull(spanNames);
+      Utils.checkNotNull(spanNames, "spanNames");
       synchronized (registeredSpanNames) {
         registeredSpanNames.removeAll(spanNames);
       }

--- a/api/src/main/java/io/opencensus/trace/export/SpanData.java
+++ b/api/src/main/java/io/opencensus/trace/export/SpanData.java
@@ -28,7 +28,7 @@ import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.Status;
-import io.opencensus.trace.internal.BaseMessageEventUtil;
+import io.opencensus.trace.internal.BaseMessageEventUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -101,7 +101,7 @@ public abstract class SpanData {
       } else {
         messageEventsList.add(
             TimedEvent.<MessageEvent>create(
-                timedEvent.getTimestamp(), BaseMessageEventUtil.asMessageEvent(event)));
+                timedEvent.getTimestamp(), BaseMessageEventUtils.asMessageEvent(event)));
       }
     }
     TimedEvents<MessageEvent> messageEvents =
@@ -200,7 +200,7 @@ public abstract class SpanData {
       networkEventsList.add(
           TimedEvent.<io.opencensus.trace.NetworkEvent>create(
               timedEvent.getTimestamp(),
-              BaseMessageEventUtil.asNetworkEvent(timedEvent.getEvent())));
+              BaseMessageEventUtils.asNetworkEvent(timedEvent.getEvent())));
     }
     return TimedEvents.<io.opencensus.trace.NetworkEvent>create(
         networkEventsList, timedEvents.getDroppedEventsCount());

--- a/api/src/main/java/io/opencensus/trace/export/SpanData.java
+++ b/api/src/main/java/io/opencensus/trace/export/SpanData.java
@@ -16,10 +16,9 @@
 
 package io.opencensus.trace.export;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Timestamp;
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Link;
@@ -319,7 +318,7 @@ public abstract class SpanData {
     public static <T> TimedEvents<T> create(List<TimedEvent<T>> events, int droppedEventsCount) {
       return new AutoValue_SpanData_TimedEvents<T>(
           Collections.unmodifiableList(
-              new ArrayList<TimedEvent<T>>(checkNotNull(events, "events"))),
+              new ArrayList<TimedEvent<T>>(Utils.checkNotNull(events, "events"))),
           droppedEventsCount);
     }
 
@@ -364,7 +363,8 @@ public abstract class SpanData {
       // for others on account of determinism.
       return new AutoValue_SpanData_Attributes(
           Collections.unmodifiableMap(
-              new HashMap<String, AttributeValue>(checkNotNull(attributeMap, "attributeMap"))),
+              new HashMap<String, AttributeValue>(
+                  Utils.checkNotNull(attributeMap, "attributeMap"))),
           droppedAttributesCount);
     }
 
@@ -405,7 +405,7 @@ public abstract class SpanData {
      */
     public static Links create(List<Link> links, int droppedLinksCount) {
       return new AutoValue_SpanData_Links(
-          Collections.unmodifiableList(new ArrayList<Link>(checkNotNull(links, "links"))),
+          Collections.unmodifiableList(new ArrayList<Link>(Utils.checkNotNull(links, "links"))),
           droppedLinksCount);
     }
 

--- a/api/src/main/java/io/opencensus/trace/internal/BaseMessageEventUtils.java
+++ b/api/src/main/java/io/opencensus/trace/internal/BaseMessageEventUtils.java
@@ -26,7 +26,7 @@ import io.opencensus.common.Internal;
  */
 @Internal
 @SuppressWarnings("deprecation")
-public final class BaseMessageEventUtil {
+public final class BaseMessageEventUtils {
   /**
    * Cast or convert a {@link io.opencensus.trace.BaseMessageEvent} to {@link
    * io.opencensus.trace.MessageEvent}.
@@ -78,5 +78,5 @@ public final class BaseMessageEventUtil {
         .build();
   }
 
-  private BaseMessageEventUtil() {}
+  private BaseMessageEventUtils() {}
 }

--- a/api/src/main/java/io/opencensus/trace/internal/BaseMessageEventUtils.java
+++ b/api/src/main/java/io/opencensus/trace/internal/BaseMessageEventUtils.java
@@ -16,9 +16,8 @@
 
 package io.opencensus.trace.internal;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import io.opencensus.common.Internal;
+import io.opencensus.internal.Utils;
 
 /**
  * Helper class to convert/cast between for {@link io.opencensus.trace.MessageEvent} and {@link
@@ -39,7 +38,7 @@ public final class BaseMessageEventUtils {
    */
   public static io.opencensus.trace.MessageEvent asMessageEvent(
       io.opencensus.trace.BaseMessageEvent event) {
-    checkNotNull(event);
+    Utils.checkNotNull(event, "event");
     if (event instanceof io.opencensus.trace.MessageEvent) {
       return (io.opencensus.trace.MessageEvent) event;
     }
@@ -63,7 +62,7 @@ public final class BaseMessageEventUtils {
    */
   public static io.opencensus.trace.NetworkEvent asNetworkEvent(
       io.opencensus.trace.BaseMessageEvent event) {
-    checkNotNull(event);
+    Utils.checkNotNull(event, "event");
     if (event instanceof io.opencensus.trace.NetworkEvent) {
       return (io.opencensus.trace.NetworkEvent) event;
     }

--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -16,8 +16,7 @@
 
 package io.opencensus.trace.propagation;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.SpanContext;
 import java.text.ParseException;
 
@@ -138,13 +137,13 @@ public abstract class BinaryFormat {
   private static final class NoopBinaryFormat extends BinaryFormat {
     @Override
     public byte[] toByteArray(SpanContext spanContext) {
-      checkNotNull(spanContext, "spanContext");
+      Utils.checkNotNull(spanContext, "spanContext");
       return new byte[0];
     }
 
     @Override
     public SpanContext fromByteArray(byte[] bytes) {
-      checkNotNull(bytes, "bytes");
+      Utils.checkNotNull(bytes, "bytes");
       return SpanContext.INVALID;
     }
 

--- a/api/src/main/java/io/opencensus/trace/propagation/TextFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/TextFormat.java
@@ -16,9 +16,8 @@
 
 package io.opencensus.trace.propagation;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 import io.opencensus.common.ExperimentalApi;
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.SpanContext;
 import java.util.Collections;
 import java.util.List;
@@ -190,15 +189,15 @@ public abstract class TextFormat {
     @Override
     public <C /*>>> extends @NonNull Object*/> void inject(
         SpanContext spanContext, C carrier, Setter<C> setter) {
-      checkNotNull(spanContext, "spanContext");
-      checkNotNull(carrier, "carrier");
-      checkNotNull(setter, "setter");
+      Utils.checkNotNull(spanContext, "spanContext");
+      Utils.checkNotNull(carrier, "carrier");
+      Utils.checkNotNull(setter, "setter");
     }
 
     @Override
     public <C /*>>> extends @NonNull Object*/> SpanContext extract(C carrier, Getter<C> getter) {
-      checkNotNull(carrier, "carrier");
-      checkNotNull(getter, "getter");
+      Utils.checkNotNull(carrier, "carrier");
+      Utils.checkNotNull(getter, "getter");
       return SpanContext.INVALID;
     }
   }

--- a/api/src/main/java/io/opencensus/trace/propagation/TextFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/TextFormat.java
@@ -24,6 +24,10 @@ import java.util.Collections;
 import java.util.List;
 import javax.annotation.Nullable;
 
+/*>>>
+import org.checkerframework.checker.nullness.qual.NonNull;
+*/
+
 /**
  * Injects and extracts {@link SpanContext trace identifiers} as text into carriers that travel
  * in-band across process boundaries. Identifiers are often encoded as messaging or RPC request
@@ -103,7 +107,8 @@ public abstract class TextFormat {
    * @param setter invoked for each propagation key to add or remove.
    * @since 0.11
    */
-  public abstract <C> void inject(SpanContext spanContext, C carrier, Setter<C> setter);
+  public abstract <C /*>>> extends @NonNull Object*/> void inject(
+      SpanContext spanContext, C carrier, Setter<C> setter);
 
   /**
    * Class that allows a {@code TextFormat} to set propagated fields into a carrier.
@@ -138,8 +143,8 @@ public abstract class TextFormat {
    * @throws SpanContextParseException if the input is invalid
    * @since 0.11
    */
-  public abstract <C> SpanContext extract(C carrier, Getter<C> getter)
-      throws SpanContextParseException;
+  public abstract <C /*>>> extends @NonNull Object*/> SpanContext extract(
+      C carrier, Getter<C> getter) throws SpanContextParseException;
 
   /**
    * Class that allows a {@code TextFormat} to read propagated fields from a carrier.
@@ -183,14 +188,15 @@ public abstract class TextFormat {
     }
 
     @Override
-    public <C> void inject(SpanContext spanContext, C carrier, Setter<C> setter) {
+    public <C /*>>> extends @NonNull Object*/> void inject(
+        SpanContext spanContext, C carrier, Setter<C> setter) {
       checkNotNull(spanContext, "spanContext");
       checkNotNull(carrier, "carrier");
       checkNotNull(setter, "setter");
     }
 
     @Override
-    public <C> SpanContext extract(C carrier, Getter<C> getter) {
+    public <C /*>>> extends @NonNull Object*/> SpanContext extract(C carrier, Getter<C> getter) {
       checkNotNull(carrier, "carrier");
       checkNotNull(getter, "getter");
       return SpanContext.INVALID;

--- a/api/src/main/java/io/opencensus/trace/samplers/ProbabilitySampler.java
+++ b/api/src/main/java/io/opencensus/trace/samplers/ProbabilitySampler.java
@@ -16,9 +16,8 @@
 
 package io.opencensus.trace.samplers;
 
-import static com.google.common.base.Preconditions.checkArgument;
-
 import com.google.auto.value.AutoValue;
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.Sampler;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
@@ -54,7 +53,7 @@ abstract class ProbabilitySampler extends Sampler {
    * @throws IllegalArgumentException if {@code probability} is out of range
    */
   static ProbabilitySampler create(double probability) {
-    checkArgument(
+    Utils.checkArgument(
         probability >= 0.0 && probability <= 1.0, "probability must be in range [0.0, 1.0]");
     long idUpperBound;
     // Special case the limits, to avoid any possible issues with lack of precision across

--- a/api/src/test/java/io/opencensus/internal/StringUtilsTest.java
+++ b/api/src/test/java/io/opencensus/internal/StringUtilsTest.java
@@ -23,13 +23,13 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Tests for {@link StringUtil}. */
+/** Tests for {@link StringUtils}. */
 @RunWith(JUnit4.class)
-public final class StringUtilTest {
+public final class StringUtilsTest {
 
   @Test
   public void isPrintableString() {
-    assertTrue(StringUtil.isPrintableString("abcd"));
-    assertFalse(StringUtil.isPrintableString("\2ab\3cd"));
+    assertTrue(StringUtils.isPrintableString("abcd"));
+    assertFalse(StringUtils.isPrintableString("\2ab\3cd"));
   }
 }

--- a/api/src/test/java/io/opencensus/internal/UtilsTest.java
+++ b/api/src/test/java/io/opencensus/internal/UtilsTest.java
@@ -16,6 +16,8 @@
 
 package io.opencensus.internal;
 
+import static com.google.common.truth.Truth.assertThat;
+
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -84,5 +86,33 @@ public final class UtilsTest {
     thrown.expect(IndexOutOfBoundsException.class);
     thrown.expectMessage("Index out of bounds: size=10, index=11");
     Utils.checkIndex(11, 10);
+  }
+
+  @Test
+  public void compareLongs() {
+    assertThat(Utils.compareLongs(-1L, 1L)).isLessThan(0);
+    assertThat(Utils.compareLongs(10L, 10L)).isEqualTo(0);
+    assertThat(Utils.compareLongs(1L, 0L)).isGreaterThan(0);
+  }
+
+  @Test
+  public void checkedAdd_TooLow() {
+    thrown.expect(ArithmeticException.class);
+    thrown.expectMessage("Long sum overflow: x=-9223372036854775807, y=-2");
+    Utils.checkedAdd(Long.MIN_VALUE + 1, -2);
+  }
+
+  @Test
+  public void checkedAdd_TooHigh() {
+    thrown.expect(ArithmeticException.class);
+    thrown.expectMessage("Long sum overflow: x=9223372036854775806, y=2");
+    Utils.checkedAdd(Long.MAX_VALUE - 1, 2);
+  }
+
+  @Test
+  public void checkedAdd_Valid() {
+    assertThat(Utils.checkedAdd(1, 2)).isEqualTo(3);
+    assertThat(Utils.checkedAdd(Integer.MAX_VALUE, Integer.MAX_VALUE))
+        .isEqualTo(2L * Integer.MAX_VALUE);
   }
 }

--- a/api/src/test/java/io/opencensus/internal/UtilsTest.java
+++ b/api/src/test/java/io/opencensus/internal/UtilsTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.internal;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Utils}. */
+@RunWith(JUnit4.class)
+public final class UtilsTest {
+  private static final String TEST_MESSAGE = "test message";
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void checkArgument() {
+    Utils.checkArgument(true, TEST_MESSAGE);
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(TEST_MESSAGE);
+    Utils.checkArgument(false, TEST_MESSAGE);
+  }
+
+  @Test
+  public void checkState() {
+    Utils.checkNotNull(true, TEST_MESSAGE);
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage(TEST_MESSAGE);
+    Utils.checkState(false, TEST_MESSAGE);
+  }
+
+  @Test
+  public void checkNotNull() {
+    Utils.checkNotNull(new Object(), TEST_MESSAGE);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage(TEST_MESSAGE);
+    Utils.checkNotNull(null, TEST_MESSAGE);
+  }
+
+  @Test
+  public void checkIndex_Valid() {
+    Utils.checkIndex(1, 2);
+  }
+
+  @Test
+  public void checkIndex_NegativeSize() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Negative size: -1");
+    Utils.checkIndex(0, -1);
+  }
+
+  @Test
+  public void checkIndex_NegativeIndex() {
+    thrown.expect(IndexOutOfBoundsException.class);
+    thrown.expectMessage("Index out of bounds: size=10, index=-2");
+    Utils.checkIndex(-2, 10);
+  }
+
+  @Test
+  public void checkIndex_IndexEqualToSize() {
+    thrown.expect(IndexOutOfBoundsException.class);
+    thrown.expectMessage("Index out of bounds: size=5, index=5");
+    Utils.checkIndex(5, 5);
+  }
+
+  @Test
+  public void checkIndex_IndexGreaterThanSize() {
+    thrown.expect(IndexOutOfBoundsException.class);
+    thrown.expectMessage("Index out of bounds: size=10, index=11");
+    Utils.checkIndex(11, 10);
+  }
+}

--- a/api/src/test/java/io/opencensus/internal/UtilsTest.java
+++ b/api/src/test/java/io/opencensus/internal/UtilsTest.java
@@ -17,7 +17,10 @@
 package io.opencensus.internal;
 
 import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.util.Date;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -86,6 +89,19 @@ public final class UtilsTest {
     thrown.expect(IndexOutOfBoundsException.class);
     thrown.expectMessage("Index out of bounds: size=10, index=11");
     Utils.checkIndex(11, 10);
+  }
+
+  @Test
+  public void equalsObjects_Equal() {
+    assertTrue(Utils.equalsObjects(null, null));
+    assertTrue(Utils.equalsObjects(new Date(1L), new Date(1L)));
+  }
+
+  @Test
+  public void equalsObjects_Unequal() {
+    assertFalse(Utils.equalsObjects(null, new Object()));
+    assertFalse(Utils.equalsObjects(new Object(), null));
+    assertFalse(Utils.equalsObjects(new Object(), new Object()));
   }
 
   @Test

--- a/api/src/test/java/io/opencensus/trace/internal/BaseMessageEventUtilsTest.java
+++ b/api/src/test/java/io/opencensus/trace/internal/BaseMessageEventUtilsTest.java
@@ -24,9 +24,9 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link BaseMessageEventUtil}. */
+/** Unit tests for {@link BaseMessageEventUtils}. */
 @RunWith(JUnit4.class)
-public class BaseMessageEventUtilTest {
+public class BaseMessageEventUtilsTest {
   private static final long SENT_EVENT_ID = 12345L;
   private static final long RECV_EVENT_ID = 67890L;
   private static final long UNCOMPRESSED_SIZE = 100;
@@ -55,17 +55,17 @@ public class BaseMessageEventUtilTest {
 
   @Test
   public void networkEventToMessageEvent() {
-    assertThat(BaseMessageEventUtil.asMessageEvent(SENT_NETWORK_EVENT))
+    assertThat(BaseMessageEventUtils.asMessageEvent(SENT_NETWORK_EVENT))
         .isEqualTo(SENT_MESSAGE_EVENT);
-    assertThat(BaseMessageEventUtil.asMessageEvent(RECV_NETWORK_EVENT))
+    assertThat(BaseMessageEventUtils.asMessageEvent(RECV_NETWORK_EVENT))
         .isEqualTo(RECV_MESSAGE_EVENT);
   }
 
   @Test
   public void messageEventToNetworkEvent() {
-    assertThat(BaseMessageEventUtil.asNetworkEvent(SENT_MESSAGE_EVENT))
+    assertThat(BaseMessageEventUtils.asNetworkEvent(SENT_MESSAGE_EVENT))
         .isEqualTo(SENT_NETWORK_EVENT);
-    assertThat(BaseMessageEventUtil.asNetworkEvent(RECV_MESSAGE_EVENT))
+    assertThat(BaseMessageEventUtils.asNetworkEvent(RECV_MESSAGE_EVENT))
         .isEqualTo(RECV_NETWORK_EVENT);
   }
 }

--- a/checker-framework/stubs/guava.astub
+++ b/checker-framework/stubs/guava.astub
@@ -1,4 +1,5 @@
 import org.checkerframework.checker.nullness.qual.EnsuresNonNullIf;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 package com.google.common.base;
@@ -6,4 +7,8 @@ package com.google.common.base;
 class Strings {
   @EnsuresNonNullIf(result = false, expression = "#1")
   static boolean isNullOrEmpty(@Nullable String str);
+}
+
+class Preconditions {
+  static <T extends @NonNull Object> T checkNotNull(T reference, @Nullable Object errorMessage);
 }

--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/util/CloudTraceFormat.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/util/CloudTraceFormat.java
@@ -31,6 +31,10 @@ import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.List;
 
+/*>>>
+import org.checkerframework.checker.nullness.qual.NonNull;
+*/
+
 /**
  * Implementation of the "X-Cloud-Trace-Context" format, defined by the Google Cloud Trace.
  *
@@ -80,7 +84,8 @@ final class CloudTraceFormat extends TextFormat {
   }
 
   @Override
-  public <C> void inject(SpanContext spanContext, C carrier, Setter<C> setter) {
+  public <C /*>>> extends @NonNull Object*/> void inject(
+      SpanContext spanContext, C carrier, Setter<C> setter) {
     checkNotNull(spanContext, "spanContext");
     checkNotNull(setter, "setter");
     checkNotNull(carrier, "carrier");
@@ -96,7 +101,8 @@ final class CloudTraceFormat extends TextFormat {
   }
 
   @Override
-  public <C> SpanContext extract(C carrier, Getter<C> getter) throws SpanContextParseException {
+  public <C /*>>> extends @NonNull Object*/> SpanContext extract(C carrier, Getter<C> getter)
+      throws SpanContextParseException {
     checkNotNull(carrier, "carrier");
     checkNotNull(getter, "getter");
     try {

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -20,7 +20,7 @@
   <Match>
     <!-- Reason: BaseMessageEvent only has two visible subclasses. -->
     <Bug pattern="BC_UNCONFIRMED_CAST"/>
-    <Class name="io.opencensus.trace.internal.BaseMessageEventUtil" />
+    <Class name="io.opencensus.trace.internal.BaseMessageEventUtils" />
   </Match>
 
   <!-- Suppress some FindBugs warnings related to performance or robustness -->

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -22,6 +22,12 @@
     <Bug pattern="BC_UNCONFIRMED_CAST"/>
     <Class name="io.opencensus.trace.internal.BaseMessageEventUtils" />
   </Match>
+  <Match>
+    <!-- Reason: This test is testing for a NPE. -->
+    <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
+    <Class name="io.opencensus.internal.UtilsTest" />
+    <Method name="checkNotNull" />
+  </Match>
 
   <!-- Suppress some FindBugs warnings related to performance or robustness -->
   <!-- in test classes, where those issues are less important. -->

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -28,6 +28,13 @@
     <Class name="io.opencensus.internal.UtilsTest" />
     <Method name="checkNotNull" />
   </Match>
+  <Match>
+    <!-- Reason: It seems like FindBugs incorrectly assumes that all -->
+    <!-- Throwables are subclasses of Error or Exception. -->
+    <Bug pattern="BC_VACUOUS_INSTANCEOF"/>
+    <Class name="io.opencensus.trace.CurrentSpanUtils$CallableInSpan" />
+    <Method name="call" />
+  </Match>
 
   <!-- Suppress some FindBugs warnings related to performance or robustness -->
   <!-- in test classes, where those issues are less important. -->

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/B3Format.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/B3Format.java
@@ -29,6 +29,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
+/*>>>
+import org.checkerframework.checker.nullness.qual.NonNull;
+*/
+
 /**
  * Implementation of the B3 propagation protocol. See <a
  * href=https://github.com/openzipkin/b3-propagation>b3-propagation</a>.
@@ -58,7 +62,8 @@ final class B3Format extends TextFormat {
   }
 
   @Override
-  public <C> void inject(SpanContext spanContext, C carrier, Setter<C> setter) {
+  public <C /*>>> extends @NonNull Object*/> void inject(
+      SpanContext spanContext, C carrier, Setter<C> setter) {
     checkNotNull(spanContext, "spanContext");
     checkNotNull(setter, "setter");
     checkNotNull(carrier, "carrier");
@@ -70,7 +75,8 @@ final class B3Format extends TextFormat {
   }
 
   @Override
-  public <C> SpanContext extract(C carrier, Getter<C> getter) throws SpanContextParseException {
+  public <C /*>>> extends @NonNull Object*/> SpanContext extract(C carrier, Getter<C> getter)
+      throws SpanContextParseException {
     checkNotNull(carrier, "carrier");
     checkNotNull(getter, "getter");
     try {


### PR DESCRIPTION
After this PR, opencensus-api only uses Guava in two places: `SpanId` and `TraceId` both use `com.google.common.io.BaseEncoding` for base 16 encoding.  This PR also adds an internal `Util` class that replaces some of the commonly used functionality, such as argument checking.