### PR TITLE
Rename StatsRunner to TagContextExample because it's more about TagContext.

### DIFF
--- a/examples/BUILD.bazel
+++ b/examples/BUILD.bazel
@@ -92,8 +92,8 @@ java_library(
 )
 
 java_binary(
-    name = "StatsRunner",
-    main_class = "io.opencensus.examples.stats.StatsRunner",
+    name = "TagContextExample",
+    main_class = "io.opencensus.examples.tags.TagContextExample",
     runtime_deps = [
         ":opencensus_examples",
     ],

--- a/examples/README.md
+++ b/examples/README.md
@@ -17,21 +17,21 @@ $ mvn package appassembler:assemble
 $ bazel build :all
 ```
 
-## To run "StatsRunner" example use
+## To run "TagContextExample" use
 
 ### Gradle
 ```
-$ ./build/install/opencensus-examples/bin/StatsRunner
+$ ./build/install/opencensus-examples/bin/TagContextExample
 ```
 
 ### Maven
 ```
-$ ./target/appassembler/bin/StatsRunner
+$ ./target/appassembler/bin/TagContextExample
 ```
 
 ### Bazel
 ```
-$ ./bazel-bin/StatsRunner
+$ ./bazel-bin/TagContextExample
 ```
 
 ## To run "ZPagesTester"

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -84,9 +84,9 @@ apply plugin: 'application'
 
 startScripts.enabled = false
 
-task statsRunner(type: CreateStartScripts) {
-    mainClassName = 'io.opencensus.examples.stats.StatsRunner'
-    applicationName = 'StatsRunner'
+task tagContextExample(type: CreateStartScripts) {
+    mainClassName = 'io.opencensus.examples.tags.TagContextExample'
+    applicationName = 'TagContextExample'
     outputDir = new File(project.buildDir, 'tmp')
     classpath = jar.outputs.files + project.configurations.runtime
 }
@@ -144,7 +144,7 @@ applicationDistribution.into('bin') {
     from(multiSpansTracing)
     from(multiSpansScopedTracing)
     from(multiSpansContextTracing)
-    from(statsRunner)
+    from(tagContextExample)
     from(zPagesTester)
     from(quickStart)
     from(helloWorldServer)

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -105,8 +105,8 @@
         <configuration>
           <programs>
             <program>
-              <id>StatsRunner</id>
-              <mainClass>io.opencensus.examples.stats.StatsRunner</mainClass>
+              <id>TagContextExample</id>
+              <mainClass>io.opencensus.examples.tags.TagContextExample</mainClass>
             </program>
             <program>
               <id>MultiSpansTracing</id>

--- a/examples/src/main/java/io/opencensus/examples/tags/TagContextExample.java
+++ b/examples/src/main/java/io/opencensus/examples/tags/TagContextExample.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opencensus.examples.stats;
+package io.opencensus.examples.tags;
 
 import io.opencensus.common.Scope;
 import io.opencensus.stats.Measure.MeasureDouble;
@@ -26,8 +26,8 @@ import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.Tags;
 
-/** Simple program that uses Stats contexts. */
-public class StatsRunner {
+/** Simple program that uses {@link TagContext}. */
+public class TagContextExample {
 
   private static final TagKey K1 = TagKey.create("k1");
   private static final TagKey K2 = TagKey.create("k2");
@@ -46,7 +46,7 @@ public class StatsRunner {
   private static final Tagger tagger = Tags.getTagger();
   private static final StatsRecorder statsRecorder = Stats.getStatsRecorder();
 
-  private StatsRunner() {}
+  private TagContextExample() {}
 
   /**
    * Main method.


### PR DESCRIPTION
Closes https://github.com/census-instrumentation/opencensus-java/issues/1154.