### PR TITLE
Add @Internal to io.opencensus.contrib.agent.Settings constructor (issue #977).

### DIFF
--- a/contrib/agent/src/main/java/io/opencensus/contrib/agent/Settings.java
+++ b/contrib/agent/src/main/java/io/opencensus/contrib/agent/Settings.java
@@ -23,6 +23,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Strings;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import io.opencensus.common.Internal;
 
 /**
  * The {@code Settings} class provides access to user-configurable settings.
@@ -35,11 +36,8 @@ public class Settings {
 
   private final Config config;
 
-  /**
-   * Creates agent settings.
-   *
-   * @since 0.10
-   */
+  /** Creates agent settings. */
+  @Internal
   @VisibleForTesting
   public Settings(Config config) {
     this.config = checkNotNull(config);


### PR DESCRIPTION
This constructor is only made public for testing within the project, so it
should have an `@Internal` annotation to show that it is not part of the API.

_____________________________________________________________

@ubschmidt2 Is this change correct, or should the Settings constructor be considered part of the API?