### PR TITLE
Add new RPC measure and view constants, deprecate old ones.

### DIFF
--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -33,15 +33,47 @@ public final class RpcMeasureConstants {
    * https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_STATUS} and {@link #GRPC_SERVER_STATUS}.
    */
-  public static final TagKey RPC_STATUS = TagKey.create("canonical_status");
+  @Deprecated public static final TagKey RPC_STATUS = TagKey.create("canonical_status");
 
   /**
    * Tag key that represents a gRPC method.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_METHOD} and {@link #GRPC_SERVER_METHOD}.
    */
-  public static final TagKey RPC_METHOD = TagKey.create("method");
+  @Deprecated public static final TagKey RPC_METHOD = TagKey.create("method");
+
+  /**
+   * Tag key that represents a client gRPC canonical status. Refer to
+   * https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.
+   *
+   * @since 0.13
+   */
+  public static final TagKey GRPC_CLIENT_STATUS = TagKey.create("grpc_client_status");
+
+  /**
+   * Tag key that represents a server gRPC canonical status. Refer to
+   * https://github.com/grpc/grpc/blob/master/doc/statuscodes.md.
+   *
+   * @since 0.13
+   */
+  public static final TagKey GRPC_SERVER_STATUS = TagKey.create("grpc_server_status");
+
+  /**
+   * Tag key that represents a client gRPC method.
+   *
+   * @since 0.13
+   */
+  public static final TagKey GRPC_CLIENT_METHOD = TagKey.create("grpc_client_method");
+
+  /**
+   * Tag key that represents a server gRPC method.
+   *
+   * @since 0.13
+   */
+  public static final TagKey GRPC_SERVER_METHOD = TagKey.create("grpc_server_method");
 
   // Constants used to define the following Measures.
 
@@ -72,7 +104,10 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client error counts.
    *
    * @since 0.8
+   * @deprecated because error counts can be computed on your metrics backend by totalling the
+   *     different per-status values.
    */
+  @Deprecated
   public static final MeasureLong RPC_CLIENT_ERROR_COUNT =
       Measure.MeasureLong.create("grpc.io/client/error_count", "RPC Errors", COUNT);
 
@@ -80,7 +115,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client request bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_CLIENT_REQUEST_BYTES =
       Measure.MeasureDouble.create("grpc.io/client/request_bytes", "Request bytes", BYTE);
 
@@ -88,7 +125,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client response bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_CLIENT_RESPONSE_BYTES =
       Measure.MeasureDouble.create("grpc.io/client/response_bytes", "Response bytes", BYTE);
 
@@ -96,7 +135,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client roundtrip latency in milliseconds.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_ROUNDTRIP_LATENCY}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_CLIENT_ROUNDTRIP_LATENCY =
       Measure.MeasureDouble.create(
           "grpc.io/client/roundtrip_latency", "RPC roundtrip latency msec", MILLISECOND);
@@ -105,7 +146,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client server elapsed time in milliseconds.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_SERVER_LATENCY}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_CLIENT_SERVER_ELAPSED_TIME =
       Measure.MeasureDouble.create(
           "grpc.io/client/server_elapsed_time", "Server elapsed time in msecs", MILLISECOND);
@@ -114,7 +157,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client uncompressed request bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES =
       Measure.MeasureDouble.create(
           "grpc.io/client/uncompressed_request_bytes", "Uncompressed Request bytes", BYTE);
@@ -123,7 +168,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client uncompressed response bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES =
       Measure.MeasureDouble.create(
           "grpc.io/client/uncompressed_response_bytes", "Uncompressed Response bytes", BYTE);
@@ -132,7 +179,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for number of started client RPCs.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_STARTED_COUNT}.
    */
+  @Deprecated
   public static final MeasureLong RPC_CLIENT_STARTED_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/client/started_count", "Number of client RPCs (streams) started", COUNT);
@@ -141,7 +190,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for number of finished client RPCs.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_FINISHED_COUNT}.
    */
+  @Deprecated
   public static final MeasureLong RPC_CLIENT_FINISHED_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/client/finished_count", "Number of client RPCs (streams) finished", COUNT);
