### PR TITLE
 Overwrite the sampling probability to default for stats exporters.

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorker.java
@@ -31,10 +31,12 @@ import io.opencensus.common.Scope;
 import io.opencensus.stats.View;
 import io.opencensus.stats.ViewData;
 import io.opencensus.stats.ViewManager;
+import io.opencensus.trace.Sampler;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.samplers.Samplers;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -72,6 +74,7 @@ final class StackdriverExporterWorker implements Runnable {
   private final Map<View.Name, View> registeredViews = new HashMap<View.Name, View>();
 
   private static final Tracer tracer = Tracing.getTracer();
+  private static final Sampler probabilitySampler = Samplers.probabilitySampler(0.0001);
 
   StackdriverExporterWorker(
       String projectId,
@@ -204,6 +207,7 @@ final class StackdriverExporterWorker implements Runnable {
           tracer
               .spanBuilder("ExportStatsToStackdriverMonitoring")
               .setRecordEvents(true)
+              .setSampler(probabilitySampler)
               .startSpan();
       try (Scope scope = tracer.withSpan(span)) {
         export();

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
@@ -69,7 +69,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /** Exporter to Stackdriver Trace API v2. */
 final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
   private static final Tracer tracer = Tracing.getTracer();
-  private static final Sampler probabilitySpampler = Samplers.probabilitySampler(0.0001);
+  private static final Sampler probabilitySampler = Samplers.probabilitySampler(0.0001);
   private static final String AGENT_LABEL_KEY = "g.co/agent";
   private static final String AGENT_LABEL_VALUE_STRING =
       "opencensus-java [" + OpenCensusLibraryInformation.VERSION + "]";
@@ -330,7 +330,7 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
     try (Scope scope =
         tracer
             .spanBuilder("ExportStackdriverTraces")
-            .setSampler(probabilitySpampler)
+            .setSampler(probabilitySampler)
             .setRecordEvents(true)
             .startScopedSpan()) {
       List<Span> spans = new ArrayList<>(spanDataList.size());


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1218.

So that the span that instruments stats exporter should have the same sampling probability to that of [trace exporters](https://github.com/census-instrumentation/opencensus-java/blob/master/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java#L72), instead of always being sampled.

/cc @odeke-em 