### PR TITLE
Metrics: Move Metrics to a separate artifact.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -386,6 +386,8 @@ subprojects {
                  'opencensus-impl-core',
                  'opencensus-impl-lite',
                  'opencensus-impl',
+                 // TODO(songya): uncomment this once classes were added to Metrics library
+                 // 'opencensus-metrics',
                  'opencensus-testing']
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -386,8 +386,7 @@ subprojects {
                  'opencensus-impl-core',
                  'opencensus-impl-lite',
                  'opencensus-impl',
-                 // TODO(songya): uncomment this once classes were added to Metrics library
-                 // 'opencensus-metrics',
+                 // TODO(songya): add the Export (or Metrics + SpanData) artifact once we agree on its name
                  'opencensus-testing']
     }
 

--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -40,7 +40,6 @@ General guidelines on imports:
   </subpackage>
   <subpackage name="metrics">
     <allow pkg="io.opencensus.common"/>
-    <allow pkg="io.opencensus.internal"/>
     <allow pkg="io.opencensus.stats"/>
     <allow pkg="io.opencensus.tags"/>
   </subpackage>

--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -38,6 +38,12 @@ General guidelines on imports:
     <allow pkg="io.opencensus.internal"/>
     <allow pkg="io.opencensus.tags"/>
   </subpackage>
+  <subpackage name="metrics">
+    <allow pkg="io.opencensus.common"/>
+    <allow pkg="io.opencensus.internal"/>
+    <allow pkg="io.opencensus.stats"/>
+    <allow pkg="io.opencensus.tags"/>
+  </subpackage>
   <subpackage name="stats">
     <allow pkg="io.opencensus.common"/>
     <allow pkg="io.opencensus.internal"/>

--- a/metrics/README
+++ b/metrics/README
@@ -1,0 +1,7 @@
+OpenCensus Metrics
+======================================================
+
+* The Metrics data model used by Stats exporters. This data model may eventually become the wire
+format for metrics.
+* Currently all the the public classes under this package are marked as `ExperimentalApi`.
+* Java 7 and compatible.

--- a/metrics/README.md
+++ b/metrics/README.md
@@ -3,5 +3,5 @@ OpenCensus Metrics
 
 * The Metrics data model used by Stats exporters. This data model may eventually become the wire
 format for metrics.
-* Currently all the the public classes under this package are marked as `ExperimentalApi`.
+* Currently all the public classes under this package are marked as `ExperimentalApi`.
 * Java 7 and compatible.

--- a/metrics/build.gradle
+++ b/metrics/build.gradle
@@ -1,0 +1,11 @@
+description = 'OpenCensus Metrics Data Model'
+
+dependencies {
+    compile project(':opencensus-api')
+
+    compileOnly libraries.auto_value
+
+    testCompile project(':opencensus-api')
+
+    signature "org.codehaus.mojo.signature:java16:+@signature"
+}

--- a/metrics/build.gradle
+++ b/metrics/build.gradle
@@ -1,4 +1,4 @@
-description = 'OpenCensus Metrics Data Model'
+description = 'OpenCensus Metrics'
 
 dependencies {
     compile project(':opencensus-api')

--- a/metrics/src/main/java/io/opencensus/metrics/package-info.java
+++ b/metrics/src/main/java/io/opencensus/metrics/package-info.java
@@ -28,4 +28,4 @@
  * for more details.
  */
 @io.opencensus.common.ExperimentalApi
-package io.opencensus.stats.metrics;
+package io.opencensus.metrics;

--- a/settings.gradle
+++ b/settings.gradle
@@ -19,6 +19,8 @@ include ":opencensus-contrib-grpc-metrics"
 include ":opencensus-contrib-grpc-util"
 include ":opencensus-contrib-http-util"
 include ":opencensus-contrib-monitored-resource-util"
+// TODO(songya): uncomment this once classes were added to Metrics library.
+//include ":opencensus-metrics"
 
 project(':opencensus-api').projectDir = "$rootDir/api" as File
 project(':opencensus-impl-core').projectDir = "$rootDir/impl_core" as File
@@ -44,6 +46,8 @@ project(':opencensus-exporter-trace-jaeger').projectDir = "$rootDir/exporters/tr
 project(':opencensus-exporter-stats-signalfx').projectDir = "$rootDir/exporters/stats/signalfx" as File
 project(':opencensus-exporter-stats-stackdriver').projectDir = "$rootDir/exporters/stats/stackdriver" as File
 project(':opencensus-exporter-stats-prometheus').projectDir = "$rootDir/exporters/stats/prometheus" as File
+// TODO(songya): uncomment this once classes were added to Metrics library.
+//project(':opencensus-metrics').projectDir = "$rootDir/metrics" as File
 
 
 // Java8 projects only


### PR DESCRIPTION
I haven't added this artifact to `build.gradle` or `setting.gradle` since it doesn't have any classes yet, and the `javaDoc` task will fail (I haven't found a way to disable this task).