### PR TITLE
Stackdriver Trace Exporter: add resource labels to Spans.

### DIFF
--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -141,6 +141,7 @@ General guidelines on imports:
       <subpackage name="stackdriver">
         <allow pkg="com.google"/>
         <allow pkg="io.opencensus.exporter.trace.stackdriver"/>
+        <allow pkg="io.opencensus.contrib.monitoredresource.util"/>
       </subpackage>
       <subpackage name="zipkin">
         <allow pkg="io.opencensus.exporter.trace.zipkin"/>

--- a/exporters/trace/stackdriver/build.gradle
+++ b/exporters/trace/stackdriver/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly libraries.auto_value
 
     compile project(':opencensus-api'),
+            project(':opencensus-contrib-monitored-resource-util'),
             libraries.google_auth
 
     compile (libraries.google_cloud_trace) {

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
@@ -334,9 +334,8 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
         putToResourceAttributeMap(
             resourceLabels, resourceType, "pod_id", gcpGkeContainerMonitoredResource.getPodId());
         return Collections.unmodifiableMap(resourceLabels);
-      default:
-        return Collections.emptyMap();
     }
+    return Collections.emptyMap();
   }
 
   private static void putToResourceAttributeMap(

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
@@ -265,7 +265,6 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
     ResourceType resourceType = resource.getResourceType();
     switch (resourceType) {
       case AWS_EC2_INSTANCE:
-        @SuppressWarnings("unchecked")
         AwsEc2InstanceMonitoredResource awsEc2InstanceMonitoredResource =
             (AwsEc2InstanceMonitoredResource) resource;
         putToResourceAttributeMap(
@@ -285,7 +284,6 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
             "aws:" + awsEc2InstanceMonitoredResource.getRegion());
         return Collections.unmodifiableMap(resourceLabels);
       case GCP_GCE_INSTANCE:
-        @SuppressWarnings("unchecked")
         GcpGceInstanceMonitoredResource gcpGceInstanceMonitoredResource =
             (GcpGceInstanceMonitoredResource) resource;
         putToResourceAttributeMap(
@@ -302,7 +300,6 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
             resourceLabels, resourceType, "zone", gcpGceInstanceMonitoredResource.getZone());
         return Collections.unmodifiableMap(resourceLabels);
       case GCP_GKE_CONTAINER:
-        @SuppressWarnings("unchecked")
         GcpGkeContainerMonitoredResource gcpGkeContainerMonitoredResource =
             (GcpGkeContainerMonitoredResource) resource;
         putToResourceAttributeMap(

--- a/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandlerProtoTest.java
+++ b/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandlerProtoTest.java
@@ -17,12 +17,8 @@
 package io.opencensus.exporter.trace.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
-import static io.opencensus.contrib.monitoredresource.util.ResourceType.AWS_EC2_INSTANCE;
-import static io.opencensus.contrib.monitoredresource.util.ResourceType.GCP_GCE_INSTANCE;
-import static io.opencensus.contrib.monitoredresource.util.ResourceType.GCP_GKE_CONTAINER;
 import static io.opencensus.exporter.trace.stackdriver.StackdriverV2ExporterHandler.createResourceLabelKey;
 import static io.opencensus.exporter.trace.stackdriver.StackdriverV2ExporterHandler.toStringAttributeValueProto;
-import static org.mockito.Mockito.when;
 
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
@@ -37,9 +33,7 @@ import com.google.devtools.cloudtrace.v2.StackTrace;
 import com.google.devtools.cloudtrace.v2.TruncatableString;
 import com.google.protobuf.Int32Value;
 import io.opencensus.common.Timestamp;
-import io.opencensus.contrib.monitoredresource.util.MonitoredResource.AwsEc2InstanceMonitoredResource;
-import io.opencensus.contrib.monitoredresource.util.MonitoredResource.GcpGceInstanceMonitoredResource;
-import io.opencensus.contrib.monitoredresource.util.MonitoredResource.GcpGkeContainerMonitoredResource;
+import io.opencensus.contrib.monitoredresource.util.ResourceType;
 import io.opencensus.trace.Annotation;
 import io.opencensus.trace.Link;
 import io.opencensus.trace.Span.Kind;
@@ -60,8 +54,6 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.mockito.Mock;
-import org.mockito.Mockito;
 
 @RunWith(JUnit4.class)
 public final class StackdriverV2ExporterHandlerProtoTest {
@@ -132,18 +124,6 @@ public final class StackdriverV2ExporterHandlerProtoTest {
   private static final SpanData.Links links = SpanData.Links.create(linksList, DROPPED_LINKS_COUNT);
 
   private StackdriverV2ExporterHandler handler;
-
-  @Mock
-  private final AwsEc2InstanceMonitoredResource mockAwsEc2Resource =
-      Mockito.mock(AwsEc2InstanceMonitoredResource.class);
-
-  @Mock
-  private final GcpGceInstanceMonitoredResource mockGcpGceResource =
-      Mockito.mock(GcpGceInstanceMonitoredResource.class);
-
-  @Mock
-  private final GcpGkeContainerMonitoredResource mockGcpGkeResource =
-      Mockito.mock(GcpGkeContainerMonitoredResource.class);
 
   @Before
   public void setUp() throws IOException {
@@ -250,7 +230,7 @@ public final class StackdriverV2ExporterHandlerProtoTest {
             .setNanos(endTimestamp.getNanos())
             .build();
 
-    Span span = handler.generateSpan(spanData, null);
+    Span span = handler.generateSpan(spanData);
     assertThat(span.getName()).isEqualTo(SD_SPAN_NAME);
     assertThat(span.getSpanId()).isEqualTo(SPAN_ID);
     assertThat(span.getParentSpanId()).isEqualTo(PARENT_SPAN_ID);
@@ -265,6 +245,7 @@ public final class StackdriverV2ExporterHandlerProtoTest {
         .containsEntry(ATTRIBUTE_KEY_1, AttributeValue.newBuilder().setIntValue(10L).build());
     assertThat(span.getAttributes().getAttributeMapMap())
         .containsEntry(ATTRIBUTE_KEY_2, AttributeValue.newBuilder().setBoolValue(true).build());
+    verifyResourceLabels(span.getAttributes().getAttributeMapMap());
     // TODO(@Hailong): add stack trace test in the future.
     assertThat(span.getStackTrace()).isEqualTo(StackTrace.newBuilder().build());
     assertThat(span.getTimeEvents().getDroppedMessageEventsCount())
@@ -281,97 +262,33 @@ public final class StackdriverV2ExporterHandlerProtoTest {
         .isEqualTo(Int32Value.newBuilder().setValue(CHILD_SPAN_COUNT).build());
   }
 
-  @Test
-  public void generateSpan_AwsEc2Resource() {
-    when(mockAwsEc2Resource.getResourceType()).thenReturn(AWS_EC2_INSTANCE);
-    when(mockAwsEc2Resource.getAccount()).thenReturn("");
-    when(mockAwsEc2Resource.getInstanceId()).thenReturn("");
-    when(mockAwsEc2Resource.getRegion()).thenReturn("");
-    SpanData spanData =
-        SpanData.create(
-            spanContext,
-            parentSpanId,
-            /* hasRemoteParent= */ true,
-            SPAN_NAME,
-            null,
-            startTimestamp,
-            attributes,
-            annotations,
-            messageEvents,
-            links,
-            CHILD_SPAN_COUNT,
-            status,
-            endTimestamp);
-    Span span = handler.generateSpan(spanData, mockAwsEc2Resource);
-    Map<String, AttributeValue> attributeMap = span.getAttributes().getAttributeMapMap();
-    assertThat(attributeMap).containsKey(createResourceLabelKey(AWS_EC2_INSTANCE, "aws_account"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(AWS_EC2_INSTANCE, "instance_id"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(AWS_EC2_INSTANCE, "region"));
-  }
-
-  @Test
-  public void generateSpan_GcpGceResource() {
-    when(mockGcpGceResource.getResourceType()).thenReturn(GCP_GCE_INSTANCE);
-    when(mockGcpGceResource.getAccount()).thenReturn("");
-    when(mockGcpGceResource.getInstanceId()).thenReturn("");
-    when(mockGcpGceResource.getZone()).thenReturn("");
-    SpanData spanData =
-        SpanData.create(
-            spanContext,
-            parentSpanId,
-            /* hasRemoteParent= */ true,
-            SPAN_NAME,
-            null,
-            startTimestamp,
-            attributes,
-            annotations,
-            messageEvents,
-            links,
-            CHILD_SPAN_COUNT,
-            status,
-            endTimestamp);
-    Span span = handler.generateSpan(spanData, mockGcpGceResource);
-    Map<String, AttributeValue> attributeMap = span.getAttributes().getAttributeMapMap();
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GCE_INSTANCE, "project_id"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GCE_INSTANCE, "instance_id"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GCE_INSTANCE, "zone"));
-  }
-
-  @Test
-  public void generateSpan_GcpGkeResource() {
-    when(mockGcpGkeResource.getResourceType()).thenReturn(GCP_GKE_CONTAINER);
-    when(mockGcpGkeResource.getAccount()).thenReturn("");
-    when(mockGcpGkeResource.getInstanceId()).thenReturn("");
-    when(mockGcpGkeResource.getZone()).thenReturn("");
-    when(mockGcpGkeResource.getClusterName()).thenReturn("");
-    when(mockGcpGkeResource.getContainerName()).thenReturn("");
-    when(mockGcpGkeResource.getNamespaceId()).thenReturn("");
-    when(mockGcpGkeResource.getPodId()).thenReturn("");
-    SpanData spanData =
-        SpanData.create(
-            spanContext,
-            parentSpanId,
-            /* hasRemoteParent= */ true,
-            SPAN_NAME,
-            null,
-            startTimestamp,
-            attributes,
-            annotations,
-            messageEvents,
-            links,
-            CHILD_SPAN_COUNT,
-            status,
-            endTimestamp);
-    Span span = handler.generateSpan(spanData, mockGcpGkeResource);
-    Map<String, AttributeValue> attributeMap = span.getAttributes().getAttributeMapMap();
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GKE_CONTAINER, "project_id"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GKE_CONTAINER, "instance_id"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GKE_CONTAINER, "zone"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GKE_CONTAINER, "cluster_name"));
-    assertThat(attributeMap)
-        .containsKey(createResourceLabelKey(GCP_GKE_CONTAINER, "container_name"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GKE_CONTAINER, "namespace_id"));
-    assertThat(attributeMap).containsKey(createResourceLabelKey(GCP_GKE_CONTAINER, "pod_id"));
+  private static void verifyResourceLabels(Map<String, AttributeValue> attributeMap) {
+    if (StackdriverV2ExporterHandler.RESOURCE == null) {
+      return;
+    }
+    ResourceType resourceType = StackdriverV2ExporterHandler.RESOURCE.getResourceType();
+    switch (resourceType) {
+      case AWS_EC2_INSTANCE:
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "aws_account"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "instance_id"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "region"));
+        return;
+      case GCP_GCE_INSTANCE:
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "project_id"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "instance_id"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "zone"));
+        return;
+      case GCP_GKE_CONTAINER:
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "project_id"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "instance_id"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "zone"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "cluster_name"));
+        assertThat(attributeMap)
+            .containsKey(createResourceLabelKey(resourceType, "container_name"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "namespace_id"));
+        assertThat(attributeMap).containsKey(createResourceLabelKey(resourceType, "pod_id"));
+        return;
+    }
   }
 
   @Test
@@ -406,7 +323,7 @@ public final class StackdriverV2ExporterHandlerProtoTest {
             status,
             endTimestamp);
 
-    Span span = handler.generateSpan(spanData, null);
+    Span span = handler.generateSpan(spanData);
     Map<String, AttributeValue> attributes = span.getAttributes().getAttributeMapMap();
 
     assertThat(attributes).containsEntry("/http/host", toStringAttributeValueProto("host"));
@@ -436,7 +353,7 @@ public final class StackdriverV2ExporterHandlerProtoTest {
             CHILD_SPAN_COUNT,
             status,
             endTimestamp);
-    assertThat(handler.generateSpan(spanData, null).getDisplayName().getValue())
+    assertThat(handler.generateSpan(spanData).getDisplayName().getValue())
         .isEqualTo("Recv." + SPAN_NAME);
   }
 
