### PR TITLE
Remove java doc about overflow cases in Duration.toMillis().

### DIFF
--- a/api/src/main/java/io/opencensus/common/Duration.java
+++ b/api/src/main/java/io/opencensus/common/Duration.java
@@ -82,9 +82,6 @@ public abstract class Duration implements Comparable<Duration> {
   /**
    * Converts a {@link Duration} to milliseconds.
    *
-   * <p>Returns {@code Long.MIN_VALUE} if conversion would negatively overflow, or {@code
-   * Long.MAX_VALUE} if it would positively overflow.
-   *
    * @return the milliseconds representation of this {@code Duration}.
    * @since 0.13
    */


### PR DESCRIPTION
Closes https://github.com/census-instrumentation/opencensus-java/issues/1133.

We have a [limit on seconds](https://github.com/census-instrumentation/opencensus-java/blob/master/api/src/main/java/io/opencensus/common/Duration.java#L44) and [nanoseconds](https://github.com/census-instrumentation/opencensus-java/blob/master/api/src/main/java/io/opencensus/common/Duration.java#L49) for Duration. That range is within (Long.MIN_VALUE, Long.MAX_VALUE) so the conversion should never cause overflow.