### PR TITLE
Set bucket bounds as le labels for Prometheus exporter.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 - Fix a typo on displaying Aggregation Type for a View on StatsZ page.
-- Set bucket bounds as le labels for Prometheus Stats exporter.
+- Set bucket bounds as "le" labels for Prometheus Stats exporter.
 
 ## 0.13.0 - 2018-04-27
 - Support building with Java 9.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Fix a typo on displaying Aggregation Type for a View on StatsZ page.
+- Set bucket bounds as le labels for Prometheus Stats exporter.
 
 ## 0.13.0 - 2018-04-27
 - Support building with Java 9.

--- a/exporters/stats/prometheus/README.md
+++ b/exporters/stats/prometheus/README.md
@@ -79,3 +79,9 @@ and [Bridges](https://github.com/prometheus/client_java#bridges).
 Java 7 or above is required for using this exporter.
 
 ## FAQ
+
+### Why did I get an IllegalStateException when exporting histogram stats?
+
+If you want to export histogram stats, please make sure you don't have an "le" tag key in your 
+distribution views. 
+For Prometheus Histogram, ["le" is a reserved label for bucket boundaries](https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L88).

--- a/exporters/stats/prometheus/README.md
+++ b/exporters/stats/prometheus/README.md
@@ -79,9 +79,3 @@ and [Bridges](https://github.com/prometheus/client_java#bridges).
 Java 7 or above is required for using this exporter.
 
 ## FAQ
-
-### Why did I get an IllegalStateException when exporting histogram stats?
-
-If you want to export histogram stats, please make sure you don't have an "le" tag key in your 
-distribution views. 
-For Prometheus Histogram, ["le" is a reserved label for bucket boundaries](https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L88).

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
@@ -97,7 +97,6 @@ final class PrometheusExportUtils {
         Collector.sanitizeMetricName(OPENCENSUS_NAMESPACE + '_' + view.getName().asString());
     Type type = getType(view.getAggregation(), view.getWindow());
     List<String> labelNames = convertToLabelNames(view.getColumns());
-    checkLeLabelInLabelNames(labelNames, type);
     List<Sample> samples = Lists.newArrayList();
     for (Entry<List</*@Nullable*/ TagValue>, AggregationData> entry :
         viewData.getAggregationMap().entrySet()) {
@@ -182,9 +181,8 @@ final class PrometheusExportUtils {
         new Function<DistributionData, Void>() {
           @Override
           public Void apply(DistributionData arg) {
-            // For histogram buckets, manually add the bucket boundaries as "le" labels.
-            // See github.com/prometheus/client_java/blob/master/
-            // simpleclient/src/main/java/io/prometheus/client/Histogram.java#L329
+            // For histogram buckets, manually add the bucket boundaries as "le" labels. See
+            // https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L329
             @SuppressWarnings("unchecked")
             Distribution distribution = (Distribution) aggregation;
             List<Double> boundaries = distribution.getBucketBoundaries().getBoundaries();
@@ -268,8 +266,8 @@ final class PrometheusExportUtils {
     return labelNames;
   }
 
-  // Similar check to github.com/prometheus/client_java/blob/master/
-  // simpleclient/src/main/java/io/prometheus/client/Histogram.java#L88
+  // Similar check to
+  // https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L88
   private static void checkLeLabelInLabelNames(List<String> labelNames, Type type) {
     if (!Type.HISTOGRAM.equals(type)) {
       return;

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
@@ -182,7 +182,7 @@ final class PrometheusExportUtils {
           @Override
           public Void apply(DistributionData arg) {
             // For histogram buckets, manually add the bucket boundaries as "le" labels. See
-            // https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L329
+            // https://github.com/prometheus/client_java/commit/ed184d8e50c82e98bb2706723fff764424840c3a#diff-c505abbde72dd6bf36e89917b3469404R241
             @SuppressWarnings("unchecked")
             Distribution distribution = (Distribution) aggregation;
             List<Double> boundaries = distribution.getBucketBoundaries().getBoundaries();
@@ -267,7 +267,7 @@ final class PrometheusExportUtils {
   }
 
   // Similar check to
-  // https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L88
+  // https://github.com/prometheus/client_java/commit/ed184d8e50c82e98bb2706723fff764424840c3a#diff-c505abbde72dd6bf36e89917b3469404R78
   private static void checkLeLabelInLabelNames(List<String> labelNames, Type type) {
     if (!Type.HISTOGRAM.equals(type)) {
       return;

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
@@ -263,7 +263,10 @@ final class PrometheusExportUtils {
   private static void checkLeLabelInLabelNames(List<String> labelNames) {
     for (String label : labelNames) {
       if (LABEL_NAME_BUCKET_BOUND.equals(label)) {
-        throw new IllegalStateException("Prometheus Histogram cannot have a label named 'le'.");
+        throw new IllegalStateException(
+            "Prometheus Histogram cannot have a label named 'le', "
+                + "because it is a reserved label for bucket boundaries. "
+                + "Please remove this tag key from your view.");
       }
     }
   }

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.exporter.stats.prometheus;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.exporter.stats.prometheus.PrometheusExportUtils.LABEL_NAME_BUCKET_BOUND;
 import static io.opencensus.exporter.stats.prometheus.PrometheusExportUtils.OPENCENSUS_HELP_MSG;
 import static io.opencensus.exporter.stats.prometheus.PrometheusExportUtils.OPENCENSUS_NAMESPACE;
 import static io.opencensus.exporter.stats.prometheus.PrometheusExportUtils.SAMPLE_SUFFIX_BUCKET;
@@ -85,6 +86,7 @@ public class PrometheusExportUtilsTest {
   private static final TagKey K1 = TagKey.create("k1");
   private static final TagKey K2 = TagKey.create("k2");
   private static final TagKey K3 = TagKey.create("k-3");
+  private static final TagKey TAG_KEY_LE = TagKey.create(LABEL_NAME_BUCKET_BOUND);
   private static final TagValue V1 = TagValue.create("v1");
   private static final TagValue V2 = TagValue.create("v2");
   private static final TagValue V3 = TagValue.create("v-3");
@@ -118,6 +120,7 @@ public class PrometheusExportUtilsTest {
     assertThat(SAMPLE_SUFFIX_BUCKET).isEqualTo("_bucket");
     assertThat(SAMPLE_SUFFIX_COUNT).isEqualTo("_count");
     assertThat(SAMPLE_SUFFIX_SUM).isEqualTo("_sum");
+    assertThat(LABEL_NAME_BUCKET_BOUND).isEqualTo("le");
   }
 
   @Test
@@ -166,45 +169,57 @@ public class PrometheusExportUtilsTest {
   public void getSamples() {
     assertThat(
             PrometheusExportUtils.getSamples(
-                SAMPLE_NAME, Arrays.asList(K1, K2), Arrays.asList(V1, V2), SUM_DATA_DOUBLE))
+                SAMPLE_NAME, Arrays.asList(K1, K2), Arrays.asList(V1, V2), SUM_DATA_DOUBLE, SUM))
         .containsExactly(
             new Sample(SAMPLE_NAME, Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), -5.5));
     assertThat(
             PrometheusExportUtils.getSamples(
-                SAMPLE_NAME, Arrays.asList(K3), Arrays.asList(V3), SUM_DATA_LONG))
+                SAMPLE_NAME, Arrays.asList(K3), Arrays.asList(V3), SUM_DATA_LONG, SUM))
         .containsExactly(
             new Sample(SAMPLE_NAME, Arrays.asList("k_3"), Arrays.asList("v-3"), 123456789));
     assertThat(
             PrometheusExportUtils.getSamples(
-                SAMPLE_NAME, Arrays.asList(K1, K3), Arrays.asList(V1, null), COUNT_DATA))
+                SAMPLE_NAME, Arrays.asList(K1, K3), Arrays.asList(V1, null), COUNT_DATA, COUNT))
         .containsExactly(
             new Sample(SAMPLE_NAME, Arrays.asList("k1", "k_3"), Arrays.asList("v1", ""), 12345));
     assertThat(
             PrometheusExportUtils.getSamples(
-                SAMPLE_NAME, Arrays.asList(K3), Arrays.asList(V3), MEAN_DATA))
+                SAMPLE_NAME, Arrays.asList(K3), Arrays.asList(V3), MEAN_DATA, MEAN))
         .containsExactly(
             new Sample(SAMPLE_NAME + "_count", Arrays.asList("k_3"), Arrays.asList("v-3"), 22),
             new Sample(SAMPLE_NAME + "_sum", Arrays.asList("k_3"), Arrays.asList("v-3"), 74.8))
         .inOrder();
     assertThat(
             PrometheusExportUtils.getSamples(
-                SAMPLE_NAME, Arrays.asList(K1), Arrays.asList(V1), DISTRIBUTION_DATA))
+                SAMPLE_NAME, Arrays.asList(K1), Arrays.asList(V1), DISTRIBUTION_DATA, DISTRIBUTION))
         .containsExactly(
-            new Sample(SAMPLE_NAME + "_bucket", Arrays.asList("k1"), Arrays.asList("v1"), 0),
-            new Sample(SAMPLE_NAME + "_bucket", Arrays.asList("k1"), Arrays.asList("v1"), 2),
-            new Sample(SAMPLE_NAME + "_bucket", Arrays.asList("k1"), Arrays.asList("v1"), 2),
-            new Sample(SAMPLE_NAME + "_bucket", Arrays.asList("k1"), Arrays.asList("v1"), 1),
+            new Sample(
+                SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "-5.0"), 0),
+            new Sample(
+                SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "0.0"), 2),
+            new Sample(
+                SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "5.0"), 2),
+            new Sample(
+                SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "+Inf"), 1),
             new Sample(SAMPLE_NAME + "_count", Arrays.asList("k1"), Arrays.asList("v1"), 5),
             new Sample(SAMPLE_NAME + "_sum", Arrays.asList("k1"), Arrays.asList("v1"), 22.0))
         .inOrder();
     assertThat(
             PrometheusExportUtils.getSamples(
-                SAMPLE_NAME, Arrays.asList(K1, K2), Arrays.asList(V1, V2), LAST_VALUE_DATA_DOUBLE))
+                SAMPLE_NAME,
+                Arrays.asList(K1, K2),
+                Arrays.asList(V1, V2),
+                LAST_VALUE_DATA_DOUBLE,
+                LAST_VALUE))
         .containsExactly(
             new Sample(SAMPLE_NAME, Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), 7.9));
     assertThat(
             PrometheusExportUtils.getSamples(
-                SAMPLE_NAME, Arrays.asList(K3), Arrays.asList(V3), LAST_VALUE_DATA_LONG))
+                SAMPLE_NAME,
+                Arrays.asList(K3),
+                Arrays.asList(V3),
+                LAST_VALUE_DATA_LONG,
+                LAST_VALUE))
         .containsExactly(
             new Sample(SAMPLE_NAME, Arrays.asList("k_3"), Arrays.asList("v-3"), 66666666));
   }
