### PR TITLE
Add ALL_SPANS/NO_SPANS/SAMPLED_SPANS property to OpenCensusTraceLoggingEnhancer.

### DIFF
--- a/contrib/log_correlation/stackdriver/build.gradle
+++ b/contrib/log_correlation/stackdriver/build.gradle
@@ -6,5 +6,7 @@ dependencies {
     compile project(':opencensus-api'),
             libraries.google_cloud_logging
 
+    testCompile libraries.guava
+
     signature "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -24,35 +24,117 @@ import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.TraceId;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracing;
+import java.util.logging.LogManager;
 
 /**
  * Stackdriver {@link LoggingEnhancer} that adds OpenCensus tracing data to log entries.
  *
  * <p>This feature is currently experimental.
  */
-
-// TODO(sebright): Allow configuring the LoggingEnhancer with Java properties. One property should
-// control the types of spans to correlate, with these three choices:
-// - off
-// - only add tracing data for sampled spans
-// - add tracing data for all spans
 @ExperimentalApi
 public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
-  private static final String SAMPLED_KEY = "sampled";
+  private static final String SAMPLED_LABEL_KEY = "sampled";
+  private static final SpanSelection DEFAULT_SPAN_SELECTION = SpanSelection.ALL_SPANS;
+
+  /** Name of the property that defines the {@link SpanSelection}. The value is {@value}. */
+  public static final String SPAN_SELECTION_PROPERTY_NAME =
+      "io.opencensus.contrib.logcorrelation.stackdriver."
+          + "OpenCensusTraceLoggingEnhancer.spanSelection";
 
   private static final Tracer tracer = Tracing.getTracer();
 
-  /** Constructor to be called by Stackdriver logging. */
-  public OpenCensusTraceLoggingEnhancer() {}
+  private final SpanSelection spanSelection;
 
+  /** How to decide whether to add tracing data from the current span to a log entry. */
+  public enum SpanSelection {
+
+    /**
+     * Never add tracing data to log entries. This constant disables the log correlation feature.
+     */
+    NO_SPANS,
+
+    /** Add tracing data to a log entry iff the current span is sampled. */
+    SAMPLED_SPANS,
+
+    /**
+     * Always add tracing data to log entries, even when the current span is not sampled. This is
+     * the default.
+     */
+    ALL_SPANS
+  }
+
+  /**
+   * Constructor to be called by Stackdriver logging.
+   *
+   * <p>This constructor looks up the {@link SpanSelection} from the environment using the property
+   * name {@value SPAN_SELECTION_PROPERTY_NAME}. It looks for a {@link java.util.logging} property
+   * or a system property, giving preference to the logging property.
+   */
+  public OpenCensusTraceLoggingEnhancer() {
+    this(lookUpSpanSelectionProperty());
+  }
+
+  /** Constructor used for testing. */
+  OpenCensusTraceLoggingEnhancer(SpanSelection spanSelection) {
+    this.spanSelection = spanSelection;
+  }
+
+  private static SpanSelection lookUpSpanSelectionProperty() {
+    String spanSelectionProperty = lookUpProperty(SPAN_SELECTION_PROPERTY_NAME);
+    return spanSelectionProperty == null || spanSelectionProperty.isEmpty()
+        ? DEFAULT_SPAN_SELECTION
+        : parseSpanSelection(spanSelectionProperty);
+  }
+
+  private static SpanSelection parseSpanSelection(String spanSelection) {
+    try {
+      return SpanSelection.valueOf(spanSelection);
+    } catch (IllegalArgumentException e) {
+      return DEFAULT_SPAN_SELECTION;
+    }
+  }
+
+  // An OpenCensusTraceLoggingEnhancer property can be set with a logging property or a system
+  // property.
+  private static String lookUpProperty(String name) {
+    String property = LogManager.getLogManager().getProperty(name);
+    return property == null || property.isEmpty() ? System.getProperty(name) : property;
+  }
+
+  /**
+   * Returns the {@code SpanSelection} setting for this instance.
+   *
+   * @return the {@code SpanSelection} setting for this instance.
+   */
+  public SpanSelection getSpanSelection() {
+    return spanSelection;
+  }
+
+  // This method avoids getting the current span when the feature is disabled, for efficiency.
   @Override
   public void enhanceLogEntry(LogEntry.Builder builder) {
-    SpanContext span = tracer.getCurrentSpan().getContext();
+    switch (spanSelection) {
+      case NO_SPANS:
+        return;
+      case SAMPLED_SPANS:
+        SpanContext span = tracer.getCurrentSpan().getContext();
+        if (span.getTraceOptions().isSampled()) {
+          addTracingData(span, builder);
+        }
+        return;
+      case ALL_SPANS:
+        addTracingData(tracer.getCurrentSpan().getContext(), builder);
+        return;
+    }
+    throw new AssertionError("Unknown spanSelection: " + spanSelection);
+  }
+
+  private static void addTracingData(SpanContext span, LogEntry.Builder builder) {
     builder.setTrace(formatTraceId(span.getTraceId()));
     builder.setSpanId(span.getSpanId().toLowerBase16());
 
     // TODO(sebright): Find the correct way to add the sampling decision.
-    builder.addLabel(SAMPLED_KEY, Boolean.toString(span.getTraceOptions().isSampled()));
+    builder.addLabel(SAMPLED_LABEL_KEY, Boolean.toString(span.getTraceOptions().isSampled()));
   }
 
   private static String formatTraceId(TraceId traceId) {


### PR DESCRIPTION
The full name of the property is
`io.opencensus.contrib.logcorrelation.stackdriver.OpenCensusTraceLoggingEnhancer.spanSelection`.
It can be set in logging.properties or set as a system property.

Allowed values for spanSelection:

NO_SPANS: disables the log correlation feature
ALL_SPANS: adds tracing data to all log entries
SAMPLED_SPANS: adds tracing data to log entries when the current span is sampled

SAMPLED_SPANS is the default.

_______________________________________________________________________

I'm not sure if this is the best way to allow configuration of the `spanSelection` field.  My goal is to make it work with as many logging frameworks as possible that could be used in combination with google-cloud-logging, though I've only tested it with Logback and java.util.logging so far.  With the current design, `spanSelection` could be set with

```xml
<property scope="system" name="io.opencensus.contrib.logcorrelation.stackdriver.OpenCensusTraceLoggingEnhancer.spanSelection" value="ALL_SPANS" />
```

in logback.xml or

```properties
io.opencensus.contrib.logcorrelation.stackdriver.OpenCensusTraceLoggingEnhancer.spanSelection=ALL_SPANS
```

in logging.properties.

/cc @songy23 @adriancole @ramonza @HailongWen 