### PR TITLE
Expose the factory methods of MonitoredResource.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Expose the constructor of MonitoredResource.
 
 ## 0.14.0 - 2018-06-04
 - Adds Tracing.getExportComponent().shutdown() for use within application shutdown hooks.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-- Expose the constructor of MonitoredResource.
+- Expose the factory methods of MonitoredResource.
 
 ## 0.14.0 - 2018-06-04
 - Adds Tracing.getExportComponent().shutdown() for use within application shutdown hooks.

--- a/contrib/monitored_resource_util/src/main/java/io/opencensus/contrib/monitoredresource/util/MonitoredResource.java
+++ b/contrib/monitored_resource_util/src/main/java/io/opencensus/contrib/monitoredresource/util/MonitoredResource.java
@@ -102,9 +102,29 @@ public abstract class MonitoredResource {
      */
     public abstract String getRegion();
 
-    static AwsEc2InstanceMonitoredResource create() {
+    /**
+     * Returns an {@link AwsEc2InstanceMonitoredResource}.
+     *
+     * @param account the AWS account ID.
+     * @param instanceId the AWS EC2 instance ID.
+     * @param region the AWS region.
+     * @return an {@code AwsEc2InstanceMonitoredResource}.
+     * @since 0.15
+     */
+    public static AwsEc2InstanceMonitoredResource create(
+        String account, String instanceId, String region) {
       return new AutoValue_MonitoredResource_AwsEc2InstanceMonitoredResource(
-          AWS_ACCOUNT, AWS_INSTANCE_ID, AWS_REGION);
+          account, instanceId, region);
+    }
+
+    /**
+     * Returns an {@link AwsEc2InstanceMonitoredResource} with the default parameters.
+     *
+     * @return an {@code AwsEc2InstanceMonitoredResource}.
+     * @since 0.15
+     */
+    public static AwsEc2InstanceMonitoredResource create() {
+      return create(AWS_ACCOUNT, AWS_INSTANCE_ID, AWS_REGION);
     }
   }
 
@@ -151,9 +171,29 @@ public abstract class MonitoredResource {
      */
     public abstract String getZone();
 
-    static GcpGceInstanceMonitoredResource create() {
+    /**
+     * Returns a {@link GcpGceInstanceMonitoredResource}.
+     *
+     * @param account the GCP account number.
+     * @param instanceId the GCP GCE instance ID.
+     * @param zone the GCP zone.
+     * @return a {@code GcpGceInstanceMonitoredResource}.
+     * @since 0.15
+     */
+    public static GcpGceInstanceMonitoredResource create(
+        String account, String instanceId, String zone) {
       return new AutoValue_MonitoredResource_GcpGceInstanceMonitoredResource(
-          GCP_ACCOUNT_ID, GCP_INSTANCE_ID, GCP_ZONE);
+          account, instanceId, zone);
+    }
+
+    /**
+     * Returns a {@link GcpGceInstanceMonitoredResource} with the default parameters.
+     *
+     * @return a {@code GcpGceInstanceMonitoredResource}.
+     * @since 0.15
+     */
+    public static GcpGceInstanceMonitoredResource create() {
+      return create(GCP_ACCOUNT_ID, GCP_INSTANCE_ID, GCP_ZONE);
     }
   }
 
