### PR TITLE
Cleanup trace exporters.

### DIFF
--- a/exporters/trace/instana/src/test/java/io/opencensus/exporter/trace/instana/InstanaExporterHandlerTest.java
+++ b/exporters/trace/instana/src/test/java/io/opencensus/exporter/trace/instana/InstanaExporterHandlerTest.java
@@ -19,12 +19,14 @@ package io.opencensus.exporter.trace.instana;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import io.opencensus.common.Timestamp;
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Link;
-import io.opencensus.trace.NetworkEvent;
-import io.opencensus.trace.NetworkEvent.Type;
+import io.opencensus.trace.MessageEvent;
+import io.opencensus.trace.MessageEvent.Type;
+import io.opencensus.trace.Span.Kind;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.Status;
@@ -45,37 +47,37 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link InstanaExporterHandler}. */
 @RunWith(JUnit4.class)
 public class InstanaExporterHandlerTest {
+  private static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
+  private static final String SPAN_ID = "9cc1e3049173be09";
+  private static final String PARENT_SPAN_ID = "8b03ab423da481c5";
+  private static final Map<String, AttributeValue> attributes =
+      ImmutableMap.of("http.url", AttributeValue.stringAttributeValue("http://localhost/foo"));
+  private static final List<TimedEvent<Annotation>> annotations = Collections.emptyList();
+  private static final List<TimedEvent<MessageEvent>> messageEvents =
+      ImmutableList.of(
+          TimedEvent.create(
+              Timestamp.create(1505855799, 433901068),
+              MessageEvent.builder(Type.RECEIVED, 0).setCompressedMessageSize(7).build()),
+          TimedEvent.create(
+              Timestamp.create(1505855799, 459486280),
+              MessageEvent.builder(Type.SENT, 0).setCompressedMessageSize(13).build()));
 
   @Test
-  public void generateSpan() {
-    String traceId = "d239036e7d5cec116b562147388b35bf";
-    String spanId = "9cc1e3049173be09";
-    String parentId = "8b03ab423da481c5";
-    Map<String, AttributeValue> attributes =
-        Collections.singletonMap(
-            "http.url", AttributeValue.stringAttributeValue("http://localhost/foo"));
-    List<TimedEvent<Annotation>> annotations = Collections.emptyList();
-    List<TimedEvent<NetworkEvent>> networkEvents =
-        ImmutableList.of(
-            TimedEvent.create(
-                Timestamp.create(1505855799, 433901068),
-                NetworkEvent.builder(Type.RECV, 0).setCompressedMessageSize(7).build()),
-            TimedEvent.create(
-                Timestamp.create(1505855799, 459486280),
-                NetworkEvent.builder(Type.SENT, 0).setCompressedMessageSize(13).build()));
+  public void generateSpan_NoKindAndRemoteParent() {
     SpanData data =
         SpanData.create(
             SpanContext.create(
-                TraceId.fromLowerBase16(traceId),
-                SpanId.fromLowerBase16(spanId),
+                TraceId.fromLowerBase16(TRACE_ID),
+                SpanId.fromLowerBase16(SPAN_ID),
                 TraceOptions.fromBytes(new byte[] {1} /* sampled */)),
-            SpanId.fromLowerBase16(parentId),
+            SpanId.fromLowerBase16(PARENT_SPAN_ID),
             true, /* hasRemoteParent */
             "SpanName", /* name */
+            null, /* kind */
             Timestamp.create(1505855794, 194009601) /* startTimestamp */,
             Attributes.create(attributes, 0 /* droppedAttributesCount */),
             TimedEvents.create(annotations, 0 /* droppedEventsCount */),
-            TimedEvents.create(networkEvents, 0 /* droppedEventsCount */),
+            TimedEvents.create(messageEvents, 0 /* droppedEventsCount */),
             Links.create(Collections.<Link>emptyList(), 0 /* droppedLinksCount */),
             null, /* childSpanCount */
             Status.OK,
@@ -92,6 +94,82 @@ public class InstanaExporterHandlerTest {
                 + "\"duration\":5271,"
                 + "\"name\":\"SpanName\","
                 + "\"type\":\"ENTRY\","
+                + "\"data\":"
+                + "{\"http.url\":\"http://localhost/foo\"}"
+                + "}"
+                + "]");
+  }
+
+  @Test
+  public void generateSpan_ServerKind() {
+    SpanData data =
+        SpanData.create(
+            SpanContext.create(
+                TraceId.fromLowerBase16(TRACE_ID),
+                SpanId.fromLowerBase16(SPAN_ID),
+                TraceOptions.fromBytes(new byte[] {1} /* sampled */)),
+            SpanId.fromLowerBase16(PARENT_SPAN_ID),
+            true, /* hasRemoteParent */
+            "SpanName", /* name */
+            Kind.SERVER, /* kind */
+            Timestamp.create(1505855794, 194009601) /* startTimestamp */,
+            Attributes.create(attributes, 0 /* droppedAttributesCount */),
+            TimedEvents.create(annotations, 0 /* droppedEventsCount */),
+            TimedEvents.create(messageEvents, 0 /* droppedEventsCount */),
+            Links.create(Collections.<Link>emptyList(), 0 /* droppedLinksCount */),
+            null, /* childSpanCount */
+            Status.OK,
+            Timestamp.create(1505855799, 465726528) /* endTimestamp */);
+
+    assertThat(InstanaExporterHandler.convertToJson(Collections.singletonList(data)))
+        .isEqualTo(
+            "["
+                + "{"
+                + "\"spanId\":\"9cc1e3049173be09\","
+                + "\"traceId\":\"d239036e7d5cec11\","
+                + "\"parentId\":\"8b03ab423da481c5\","
+                + "\"timestamp\":1505855794194,"
+                + "\"duration\":5271,"
+                + "\"name\":\"SpanName\","
+                + "\"type\":\"ENTRY\","
+                + "\"data\":"
+                + "{\"http.url\":\"http://localhost/foo\"}"
+                + "}"
+                + "]");
+  }
+
+  @Test
+  public void generateSpan_ClientKind() {
+    SpanData data =
+        SpanData.create(
+            SpanContext.create(
+                TraceId.fromLowerBase16(TRACE_ID),
+                SpanId.fromLowerBase16(SPAN_ID),
+                TraceOptions.fromBytes(new byte[] {1} /* sampled */)),
+            SpanId.fromLowerBase16(PARENT_SPAN_ID),
+            true, /* hasRemoteParent */
+            "SpanName", /* name */
+            Kind.CLIENT, /* kind */
+            Timestamp.create(1505855794, 194009601) /* startTimestamp */,
+            Attributes.create(attributes, 0 /* droppedAttributesCount */),
+            TimedEvents.create(annotations, 0 /* droppedEventsCount */),
+            TimedEvents.create(messageEvents, 0 /* droppedEventsCount */),
+            Links.create(Collections.<Link>emptyList(), 0 /* droppedLinksCount */),
+            null, /* childSpanCount */
+            Status.OK,
+            Timestamp.create(1505855799, 465726528) /* endTimestamp */);
+
+    assertThat(InstanaExporterHandler.convertToJson(Collections.singletonList(data)))
+        .isEqualTo(
+            "["
+                + "{"
+                + "\"spanId\":\"9cc1e3049173be09\","
+                + "\"traceId\":\"d239036e7d5cec11\","
+                + "\"parentId\":\"8b03ab423da481c5\","
+                + "\"timestamp\":1505855794194,"
+                + "\"duration\":5271,"
+                + "\"name\":\"SpanName\","
+                + "\"type\":\"EXIT\","
                 + "\"data\":"
                 + "{\"http.url\":\"http://localhost/foo\"}"
                 + "}"

--- a/exporters/trace/zipkin/src/test/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterHandlerTest.java
+++ b/exporters/trace/zipkin/src/test/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterHandlerTest.java
@@ -19,13 +19,13 @@ package io.opencensus.exporter.trace.zipkin;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.io.BaseEncoding;
 import io.opencensus.common.Timestamp;
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.AttributeValue;
 import io.opencensus.trace.Link;
-import io.opencensus.trace.NetworkEvent;
-import io.opencensus.trace.NetworkEvent.Type;
+import io.opencensus.trace.MessageEvent;
+import io.opencensus.trace.MessageEvent.Type;
+import io.opencensus.trace.Span.Kind;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.Status;
@@ -44,44 +44,43 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import zipkin2.Endpoint;
 import zipkin2.Span;
-import zipkin2.Span.Kind;
 
 /** Unit tests for {@link ZipkinExporterHandler}. */
 @RunWith(JUnit4.class)
 public class ZipkinExporterHandlerTest {
+  private static final Endpoint localEndpoint =
+      Endpoint.newBuilder().serviceName("tweetiebird").build();
+  private static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
+  private static final String SPAN_ID = "9cc1e3049173be09";
+  private static final String PARENT_SPAN_ID = "8b03ab423da481c5";
+  private static final Map<String, AttributeValue> attributes = Collections.emptyMap();
+  private static final List<TimedEvent<Annotation>> annotations = Collections.emptyList();
+  private static final List<TimedEvent<MessageEvent>> messageEvents =
+      ImmutableList.of(
+          TimedEvent.create(
+              Timestamp.create(1505855799, 433901068),
+              MessageEvent.builder(Type.RECEIVED, 0).setCompressedMessageSize(7).build()),
+          TimedEvent.create(
+              Timestamp.create(1505855799, 459486280),
+              MessageEvent.builder(Type.SENT, 0).setCompressedMessageSize(13).build()));
 
   @Test
-  public void generateSpan() {
-    Endpoint localEndpoint = Endpoint.newBuilder().serviceName("tweetiebird").build();
-    String traceId = "d239036e7d5cec116b562147388b35bf";
-    String spanId = "9cc1e3049173be09";
-    String parentId = "8b03ab423da481c5";
-    Map<String, AttributeValue> attributes = Collections.emptyMap();
-    List<TimedEvent<Annotation>> annotations = Collections.emptyList();
-    List<TimedEvent<NetworkEvent>> networkEvents =
-        ImmutableList.of(
-            TimedEvent.create(
-                Timestamp.create(1505855799, 433901068),
-                NetworkEvent.builder(Type.RECV, 0).setCompressedMessageSize(7).build()),
-            TimedEvent.create(
-                Timestamp.create(1505855799, 459486280),
-                NetworkEvent.builder(Type.SENT, 0).setCompressedMessageSize(13).build()));
+  public void generateSpan_NoKindAndRemoteParent() {
     SpanData data =
         SpanData.create(
             SpanContext.create(
-                // TODO SpanId.fromLowerBase16
-                TraceId.fromBytes(BaseEncoding.base16().lowerCase().decode(traceId)),
-                // TODO SpanId.fromLowerBase16
-                SpanId.fromBytes(BaseEncoding.base16().lowerCase().decode(spanId)),
+                TraceId.fromLowerBase16(TRACE_ID),
+                SpanId.fromLowerBase16(SPAN_ID),
                 TraceOptions.fromBytes(new byte[] {1} /* sampled */)),
             // TODO SpanId.fromLowerBase16
-            SpanId.fromBytes(BaseEncoding.base16().lowerCase().decode(parentId)),
+            SpanId.fromLowerBase16(PARENT_SPAN_ID),
             true, /* hasRemoteParent */
             "Recv.helloworld.Greeter.SayHello", /* name */
+            null, /* kind */
             Timestamp.create(1505855794, 194009601) /* startTimestamp */,
             Attributes.create(attributes, 0 /* droppedAttributesCount */),
             TimedEvents.create(annotations, 0 /* droppedEventsCount */),
-            TimedEvents.create(networkEvents, 0 /* droppedEventsCount */),
+            TimedEvents.create(messageEvents, 0 /* droppedEventsCount */),
             Links.create(Collections.<Link>emptyList(), 0 /* droppedLinksCount */),
             null, /* childSpanCount */
             Status.OK,
@@ -90,17 +89,99 @@ public class ZipkinExporterHandlerTest {
     assertThat(ZipkinExporterHandler.generateSpan(data, localEndpoint))
         .isEqualTo(
             Span.newBuilder()
-                .traceId(traceId)
-                .parentId(parentId)
-                .id(spanId)
-                .kind(Kind.SERVER)
+                .traceId(TRACE_ID)
+                .parentId(PARENT_SPAN_ID)
+                .id(SPAN_ID)
+                .kind(Span.Kind.SERVER)
                 .name(data.getName())
                 .timestamp(1505855794000000L + 194009601L / 1000)
                 .duration(
                     (1505855799000000L + 465726528L / 1000)
                         - (1505855794000000L + 194009601L / 1000))
                 .localEndpoint(localEndpoint)
-                .addAnnotation(1505855799000000L + 433901068L / 1000, "RECV")
+                .addAnnotation(1505855799000000L + 433901068L / 1000, "RECEIVED")
+                .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT")
+                .putTag("census.status_code", "OK")
+                .build());
+  }
+
+  @Test
+  public void generateSpan_ServerKind() {
+    SpanData data =
+        SpanData.create(
+            SpanContext.create(
+                TraceId.fromLowerBase16(TRACE_ID),
+                SpanId.fromLowerBase16(SPAN_ID),
+                TraceOptions.fromBytes(new byte[] {1} /* sampled */)),
+            // TODO SpanId.fromLowerBase16
+            SpanId.fromLowerBase16(PARENT_SPAN_ID),
+            true, /* hasRemoteParent */
+            "Recv.helloworld.Greeter.SayHello", /* name */
+            Kind.SERVER, /* kind */
+            Timestamp.create(1505855794, 194009601) /* startTimestamp */,
+            Attributes.create(attributes, 0 /* droppedAttributesCount */),
+            TimedEvents.create(annotations, 0 /* droppedEventsCount */),
+            TimedEvents.create(messageEvents, 0 /* droppedEventsCount */),
+            Links.create(Collections.<Link>emptyList(), 0 /* droppedLinksCount */),
+            null, /* childSpanCount */
+            Status.OK,
+            Timestamp.create(1505855799, 465726528) /* endTimestamp */);
+
+    assertThat(ZipkinExporterHandler.generateSpan(data, localEndpoint))
+        .isEqualTo(
+            Span.newBuilder()
+                .traceId(TRACE_ID)
+                .parentId(PARENT_SPAN_ID)
+                .id(SPAN_ID)
+                .kind(Span.Kind.SERVER)
+                .name(data.getName())
+                .timestamp(1505855794000000L + 194009601L / 1000)
+                .duration(
+                    (1505855799000000L + 465726528L / 1000)
+                        - (1505855794000000L + 194009601L / 1000))
+                .localEndpoint(localEndpoint)
+                .addAnnotation(1505855799000000L + 433901068L / 1000, "RECEIVED")
+                .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT")
+                .putTag("census.status_code", "OK")
+                .build());
+  }
+
+  @Test
+  public void generateSpan_ClientKind() {
+    SpanData data =
+        SpanData.create(
+            SpanContext.create(
+                TraceId.fromLowerBase16(TRACE_ID),
+                SpanId.fromLowerBase16(SPAN_ID),
+                TraceOptions.fromBytes(new byte[] {1} /* sampled */)),
+            // TODO SpanId.fromLowerBase16
+            SpanId.fromLowerBase16(PARENT_SPAN_ID),
+            true, /* hasRemoteParent */
+            "Sent.helloworld.Greeter.SayHello", /* name */
+            Kind.CLIENT, /* kind */
+            Timestamp.create(1505855794, 194009601) /* startTimestamp */,
+            Attributes.create(attributes, 0 /* droppedAttributesCount */),
+            TimedEvents.create(annotations, 0 /* droppedEventsCount */),
+            TimedEvents.create(messageEvents, 0 /* droppedEventsCount */),
+            Links.create(Collections.<Link>emptyList(), 0 /* droppedLinksCount */),
+            null, /* childSpanCount */
+            Status.OK,
+            Timestamp.create(1505855799, 465726528) /* endTimestamp */);
+
+    assertThat(ZipkinExporterHandler.generateSpan(data, localEndpoint))
+        .isEqualTo(
+            Span.newBuilder()
+                .traceId(TRACE_ID)
+                .parentId(PARENT_SPAN_ID)
+                .id(SPAN_ID)
+                .kind(Span.Kind.CLIENT)
+                .name(data.getName())
+                .timestamp(1505855794000000L + 194009601L / 1000)
+                .duration(
+                    (1505855799000000L + 465726528L / 1000)
+                        - (1505855794000000L + 194009601L / 1000))
+                .localEndpoint(localEndpoint)
+                .addAnnotation(1505855799000000L + 433901068L / 1000, "RECEIVED")
                 .addAnnotation(1505855799000000L + 459486280L / 1000, "SENT")
                 .putTag("census.status_code", "OK")
                 .build());


### PR DESCRIPTION
* Change to use the new Span.Kind.
  * In SD add Sent/Recv based on Span.Kind.
  * In Zipkin/Instana use this to determine the kind of the Span in the backend format.
* Cleanup usage of the deprecated NetworkEvents.
* Make static final immutable fields in tests.

Fixes https://github.com/census-instrumentation/opencensus-java/issues/1054