@@ -214,7 +229,23 @@ public class PrometheusExportUtilsTest {
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Tag keys and tag values have different sizes.");
     PrometheusExportUtils.getSamples(
-        SAMPLE_NAME, Arrays.asList(K1, K2, K3), Arrays.asList(V1, V2), DISTRIBUTION_DATA);
+        SAMPLE_NAME,
+        Arrays.asList(K1, K2, K3),
+        Arrays.asList(V1, V2),
+        DISTRIBUTION_DATA,
+        DISTRIBUTION);
+  }
+
+  @Test
+  public void getSamples_Histogram_DisallowLeLabelName() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("Prometheus Histogram cannot have a label named 'le'.");
+    PrometheusExportUtils.getSamples(
+        SAMPLE_NAME,
+        Arrays.asList(K1, K2, TAG_KEY_LE),
+        Arrays.asList(V1, V2, V3),
+        DISTRIBUTION_DATA,
+        DISTRIBUTION);
   }
 
   @Test
@@ -266,23 +297,23 @@ public class PrometheusExportUtilsTest {
                 Arrays.asList(
                     new Sample(
                         OPENCENSUS_NAMESPACE + "_view_3_bucket",
-                        Arrays.asList("k1"),
-                        Arrays.asList("v-3"),
+                        Arrays.asList("k1", "le"),
+                        Arrays.asList("v-3", "-5.0"),
                         0),
                     new Sample(
                         OPENCENSUS_NAMESPACE + "_view_3_bucket",
-                        Arrays.asList("k1"),
-                        Arrays.asList("v-3"),
+                        Arrays.asList("k1", "le"),
+                        Arrays.asList("v-3", "0.0"),
                         2),
                     new Sample(
                         OPENCENSUS_NAMESPACE + "_view_3_bucket",
-                        Arrays.asList("k1"),
-                        Arrays.asList("v-3"),
+                        Arrays.asList("k1", "le"),
+                        Arrays.asList("v-3", "5.0"),
                         2),
                     new Sample(
                         OPENCENSUS_NAMESPACE + "_view_3_bucket",
-                        Arrays.asList("k1"),
-                        Arrays.asList("v-3"),
+                        Arrays.asList("k1", "le"),
+                        Arrays.asList("v-3", "+Inf"),
                         1),
                     new Sample(
                         OPENCENSUS_NAMESPACE + "_view_3_count",

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
@@ -239,7 +239,10 @@ public class PrometheusExportUtilsTest {
   @Test
   public void getSamples_Histogram_DisallowLeLabelName() {
     thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("Prometheus Histogram cannot have a label named 'le'.");
+    thrown.expectMessage(
+        "Prometheus Histogram cannot have a label named 'le', "
+            + "because it is a reserved label for bucket boundaries. "
+            + "Please remove this tag key from your view.");
     PrometheusExportUtils.getSamples(
         SAMPLE_NAME,
         Arrays.asList(K1, K2, TAG_KEY_LE),

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
@@ -33,7 +33,6 @@ import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.Aggregation.LastValue;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Aggregation.Sum;
-import io.opencensus.stats.AggregationData;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
 import io.opencensus.stats.AggregationData.LastValueDataDouble;
@@ -56,7 +55,6 @@ import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.Collector.Type;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -275,18 +273,6 @@ public class PrometheusExportUtilsTest {
             + "because it is a reserved label for bucket boundaries. "
             + "Please remove this tag key from your view.");
     PrometheusExportUtils.createDescribableMetricFamilySamples(DISTRIBUTION_VIEW_WITH_LE_KEY);
-  }
-
-  @Test
-  public void createMetricFamilySamples_Histogram_SkipStatsWithLeLabelName() {
-    ViewData viewData =
-        ViewData.create(
-            DISTRIBUTION_VIEW_WITH_LE_KEY,
-            ImmutableMap.<List<TagValue>, AggregationData>of(
-                Arrays.asList(V1, V2), DISTRIBUTION_DATA),
-            CUMULATIVE_DATA);
-    MetricFamilySamples metricSamples = PrometheusExportUtils.createMetricFamilySamples(viewData);
-    assertThat(metricSamples.samples).isEmpty();
   }
 
   @Test

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
@@ -33,7 +33,6 @@ import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.Aggregation.LastValue;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Aggregation.Sum;
-import io.opencensus.stats.AggregationData;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
 import io.opencensus.stats.AggregationData.LastValueDataDouble;
@@ -56,7 +55,6 @@ import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.Collector.Type;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -265,20 +263,6 @@ public class PrometheusExportUtilsTest {
         Arrays.asList(V1, V2),
         DISTRIBUTION_DATA,
         DISTRIBUTION);
-  }
-
-  @Test
-  public void createMetricFamilySamples_Histogram_DisallowLeLabelName() {
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage(
-        "Prometheus Histogram cannot have a label named 'le', "
-            + "because it is a reserved label for bucket boundaries. "
-            + "Please remove this tag key from your view.");
-    PrometheusExportUtils.createMetricFamilySamples(
-        ViewData.create(
-            DISTRIBUTION_VIEW_WITH_LE_KEY,
-            Collections.<List<TagValue>, AggregationData>emptyMap(),
-            CUMULATIVE_DATA));
   }
 
   @Test

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
@@ -33,6 +33,7 @@ import io.opencensus.stats.Aggregation.Distribution;
 import io.opencensus.stats.Aggregation.LastValue;
 import io.opencensus.stats.Aggregation.Mean;
 import io.opencensus.stats.Aggregation.Sum;
+import io.opencensus.stats.AggregationData;
 import io.opencensus.stats.AggregationData.CountData;
 import io.opencensus.stats.AggregationData.DistributionData;
 import io.opencensus.stats.AggregationData.LastValueDataDouble;
@@ -55,6 +56,7 @@ import io.prometheus.client.Collector.MetricFamilySamples.Sample;
 import io.prometheus.client.Collector.Type;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.List;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -273,6 +275,18 @@ public class PrometheusExportUtilsTest {
             + "because it is a reserved label for bucket boundaries. "
             + "Please remove this tag key from your view.");
     PrometheusExportUtils.createDescribableMetricFamilySamples(DISTRIBUTION_VIEW_WITH_LE_KEY);
+  }
+
+  @Test
+  public void createMetricFamilySamples_Histogram_SkipStatsWithLeLabelName() {
+    ViewData viewData =
+        ViewData.create(
+            DISTRIBUTION_VIEW_WITH_LE_KEY,
+            ImmutableMap.<List<TagValue>, AggregationData>of(
+                Arrays.asList(V1, V2), DISTRIBUTION_DATA),
+            CUMULATIVE_DATA);
+    MetricFamilySamples metricSamples = PrometheusExportUtils.createMetricFamilySamples(viewData);
+    assertThat(metricSamples.samples).isEmpty();
   }
 
   @Test

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollectorTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollectorTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.exporter.stats.prometheus;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.exporter.stats.prometheus.PrometheusExportUtils.LABEL_NAME_BUCKET_BOUND;
 import static org.mockito.Mockito.doReturn;
 
 import com.google.common.collect.ImmutableMap;
@@ -60,6 +61,7 @@ public class PrometheusStatsCollectorTest {
       MeasureDouble.create("measure", "description", "1");
   private static final TagKey K1 = TagKey.create("k1");
   private static final TagKey K2 = TagKey.create("k2");
+  private static final TagKey LE_TAG_KEY = TagKey.create(LABEL_NAME_BUCKET_BOUND);
   private static final TagValue V1 = TagValue.create("v1");
   private static final TagValue V2 = TagValue.create("v2");
   private static final DistributionData DISTRIBUTION_DATA =
@@ -67,11 +69,24 @@ public class PrometheusStatsCollectorTest {
   private static final View VIEW =
       View.create(
           VIEW_NAME, DESCRIPTION, MEASURE_DOUBLE, DISTRIBUTION, Arrays.asList(K1, K2), CUMULATIVE);
+  private static final View VIEW_WITH_LE_TAG_KEY =
+      View.create(
+          VIEW_NAME,
+          DESCRIPTION,
+          MEASURE_DOUBLE,
+          DISTRIBUTION,
+          Arrays.asList(K1, LE_TAG_KEY),
+          CUMULATIVE);
   private static final CumulativeData CUMULATIVE_DATA =
       CumulativeData.create(Timestamp.fromMillis(1000), Timestamp.fromMillis(2000));
   private static final ViewData VIEW_DATA =
       ViewData.create(
           VIEW, ImmutableMap.of(Arrays.asList(V1, V2), DISTRIBUTION_DATA), CUMULATIVE_DATA);
+  private static final ViewData VIEW_DATA_WITH_LE_TAG_KEY =
+      ViewData.create(
+          VIEW_WITH_LE_TAG_KEY,
+          ImmutableMap.of(Arrays.asList(V1, V2), DISTRIBUTION_DATA),
+          CUMULATIVE_DATA);
 
   @Mock private ViewManager mockViewManager;
 
@@ -120,6 +135,14 @@ public class PrometheusStatsCollectorTest {
                         Arrays.asList("k1", "k2"),
                         Arrays.asList("v1", "v2"),
                         22.0))));
+  }
+
+  @Test
+  public void testCollect_SkipDistributionViewWithLeTagKey() {
+    doReturn(ImmutableSet.of(VIEW_WITH_LE_TAG_KEY)).when(mockViewManager).getAllExportedViews();
+    doReturn(VIEW_DATA_WITH_LE_TAG_KEY).when(mockViewManager).getView(VIEW_NAME);
+    PrometheusStatsCollector collector = new PrometheusStatsCollector(mockViewManager);
+    assertThat(collector.collect()).isEmpty();
   }
 
   @Test

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollectorTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollectorTest.java
@@ -94,13 +94,25 @@ public class PrometheusStatsCollectorTest {
                 "Opencensus Prometheus metrics: View description",
                 Arrays.asList(
                     new Sample(
-                        name + "_bucket", Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), 0),
+                        name + "_bucket",
+                        Arrays.asList("k1", "k2", "le"),
+                        Arrays.asList("v1", "v2", "-5.0"),
+                        0),
                     new Sample(
-                        name + "_bucket", Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), 2),
+                        name + "_bucket",
+                        Arrays.asList("k1", "k2", "le"),
+                        Arrays.asList("v1", "v2", "0.0"),
+                        2),
                     new Sample(
-                        name + "_bucket", Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), 2),
+                        name + "_bucket",
+                        Arrays.asList("k1", "k2", "le"),
+                        Arrays.asList("v1", "v2", "5.0"),
+                        2),
                     new Sample(
-                        name + "_bucket", Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), 1),
+                        name + "_bucket",
+                        Arrays.asList("k1", "k2", "le"),
+                        Arrays.asList("v1", "v2", "+Inf"),
+                        1),
                     new Sample(
                         name + "_count", Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), 5),
                     new Sample(


### PR DESCRIPTION
Closes https://github.com/census-instrumentation/opencensus-java/issues/1164.

Previously we don't set the bucket bounds for Prometheus `Sample`s, since bucket bounds is a [built-in feature](https://github.com/prometheus/client_java/blob/master/simpleclient/src/main/java/io/prometheus/client/Histogram.java#L329) for Prometheus Histogram. However, as https://github.com/census-instrumentation/opencensus-java/issues/1164 suggested, we can manually set the bucket bounds with the same label `le` that the built-in Histogram uses, to achieve the same output as the built-in Prometheus Histogram `Sample`s.

Prometheus metrics page with this change:
![image](https://user-images.githubusercontent.com/10536136/39446708-35da19f4-4c74-11e8-90da-37dc36ea0b54.png)
Which is the expected output for https://github.com/census-instrumentation/opencensus-java/issues/1164. 