@@ -238,8 +278,39 @@ public abstract class MonitoredResource {
      */
     public abstract String getZone();
 
-    static GcpGkeContainerMonitoredResource create() {
+    /**
+     * Returns a {@link GcpGkeContainerMonitoredResource}.
+     *
+     * @param account the GCP account number.
+     * @param clusterName the GCP GKE cluster name.
+     * @param containerName the GCP GKE container name.
+     * @param namespaceId the GCP GKE namespace ID.
+     * @param instanceId the GCP GKE instance ID.
+     * @param podId the GCP GKE Pod ID.
+     * @param zone the GCP zone.
+     * @return a {@code GcpGkeContainerMonitoredResource}.
+     * @since 0.15
+     */
+    public static GcpGkeContainerMonitoredResource create(
+        String account,
+        String clusterName,
+        String containerName,
+        String namespaceId,
+        String instanceId,
+        String podId,
+        String zone) {
       return new AutoValue_MonitoredResource_GcpGkeContainerMonitoredResource(
+          account, clusterName, containerName, namespaceId, instanceId, podId, zone);
+    }
+
+    /**
+     * Returns a {@link GcpGkeContainerMonitoredResource} with the default parameters.
+     *
+     * @return a {@code GcpGkeContainerMonitoredResource}
+     * @since 0.15
+     */
+    public static GcpGkeContainerMonitoredResource create() {
+      return create(
           GCP_ACCOUNT_ID,
           GCP_CLUSTER_NAME,
           GCP_CONTAINER_NAME,

--- a/contrib/monitored_resource_util/src/main/java/io/opencensus/contrib/monitoredresource/util/MonitoredResource.java
+++ b/contrib/monitored_resource_util/src/main/java/io/opencensus/contrib/monitoredresource/util/MonitoredResource.java
@@ -117,13 +117,7 @@ public abstract class MonitoredResource {
           account, instanceId, region);
     }
 
-    /**
-     * Returns an {@link AwsEc2InstanceMonitoredResource} with the default parameters.
-     *
-     * @return an {@code AwsEc2InstanceMonitoredResource}.
-     * @since 0.15
-     */
-    public static AwsEc2InstanceMonitoredResource create() {
+    static AwsEc2InstanceMonitoredResource create() {
       return create(AWS_ACCOUNT, AWS_INSTANCE_ID, AWS_REGION);
     }
   }
@@ -186,13 +180,7 @@ public abstract class MonitoredResource {
           account, instanceId, zone);
     }
 
-    /**
-     * Returns a {@link GcpGceInstanceMonitoredResource} with the default parameters.
-     *
-     * @return a {@code GcpGceInstanceMonitoredResource}.
-     * @since 0.15
-     */
-    public static GcpGceInstanceMonitoredResource create() {
+    static GcpGceInstanceMonitoredResource create() {
       return create(GCP_ACCOUNT_ID, GCP_INSTANCE_ID, GCP_ZONE);
     }
   }
@@ -303,13 +291,7 @@ public abstract class MonitoredResource {
           account, clusterName, containerName, namespaceId, instanceId, podId, zone);
     }
 
-    /**
-     * Returns a {@link GcpGkeContainerMonitoredResource} with the default parameters.
-     *
-     * @return a {@code GcpGkeContainerMonitoredResource}
-     * @since 0.15
-     */
-    public static GcpGkeContainerMonitoredResource create() {
+    static GcpGkeContainerMonitoredResource create() {
       return create(
           GCP_ACCOUNT_ID,
           GCP_CLUSTER_NAME,

--- a/contrib/monitored_resource_util/src/test/java/io/opencensus/contrib/monitoredresource/util/MonitoredResourceTest.java
+++ b/contrib/monitored_resource_util/src/test/java/io/opencensus/contrib/monitoredresource/util/MonitoredResourceTest.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.monitoredresource.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.contrib.monitoredresource.util.MonitoredResource.AwsEc2InstanceMonitoredResource;
+import io.opencensus.contrib.monitoredresource.util.MonitoredResource.GcpGceInstanceMonitoredResource;
+import io.opencensus.contrib.monitoredresource.util.MonitoredResource.GcpGkeContainerMonitoredResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link MonitoredResource}. */
+@RunWith(JUnit4.class)
+public class MonitoredResourceTest {
+
+  private static final String AWS_ACCOUNT = "aws-account";
+  private static final String AWS_INSTANCE = "instance";
+  private static final String AWS_REGION = "us-west-2";
+  private static final String GCP_PROJECT = "gcp-project";
+  private static final String GCP_INSTANCE = "instance";
+  private static final String GCP_ZONE = "us-east1";
+  private static final String GCP_GKE_NAMESPACE = "namespace";
+  private static final String GCP_GKE_POD_ID = "pod-id";
+  private static final String GCP_GKE_CONTAINER_NAME = "container";
+  private static final String GCP_GKE_CLUSTER_NAME = "cluster";
+
+  @Test
+  public void testAwsEc2InstanceMonitoredResource() {
+    AwsEc2InstanceMonitoredResource resource =
+        AwsEc2InstanceMonitoredResource.create(AWS_ACCOUNT, AWS_INSTANCE, AWS_REGION);
+    assertThat(resource.getResourceType()).isEqualTo(ResourceType.AWS_EC2_INSTANCE);
+    assertThat(resource.getAccount()).isEqualTo(AWS_ACCOUNT);
+    assertThat(resource.getInstanceId()).isEqualTo(AWS_INSTANCE);
+    assertThat(resource.getRegion()).isEqualTo(AWS_REGION);
+  }
+
+  @Test
+  public void testGcpGceInstanceMonitoredResource() {
+    GcpGceInstanceMonitoredResource resource =
+        GcpGceInstanceMonitoredResource.create(GCP_PROJECT, GCP_INSTANCE, GCP_ZONE);
+    assertThat(resource.getResourceType()).isEqualTo(ResourceType.GCP_GCE_INSTANCE);
+    assertThat(resource.getAccount()).isEqualTo(GCP_PROJECT);
+    assertThat(resource.getInstanceId()).isEqualTo(GCP_INSTANCE);
+    assertThat(resource.getZone()).isEqualTo(GCP_ZONE);
+  }
+
+  @Test
+  public void testGcpGkeContainerMonitoredResource() {
+    GcpGkeContainerMonitoredResource resource =
+        GcpGkeContainerMonitoredResource.create(
+            GCP_PROJECT,
+            GCP_GKE_CLUSTER_NAME,
+            GCP_GKE_CONTAINER_NAME,
+            GCP_GKE_NAMESPACE,
+            GCP_INSTANCE,
+            GCP_GKE_POD_ID,
+            GCP_ZONE);
+    assertThat(resource.getResourceType()).isEqualTo(ResourceType.GCP_GKE_CONTAINER);
+    assertThat(resource.getAccount()).isEqualTo(GCP_PROJECT);
+    assertThat(resource.getClusterName()).isEqualTo(GCP_GKE_CLUSTER_NAME);
+    assertThat(resource.getContainerName()).isEqualTo(GCP_GKE_CONTAINER_NAME);
+    assertThat(resource.getNamespaceId()).isEqualTo(GCP_GKE_NAMESPACE);
+    assertThat(resource.getInstanceId()).isEqualTo(GCP_INSTANCE);
+    assertThat(resource.getPodId()).isEqualTo(GCP_GKE_POD_ID);
+    assertThat(resource.getZone()).isEqualTo(GCP_ZONE);
+  }
+}


### PR DESCRIPTION
To make the unit tests of other libraries that depend on `monitored-resource-utils` easier to write.