### PR TITLE
Checker Framework: 2.3.2 -> 2.4.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ subprojects {
 
     dependencies {
         if (useCheckerFramework) {
-            ext.checkerFrameworkVersion = '2.3.2'
+            ext.checkerFrameworkVersion = '2.4.0'
             ext.jdkVersion = 'jdk8'
             checkerFrameworkAnnotatedJDK "org.checkerframework:${jdkVersion}:${checkerFrameworkVersion}"
             checkerFrameworkJavac "org.checkerframework:compiler:${checkerFrameworkVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -389,7 +389,8 @@ subprojects {
                     compile.options.compilerArgs += [
                         '-Xmaxerrs', '10000',
                         "-Xbootclasspath/p:${configurations.checkerFrameworkAnnotatedJDK.asPath}",
-                        "-AskipDefs=\\.AutoValue_"
+                        "-AskipDefs=\\.AutoValue_",
+                        "-AinvariantArrays"
                     ]
                     options.fork = true
                     options.forkOptions.jvmArgs += ["-Xbootclasspath/p:${configurations.checkerFrameworkJavac.asPath}"]


### PR DESCRIPTION
Checker Framework 2.4.0 is the second latest version.  The latest, 2.5.0, ends support for annotations in comments (https://github.com/typetools/checker-framework/releases/tag/checker-framework-2.5.0), so we probably can't upgrade further until we can use Java 8 syntax.

This PR also enables `-AinvariantArrays`.