@@ -151,6 +202,7 @@ public final class RpcMeasureConstants {
    *
    * @since 0.8
    */
+  @Deprecated
   public static final MeasureLong RPC_CLIENT_REQUEST_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/client/request_count", "Number of client RPC request messages", COUNT);
@@ -160,9 +212,113 @@ public final class RpcMeasureConstants {
    *
    * @since 0.8
    */
+  @Deprecated
   public static final MeasureLong RPC_CLIENT_RESPONSE_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/client/response_count", "Number of client RPC response messages", COUNT);
+
+  /**
+   * {@link Measure} for total bytes sent across all request messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_SENT_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/sent_bytes_per_rpc",
+          "Total bytes sent across all request messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for total bytes received across all response messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_RECEIVED_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/received_bytes_per_rpc",
+          "Total bytes received across all response messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for gRPC client roundtrip latency in milliseconds.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_ROUNDTRIP_LATENCY =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/roundtrip_latency",
+          "Time between first byte of request sent to last byte of response received, "
+              + "or terminal error.",
+          MILLISECOND);
+
+  /**
+   * {@link Measure} for total uncompressed bytes sent across all request messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/uncompressed_sent_bytes_per_rpc",
+          "Total uncompressed bytes sent across all request messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for total uncompressed bytes received across all response messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/uncompressed_received_bytes_per_rpc",
+          "Total uncompressed bytes received across all request messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for number of started client RPCs.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_CLIENT_STARTED_COUNT =
+      Measure.MeasureLong.create(
+          "grpc.io/client/started_count", "Number of client RPCs (streams) started", COUNT);
+
+  /**
+   * {@link Measure} for number of finished client RPCs.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_CLIENT_FINISHED_COUNT =
+      Measure.MeasureLong.create(
+          "grpc.io/client/finished_count", "Number of client RPCs (streams) finished", COUNT);
+
+  /**
+   * {@link Measure} for number of messages sent in the RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_CLIENT_SENT_MESSAGES_PER_RPC =
+      Measure.MeasureLong.create(
+          "grpc.io/client/sent_messages_per_rpc", "Number of messages sent in the RPC", COUNT);
+
+  /**
+   * {@link Measure} for number of response messages received per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC =
+      Measure.MeasureLong.create(
+          "grpc.io/client/received_messages_per_rpc",
+          "Number of response messages received per RPC",
+          COUNT);
+
+  /**
+   * {@link Measure} for gRPC server latency in milliseconds.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_SERVER_LATENCY =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/server_latency", "Server latency in msecs", MILLISECOND);
 
   // RPC server Measures.
 
@@ -170,7 +326,10 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server error counts.
    *
    * @since 0.8
+   * @deprecated because error counts can be computed on your metrics backend by totalling the
+   *     different per-status values.
    */
+  @Deprecated
   public static final MeasureLong RPC_SERVER_ERROR_COUNT =
       Measure.MeasureLong.create("grpc.io/server/error_count", "RPC Errors", COUNT);
 
@@ -178,7 +337,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server request bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_SERVER_REQUEST_BYTES =
       Measure.MeasureDouble.create("grpc.io/server/request_bytes", "Request bytes", BYTE);
 
@@ -186,7 +347,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server response bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_SERVER_RESPONSE_BYTES =
       Measure.MeasureDouble.create("grpc.io/server/response_bytes", "Response bytes", BYTE);
 
@@ -194,7 +357,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server elapsed time in milliseconds.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_SERVER_SERVER_ELAPSED_TIME =
       Measure.MeasureDouble.create(
           "grpc.io/server/server_elapsed_time", "Server elapsed time in msecs", MILLISECOND);
@@ -203,7 +368,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server latency in milliseconds.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_SERVER_SERVER_LATENCY =
       Measure.MeasureDouble.create(
           "grpc.io/server/server_latency", "Latency in msecs", MILLISECOND);
@@ -212,7 +379,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server uncompressed request bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES =
       Measure.MeasureDouble.create(
           "grpc.io/server/uncompressed_request_bytes", "Uncompressed Request bytes", BYTE);
@@ -221,7 +390,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server uncompressed response bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES =
       Measure.MeasureDouble.create(
           "grpc.io/server/uncompressed_response_bytes", "Uncompressed Response bytes", BYTE);
@@ -230,7 +401,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for number of started server RPCs.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_STARTED_COUNT}.
    */
+  @Deprecated
   public static final MeasureLong RPC_SERVER_STARTED_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/server/started_count", "Number of server RPCs (streams) started", COUNT);
@@ -239,7 +412,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for number of finished server RPCs.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_FINISHED_COUNT}.
    */
+  @Deprecated
   public static final MeasureLong RPC_SERVER_FINISHED_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/server/finished_count", "Number of server RPCs (streams) finished", COUNT);
@@ -248,7 +423,9 @@ public final class RpcMeasureConstants {
    * {@link Measure} for server RPC request message counts.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_MESSAGES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureLong RPC_SERVER_REQUEST_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/server/request_count", "Number of server RPC request messages", COUNT);
@@ -257,10 +434,106 @@ public final class RpcMeasureConstants {
    * {@link Measure} for server RPC response message counts.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC}.
    */
+  @Deprecated
   public static final MeasureLong RPC_SERVER_RESPONSE_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/server/response_count", "Number of server RPC response messages", COUNT);
+
+  /**
+   * {@link Measure} for total bytes sent across all request messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_SERVER_SENT_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/sent_bytes_per_rpc",
+          "Total bytes sent across all request messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for total bytes received across all response messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_SERVER_RECEIVED_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/received_bytes_per_rpc",
+          "Total bytes received across all response messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for total uncompressed bytes sent across all request messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/uncompressed_sent_bytes_per_rpc",
+          "Total uncompressed bytes sent across all request messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for total uncompressed bytes received across all response messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/uncompressed_received_bytes_per_rpc",
+          "Total uncompressed bytes received across all request messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for number of started server RPCs.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_SERVER_STARTED_COUNT =
+      Measure.MeasureLong.create(
+          "grpc.io/server/started_count", "Number of server RPCs (streams) started", COUNT);
+
+  /**
+   * {@link Measure} for number of finished server RPCs.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_SERVER_FINISHED_COUNT =
+      Measure.MeasureLong.create(
+          "grpc.io/server/finished_count", "Number of server RPCs (streams) finished", COUNT);
+
+  /**
+   * {@link Measure} for number of messages sent in the RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_SERVER_SENT_MESSAGES_PER_RPC =
+      Measure.MeasureLong.create(
+          "grpc.io/server/sent_messages_per_rpc", "Number of messages sent in the RPC", COUNT);
+
+  /**
+   * {@link Measure} for number of response messages received per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC =
+      Measure.MeasureLong.create(
+          "grpc.io/server/received_messages_per_rpc",
+          "Number of response messages received per RPC",
+          COUNT);
+
+  /**
+   * {@link Measure} for gRPC server latency in milliseconds.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_SERVER_SERVER_LATENCY =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/server_latency",
+          "Time between first byte of request received to last byte of response sent, "
+              + "or terminal error.",
+          MILLISECOND);
 
   private RpcMeasureConstants() {}
 }

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -157,7 +157,7 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client uncompressed request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC}.
    */
   @Deprecated
   public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES =
@@ -168,7 +168,7 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC client uncompressed response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC}.
    */
   @Deprecated
   public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES =
