### PR TITLE
Starts adding a metrics package.

### DIFF
--- a/api/src/main/java/io/opencensus/stats/metrics/package-info.java
+++ b/api/src/main/java/io/opencensus/stats/metrics/package-info.java
@@ -27,4 +27,5 @@
  * https://github.com/census-instrumentation/opencensus-proto/blob/master/opencensus/proto/stats/metrics/metrics.proto
  * for more details.
  */
+@io.opencensus.common.ExperimentalApi
 package io.opencensus.stats.metrics;

--- a/api/src/main/java/io/opencensus/stats/metrics/package-info.java
+++ b/api/src/main/java/io/opencensus/stats/metrics/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * This package describes the Metrics data model. Metrics are a data model for what stats exporters
+ * take as input.
+ *
+ * <p>Currently all the public classes under this package are marked as {@link
+ * io.opencensus.common.ExperimentalApi}. This data model may eventually become the wire format for
+ * metrics.
+ *
+ * <p>Please see
+ * https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/Metrics.md and
+ * https://github.com/census-instrumentation/opencensus-proto/blob/master/opencensus/proto/stats/metrics/metrics.proto
+ * for more details.
+ */
+package io.opencensus.stats.metrics;


### PR DESCRIPTION
Add package info first, will send separate PRs that implement each of the data types in [metrics.proto](https://github.com/census-instrumentation/opencensus-proto/blob/master/opencensus/proto/stats/metrics/metrics.proto).