### PR TITLE
Update CHANGELOG about v0.13.1 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+
+## 0.13.1 - 2018-05-02
 - Fix a typo on displaying Aggregation Type for a View on StatsZ page.
 - Set bucket bounds as "le" labels for Prometheus Stats exporter.
 


### PR DESCRIPTION
Should be submitted after https://github.com/census-instrumentation/opencensus-java/pull/1173.