@@ -190,7 +190,8 @@ public final class RpcMeasureConstants {
    * {@link Measure} for number of finished client RPCs.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_FINISHED_COUNT}.
+   * @deprecated since finished count can be inferred with a {@code Count} aggregation on {@link
+   *     #GRPC_CLIENT_SERVER_LATENCY}.
    */
   @Deprecated
   public static final MeasureLong RPC_CLIENT_FINISHED_COUNT =
@@ -252,28 +253,6 @@ public final class RpcMeasureConstants {
           MILLISECOND);
 
   /**
-   * {@link Measure} for total uncompressed bytes sent across all request messages per RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureDouble GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/uncompressed_sent_bytes_per_rpc",
-          "Total uncompressed bytes sent across all request messages per RPC",
-          BYTE);
-
-  /**
-   * {@link Measure} for total uncompressed bytes received across all response messages per RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureDouble GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/uncompressed_received_bytes_per_rpc",
-          "Total uncompressed bytes received across all request messages per RPC",
-          BYTE);
-
-  /**
    * {@link Measure} for number of started client RPCs.
    *
    * @since 0.13
@@ -281,15 +260,6 @@ public final class RpcMeasureConstants {
   public static final MeasureLong GRPC_CLIENT_STARTED_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/client/started_count", "Number of client RPCs (streams) started", COUNT);
-
-  /**
-   * {@link Measure} for number of finished client RPCs.
-   *
-   * @since 0.13
-   */
-  public static final MeasureLong GRPC_CLIENT_FINISHED_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/client/finished_count", "Number of client RPCs (streams) finished", COUNT);
 
   /**
    * {@link Measure} for number of messages sent in the RPC.
@@ -379,7 +349,7 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server uncompressed request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC}.
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC}.
    */
   @Deprecated
   public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES =
@@ -390,7 +360,7 @@ public final class RpcMeasureConstants {
    * {@link Measure} for gRPC server uncompressed response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC}.
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC}.
    */
   @Deprecated
   public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES =
@@ -412,7 +382,8 @@ public final class RpcMeasureConstants {
    * {@link Measure} for number of finished server RPCs.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_FINISHED_COUNT}.
