### PR TITLE
Remove Checkstyle rule VariableDeclarationUsageDistance

### DIFF
--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -170,7 +170,6 @@
             <property name="allowedAbbreviationLength" value="1"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
-        <module name="VariableDeclarationUsageDistance"/>
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>


### PR DESCRIPTION
The `VariableDeclarationUsageDistance` rules restricts the distance between variable declaration and its first usage to 3 lines. In my opinion it's not useful, especially in unit tests where we define all the variables first.