@@ -457,7 +374,7 @@ public final class StackdriverV2ExporterHandlerProtoTest {
             CHILD_SPAN_COUNT,
             status,
             endTimestamp);
-    assertThat(handler.generateSpan(spanData, null).getDisplayName().getValue())
+    assertThat(handler.generateSpan(spanData).getDisplayName().getValue())
         .isEqualTo("Recv." + SPAN_NAME);
   }
 
@@ -478,7 +395,7 @@ public final class StackdriverV2ExporterHandlerProtoTest {
             CHILD_SPAN_COUNT,
             status,
             endTimestamp);
-    assertThat(handler.generateSpan(spanData, null).getDisplayName().getValue())
+    assertThat(handler.generateSpan(spanData).getDisplayName().getValue())
         .isEqualTo("Sent." + SPAN_NAME);
   }
 
@@ -499,7 +416,7 @@ public final class StackdriverV2ExporterHandlerProtoTest {
             CHILD_SPAN_COUNT,
             status,
             endTimestamp);
-    assertThat(handler.generateSpan(spanData, null).getDisplayName().getValue())
+    assertThat(handler.generateSpan(spanData).getDisplayName().getValue())
         .isEqualTo("Sent." + SPAN_NAME);
   }
 }

--- a/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandlerProtoTest.java
+++ b/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandlerProtoTest.java
@@ -17,7 +17,9 @@
 package io.opencensus.exporter.trace.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.contrib.monitoredresource.util.ResourceType.AWS_EC2_INSTANCE;
 import static io.opencensus.contrib.monitoredresource.util.ResourceType.GCP_GCE_INSTANCE;
