### PR TITLE
Throw IllegalArgumentException when Timestamp.create receives invalid arguments.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Adds Tracing.getExportComponent().shutdown() for use within application shutdown hooks.
 - `Duration.create` now throws an `IllegalArgumentException` instead of
   returning a zero `Duration` when the arguments are invalid.
+- `Timestamp.create` now throws an `IllegalArgumentException` instead of
+  returning a zero `Timestamp` when the arguments are invalid.
 
 ## 0.13.2 - 2018-05-08
 - Map http attributes to Stackdriver format (fix [#1153](https://github.com/census-instrumentation/opencensus-java/issues/1153)).

--- a/api/src/main/java/io/opencensus/common/Timestamp.java
+++ b/api/src/main/java/io/opencensus/common/Timestamp.java
@@ -39,7 +39,6 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 @AutoValue
 public abstract class Timestamp implements Comparable<Timestamp> {
-  private static final Timestamp EPOCH = new AutoValue_Timestamp(0, 0);
 
   Timestamp() {}
 
@@ -51,16 +50,25 @@ public abstract class Timestamp implements Comparable<Timestamp> {
    * @param nanos Non-negative fractions of a second at nanosecond resolution. Negative second
    *     values with fractions must still have non-negative nanos values that count forward in time.
    *     Must be from 0 to 999,999,999 inclusive.
-   * @return new {@code Timestamp} with specified fields. For invalid inputs, a {@code Timestamp} of
-   *     zero is returned.
+   * @return new {@code Timestamp} with specified fields.
+   * @throws IllegalArgumentException if the arguments are out of range.
    * @since 0.5
    */
   public static Timestamp create(long seconds, int nanos) {
-    if (seconds < -MAX_SECONDS || seconds > MAX_SECONDS) {
-      return EPOCH;
+    if (seconds < -MAX_SECONDS) {
+      throw new IllegalArgumentException(
+          "'seconds' is less than minimum (" + -MAX_SECONDS + "): " + seconds);
     }
-    if (nanos < 0 || nanos > MAX_NANOS) {
-      return EPOCH;
+    if (seconds > MAX_SECONDS) {
+      throw new IllegalArgumentException(
+          "'seconds' is greater than maximum (" + MAX_SECONDS + "): " + seconds);
+    }
+    if (nanos < 0) {
+      throw new IllegalArgumentException("'nanos' is less than zero: " + nanos);
+    }
+    if (nanos > MAX_NANOS) {
+      throw new IllegalArgumentException(
+          "'nanos' is greater than maximum (" + MAX_NANOS + "): " + nanos);
     }
     return new AutoValue_Timestamp(seconds, nanos);
   }
@@ -69,8 +77,9 @@ public abstract class Timestamp implements Comparable<Timestamp> {
    * Creates a new timestamp from the given milliseconds.
    *
    * @param epochMilli the timestamp represented in milliseconds since epoch.
-   * @return new {@code Timestamp} with specified fields. For invalid inputs, a {@code Timestamp} of
-   *     zero is returned.
+   * @return new {@code Timestamp} with specified fields.
+   * @throws IllegalArgumentException if the number of milliseconds is out of the range that can be
+   *     represented by {@code Timestamp}.
    * @since 0.5
    */
   public static Timestamp fromMillis(long epochMilli) {

--- a/api/src/test/java/io/opencensus/common/TimestampTest.java
+++ b/api/src/test/java/io/opencensus/common/TimestampTest.java
@@ -18,13 +18,17 @@ package io.opencensus.common;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link Timestamp}. */
 @RunWith(JUnit4.class)
 public class TimestampTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void timestampCreate() {
     assertThat(Timestamp.create(24, 42).getSeconds()).isEqualTo(24);
@@ -38,13 +42,45 @@ public class TimestampTest {
   }
 
   @Test
-  public void timestampCreate_InvalidInput() {
-    assertThat(Timestamp.create(-315576000001L, 0)).isEqualTo(Timestamp.create(0, 0));
-    assertThat(Timestamp.create(315576000001L, 0)).isEqualTo(Timestamp.create(0, 0));
-    assertThat(Timestamp.create(1, 1000000000)).isEqualTo(Timestamp.create(0, 0));
-    assertThat(Timestamp.create(1, -1)).isEqualTo(Timestamp.create(0, 0));
-    assertThat(Timestamp.create(-1, 1000000000)).isEqualTo(Timestamp.create(0, 0));
-    assertThat(Timestamp.create(-1, -1)).isEqualTo(Timestamp.create(0, 0));
+  public void create_SecondsTooLow() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("'seconds' is less than minimum (-315576000000): -315576000001");
+    Timestamp.create(-315576000001L, 0);
+  }
+
+  @Test
+  public void create_SecondsTooHigh() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("'seconds' is greater than maximum (315576000000): 315576000001");
+    Timestamp.create(315576000001L, 0);
+  }
+
+  @Test
+  public void create_NanosTooLow_PositiveTime() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("'nanos' is less than zero: -1");
+    Timestamp.create(1, -1);
+  }
+
+  @Test
+  public void create_NanosTooHigh_PositiveTime() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("'nanos' is greater than maximum (999999999): 1000000000");
+    Timestamp.create(1, 1000000000);
+  }
+
+  @Test
+  public void create_NanosTooLow_NegativeTime() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("'nanos' is less than zero: -1");
+    Timestamp.create(-1, -1);
+  }
+
+  @Test
+  public void create_NanosTooHigh_NegativeTime() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("'nanos' is greater than maximum (999999999): 1000000000");
+    Timestamp.create(-1, 1000000000);
   }
 
   @Test
@@ -59,6 +95,20 @@ public class TimestampTest {
     assertThat(Timestamp.fromMillis(-1)).isEqualTo(Timestamp.create(-1, 999000000));
     assertThat(Timestamp.fromMillis(-999)).isEqualTo(Timestamp.create(-1, 1000000));
     assertThat(Timestamp.fromMillis(-3456)).isEqualTo(Timestamp.create(-4, 544000000));
+  }
+
+  @Test
+  public void fromMillis_TooLow() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("'seconds' is less than minimum (-315576000000): -315576000001");
+    Timestamp.fromMillis(-315576000001000L);
+  }
+
+  @Test
+  public void fromMillis_TooHigh() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("'seconds' is greater than maximum (315576000000): 315576000001");
+    Timestamp.fromMillis(315576000001000L);
   }
 
   @Test

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -394,6 +394,10 @@ final class StackdriverExportUtils {
   // Convert a Census Timestamp to a StackDriver Timestamp
   @VisibleForTesting
   static Timestamp convertTimestamp(io.opencensus.common.Timestamp censusTimestamp) {
+    if (censusTimestamp.getSeconds() < 0) {
+      // Stackdriver doesn't handle negative timestamps.
+      return Timestamp.newBuilder().build();
+    }
     return Timestamp.newBuilder()
         .setSeconds(censusTimestamp.getSeconds())
         .setNanos(censusTimestamp.getNanos())

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -226,12 +226,10 @@ public class StackdriverExportUtilsTest {
     assertThat(StackdriverExportUtils.convertTimestamp(censusTimestamp1))
         .isEqualTo(
             com.google.protobuf.Timestamp.newBuilder().setSeconds(100).setNanos(3000).build());
-
-    // Proto timestamp doesn't allow negative values, instead it will replace the negative values
-    // by returning a default instance.
-    Timestamp censusTimestamp2 = Timestamp.create(-100, -3000);
+    Timestamp censusTimestamp2 = Timestamp.create(-100, 3000);
     assertThat(StackdriverExportUtils.convertTimestamp(censusTimestamp2))
-        .isEqualTo(com.google.protobuf.Timestamp.newBuilder().build());
+        .isEqualTo(
+            com.google.protobuf.Timestamp.newBuilder().setSeconds(-100).setNanos(3000).build());
   }
 
   @Test

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -226,10 +226,12 @@ public class StackdriverExportUtilsTest {
     assertThat(StackdriverExportUtils.convertTimestamp(censusTimestamp1))
         .isEqualTo(
             com.google.protobuf.Timestamp.newBuilder().setSeconds(100).setNanos(3000).build());
+
+    // Stackdriver doesn't allow negative values, instead it will replace the negative values
+    // by returning a default instance.
     Timestamp censusTimestamp2 = Timestamp.create(-100, 3000);
     assertThat(StackdriverExportUtils.convertTimestamp(censusTimestamp2))
-        .isEqualTo(
-            com.google.protobuf.Timestamp.newBuilder().setSeconds(-100).setNanos(3000).build());
+        .isEqualTo(com.google.protobuf.Timestamp.newBuilder().build());
   }
 
   @Test


### PR DESCRIPTION
Throwing IllegalArgumentException for invalid arguments is more consistent with
the rest of the opencensus-java API.  This commit also fixes a test that created
an invalid Timestamp.

___________________________________________________________________

This change is similar to #1198, but applied to Timestamp.  @songy23 is this the correct fix for StackdriverExportUtilsTest?