### PR TITLE
Checker Framework: 2.5.0 -> 2.5.1

### DIFF
--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -30,10 +30,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.Immutable;
 import javax.annotation.concurrent.ThreadSafe;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
 
 /** No-op implementations of stats classes. */
 final class NoopStats {
@@ -149,7 +152,7 @@ final class NoopStats {
 
     // Cached set of exported views. It must be set to null whenever a view is registered or
     // unregistered.
-    @Nullable private volatile Set<View> exportedViews;
+    @javax.annotation.Nullable private volatile Set<View> exportedViews;
 
     @Override
     public void registerView(View newView) {
@@ -167,7 +170,7 @@ final class NoopStats {
     }
 
     @Override
-    @Nullable
+    @javax.annotation.Nullable
     @SuppressWarnings("deprecation")
     public ViewData getView(View.Name name) {
       Utils.checkNotNull(name, "name");
@@ -178,7 +181,7 @@ final class NoopStats {
         } else {
           return ViewData.create(
               view,
-              Collections.<List<TagValue>, AggregationData>emptyMap(),
+              Collections.<List</*@Nullable*/ TagValue>, AggregationData>emptyMap(),
               view.getWindow()
                   .match(
                       Functions.<ViewData.AggregationWindowData>returnConstant(

--- a/build.gradle
+++ b/build.gradle
@@ -206,7 +206,7 @@ subprojects {
 
     dependencies {
         if (useCheckerFramework) {
-            ext.checkerFrameworkVersion = '2.5.0'
+            ext.checkerFrameworkVersion = '2.5.1'
 
             // 2.4.0 is the last version of the Checker Framework compiler that supports annotations
             // in comments, though it should continue to work with newer versions of the Checker Framework.

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -227,7 +227,7 @@ abstract class MutableViewData {
         // If Stats state is DISABLED, return an empty ViewData.
         return ViewData.create(
             super.view,
-            Collections.<List<TagValue>, AggregationData>emptyMap(),
+            Collections.<List</*@Nullable*/ TagValue>, AggregationData>emptyMap(),
             ViewData.AggregationWindowData.CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP));
       }
     }
@@ -320,7 +320,7 @@ abstract class MutableViewData {
         // If Stats state is DISABLED, return an empty ViewData.
         return ViewData.create(
             super.view,
-            Collections.<List<TagValue>, AggregationData>emptyMap(),
+            Collections.<List</*@Nullable*/ TagValue>, AggregationData>emptyMap(),
             ViewData.AggregationWindowData.IntervalData.create(ZERO_TIMESTAMP));
       }
     }


### PR DESCRIPTION
2.5.1 includes a fix for
https://github.com/typetools/checker-framework/issues/1838.  This commit also
adds a few more `@Nullable` annotations that are required now.