### PR TITLE
Add missing Nullable annotation to Functions.returnNull().

### DIFF
--- a/api/src/main/java/io/opencensus/common/Functions.java
+++ b/api/src/main/java/io/opencensus/common/Functions.java
@@ -16,6 +16,10 @@
 
 package io.opencensus.common;
 
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
 /**
  * Commonly used {@link Function} instances.
  *
@@ -24,9 +28,10 @@ package io.opencensus.common;
 public final class Functions {
   private Functions() {}
 
-  private static final Function<Object, Void> RETURN_NULL =
-      new Function<Object, Void>() {
+  private static final Function<Object, /*@Nullable*/ Void> RETURN_NULL =
+      new Function<Object, /*@Nullable*/ Void>() {
         @Override
+        @javax.annotation.Nullable
         public Void apply(Object ignored) {
           return null;
         }
@@ -54,10 +59,10 @@ public final class Functions {
    * @return a {@code Function} that always ignores its argument and returns {@code null}.
    * @since 0.5
    */
-  public static <T> Function<Object, T> returnNull() {
+  public static <T> Function<Object, /*@Nullable*/ T> returnNull() {
     // It is safe to cast a producer of Void to anything, because Void is always null.
     @SuppressWarnings("unchecked")
-    Function<Object, T> function = (Function<Object, T>) RETURN_NULL;
+    Function<Object, /*@Nullable*/ T> function = (Function<Object, /*@Nullable*/ T>) RETURN_NULL;
     return function;
   }
 

--- a/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/TracezZPageHandler.java
+++ b/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/TracezZPageHandler.java
@@ -61,7 +61,10 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nullable;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
 
 // TODO(hailongwen): remove the usage of `NetworkEvent` in the future.
 /**
@@ -122,11 +125,12 @@ final class TracezZPageHandler extends ZPageHandler {
   // Map from LatencyBucketBoundaries to the human string displayed on the UI for each bucket.
   private static final Map<LatencyBucketBoundaries, String> LATENCY_BUCKET_BOUNDARIES_STRING_MAP =
       buildLatencyBucketBoundariesStringMap();
-  @Nullable private final RunningSpanStore runningSpanStore;
-  @Nullable private final SampledSpanStore sampledSpanStore;
+  @javax.annotation.Nullable private final RunningSpanStore runningSpanStore;
+  @javax.annotation.Nullable private final SampledSpanStore sampledSpanStore;
 
   private TracezZPageHandler(
-      @Nullable RunningSpanStore runningSpanStore, @Nullable SampledSpanStore sampledSpanStore) {
+      @javax.annotation.Nullable RunningSpanStore runningSpanStore,
+      @javax.annotation.Nullable SampledSpanStore sampledSpanStore) {
     this.runningSpanStore = runningSpanStore;
     this.sampledSpanStore = sampledSpanStore;
   }
@@ -139,7 +143,8 @@ final class TracezZPageHandler extends ZPageHandler {
    * @return a new {@code TracezZPageHandler}.
    */
   static TracezZPageHandler create(
-      @Nullable RunningSpanStore runningSpanStore, @Nullable SampledSpanStore sampledSpanStore) {
+      @javax.annotation.Nullable RunningSpanStore runningSpanStore,
+      @javax.annotation.Nullable SampledSpanStore sampledSpanStore) {
     return new TracezZPageHandler(runningSpanStore, sampledSpanStore);
   }
 
@@ -385,7 +390,7 @@ final class TracezZPageHandler extends ZPageHandler {
 
   // TODO(sebright): Remove this method.
   @SuppressWarnings("nullness")
-  private static <T> T castNonNull(@Nullable T arg) {
+  private static <T> T castNonNull(@javax.annotation.Nullable T arg) {
     return arg;
   }
 
@@ -630,27 +635,28 @@ final class TracezZPageHandler extends ZPageHandler {
     return stringBuilder.toString();
   }
 
+  @javax.annotation.Nullable
   private static String attributeValueToString(AttributeValue attributeValue) {
     return attributeValue.match(
-        new Function<String, String>() {
+        new Function<String, /*@Nullable*/ String>() {
           @Override
           public String apply(String stringValue) {
             return stringValue;
           }
         },
-        new Function<Boolean, String>() {
+        new Function<Boolean, /*@Nullable*/ String>() {
           @Override
           public String apply(Boolean booleanValue) {
             return booleanValue.toString();
           }
         },
-        new Function<Long, String>() {
+        new Function<Long, /*@Nullable*/ String>() {
           @Override
           public String apply(Long longValue) {
             return longValue.toString();
           }
         },
-        Functions.<String>returnNull());
+        Functions.</*@Nullable*/ String>returnNull());
   }
 
   private static final class TimedEventComparator

--- a/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterHandler.java
+++ b/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterHandler.java
@@ -20,8 +20,6 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import com.google.common.io.BaseEncoding;
-import io.opencensus.common.Function;
-import io.opencensus.common.Functions;
 import io.opencensus.common.Scope;
 import io.opencensus.common.Timestamp;
 import io.opencensus.trace.Annotation;
@@ -61,13 +59,6 @@ final class ZipkinExporterHandler extends SpanExporter.Handler {
 
   private static final String STATUS_CODE = "census.status_code";
   private static final String STATUS_DESCRIPTION = "census.status_description";
-  private static final Function<Object, String> RETURN_STRING =
-      new Function<Object, String>() {
-        @Override
-        public String apply(Object input) {
-          return input.toString();
-        }
-      };
   private final SpanBytesEncoder encoder;
   private final Sender sender;
   private final Endpoint localEndpoint;
@@ -185,8 +176,7 @@ final class ZipkinExporterHandler extends SpanExporter.Handler {
   }
 
   private static String attributeValueToString(AttributeValue attributeValue) {
-    return attributeValue.match(
-        RETURN_STRING, RETURN_STRING, RETURN_STRING, Functions.<String>returnNull());
+    return attributeValue.toString();
   }
 
   @Override


### PR DESCRIPTION
The Checker Framework didn't detect this error, because the method used
`@SuppressWarnings("unchecked")` for a different reason.

This commit also fixes a potential NPE in ZipkinExporterHandler.