### PR TITLE
Add a Markdown changelog, starting at version 0.9.0 (closes #945).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,82 @@
+## Unreleased
+
+- Support building with Java 9.
+- Add a QuickStart example.
+- Remove extraneous dependencies from the Agent's `pom.xml`.
+- Deprecate `Window` and `WindowData`.
+- Add a configuration class to the Prometheus stats exporter.
+- Fix build on platforms that are not supported by `netty-tcnative`.
+- Add Jaeger trace exporter.
+- Add a gRPC Hello World example.
+- Remove usages of Guava collections in `opencensus-api`.
+- Set unit "1" when the aggregation type is Count.
+- Auto detect GCE and GKE Stackdriver MonitoredResources.
+- Make Error Prone and FindBugs annotations `compileOnly` dependencies.
+- Deprecate `Mean` and `MeanData`.
+- Sort `TagKey`s in `View.create(...)`.
+- Add utility class to expose default HTTP measures, tags and view, and register
+  default views.
+- Add new RPC measure and view constants, deprecate old ones.
+- Makes the trace and span ID fields mandatory in binary format.
+- Auto detect AWS EC2 resources.
+- Add `Duration.toMillis()`.
+
+## 0.12.3 - 2018-04-13
+- Substitute non-ascii characters in B3Format header key.
+
+## 0.12.2 - 2018-02-26
+- Upgrade disruptor to include the fix for SleepingWaitStrategy causing 100%
+  CPU.
+
+## 0.12.1 - 2018-02-26
+- Fix performance issue where unused objects were referenced by the Disruptor.
+- Fix synchonization issue in the use of the Disruptor.
+
+## 0.12.0 - 2018-02-16
+- Rename trace exporters that have inconsistent naming. Exporters with legacy
+  names are deprecated.
+- Fixed bug in CloudTraceFormat that made it impossible to use short span id's.
+- Add `since` Javadoc tag to all APIs.
+- Add a configuration class to create StackdriverTraceExporter.
+- Add MessageEvent and deprecate NetworkEvent.
+- Instana Trace Exporter.
+- Prometheus Stats Exporter.
+- Stats Zpages: RpcZ and StatsZ.
+- Dependency updates.
+
+## 0.11.1 - 2018-01-23
+- Fixed bug that made it impossible to use short span id's (#950).
+
+## 0.11.0 - 2018-01-19
+- Add TextFormat API and two implementations (B3Format and CloudTraceFormat).
+- Add helper class to configure and create StackdriverStatsExporter.
+- Add helper methods in tracer to wrap Runnable and Callbacks and to run them.
+- Increase trace exporting interval to 5s.
+- Add helper class to register views.
+- Make stackdriver stats exporter compatible with GAE Java7.
+- Add SignalFX stats exporter.
+- Add http propagation APIs.
+- Dependency updates.
+
+## 0.10.0 - 2017-12-04
+- Add NoopRunningSpanStore and NoopSampledSpanStore.
+- Change the message event to include (un)compressed sizes for Tracez Zpage.
+- Use AppEngine compatible way to create threads.
+- Add new factory methods that support setting custom Stackdriver
+  MonitoredResource for Stackdriver Stats Exporter.
+- Dependency updates.
+
+## 0.9.1 - 2017-11-29
+- Fix several implementation bugs in Stackdriver Stats Exporter (#830, #831,
+  etc.).
+- Update length limit for View.Name to 255 (previously it's 256).
+
+## 0.9.0 - 2017-11-17
+- Initial stats and tagging implementation for Java (`impl`) and Android
+  (`impl-lite`). This implements all the stats and tagging APIs since v0.8.0.
+- Deprecate Tags.setState and Stats.setState.
+- Add a setStatus method in the Span.
+- OpenCensus Stackdriver Stats Exporter.
+- OpenCensus Stackdriver Trace Exporter is updated to use Stackdriver Trace V2
+  APIs.
+- Dependency updates.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -121,7 +121,8 @@ could mean that `import-control.xml` needs to be updated.
 
 ## Proposing changes
 
-Create a Pull Request with your changes. The continuous integration build will
-run the tests and static analysis. It will also check that the pull request
-branch has no merge commits. When the changes are accepted, they will be merged
-or cherry-picked by an OpenCensus core developer.
+Create a Pull Request with your changes. Please add any user-visible changes to
+CHANGELOG.md. The continuous integration build will run the tests and static
+analysis. It will also check that the pull request branch has no merge commits.
+When the changes are accepted, they will be merged or cherry-picked by an
+OpenCensus core developer.


### PR DESCRIPTION
Most of the entries are copied from the GitHub releases page or commit messages.