### PR TITLE
Add started_rpcs measures and views to RPC constants.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Add an util artifact `opencensus-contrib-appengine-standard-util` to interact with the AppEngine
   CloudTraceContext.
 - Add support for Span kinds. (fix [#1054](https://github.com/census-instrumentation/opencensus-java/issues/1054)).
+- Add client/server started_rpcs measures and views to RPC constants.
 
 ## 0.13.2 - 2018-05-08
 - Map http attributes to Stackdriver format (fix [#1153](https://github.com/census-instrumentation/opencensus-java/issues/1153)).

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -191,6 +191,7 @@ public final class RpcMeasureConstants {
    * {@link Measure} for number of started client RPCs.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_STARTED_RPCS}.
    */
   @Deprecated
   public static final MeasureLong RPC_CLIENT_STARTED_COUNT =
@@ -294,6 +295,16 @@ public final class RpcMeasureConstants {
       Measure.MeasureDouble.create(
           "grpc.io/client/server_latency", "Server latency in msecs", MILLISECOND);
 
+  /**
+   * {@link Measure} for total number of client RPCs ever opened, including those that have not
+   * completed.
+   *
+   * @since 0.14
+   */
+  public static final MeasureDouble GRPC_CLIENT_STARTED_RPCS =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/started_rpcs", "Number of started client RPCs.", COUNT);
+
   // RPC server Measures.
 
   /**
@@ -375,6 +386,7 @@ public final class RpcMeasureConstants {
    * {@link Measure} for number of started server RPCs.
    *
    * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_STARTED_RPCS}.
    */
   @Deprecated
   public static final MeasureLong RPC_SERVER_STARTED_COUNT =
@@ -468,6 +480,16 @@ public final class RpcMeasureConstants {
           "Time between first byte of request received to last byte of response sent, "
               + "or terminal error.",
           MILLISECOND);
+
+  /**
+   * {@link Measure} for total number of server RPCs ever opened, including those that have not
+   * completed.
+   *
+   * @since 0.14
+   */
+  public static final MeasureDouble GRPC_SERVER_STARTED_RPCS =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/started_rpcs", "Number of started server RPCs.", COUNT);
 
   private RpcMeasureConstants() {}
 }

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -301,8 +301,8 @@ public final class RpcMeasureConstants {
    *
    * @since 0.14
    */
-  public static final MeasureDouble GRPC_CLIENT_STARTED_RPCS =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong GRPC_CLIENT_STARTED_RPCS =
+      Measure.MeasureLong.create(
           "grpc.io/client/started_rpcs", "Number of started client RPCs.", COUNT);
 
   // RPC server Measures.
@@ -487,8 +487,8 @@ public final class RpcMeasureConstants {
    *
    * @since 0.14
    */
-  public static final MeasureDouble GRPC_SERVER_STARTED_RPCS =
-      Measure.MeasureDouble.create(
+  public static final MeasureLong GRPC_SERVER_STARTED_RPCS =
+      Measure.MeasureLong.create(
           "grpc.io/server/started_rpcs", "Number of started server RPCs.", COUNT);
 
   private RpcMeasureConstants() {}

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -23,6 +23,7 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STATUS;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC;
@@ -30,6 +31,7 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STATUS;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_CLIENT_ERROR_COUNT;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.RPC_CLIENT_FINISHED_COUNT;
@@ -302,6 +304,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for started client RPCs.
    *
    * @since 0.12
+   * @deprecated in favor of {@link #GRPC_CLIENT_STARTED_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_CLIENT_STARTED_COUNT_CUMULATIVE_VIEW =
@@ -421,6 +424,19 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/completed_rpcs"),
           "Number of completed client RPCs",
           GRPC_CLIENT_ROUNDTRIP_LATENCY,
+          COUNT,
+          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
+
+  /**
+   * {@link View} for started client RPCs.
+   *
+   * @since 0.14
+   */
+  public static final View GRPC_CLIENT_STARTED_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/started_rpcs"),
+          "Number of started client RPCs",
+          GRPC_CLIENT_STARTED_RPCS,
           COUNT,
           Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
 
@@ -574,6 +590,7 @@ public final class RpcViewConstants {
    * Cumulative {@link View} for started server RPCs.
    *
    * @since 0.12
+   * @deprecated in favor of {@link #GRPC_SERVER_STARTED_RPC_VIEW}.
    */
   @Deprecated
   public static final View RPC_SERVER_STARTED_COUNT_CUMULATIVE_VIEW =
@@ -680,6 +697,19 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/server/completed_rpcs"),
           "Number of completed server RPCs",
           GRPC_SERVER_SERVER_LATENCY,
+          COUNT,
+          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
+
+  /**
+   * {@link View} for started server RPCs.
+   *
+   * @since 0.14
+   */
+  public static final View GRPC_SERVER_STARTED_RPC_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/started_rpcs"),
+          "Number of started server RPCs",
+          GRPC_SERVER_STARTED_RPCS,
           COUNT,
           Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -438,7 +438,7 @@ public final class RpcViewConstants {
           "Number of started client RPCs",
           GRPC_CLIENT_STARTED_RPCS,
           COUNT,
-          Arrays.asList(GRPC_CLIENT_METHOD, GRPC_CLIENT_STATUS));
+          Arrays.asList(GRPC_CLIENT_METHOD));
 
   // Rpc server cumulative views.
 
@@ -711,7 +711,7 @@ public final class RpcViewConstants {
           "Number of started server RPCs",
           GRPC_SERVER_STARTED_RPCS,
           COUNT,
-          Arrays.asList(GRPC_SERVER_METHOD, GRPC_SERVER_STATUS));
+          Arrays.asList(GRPC_SERVER_METHOD));
 
   // Interval Stats
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -65,12 +65,14 @@ public final class RpcViews {
           RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_CLIENT_SERVER_LATENCY_VIEW,
           RpcViewConstants.GRPC_CLIENT_COMPLETED_RPC_VIEW,
+          RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW,
           RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW,
           RpcViewConstants.GRPC_SERVER_SENT_BYTES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW,
           RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW,
-          RpcViewConstants.GRPC_SERVER_COMPLETED_RPC_VIEW);
+          RpcViewConstants.GRPC_SERVER_COMPLETED_RPC_VIEW,
+          RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW);
 
   @VisibleForTesting
   static final ImmutableSet<View> RPC_INTERVAL_VIEWS_SET =

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
@@ -54,6 +54,7 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS).isNotNull();
 
     // Test server measurement descriptors.
     assertThat(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT).isNotNull();
@@ -72,5 +73,6 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS).isNotNull();
   }
 }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -108,6 +108,7 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_SERVER_LATENCY_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW).isNotNull();
 
     // Test server distribution view descriptors.
     assertThat(RpcViewConstants.RPC_SERVER_ERROR_COUNT_VIEW).isNotNull();
@@ -124,6 +125,7 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW).isNotNull();
 
     // Test client interval view descriptors.
     assertThat(RpcViewConstants.RPC_CLIENT_ERROR_COUNT_MINUTE_VIEW).isNotNull();


### PR DESCRIPTION
Related to https://github.com/census-instrumentation/opencensus-specs/pull/120.

Client/server started_rpcs are required by gRPC, add them back to RPC constants.

/cc @zhangkun83 