### PR TITLE
Stackdriver Stats Exporter: don't set StartTime for Gauge values.

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -271,21 +271,24 @@ final class StackdriverExportUtils {
       ViewData.AggregationWindowData windowData,
       Aggregation aggregation) {
     Point.Builder builder = Point.newBuilder();
-    builder.setInterval(createTimeInterval(windowData));
+    builder.setInterval(createTimeInterval(windowData, aggregation));
     builder.setValue(createTypedValue(aggregation, aggregationData));
     return builder.build();
   }
 
   // Convert AggregationWindowData to TimeInterval, currently only support CumulativeData.
   @VisibleForTesting
-  static TimeInterval createTimeInterval(ViewData.AggregationWindowData windowData) {
+  static TimeInterval createTimeInterval(
+      ViewData.AggregationWindowData windowData, final Aggregation aggregation) {
     final TimeInterval.Builder builder = TimeInterval.newBuilder();
     windowData.match(
         new Function<ViewData.AggregationWindowData.CumulativeData, Void>() {
           @Override
           public Void apply(ViewData.AggregationWindowData.CumulativeData arg) {
-            builder.setStartTime(convertTimestamp(arg.getStart()));
             builder.setEndTime(convertTimestamp(arg.getEnd()));
+            if (!(aggregation instanceof LastValue)) {
+              builder.setStartTime(convertTimestamp(arg.getStart()));
+            }
             return null;
           }
         },

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -240,10 +240,17 @@ public class StackdriverExportUtilsTest {
     Timestamp censusTimestamp2 = Timestamp.create(200, 0);
     assertThat(
             StackdriverExportUtils.createTimeInterval(
-                CumulativeData.create(censusTimestamp1, censusTimestamp2)))
+                CumulativeData.create(censusTimestamp1, censusTimestamp2), DISTRIBUTION))
         .isEqualTo(
             TimeInterval.newBuilder()
                 .setStartTime(StackdriverExportUtils.convertTimestamp(censusTimestamp1))
+                .setEndTime(StackdriverExportUtils.convertTimestamp(censusTimestamp2))
+                .build());
+    assertThat(
+            StackdriverExportUtils.createTimeInterval(
+                CumulativeData.create(censusTimestamp1, censusTimestamp2), LAST_VALUE))
+        .isEqualTo(
+            TimeInterval.newBuilder()
                 .setEndTime(StackdriverExportUtils.convertTimestamp(censusTimestamp2))
                 .build());
   }
@@ -253,7 +260,7 @@ public class StackdriverExportUtilsTest {
     IntervalData intervalData = IntervalData.create(Timestamp.create(200, 0));
     // Only Cumulative view will supported in this version.
     thrown.expect(IllegalArgumentException.class);
-    StackdriverExportUtils.createTimeInterval(intervalData);
+    StackdriverExportUtils.createTimeInterval(intervalData, SUM);
   }
 
   @Test
@@ -318,7 +325,7 @@ public class StackdriverExportUtilsTest {
     assertThat(StackdriverExportUtils.createPoint(sumDataDouble, cumulativeData, SUM))
         .isEqualTo(
             Point.newBuilder()
-                .setInterval(StackdriverExportUtils.createTimeInterval(cumulativeData))
+                .setInterval(StackdriverExportUtils.createTimeInterval(cumulativeData, SUM))
                 .setValue(StackdriverExportUtils.createTypedValue(SUM, sumDataDouble))
                 .build());
   }


### PR DESCRIPTION
From https://cloud.google.com/monitoring/api/ref_v3/rest/v3/TimeSeries#point:

> For GAUGE metrics, only the end time of the interval is used. 

Equivalent to https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/pull/18.