+import static io.opencensus.contrib.monitoredresource.util.ResourceType.GCP_GKE_CONTAINER;
 import static io.opencensus.exporter.trace.stackdriver.StackdriverV2ExporterHandler.createResourceLabelKey;
 import static io.opencensus.exporter.trace.stackdriver.StackdriverV2ExporterHandler.toStringAttributeValueProto;
 
@@ -124,14 +126,46 @@ public final class StackdriverV2ExporterHandlerProtoTest {
       TimedEvents.create(networkEventsList, DROPPED_NETWORKEVENTS_COUNT);
   private static final SpanData.Links links = SpanData.Links.create(linksList, DROPPED_LINKS_COUNT);
   private static final Map<String, AttributeValue> EMPTY_RESOURCE_LABELS = Collections.emptyMap();
+  private static final ImmutableMap<String, AttributeValue> AWS_RESOURCE_LABELS =
+      ImmutableMap.of(
+          createResourceLabelKey(AWS_EC2_INSTANCE, "aws_account"),
+          toStringAttributeValueProto("my-project"),
+          createResourceLabelKey(AWS_EC2_INSTANCE, "instance_id"),
+          toStringAttributeValueProto("my-instance"),
+          createResourceLabelKey(AWS_EC2_INSTANCE, "region"),
+          toStringAttributeValueProto("us-east-1"));
   private static final ImmutableMap<String, AttributeValue> GCE_RESOURCE_LABELS =
       ImmutableMap.of(
-          createResourceLabelKey(GCP_GCE_INSTANCE, "project-id"),
+          createResourceLabelKey(GCP_GCE_INSTANCE, "project_id"),
           toStringAttributeValueProto("my-project"),
-          createResourceLabelKey(GCP_GCE_INSTANCE, "instance-id"),
+          createResourceLabelKey(GCP_GCE_INSTANCE, "instance_id"),
           toStringAttributeValueProto("my-instance"),
           createResourceLabelKey(GCP_GCE_INSTANCE, "zone"),
           toStringAttributeValueProto("us-east1"));
+  private static final ImmutableMap<String, AttributeValue> GKE_RESOURCE_LABELS =
+      ImmutableMap.<String, AttributeValue>builder()
+          .put(
+              createResourceLabelKey(GCP_GKE_CONTAINER, "project_id"),
+              toStringAttributeValueProto("my-project"))
+          .put(
+              createResourceLabelKey(GCP_GKE_CONTAINER, "cluster_name"),
+              toStringAttributeValueProto("cluster"))
+          .put(
+              createResourceLabelKey(GCP_GKE_CONTAINER, "container_name"),
+              toStringAttributeValueProto("container"))
+          .put(
+              createResourceLabelKey(GCP_GKE_CONTAINER, "namespace_id"),
+              toStringAttributeValueProto("namespace"))
+          .put(
+              createResourceLabelKey(GCP_GKE_CONTAINER, "instance_id"),
+              toStringAttributeValueProto("my-instance"))
+          .put(
+              createResourceLabelKey(GCP_GKE_CONTAINER, "pod_id"),
+              toStringAttributeValueProto("pod"))
+          .put(
+              createResourceLabelKey(GCP_GKE_CONTAINER, "zone"),
+              toStringAttributeValueProto("us-east1"))
+          .build();
 
   private StackdriverV2ExporterHandler handler;
 
@@ -272,7 +306,21 @@ public final class StackdriverV2ExporterHandlerProtoTest {
   }
 
   @Test
-  public void generateSpan_WithResourceLabels() {
+  public void generateSpan_WithAwsEc2ResourceLabels() {
+    generateSpan_WithResourceLabels(AWS_RESOURCE_LABELS);
+  }
+
+  @Test
+  public void generateSpan_WithGceResourceLabels() {
+    generateSpan_WithResourceLabels(GCE_RESOURCE_LABELS);
+  }
+
+  @Test
+  public void generateSpan_WithGkeResourceLabels() {
+    generateSpan_WithResourceLabels(GKE_RESOURCE_LABELS);
+  }
+
+  private void generateSpan_WithResourceLabels(Map<String, AttributeValue> resourceLabels) {
     SpanData spanData =
         SpanData.create(
             spanContext,
@@ -288,20 +336,9 @@ public final class StackdriverV2ExporterHandlerProtoTest {
             CHILD_SPAN_COUNT,
             status,
             endTimestamp);
-    Span span = handler.generateSpan(spanData, GCE_RESOURCE_LABELS);
+    Span span = handler.generateSpan(spanData, resourceLabels);
     Map<String, AttributeValue> attributeMap = span.getAttributes().getAttributeMapMap();
-    assertThat(attributeMap)
-        .containsEntry(
-            createResourceLabelKey(GCP_GCE_INSTANCE, "project-id"),
-            toStringAttributeValueProto("my-project"));
-    assertThat(attributeMap)
-        .containsEntry(
-            createResourceLabelKey(GCP_GCE_INSTANCE, "instance-id"),
-            toStringAttributeValueProto("my-instance"));
-    assertThat(attributeMap)
-        .containsEntry(
-            createResourceLabelKey(GCP_GCE_INSTANCE, "zone"),
-            toStringAttributeValueProto("us-east1"));
+    assertThat(attributeMap.entrySet()).containsAllIn(resourceLabels.entrySet());
   }
 
   @Test


### PR DESCRIPTION
Resource labels are consistent with [Specs](https://github.com/census-instrumentation/opencensus-specs/blob/master/utils/MonitoredResource.md). The format of label key is `g.co/r/<resource_type>/<label>`, for example `g.co/r/aws_ec2_instance/aws_account`.