+   * @deprecated since finished count can be inferred with a {@code Count} aggregation on {@link
+   *     #GRPC_SERVER_SERVER_LATENCY}.
    */
   @Deprecated
   public static final MeasureLong RPC_SERVER_FINISHED_COUNT =
@@ -464,28 +435,6 @@ public final class RpcMeasureConstants {
           BYTE);
 
   /**
-   * {@link Measure} for total uncompressed bytes sent across all request messages per RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureDouble GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/uncompressed_sent_bytes_per_rpc",
-          "Total uncompressed bytes sent across all request messages per RPC",
-          BYTE);
-
-  /**
-   * {@link Measure} for total uncompressed bytes received across all response messages per RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureDouble GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/uncompressed_received_bytes_per_rpc",
-          "Total uncompressed bytes received across all request messages per RPC",
-          BYTE);
-
-  /**
    * {@link Measure} for number of started server RPCs.
    *
    * @since 0.13
@@ -493,15 +442,6 @@ public final class RpcMeasureConstants {
   public static final MeasureLong GRPC_SERVER_STARTED_COUNT =
       Measure.MeasureLong.create(
           "grpc.io/server/started_count", "Number of server RPCs (streams) started", COUNT);
-
-  /**
-   * {@link Measure} for number of finished server RPCs.
-   *
-   * @since 0.13
-   */
-  public static final MeasureLong GRPC_SERVER_FINISHED_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/server/finished_count", "Number of server RPCs (streams) finished", COUNT);
 
   /**
    * {@link Measure} for number of messages sent in the RPC.

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -16,7 +16,6 @@
 
 package io.opencensus.contrib.grpc.metrics;
 
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_FINISHED_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC;
@@ -26,9 +25,6 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STARTED_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STATUS;
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC;
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC;
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_FINISHED_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC;
@@ -37,8 +33,6 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STARTED_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STATUS;
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC;
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_CLIENT_FINISHED_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_CLIENT_REQUEST_BYTES;
@@ -381,32 +375,6 @@ public final class RpcViewConstants {
           Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
-   * {@link View} for client uncompressed sent bytes per RPC.
-   *
-   * @since 0.13
-   */
-  public static final View GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW =
-      View.create(
-          View.Name.create("grpc.io/client/uncompressed_sent_bytes_per_rpc"),
-          "Uncompressed sent bytes per RPC",
-          GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC,
-          AGGREGATION_WITH_BYTES_HISTOGRAM,
-          Arrays.asList(GRPC_CLIENT_METHOD));
-
-  /**
-   * {@link View} for client uncompressed received bytes per RPC.
-   *
-   * @since 0.13
-   */
-  public static final View GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW =
-      View.create(
-          View.Name.create("grpc.io/client/uncompressed_received_bytes_per_rpc"),
-          "Uncompressed received bytes per RPC",
-          GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC,
-          AGGREGATION_WITH_BYTES_HISTOGRAM,
-          Arrays.asList(GRPC_CLIENT_METHOD));
-
-  /**
    * {@link View} for client sent messages per RPC.
    *
    * @since 0.13
@@ -448,13 +416,17 @@ public final class RpcViewConstants {
   /**
    * {@link View} for completed client RPCs.
    *
+   * <p>This {@code View} uses measure {@code GRPC_CLIENT_ROUNDTRIP_LATENCY}, since completed RPCs
+   * can be inferred over any measure recorded once per RPC (since it's just a count aggregation
+   * over the measure). It would be unnecessary to use a separate "count" measure.
+   *
    * @since 0.13
    */
   public static final View GRPC_CLIENT_COMPLETED_RPC_VIEW =
       View.create(
           View.Name.create("grpc.io/client/completed_rpcs"),
           "Number of completed client RPCs",
-          GRPC_CLIENT_FINISHED_COUNT,
+          GRPC_CLIENT_ROUNDTRIP_LATENCY,
           COUNT,
           Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
 
@@ -676,32 +648,6 @@ public final class RpcViewConstants {
           Arrays.asList(GRPC_SERVER_METHOD));
 
   /**
-   * {@link View} for server uncompressed sent bytes per RPC.
-   *
-   * @since 0.13
-   */
-  public static final View GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW =
-      View.create(
-          View.Name.create("grpc.io/server/uncompressed_sent_bytes_per_rpc"),
-          "Uncompressed sent bytes per RPC",
-          GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC,
-          AGGREGATION_WITH_BYTES_HISTOGRAM,
-          Arrays.asList(GRPC_SERVER_METHOD));
-
-  /**
-   * {@link View} for server uncompressed received bytes per RPC.
-   *
-   * @since 0.13
-   */
-  public static final View GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW =
-      View.create(
-          View.Name.create("grpc.io/server/uncompressed_received_bytes_per_rpc"),
-          "Uncompressed received bytes per RPC",
-          GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC,
-          AGGREGATION_WITH_BYTES_HISTOGRAM,
-          Arrays.asList(GRPC_SERVER_METHOD));
-
-  /**
    * {@link View} for server sent messages per RPC.
    *
    * @since 0.13
@@ -743,13 +689,17 @@ public final class RpcViewConstants {
   /**
    * {@link View} for completed server RPCs.
    *
+   * <p>This {@code View} uses measure {@code GRPC_SERVER_SERVER_LATENCY}, since completed RPCs can
+   * be inferred over any measure recorded once per RPC (since it's just a count aggregation over
+   * the measure). It would be unnecessary to use a separate "count" measure.
+   *
    * @since 0.13
    */
   public static final View GRPC_SERVER_COMPLETED_RPC_VIEW =
       View.create(
           View.Name.create("grpc.io/server/completed_rpcs"),
           "Number of completed server RPCs",
-          GRPC_SERVER_FINISHED_COUNT,
+          GRPC_SERVER_SERVER_LATENCY,
           COUNT,
           Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -172,7 +172,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client roundtrip latency in milliseconds.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
@@ -188,7 +188,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client server elapsed time in milliseconds.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_CLIENT_SERVER_LATENCY_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_SERVER_LATENCY_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW =
@@ -204,7 +204,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_CLIENT_SENT_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_REQUEST_BYTES_VIEW =
@@ -220,7 +220,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_RESPONSE_BYTES_VIEW =
@@ -236,7 +236,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client uncompressed request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW =
@@ -252,7 +252,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client uncompressed response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
@@ -268,7 +268,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client request message counts.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_REQUEST_COUNT_VIEW =
@@ -284,7 +284,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client response message counts.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_RESPONSE_COUNT_VIEW =
@@ -300,7 +300,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for started client RPCs.
    *
    * @since 0.12
-   * @deprecated in favor of {@link #RPC_CLIENT_STARTED_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_STARTED_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_STARTED_COUNT_CUMULATIVE_VIEW =
@@ -316,7 +316,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for finished client RPCs.
    *
    * @since 0.12
-   * @deprecated in favor of {@link #RPC_CLIENT_COMPLETED_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_COMPLETED_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_FINISHED_COUNT_CUMULATIVE_VIEW =
@@ -480,7 +480,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server latency in milliseconds.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_SERVER_SERVER_LATENCY_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_SERVER_LATENCY_VIEW =
@@ -496,7 +496,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server elapsed time in milliseconds.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_SERVER_SERVER_LATENCY_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_SERVER_ELAPSED_TIME_VIEW =
@@ -512,7 +512,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_SERVER_SENT_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_REQUEST_BYTES_VIEW =
@@ -528,7 +528,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_RESPONSE_BYTES_VIEW =
@@ -544,7 +544,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server uncompressed request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW =
@@ -560,7 +560,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server uncompressed response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
@@ -576,7 +576,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server request message counts.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_REQUEST_COUNT_VIEW =
@@ -592,7 +592,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server response message counts.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #RPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_RESPONSE_COUNT_VIEW =
@@ -608,7 +608,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for started server RPCs.
    *
    * @since 0.12
-   * @deprecated in favor of {@link #RPC_SERVER_STARTED_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_STARTED_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_STARTED_COUNT_CUMULATIVE_VIEW =
@@ -624,7 +624,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for finished server RPCs.
    *
    * @since 0.12
-   * @deprecated in favor of {@link #RPC_SERVER_COMPLETED_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_COMPLETED_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_FINISHED_COUNT_CUMULATIVE_VIEW =

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -16,6 +16,29 @@
 
 package io.opencensus.contrib.grpc.metrics;
 
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_FINISHED_COUNT;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_METHOD;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STARTED_COUNT;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STATUS;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_FINISHED_COUNT;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_METHOD;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STARTED_COUNT;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STATUS;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_CLIENT_FINISHED_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_CLIENT_REQUEST_BYTES;
@@ -85,9 +108,10 @@ public final class RpcViewConstants {
   static final List<Double> RPC_MILLIS_BUCKET_BOUNDARIES =
       Collections.unmodifiableList(
           Arrays.asList(
-              0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 13.0, 16.0, 20.0, 25.0, 30.0, 40.0,
-              50.0, 65.0, 80.0, 100.0, 130.0, 160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0,
-              800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0));
+              0.0, 0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 13.0,
+              16.0, 20.0, 25.0, 30.0, 40.0, 50.0, 65.0, 80.0, 100.0, 130.0, 160.0, 200.0, 250.0,
+              300.0, 400.0, 500.0, 650.0, 800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0,
+              100000.0));
 
   // Common histogram bucket boundaries for request/response count Views.
   @VisibleForTesting
@@ -132,7 +156,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client RPC errors.
    *
    * @since 0.8
+   * @deprecated since error count measure is deprecated.
    */
+  @Deprecated
   public static final View RPC_CLIENT_ERROR_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/client/error_count/cumulative"),
@@ -146,7 +172,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client roundtrip latency in milliseconds.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
       View.create(
           View.Name.create("grpc.io/client/roundtrip_latency/cumulative"),
@@ -160,7 +188,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client server elapsed time in milliseconds.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_CLIENT_SERVER_LATENCY_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW =
       View.create(
           View.Name.create("grpc.io/client/server_elapsed_time/cumulative"),
@@ -174,7 +204,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client request bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_CLIENT_SENT_BYTES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_REQUEST_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/client/request_bytes/cumulative"),
@@ -188,7 +220,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client response bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_RESPONSE_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/client/response_bytes/cumulative"),
@@ -202,7 +236,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client uncompressed request bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/client/uncompressed_request_bytes/cumulative"),
@@ -216,7 +252,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client uncompressed response bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/client/uncompressed_response_bytes/cumulative"),
@@ -230,7 +268,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client request message counts.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_REQUEST_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/client/request_count/cumulative"),
@@ -244,7 +284,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client response message counts.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_RESPONSE_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/client/response_count/cumulative"),
@@ -258,7 +300,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for started client RPCs.
    *
    * @since 0.12
+   * @deprecated in favor of {@link #RPC_CLIENT_STARTED_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_STARTED_COUNT_CUMULATIVE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/started_count/cumulative"),
@@ -272,7 +316,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for finished client RPCs.
    *
    * @since 0.12
+   * @deprecated in favor of {@link #RPC_CLIENT_COMPLETED_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_CLIENT_FINISHED_COUNT_CUMULATIVE_VIEW =
       View.create(
           View.Name.create("grpc.io/client/finished_count/cumulative"),
@@ -282,13 +328,145 @@ public final class RpcViewConstants {
           Arrays.asList(RPC_METHOD),
           CUMULATIVE);
 
+  /**
+   * {@link View} for client roundtrip latency in milliseconds.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/roundtrip_latency"),
+          "Latency in msecs",
+          GRPC_CLIENT_ROUNDTRIP_LATENCY,
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client server latency in milliseconds.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_SERVER_LATENCY_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/server_latency"),
+          "Server latency in msecs",
+          GRPC_CLIENT_SERVER_LATENCY,
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client sent bytes per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/sent_bytes_per_rpc"),
+          "Sent bytes per RPC",
+          GRPC_CLIENT_SENT_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client received bytes per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/received_bytes_per_rpc"),
+          "Received bytes per RPC",
+          GRPC_CLIENT_RECEIVED_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client uncompressed sent bytes per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/uncompressed_sent_bytes_per_rpc"),
+          "Uncompressed sent bytes per RPC",
+          GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client uncompressed received bytes per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/uncompressed_received_bytes_per_rpc"),
+          "Uncompressed received bytes per RPC",
+          GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client sent messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/sent_messages_per_rpc"),
+          "Number of messages sent in the RPC",
+          GRPC_CLIENT_SENT_MESSAGES_PER_RPC,
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client received messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/received_messages_per_rpc"),
+          "Number of response messages received per RPC",
+          GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC,
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for started client RPCs.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_STARTED_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/started_rpcs"),
+          "Number of started client RPCs",
+          GRPC_CLIENT_STARTED_COUNT,
+          COUNT,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for completed client RPCs.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_CLIENT_COMPLETED_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/completed_rpcs"),
+          "Number of completed client RPCs",
+          GRPC_CLIENT_FINISHED_COUNT,
+          COUNT,
+          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
+
   // Rpc server cumulative views.
 
   /**
    * Cumulative {@link View} for server RPC errors.
    *
    * @since 0.8
+   * @deprecated since error count measure is deprecated.
    */
+  @Deprecated
   public static final View RPC_SERVER_ERROR_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/server/error_count/cumulative"),
@@ -302,7 +480,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server latency in milliseconds.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_SERVER_SERVER_LATENCY_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_SERVER_LATENCY_VIEW =
       View.create(
           View.Name.create("grpc.io/server/server_latency/cumulative"),
@@ -316,7 +496,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server elapsed time in milliseconds.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_SERVER_SERVER_LATENCY_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_SERVER_ELAPSED_TIME_VIEW =
       View.create(
           View.Name.create("grpc.io/server/elapsed_time/cumulative"),
@@ -330,7 +512,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server request bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_SERVER_SENT_BYTES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_REQUEST_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/server/request_bytes/cumulative"),
@@ -344,7 +528,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server response bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_RESPONSE_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/server/response_bytes/cumulative"),
@@ -358,7 +544,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server uncompressed request bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/server/uncompressed_request_bytes/cumulative"),
@@ -372,7 +560,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server uncompressed response bytes.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
       View.create(
           View.Name.create("grpc.io/server/uncompressed_response_bytes/cumulative"),
@@ -386,7 +576,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server request message counts.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_REQUEST_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/server/request_count/cumulative"),
@@ -400,7 +592,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server response message counts.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #RPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_RESPONSE_COUNT_VIEW =
       View.create(
           View.Name.create("grpc.io/server/response_count/cumulative"),
@@ -414,7 +608,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for started server RPCs.
    *
    * @since 0.12
+   * @deprecated in favor of {@link #RPC_SERVER_STARTED_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_STARTED_COUNT_CUMULATIVE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/started_count/cumulative"),
@@ -428,7 +624,9 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for finished server RPCs.
    *
    * @since 0.12
+   * @deprecated in favor of {@link #RPC_SERVER_COMPLETED_RPC_VIEW}.
    */
+  @Deprecated
   public static final View RPC_SERVER_FINISHED_COUNT_CUMULATIVE_VIEW =
       View.create(
           View.Name.create("grpc.io/server/finished_count/cumulative"),
@@ -437,6 +635,123 @@ public final class RpcViewConstants {
           COUNT,
           Arrays.asList(RPC_METHOD),
           CUMULATIVE);
+
+  /**
+   * {@link View} for server server latency in milliseconds.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_SERVER_LATENCY_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/server_latency"),
+          "Server latency in msecs",
+          GRPC_SERVER_SERVER_LATENCY,
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for server sent bytes per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_SENT_BYTES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/sent_bytes_per_rpc"),
+          "Sent bytes per RPC",
+          GRPC_SERVER_SENT_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for server received bytes per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/received_bytes_per_rpc"),
+          "Received bytes per RPC",
+          GRPC_SERVER_RECEIVED_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for server uncompressed sent bytes per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/uncompressed_sent_bytes_per_rpc"),
+          "Uncompressed sent bytes per RPC",
+          GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for server uncompressed received bytes per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/uncompressed_received_bytes_per_rpc"),
+          "Uncompressed received bytes per RPC",
+          GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC,
+          AGGREGATION_WITH_BYTES_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for server sent messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/sent_messages_per_rpc"),
+          "Number of messages sent in the RPC",
+          GRPC_SERVER_SENT_MESSAGES_PER_RPC,
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for server received messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/received_messages_per_rpc"),
+          "Number of response messages received per RPC",
+          GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC,
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for started server RPCs.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_STARTED_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/started_rpcs"),
+          "Number of started server RPCs",
+          GRPC_SERVER_STARTED_COUNT,
+          COUNT,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for completed server RPCs.
+   *
+   * @since 0.13
+   */
+  public static final View GRPC_SERVER_COMPLETED_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/completed_rpcs"),
+          "Number of completed server RPCs",
+          GRPC_SERVER_FINISHED_COUNT,
+          COUNT,
+          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
 
   // Interval Stats
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -230,7 +230,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client uncompressed request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES_VIEW =
@@ -246,7 +246,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for client uncompressed response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES_VIEW =
@@ -516,7 +516,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server uncompressed request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES_VIEW =
@@ -532,7 +532,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for server uncompressed response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW}.
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW =

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -63,8 +63,6 @@ public final class RpcViews {
           RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW,
-          RpcViewConstants.GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW,
-          RpcViewConstants.GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_CLIENT_SERVER_LATENCY_VIEW,
           RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW,
           RpcViewConstants.GRPC_CLIENT_COMPLETED_RPC_VIEW,
@@ -73,8 +71,6 @@ public final class RpcViews {
           RpcViewConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW,
-          RpcViewConstants.GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW,
-          RpcViewConstants.GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW,
           RpcViewConstants.GRPC_SERVER_COMPLETED_RPC_VIEW);
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -27,6 +27,7 @@ import io.opencensus.stats.ViewManager;
  *
  * @since 0.11
  */
+@SuppressWarnings("deprecation")
 public final class RpcViews {
   @VisibleForTesting
   static final ImmutableSet<View> RPC_CUMULATIVE_VIEWS_SET =
@@ -53,6 +54,29 @@ public final class RpcViews {
           RpcViewConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW,
           RpcViewConstants.RPC_SERVER_STARTED_COUNT_CUMULATIVE_VIEW,
           RpcViewConstants.RPC_SERVER_FINISHED_COUNT_CUMULATIVE_VIEW);
+
+  @VisibleForTesting
+  static final ImmutableSet<View> GRPC_CUMULATIVE_VIEWS_SET =
+      ImmutableSet.of(
+          RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW,
+          RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_CLIENT_SERVER_LATENCY_VIEW,
+          RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW,
+          RpcViewConstants.GRPC_CLIENT_COMPLETED_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW,
+          RpcViewConstants.GRPC_SERVER_SENT_BYTES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_COMPLETED_RPC_VIEW);
 
   @VisibleForTesting
   static final ImmutableSet<View> RPC_INTERVAL_VIEWS_SET =
@@ -103,12 +127,34 @@ public final class RpcViews {
           RpcViewConstants.RPC_SERVER_FINISHED_COUNT_HOUR_VIEW);
 
   /**
+   * Registers all standard gRPC views.
+   *
+   * <p>It is recommended to call this method before doing any RPC call to avoid missing stats.
+   *
+   * @since 0.13
+   */
+  public static void registerAllGrpcViews() {
+    registerAllCumulativeViews(Stats.getViewManager());
+  }
+
+  @VisibleForTesting
+  static void registerAllGrpcViews(ViewManager viewManager) {
+    for (View view : GRPC_CUMULATIVE_VIEWS_SET) {
+      viewManager.registerView(view);
+    }
+  }
+
+  /**
    * Registers all standard cumulative views.
    *
    * <p>It is recommended to call this method before doing any RPC call to avoid missing stats.
    *
    * @since 0.11.0
+   * @deprecated in favor of {@link #registerAllGrpcViews()}. It is likely that there won't be stats
+   *     for the old views, but you may still want to register the old views before they are
+   *     completely removed.
    */
+  @Deprecated
   public static void registerAllCumulativeViews() {
     registerAllCumulativeViews(Stats.getViewManager());
   }
@@ -126,7 +172,9 @@ public final class RpcViews {
    * <p>It is recommended to call this method before doing any RPC call to avoid missing stats.
    *
    * @since 0.11.0
+   * @deprecated because interval window is deprecated. There won't be interval views in the future.
    */
+  @Deprecated
   public static void registerAllIntervalViews() {
     registerAllIntervalViews(Stats.getViewManager());
   }
@@ -141,8 +189,8 @@ public final class RpcViews {
   /**
    * Registers all views.
    *
-   * <p>This is equivalent with calling {@link #registerAllCumulativeViews()} and {@link
-   * #registerAllIntervalViews()}.
+   * <p>This is equivalent with calling {@link #registerAllCumulativeViews()}, {@link
+   * #registerAllIntervalViews()} and {@link #registerAllGrpcViews()}.
    *
    * <p>It is recommended to call this method before doing any RPC call to avoid missing stats.
    *
@@ -154,6 +202,7 @@ public final class RpcViews {
 
   @VisibleForTesting
   static void registerAllViews(ViewManager viewManager) {
+    registerAllGrpcViews(viewManager);
     registerAllCumulativeViews(viewManager);
     registerAllIntervalViews(viewManager);
   }

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -185,20 +185,21 @@ public final class RpcViews {
   /**
    * Registers all views.
    *
-   * <p>This is equivalent with calling {@link #registerAllCumulativeViews()}, {@link
-   * #registerAllIntervalViews()} and {@link #registerAllGrpcViews()}.
+   * <p>This is equivalent with calling {@link #registerAllCumulativeViews()} and {@link
+   * #registerAllIntervalViews()}.
    *
    * <p>It is recommended to call this method before doing any RPC call to avoid missing stats.
    *
    * @since 0.11.0
+   * @deprecated in favor of {@link #registerAllGrpcViews()}.
    */
+  @Deprecated
   public static void registerAllViews() {
     registerAllViews(Stats.getViewManager());
   }
 
   @VisibleForTesting
   static void registerAllViews(ViewManager viewManager) {
-    registerAllGrpcViews(viewManager);
     registerAllCumulativeViews(viewManager);
     registerAllIntervalViews(viewManager);
   }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
@@ -30,6 +30,10 @@ public class RpcMeasureConstantsTest {
   public void testConstants() {
     assertThat(RpcMeasureConstants.RPC_STATUS).isNotNull();
     assertThat(RpcMeasureConstants.RPC_METHOD).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_METHOD).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_METHOD).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_STATUS).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_STATUS).isNotNull();
 
     // Test client measurement descriptors.
     assertThat(RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT).isNotNull();
@@ -44,6 +48,17 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.RPC_CLIENT_FINISHED_COUNT).isNotNull();
     assertThat(RpcMeasureConstants.RPC_CLIENT_SERVER_ELAPSED_TIME).isNotNull();
 
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_STARTED_COUNT).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_FINISHED_COUNT).isNotNull();
+
     // Test server measurement descriptors.
     assertThat(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT).isNotNull();
     assertThat(RpcMeasureConstants.RPC_SERVER_REQUEST_BYTES).isNotNull();
@@ -55,5 +70,15 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.RPC_SERVER_RESPONSE_COUNT).isNotNull();
     assertThat(RpcMeasureConstants.RPC_SERVER_STARTED_COUNT).isNotNull();
     assertThat(RpcMeasureConstants.RPC_SERVER_FINISHED_COUNT).isNotNull();
+
+    assertThat(RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_STARTED_COUNT).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_FINISHED_COUNT).isNotNull();
   }
 }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
@@ -52,12 +52,9 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_STARTED_COUNT).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_FINISHED_COUNT).isNotNull();
 
     // Test server measurement descriptors.
     assertThat(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT).isNotNull();
@@ -75,10 +72,7 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_STARTED_COUNT).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_SERVER_FINISHED_COUNT).isNotNull();
   }
 }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -105,8 +105,6 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
-    assertThat(RpcViewConstants.GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW).isNotNull();
-    assertThat(RpcViewConstants.GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_SERVER_LATENCY_VIEW).isNotNull();
@@ -123,8 +121,6 @@ public final class RpcViewConstantsTest {
 
     assertThat(RpcViewConstants.GRPC_SERVER_SENT_BYTES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
-    assertThat(RpcViewConstants.GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW).isNotNull();
-    assertThat(RpcViewConstants.GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW).isNotNull();

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -56,9 +56,10 @@ public final class RpcViewConstantsTest {
         .inOrder();
     assertThat(RpcViewConstants.RPC_MILLIS_BUCKET_BOUNDARIES)
         .containsExactly(
-            0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 13.0, 16.0, 20.0, 25.0, 30.0, 40.0, 50.0,
-            65.0, 80.0, 100.0, 130.0, 160.0, 200.0, 250.0, 300.0, 400.0, 500.0, 650.0, 800.0,
-            1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0, 100000.0)
+            0.0, 0.01, 0.05, 0.1, 0.3, 0.6, 0.8, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 8.0, 10.0, 13.0,
+            16.0, 20.0, 25.0, 30.0, 40.0, 50.0, 65.0, 80.0, 100.0, 130.0, 160.0, 200.0, 250.0,
+            300.0, 400.0, 500.0, 650.0, 800.0, 1000.0, 2000.0, 5000.0, 10000.0, 20000.0, 50000.0,
+            100000.0)
         .inOrder();
     assertThat(RpcViewConstants.RPC_COUNT_BUCKET_BOUNDARIES)
         .containsExactly(
@@ -101,6 +102,15 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.RPC_CLIENT_RESPONSE_COUNT_VIEW).isNotNull();
     assertThat(RpcViewConstants.RPC_CLIENT_SERVER_ELAPSED_TIME_VIEW).isNotNull();
 
+    assertThat(RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_SERVER_LATENCY_VIEW).isNotNull();
+
     // Test server distribution view descriptors.
     assertThat(RpcViewConstants.RPC_SERVER_ERROR_COUNT_VIEW).isNotNull();
     assertThat(RpcViewConstants.RPC_SERVER_SERVER_LATENCY_VIEW).isNotNull();
@@ -110,6 +120,14 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES_VIEW).isNotNull();
     assertThat(RpcViewConstants.RPC_SERVER_REQUEST_COUNT_VIEW).isNotNull();
     assertThat(RpcViewConstants.RPC_SERVER_RESPONSE_COUNT_VIEW).isNotNull();
+
+    assertThat(RpcViewConstants.GRPC_SERVER_SENT_BYTES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_UNCOMPRESSED_SENT_BYTES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_UNCOMPRESSED_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW).isNotNull();
 
     // Test client interval view descriptors.
     assertThat(RpcViewConstants.RPC_CLIENT_ERROR_COUNT_MINUTE_VIEW).isNotNull();

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
@@ -43,6 +43,9 @@ public class RpcViewsTest {
     for (View view : RpcViews.RPC_INTERVAL_VIEWS_SET) {
       assertThat(fakeViewManager.isRegistered(view)).isFalse();
     }
+    for (View view : RpcViews.GRPC_CUMULATIVE_VIEWS_SET) {
+      assertThat(fakeViewManager.isRegistered(view)).isFalse();
+    }
   }
 
   @Test
@@ -55,6 +58,24 @@ public class RpcViewsTest {
     for (View view : RpcViews.RPC_INTERVAL_VIEWS_SET) {
       assertThat(fakeViewManager.isRegistered(view)).isTrue();
     }
+    for (View view : RpcViews.GRPC_CUMULATIVE_VIEWS_SET) {
+      assertThat(fakeViewManager.isRegistered(view)).isFalse();
+    }
+  }
+
+  @Test
+  public void registerGrpcViews() {
+    FakeViewManager fakeViewManager = new FakeViewManager();
+    RpcViews.registerAllGrpcViews(fakeViewManager);
+    for (View view : RpcViews.RPC_CUMULATIVE_VIEWS_SET) {
+      assertThat(fakeViewManager.isRegistered(view)).isFalse();
+    }
+    for (View view : RpcViews.RPC_INTERVAL_VIEWS_SET) {
+      assertThat(fakeViewManager.isRegistered(view)).isFalse();
+    }
+    for (View view : RpcViews.GRPC_CUMULATIVE_VIEWS_SET) {
+      assertThat(fakeViewManager.isRegistered(view)).isTrue();
+    }
   }
 
   @Test
@@ -65,6 +86,9 @@ public class RpcViewsTest {
       assertThat(fakeViewManager.isRegistered(view)).isTrue();
     }
     for (View view : RpcViews.RPC_INTERVAL_VIEWS_SET) {
+      assertThat(fakeViewManager.isRegistered(view)).isTrue();
+    }
+    for (View view : RpcViews.GRPC_CUMULATIVE_VIEWS_SET) {
       assertThat(fakeViewManager.isRegistered(view)).isTrue();
     }
   }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
@@ -89,7 +89,7 @@ public class RpcViewsTest {
       assertThat(fakeViewManager.isRegistered(view)).isTrue();
     }
     for (View view : RpcViews.GRPC_CUMULATIVE_VIEWS_SET) {
-      assertThat(fakeViewManager.isRegistered(view)).isTrue();
+      assertThat(fakeViewManager.isRegistered(view)).isFalse();
     }
   }
 


### PR DESCRIPTION
Update RPC constants according to [specs](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/gRPC.md) and our meeting today.

Equivalent changes to OC C++: https://github.com/census-instrumentation/opencensus-cpp/pull/138.