### PR TITLE
Metrics:  Add Value and Point.

### DIFF
--- a/metrics/src/main/java/io/opencensus/metrics/Distribution.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Distribution.java
@@ -119,6 +119,11 @@ public abstract class Distribution {
   /**
    * Returns the aggregated sum of squared deviations.
    *
+   * <p>The sum of squared deviations from the mean of the values in the population. For values x_i
+   * this is:
+   *
+   * <p>Sum[i=1..n]((x_i - mean)^2)
+   *
    * <p>If count is zero then this field must be zero.
    *
    * @return the aggregated sum of squared deviations.

--- a/metrics/src/main/java/io/opencensus/metrics/Distribution.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Distribution.java
@@ -1,0 +1,246 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * {@link Distribution} contains summary statistics for a population of values. It optionally
+ * contains a histogram representing the distribution of those values across a set of buckets.
+ *
+ * @since 0.16
+ */
+@ExperimentalApi
+@AutoValue
+@Immutable
+public abstract class Distribution {
+
+  Distribution() {}
+
+  /**
+   * Creates a {@link Distribution}.
+   *
+   * @param mean mean of the population values.
+   * @param count count of the population values.
+   * @param sumOfSquaredDeviations sum of squared deviations of the population values.
+   * @param range {@link Range} of the population values, or {@code null} if count is 0.
+   * @param bucketBoundaries bucket boundaries of a histogram.
+   * @param buckets {@link Bucket}s of a histogram.
+   * @return a {@code Distribution}.
+   * @since 0.16
+   */
+  public static Distribution create(
+      double mean,
+      long count,
+      double sumOfSquaredDeviations,
+      @Nullable Range range,
+      List<Double> bucketBoundaries,
+      List<Bucket> buckets) {
+    Utils.checkArgument(count >= 0, "count should be non-negative.");
+    Utils.checkArgument(
+        sumOfSquaredDeviations >= 0, "sum of squared deviations should be non-negative.");
+    if (count == 0) {
+      Utils.checkArgument(range == null, "range should not be present if count is 0.");
+      Utils.checkArgument(mean == 0, "mean should be 0 if count is 0.");
+      Utils.checkArgument(
+          sumOfSquaredDeviations == 0, "sum of squared deviations should be 0 if count is 0.");
+    } else {
+      Utils.checkArgument(range != null, "range should be present if count is not 0.");
+    }
+    return new AutoValue_Distribution(
+        mean,
+        count,
+        sumOfSquaredDeviations,
+        range,
+        copyBucketBounds(bucketBoundaries),
+        copyBucketCount(buckets));
+  }
+
+  private static List<Double> copyBucketBounds(List<Double> bucketBoundaries) {
+    Utils.checkNotNull(bucketBoundaries, "bucketBoundaries list should not be null.");
+    List<Double> bucketBoundariesCopy = new ArrayList<Double>(bucketBoundaries); // Deep copy.
+    // Check if sorted.
+    if (bucketBoundariesCopy.size() > 1) {
+      double lower = bucketBoundariesCopy.get(0);
+      for (int i = 1; i < bucketBoundariesCopy.size(); i++) {
+        double next = bucketBoundariesCopy.get(i);
+        Utils.checkArgument(lower < next, "bucket boundaries not sorted.");
+        lower = next;
+      }
+    }
+    return Collections.unmodifiableList(bucketBoundariesCopy);
+  }
+
+  private static List<Bucket> copyBucketCount(List<Bucket> buckets) {
+    Utils.checkNotNull(buckets, "bucket list should not be null.");
+    List<Bucket> bucketsCopy = new ArrayList<Bucket>(buckets);
+    for (Bucket bucket : bucketsCopy) {
+      Utils.checkNotNull(bucket, "bucket should not be null.");
+    }
+    return Collections.unmodifiableList(bucketsCopy);
+  }
+
+  /**
+   * Returns the aggregated mean.
+   *
+   * @return the aggregated mean.
+   * @since 0.16
+   */
+  public abstract double getMean();
+
+  /**
+   * Returns the aggregated count.
+   *
+   * @return the aggregated count.
+   * @since 0.16
+   */
+  public abstract long getCount();
+
+  /**
+   * Returns the aggregated sum of squared deviations.
+   *
+   * <p>If count is zero then this field must be zero.
+   *
+   * @return the aggregated sum of squared deviations.
+   * @since 0.16
+   */
+  public abstract double getSumOfSquaredDeviations();
+
+  /**
+   * Returns the {@link Range} of the population values, or returns {@code null} if there are no
+   * population values.
+   *
+   * @return the {@code Range} of the population values.
+   * @since 0.16
+   */
+  @Nullable
+  public abstract Range getRange();
+
+  /**
+   * Returns the bucket boundaries of this distribution.
+   *
+   * <p>The bucket boundaries for that histogram are described by bucket_bounds. This defines
+   * size(bucket_bounds) + 1 (= N) buckets. The boundaries for bucket index i are:
+   *
+   * <ul>
+   *   <li>{@code (-infinity, bucket_bounds[i]) for i == 0}
+   *   <li>{@code [bucket_bounds[i-1], bucket_bounds[i]) for 0 < i < N-2}
+   *   <li>{@code [bucket_bounds[i-1], +infinity) for i == N-1}
+   * </ul>
+   *
+   * <p>i.e. an underflow bucket (number 0), zero or more finite buckets (1 through N - 2, and an
+   * overflow bucket (N - 1), with inclusive lower bounds and exclusive upper bounds.
+   *
+   * <p>If bucket_bounds has no elements (zero size), then there is no histogram associated with the
+   * Distribution. If bucket_bounds has only one element, there are no finite buckets, and that
+   * single element is the common boundary of the overflow and underflow buckets. The values must be
+   * monotonically increasing.
+   *
+   * @return the bucket boundaries of this distribution.
+   * @since 0.16
+   */
+  public abstract List<Double> getBucketBoundaries();
+
+  /**
+   * Returns the the aggregated histogram {@link Bucket}s.
+   *
+   * @return the the aggregated histogram buckets.
+   * @since 0.16
+   */
+  public abstract List<Bucket> getBuckets();
+
+  /**
+   * The range of the population values.
+   *
+   * @since 0.16
+   */
+  @AutoValue
+  @Immutable
+  public abstract static class Range {
+
+    Range() {}
+
+    /**
+     * Creates a {@link Range}.
+     *
+     * @param min the minimum of the population values.
+     * @param max the maximum of the population values.
+     * @return a {@code Range}.
+     * @since 0.16
+     */
+    public static Range create(double min, double max) {
+      Utils.checkArgument(min <= max, "max should be greater or equal to min.");
+      return new AutoValue_Distribution_Range(min, max);
+    }
+
+    /**
+     * Returns the minimum of the population values.
+     *
+     * @return the minimum of the population values.
+     * @since 0.16
+     */
+    public abstract double getMin();
+
+    /**
+     * Returns the maximum of the population values.
+     *
+     * @return the maximum of the population values.
+     * @since 0.16
+     */
+    public abstract double getMax();
+  }
+
+  /**
+   * The histogram bucket of the population values.
+   *
+   * @since 0.16
+   */
+  @AutoValue
+  @Immutable
+  public abstract static class Bucket {
+
+    Bucket() {}
+
+    /**
+     * Creates a {@link Bucket}.
+     *
+     * @param count the number of values in each bucket of the histogram.
+     * @return a {@code Bucket}.
+     * @since 0.16
+     */
+    public static Bucket create(long count) {
+      Utils.checkArgument(count >= 0, "bucket count should be non-negative.");
+      return new AutoValue_Distribution_Bucket(count);
+    }
+
+    /**
+     * Returns the number of values in each bucket of the histogram.
+     *
+     * @return the number of values in each bucket of the histogram.
+     * @since 0.16
+     */
+    public abstract long getCount();
+  }
+
+  // TODO(songya): add support for exemplars.
+}

--- a/metrics/src/main/java/io/opencensus/metrics/Point.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Point.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import io.opencensus.common.Timestamp;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A timestamped measurement of a {@code TimeSeries}.
+ *
+ * @since 0.15
+ */
+@ExperimentalApi
+@AutoValue
+@Immutable
+public abstract class Point {
+
+  Point() {}
+
+  /**
+   * Creates a {@link Point}.
+   *
+   * @param value the {@link Value} of this {@link Point}.
+   * @param timestamp the {@link Timestamp} when this {@link Point} was recorded.
+   * @return a {@code Point}.
+   * @since 0.15
+   */
+  public static Point create(Value value, Timestamp timestamp) {
+    return new AutoValue_Point(value, timestamp);
+  }
+
+  /**
+   * Returns the {@link Value}.
+   *
+   * @return the {@code Value}.
+   * @since 0.15
+   */
+  public abstract Value getValue();
+
+  /**
+   * Returns the {@link Timestamp} when this {@link Point} was recorded.
+   *
+   * @return the {@code Timestamp}.
+   * @since 0.15
+   */
+  public abstract Timestamp getTimestamp();
+}

--- a/metrics/src/main/java/io/opencensus/metrics/Point.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Point.java
@@ -24,7 +24,7 @@ import javax.annotation.concurrent.Immutable;
 /**
  * A timestamped measurement of a {@code TimeSeries}.
  *
- * @since 0.15
+ * @since 0.16
  */
 @ExperimentalApi
 @AutoValue
@@ -39,7 +39,7 @@ public abstract class Point {
    * @param value the {@link Value} of this {@link Point}.
    * @param timestamp the {@link Timestamp} when this {@link Point} was recorded.
    * @return a {@code Point}.
-   * @since 0.15
+   * @since 0.16
    */
   public static Point create(Value value, Timestamp timestamp) {
     return new AutoValue_Point(value, timestamp);
@@ -49,7 +49,7 @@ public abstract class Point {
    * Returns the {@link Value}.
    *
    * @return the {@code Value}.
-   * @since 0.15
+   * @since 0.16
    */
   public abstract Value getValue();
 
@@ -57,7 +57,7 @@ public abstract class Point {
    * Returns the {@link Timestamp} when this {@link Point} was recorded.
    *
    * @return the {@code Timestamp}.
-   * @since 0.15
+   * @since 0.16
    */
   public abstract Timestamp getTimestamp();
 }

--- a/metrics/src/main/java/io/opencensus/metrics/Utils.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Utils.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.NonNull;
+*/
+
+/** General internal utility methods. */
+// TODO(songya): remove this class and use shared Utils instead.
+final class Utils {
+
+  private Utils() {}
+
+  /**
+   * Throws an {@link IllegalArgumentException} if the argument is false. This method is similar to
+   * {@code Preconditions.checkArgument(boolean, Object)} from Guava.
+   *
+   * @param isValid whether the argument check passed.
+   * @param message the message to use for the exception.
+   */
+  static void checkArgument(boolean isValid, String message) {
+    if (!isValid) {
+      throw new IllegalArgumentException(message);
+    }
+  }
+
+  /**
+   * Throws a {@link NullPointerException} if the argument is null. This method is similar to {@code
+   * Preconditions.checkNotNull(Object, Object)} from Guava.
+   *
+   * @param arg the argument to check for null.
+   * @param message the message to use for the exception.
+   * @return the argument, if it passes the null check.
+   */
+  static <T /*>>> extends @NonNull Object*/> T checkNotNull(T arg, String message) {
+    if (arg == null) {
+      throw new NullPointerException(message);
+    }
+    return arg;
+  }
+}

--- a/metrics/src/main/java/io/opencensus/metrics/Value.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Value.java
@@ -37,7 +37,7 @@ import javax.annotation.concurrent.Immutable;
  *
  * <p>Each {@link Point} contains exactly one of the three {@link Value} types.
  *
- * @since 0.15
+ * @since 0.16
  */
 @ExperimentalApi
 @Immutable
@@ -48,7 +48,7 @@ public abstract class Value {
   /**
    * Applies the given match function to the underlying data type.
    *
-   * @since 0.15
+   * @since 0.16
    */
   public abstract <T> T match(
       Function<? super DoubleValue, T> p0,
@@ -59,7 +59,7 @@ public abstract class Value {
   /**
    * A 64-bit double-precision floating-point {@link Value}.
    *
-   * @since 0.15
+   * @since 0.16
    */
   @AutoValue
   @Immutable
@@ -81,7 +81,7 @@ public abstract class Value {
      *
      * @param value the value in double.
      * @return a {@code DoubleValue}.
-     * @since 0.15
+     * @since 0.16
      */
     public static DoubleValue create(double value) {
       return new AutoValue_Value_DoubleValue(value);
@@ -91,7 +91,7 @@ public abstract class Value {
      * Returns the double value.
      *
      * @return the double value.
-     * @since 0.15
+     * @since 0.16
      */
     public abstract double getValue();
   }
@@ -99,7 +99,7 @@ public abstract class Value {
   /**
    * A 64-bit integer {@link Value}.
    *
-   * @since 0.15
+   * @since 0.16
    */
   @AutoValue
   @Immutable
@@ -121,7 +121,7 @@ public abstract class Value {
      *
      * @param value the value in long.
      * @return a {@code LongValue}.
-     * @since 0.15
+     * @since 0.16
      */
     public static LongValue create(long value) {
       return new AutoValue_Value_LongValue(value);
@@ -131,7 +131,7 @@ public abstract class Value {
      * Returns the long value.
      *
      * @return the long value.
-     * @since 0.15
+     * @since 0.16
      */
     public abstract long getValue();
   }
@@ -140,7 +140,7 @@ public abstract class Value {
    * {@link DistributionValue} contains summary statistics for a population of values. It optionally
    * contains a histogram representing the distribution of those values across a set of buckets.
    *
-   * @since 0.15
+   * @since 0.16
    */
   @AutoValue
   @Immutable
@@ -167,7 +167,7 @@ public abstract class Value {
      * @param bucketBoundaries bucket boundaries of a histogram.
      * @param buckets {@link Bucket}s of a histogram.
      * @return a {@code DistributionValue}.
-     * @since 0.15
+     * @since 0.16
      */
     public static DistributionValue create(
         double mean,
@@ -214,7 +214,7 @@ public abstract class Value {
      * Returns the aggregated mean.
      *
      * @return the aggregated mean.
-     * @since 0.15
+     * @since 0.16
      */
     public abstract double getMean();
 
@@ -222,7 +222,7 @@ public abstract class Value {
      * Returns the aggregated count.
      *
      * @return the aggregated count.
-     * @since 0.15
+     * @since 0.16
      */
     public abstract long getCount();
 
@@ -240,7 +240,7 @@ public abstract class Value {
      * <p>If count is zero then this field must be zero.
      *
      * @return the aggregated sum of squared deviations.
-     * @since 0.15
+     * @since 0.16
      */
     public abstract double getSumOfSquaredDeviations();
 
@@ -248,7 +248,7 @@ public abstract class Value {
      * Returns the {@link Range} of the population values.
      *
      * @return the {@code Range} of the population values.
-     * @since 0.15
+     * @since 0.16
      */
     public abstract Range getRange();
 
@@ -276,7 +276,7 @@ public abstract class Value {
      * when trying to modify it.
      *
      * @return the bucket boundaries of this distribution.
-     * @since 0.15
+     * @since 0.16
      */
     public abstract List<Double> getBucketBoundaries();
 
@@ -285,14 +285,14 @@ public abstract class Value {
      * to update it will throw an {@code UnsupportedOperationException}.
      *
      * @return the the aggregated histogram buckets.
-     * @since 0.15
+     * @since 0.16
      */
     public abstract List<Bucket> getBuckets();
 
     /**
      * The range of the population values.
      *
-     * @since 0.15
+     * @since 0.16
      */
     @AutoValue
     @Immutable
@@ -306,7 +306,7 @@ public abstract class Value {
        * @param min the minimum of the population values.
        * @param max the maximum of the population values.
        * @return a {@code Range}.
-       * @since 0.15
+       * @since 0.16
        */
       public static Range create(double min, double max) {
         if (min != Double.POSITIVE_INFINITY || max != Double.NEGATIVE_INFINITY) {
@@ -319,7 +319,7 @@ public abstract class Value {
        * Returns the minimum of the population values.
        *
        * @return the minimum of the population values.
-       * @since 0.15
+       * @since 0.16
        */
       public abstract double getMin();
 
@@ -327,7 +327,7 @@ public abstract class Value {
        * Returns the maximum of the population values.
        *
        * @return the maximum of the population values.
-       * @since 0.15
+       * @since 0.16
        */
       public abstract double getMax();
     }
@@ -335,7 +335,7 @@ public abstract class Value {
     /**
      * The histogram bucket of the population values.
      *
-     * @since 0.15
+     * @since 0.16
      */
     @AutoValue
     @Immutable
@@ -348,7 +348,7 @@ public abstract class Value {
        *
        * @param count the number of values in each bucket of the histogram.
        * @return a {@code Bucket}.
-       * @since 0.15
+       * @since 0.16
        */
       public static Bucket create(long count) {
         Utils.checkArgument(count >= 0, "bucket count should be non-negative.");
@@ -359,7 +359,7 @@ public abstract class Value {
        * Returns the number of values in each bucket of the histogram.
        *
        * @return the number of values in each bucket of the histogram.
-       * @since 0.15
+       * @since 0.16
        */
       public abstract long getCount();
 

--- a/metrics/src/main/java/io/opencensus/metrics/Value.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Value.java
@@ -19,10 +19,6 @@ package io.opencensus.metrics;
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.ExperimentalApi;
 import io.opencensus.common.Function;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -31,9 +27,9 @@ import javax.annotation.concurrent.Immutable;
  * <p>Currently there are three types of {@link Value}:
  *
  * <ul>
- *   <li>{@link DoubleValue}
- *   <li>{@link LongValue}
- *   <li>{@link DistributionValue}
+ *   <li>{@link ValueDouble}
+ *   <li>{@link ValueLong}
+ *   <li>{@link ValueDistribution}
  * </ul>
  *
  * <p>Each {@link Point} contains exactly one of the three {@link Value} types.
@@ -47,323 +43,152 @@ public abstract class Value {
   Value() {}
 
   /**
+   * Returns a double {@link Value}.
+   *
+   * @param value value in double.
+   * @return a double {@code Value}.
+   * @since 0.16
+   */
+  public static Value doubleValue(double value) {
+    return ValueDouble.create(value);
+  }
+
+  /**
+   * Returns a long {@link Value}.
+   *
+   * @param value value in long.
+   * @return a long {@code Value}.
+   * @since 0.16
+   */
+  public static Value longValue(long value) {
+    return ValueLong.create(value);
+  }
+
+  /**
+   * Returns a {@link Distribution} {@link Value}.
+   *
+   * @param value value in {@link Distribution}.
+   * @return a {@code Distribution} {@code Value}.
+   * @since 0.16
+   */
+  public static Value distributionValue(Distribution value) {
+    return ValueDistribution.create(value);
+  }
+
+  /**
    * Applies the given match function to the underlying data type.
    *
    * @since 0.16
    */
   public abstract <T> T match(
-      Function<? super DoubleValue, T> p0,
-      Function<? super LongValue, T> p1,
-      Function<? super DistributionValue, T> p2,
+      Function<? super Double, T> doubleFunction,
+      Function<? super Long, T> longFunction,
+      Function<? super Distribution, T> distributionFunction,
       Function<? super Value, T> defaultFunction);
 
-  /**
-   * A 64-bit double-precision floating-point {@link Value}.
-   *
-   * @since 0.16
-   */
+  /** A 64-bit double-precision floating-point {@link Value}. */
   @AutoValue
   @Immutable
-  public abstract static class DoubleValue extends Value {
+  abstract static class ValueDouble extends Value {
 
-    DoubleValue() {}
+    ValueDouble() {}
 
     @Override
     public final <T> T match(
-        Function<? super DoubleValue, T> p0,
-        Function<? super LongValue, T> p1,
-        Function<? super DistributionValue, T> p2,
+        Function<? super Double, T> doubleFunction,
+        Function<? super Long, T> longFunction,
+        Function<? super Distribution, T> distributionFunction,
         Function<? super Value, T> defaultFunction) {
-      return p0.apply(this);
+      return doubleFunction.apply(getValue());
     }
 
     /**
-     * Creates a {@link DoubleValue}.
+     * Creates a {@link ValueDouble}.
      *
      * @param value the value in double.
-     * @return a {@code DoubleValue}.
-     * @since 0.16
+     * @return a {@code ValueDouble}.
      */
-    public static DoubleValue create(double value) {
-      return new AutoValue_Value_DoubleValue(value);
+    static ValueDouble create(double value) {
+      return new AutoValue_Value_ValueDouble(value);
     }
 
     /**
      * Returns the double value.
      *
      * @return the double value.
-     * @since 0.16
      */
-    public abstract double getValue();
+    abstract double getValue();
   }
 
-  /**
-   * A 64-bit integer {@link Value}.
-   *
-   * @since 0.16
-   */
+  /** A 64-bit integer {@link Value}. */
   @AutoValue
   @Immutable
-  public abstract static class LongValue extends Value {
+  abstract static class ValueLong extends Value {
 
-    LongValue() {}
+    ValueLong() {}
 
     @Override
     public final <T> T match(
-        Function<? super DoubleValue, T> p0,
-        Function<? super LongValue, T> p1,
-        Function<? super DistributionValue, T> p2,
+        Function<? super Double, T> doubleFunction,
+        Function<? super Long, T> longFunction,
+        Function<? super Distribution, T> distributionFunction,
         Function<? super Value, T> defaultFunction) {
-      return p1.apply(this);
+      return longFunction.apply(getValue());
     }
 
     /**
-     * Creates a {@link LongValue}.
+     * Creates a {@link ValueLong}.
      *
      * @param value the value in long.
-     * @return a {@code LongValue}.
-     * @since 0.16
+     * @return a {@code ValueLong}.
      */
-    public static LongValue create(long value) {
-      return new AutoValue_Value_LongValue(value);
+    static ValueLong create(long value) {
+      return new AutoValue_Value_ValueLong(value);
     }
 
     /**
      * Returns the long value.
      *
      * @return the long value.
-     * @since 0.16
      */
-    public abstract long getValue();
+    abstract long getValue();
   }
 
   /**
-   * {@link DistributionValue} contains summary statistics for a population of values. It optionally
+   * {@link ValueDistribution} contains summary statistics for a population of values. It optionally
    * contains a histogram representing the distribution of those values across a set of buckets.
-   *
-   * @since 0.16
    */
   @AutoValue
   @Immutable
-  public abstract static class DistributionValue extends Value {
+  abstract static class ValueDistribution extends Value {
 
-    DistributionValue() {}
+    ValueDistribution() {}
 
     @Override
     public final <T> T match(
-        Function<? super DoubleValue, T> p0,
-        Function<? super LongValue, T> p1,
-        Function<? super DistributionValue, T> p2,
+        Function<? super Double, T> doubleFunction,
+        Function<? super Long, T> longFunction,
+        Function<? super Distribution, T> distributionFunction,
         Function<? super Value, T> defaultFunction) {
-      return p2.apply(this);
+      return distributionFunction.apply(getValue());
     }
 
     /**
-     * Creates a {@link DistributionValue}.
+     * Creates a {@link ValueDistribution}.
      *
-     * @param mean mean of the population values.
-     * @param count count of the population values.
-     * @param sumOfSquaredDeviations sum of squared deviations of the population values.
-     * @param range {@link Range} of the population values, or {@code null} if count is 0.
-     * @param bucketBoundaries bucket boundaries of a histogram.
-     * @param buckets {@link Bucket}s of a histogram.
-     * @return a {@code DistributionValue}.
-     * @since 0.16
+     * @param value the {@link Distribution} value.
+     * @return a {@code ValueDistribution}.
      */
-    public static DistributionValue create(
-        double mean,
-        long count,
-        double sumOfSquaredDeviations,
-        @Nullable Range range,
-        List<Double> bucketBoundaries,
-        List<Bucket> buckets) {
-      Utils.checkArgument(count >= 0, "count should be non-negative.");
-      Utils.checkArgument(
-          sumOfSquaredDeviations >= 0, "sum of squared deviations should be non-negative.");
-      if (count == 0) {
-        Utils.checkArgument(range == null, "range should not be present if count is 0.");
-        Utils.checkArgument(mean == 0, "mean should be 0 if count is 0.");
-        Utils.checkArgument(
-            sumOfSquaredDeviations == 0, "sum of squared deviations should be 0 if count is 0.");
-      } else {
-        Utils.checkArgument(range != null, "range should be present if count is not 0.");
-      }
-      return new AutoValue_Value_DistributionValue(
-          mean,
-          count,
-          sumOfSquaredDeviations,
-          range,
-          copyBucketBounds(bucketBoundaries),
-          copyBucketCount(buckets));
-    }
-
-    private static List<Double> copyBucketBounds(List<Double> bucketBoundaries) {
-      Utils.checkNotNull(bucketBoundaries, "bucketBoundaries list should not be null.");
-      List<Double> bucketBoundariesCopy = new ArrayList<Double>(bucketBoundaries); // Deep copy.
-      // Check if sorted.
-      if (bucketBoundariesCopy.size() > 1) {
-        double lower = bucketBoundariesCopy.get(0);
-        for (int i = 1; i < bucketBoundariesCopy.size(); i++) {
-          double next = bucketBoundariesCopy.get(i);
-          Utils.checkArgument(lower < next, "bucket boundaries not sorted.");
-          lower = next;
-        }
-      }
-      return Collections.unmodifiableList(bucketBoundariesCopy);
-    }
-
-    private static List<Bucket> copyBucketCount(List<Bucket> buckets) {
-      Utils.checkNotNull(buckets, "bucket list should not be null.");
-      List<Bucket> bucketsCopy = new ArrayList<Bucket>(buckets);
-      for (Bucket bucket : bucketsCopy) {
-        Utils.checkNotNull(bucket, "bucket should not be null.");
-      }
-      return Collections.unmodifiableList(bucketsCopy);
+    static ValueDistribution create(Distribution value) {
+      return new AutoValue_Value_ValueDistribution(value);
     }
 
     /**
-     * Returns the aggregated mean.
+     * Returns the {@link Distribution} value.
      *
-     * @return the aggregated mean.
-     * @since 0.16
+     * @return the {@code Distribution} value.
      */
-    public abstract double getMean();
-
-    /**
-     * Returns the aggregated count.
-     *
-     * @return the aggregated count.
-     * @since 0.16
-     */
-    public abstract long getCount();
-
-    /**
-     * Returns the aggregated sum of squared deviations.
-     *
-     * <p>If count is zero then this field must be zero.
-     *
-     * @return the aggregated sum of squared deviations.
-     * @since 0.16
-     */
-    public abstract double getSumOfSquaredDeviations();
-
-    /**
-     * Returns the {@link Range} of the population values, or returns {@code null} if there are no
-     * population values.
-     *
-     * @return the {@code Range} of the population values.
-     * @since 0.16
-     */
-    @Nullable
-    public abstract Range getRange();
-
-    /**
-     * Returns the bucket boundaries of this distribution.
-     *
-     * <p>The bucket boundaries for that histogram are described by bucket_bounds. This defines
-     * size(bucket_bounds) + 1 (= N) buckets. The boundaries for bucket index i are:
-     *
-     * <ul>
-     *   <li>{@code (-infinity, bucket_bounds[i]) for i == 0}
-     *   <li>{@code [bucket_bounds[i-1], bucket_bounds[i]) for 0 < i < N-2}
-     *   <li>{@code [bucket_bounds[i-1], +infinity) for i == N-1}
-     * </ul>
-     *
-     * <p>i.e. an underflow bucket (number 0), zero or more finite buckets (1 through N - 2, and an
-     * overflow bucket (N - 1), with inclusive lower bounds and exclusive upper bounds.
-     *
-     * <p>If bucket_bounds has no elements (zero size), then there is no histogram associated with
-     * the Distribution. If bucket_bounds has only one element, there are no finite buckets, and
-     * that single element is the common boundary of the overflow and underflow buckets. The values
-     * must be monotonically increasing.
-     *
-     * @return the bucket boundaries of this distribution.
-     * @since 0.16
-     */
-    public abstract List<Double> getBucketBoundaries();
-
-    /**
-     * Returns the the aggregated histogram {@link Bucket}s.
-     *
-     * @return the the aggregated histogram buckets.
-     * @since 0.16
-     */
-    public abstract List<Bucket> getBuckets();
-
-    /**
-     * The range of the population values.
-     *
-     * @since 0.16
-     */
-    @AutoValue
-    @Immutable
-    public abstract static class Range {
-
-      Range() {}
-
-      /**
-       * Creates a {@link Range}.
-       *
-       * @param min the minimum of the population values.
-       * @param max the maximum of the population values.
-       * @return a {@code Range}.
-       * @since 0.16
-       */
-      public static Range create(double min, double max) {
-        Utils.checkArgument(min <= max, "max should be greater or equal to min.");
-        return new AutoValue_Value_DistributionValue_Range(min, max);
-      }
-
-      /**
-       * Returns the minimum of the population values.
-       *
-       * @return the minimum of the population values.
-       * @since 0.16
-       */
-      public abstract double getMin();
-
-      /**
-       * Returns the maximum of the population values.
-       *
-       * @return the maximum of the population values.
-       * @since 0.16
-       */
-      public abstract double getMax();
-    }
-
-    /**
-     * The histogram bucket of the population values.
-     *
-     * @since 0.16
-     */
-    @AutoValue
-    @Immutable
-    public abstract static class Bucket {
-
-      Bucket() {}
-
-      /**
-       * Creates a {@link Bucket}.
-       *
-       * @param count the number of values in each bucket of the histogram.
-       * @return a {@code Bucket}.
-       * @since 0.16
-       */
-      public static Bucket create(long count) {
-        Utils.checkArgument(count >= 0, "bucket count should be non-negative.");
-        return new AutoValue_Value_DistributionValue_Bucket(count);
-      }
-
-      /**
-       * Returns the number of values in each bucket of the histogram.
-       *
-       * @return the number of values in each bucket of the histogram.
-       * @since 0.16
-       */
-      public abstract long getCount();
-
-      // TODO(songya): add support for exemplars.
-    }
+    abstract Distribution getValue();
   }
 
   // TODO(songya): Add support for Summary type.

--- a/metrics/src/main/java/io/opencensus/metrics/Value.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Value.java
@@ -27,9 +27,9 @@ import javax.annotation.concurrent.Immutable;
  * <p>Currently there are three types of {@link Value}:
  *
  * <ul>
- *   <li>{@link ValueDouble}
- *   <li>{@link ValueLong}
- *   <li>{@link ValueDistribution}
+ *   <li>{@code double}
+ *   <li>{@code long}
+ *   <li>{@link Distribution}
  * </ul>
  *
  * <p>Each {@link Point} contains exactly one of the three {@link Value} types.

--- a/metrics/src/main/java/io/opencensus/metrics/Value.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Value.java
@@ -1,0 +1,372 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import io.opencensus.common.Function;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * The actual point value for a {@link Point}.
+ *
+ * <p>Currently there are three types of {@link Value}:
+ *
+ * <ul>
+ *   <li>{@link DoubleValue}
+ *   <li>{@link LongValue}
+ *   <li>{@link DistributionValue}
+ * </ul>
+ *
+ * <p>Each {@link Point} contains exactly one of the three {@link Value} types.
+ *
+ * @since 0.15
+ */
+@ExperimentalApi
+@Immutable
+public abstract class Value {
+
+  Value() {}
+
+  /**
+   * Applies the given match function to the underlying data type.
+   *
+   * @since 0.15
+   */
+  public abstract <T> T match(
+      Function<? super DoubleValue, T> p0,
+      Function<? super LongValue, T> p1,
+      Function<? super DistributionValue, T> p2,
+      Function<? super Value, T> defaultFunction);
+
+  /**
+   * A 64-bit double-precision floating-point {@link Value}.
+   *
+   * @since 0.15
+   */
+  @AutoValue
+  @Immutable
+  public abstract static class DoubleValue extends Value {
+
+    DoubleValue() {}
+
+    @Override
+    public final <T> T match(
+        Function<? super DoubleValue, T> p0,
+        Function<? super LongValue, T> p1,
+        Function<? super DistributionValue, T> p2,
+        Function<? super Value, T> defaultFunction) {
+      return p0.apply(this);
+    }
+
+    /**
+     * Creates a {@link DoubleValue}.
+     *
+     * @param value the value in double.
+     * @return a {@code DoubleValue}.
+     * @since 0.15
+     */
+    public static DoubleValue create(double value) {
+      return new AutoValue_Value_DoubleValue(value);
+    }
+
+    /**
+     * Returns the double value.
+     *
+     * @return the double value.
+     * @since 0.15
+     */
+    public abstract double getValue();
+  }
+
+  /**
+   * A 64-bit integer {@link Value}.
+   *
+   * @since 0.15
+   */
+  @AutoValue
+  @Immutable
+  public abstract static class LongValue extends Value {
+
+    LongValue() {}
+
+    @Override
+    public final <T> T match(
+        Function<? super DoubleValue, T> p0,
+        Function<? super LongValue, T> p1,
+        Function<? super DistributionValue, T> p2,
+        Function<? super Value, T> defaultFunction) {
+      return p1.apply(this);
+    }
+
+    /**
+     * Creates a {@link LongValue}.
+     *
+     * @param value the value in long.
+     * @return a {@code LongValue}.
+     * @since 0.15
+     */
+    public static LongValue create(long value) {
+      return new AutoValue_Value_LongValue(value);
+    }
+
+    /**
+     * Returns the long value.
+     *
+     * @return the long value.
+     * @since 0.15
+     */
+    public abstract long getValue();
+  }
+
+  /**
+   * {@link DistributionValue} contains summary statistics for a population of values. It optionally
+   * contains a histogram representing the distribution of those values across a set of buckets.
+   *
+   * @since 0.15
+   */
+  @AutoValue
+  @Immutable
+  public abstract static class DistributionValue extends Value {
+
+    DistributionValue() {}
+
+    @Override
+    public final <T> T match(
+        Function<? super DoubleValue, T> p0,
+        Function<? super LongValue, T> p1,
+        Function<? super DistributionValue, T> p2,
+        Function<? super Value, T> defaultFunction) {
+      return p2.apply(this);
+    }
+
+    /**
+     * Creates a {@link DistributionValue}.
+     *
+     * @param mean mean of the population values.
+     * @param count count of the population values.
+     * @param sumOfSquaredDeviations sum of squared deviations of the population values.
+     * @param range {@link Range} of the population values.
+     * @param bucketBoundaries bucket boundaries of a histogram.
+     * @param buckets {@link Bucket}s of a histogram.
+     * @return a {@code DistributionValue}.
+     * @since 0.15
+     */
+    public static DistributionValue create(
+        double mean,
+        long count,
+        double sumOfSquaredDeviations,
+        Range range,
+        List<Double> bucketBoundaries,
+        List<Bucket> buckets) {
+      Utils.checkArgument(count >= 0, "count should be non-negative.");
+      return new AutoValue_Value_DistributionValue(
+          mean,
+          count,
+          sumOfSquaredDeviations,
+          range,
+          copyBucketBounds(bucketBoundaries),
+          copyBucketCount(buckets));
+    }
+
+    private static List<Double> copyBucketBounds(List<Double> bucketBoundaries) {
+      Utils.checkNotNull(bucketBoundaries, "bucketBoundaries list should not be null.");
+      List<Double> bucketBoundariesCopy = new ArrayList<Double>(bucketBoundaries); // Deep copy.
+      // Check if sorted.
+      if (bucketBoundariesCopy.size() > 1) {
+        double lower = bucketBoundariesCopy.get(0);
+        for (int i = 1; i < bucketBoundariesCopy.size(); i++) {
+          double next = bucketBoundariesCopy.get(i);
+          Utils.checkArgument(lower < next, "bucket boundaries not sorted.");
+          lower = next;
+        }
+      }
+      return Collections.unmodifiableList(bucketBoundariesCopy);
+    }
+
+    private static List<Bucket> copyBucketCount(List<Bucket> buckets) {
+      Utils.checkNotNull(buckets, "bucket list should not be null.");
+      List<Bucket> bucketsCopy = new ArrayList<Bucket>(buckets);
+      for (Bucket bucket : bucketsCopy) {
+        Utils.checkNotNull(bucket, "bucket should not be null.");
+      }
+      return Collections.unmodifiableList(bucketsCopy);
+    }
+
+    /**
+     * Returns the aggregated mean.
+     *
+     * @return the aggregated mean.
+     * @since 0.15
+     */
+    public abstract double getMean();
+
+    /**
+     * Returns the aggregated count.
+     *
+     * @return the aggregated count.
+     * @since 0.15
+     */
+    public abstract long getCount();
+
+    /**
+     * Returns the aggregated sum of squared deviations.
+     *
+     * <p>The sum of squared deviations from the mean of the values in the population. For values
+     * x_i this is:
+     *
+     * <p>Sum[i=1..n]((x_i - mean)^2)
+     *
+     * <p>Knuth, "The Art of Computer Programming", Vol. 2, page 323, 3rd edition describes
+     * Welford's method for accumulating this sum in one pass.
+     *
+     * <p>If count is zero then this field must be zero.
+     *
+     * @return the aggregated sum of squared deviations.
+     * @since 0.15
+     */
+    public abstract double getSumOfSquaredDeviations();
+
+    /**
+     * Returns the {@link Range} of the population values.
+     *
+     * @return the {@code Range} of the population values.
+     * @since 0.15
+     */
+    public abstract Range getRange();
+
+    /**
+     * Returns the bucket boundaries of this distribution.
+     *
+     * <p>The bucket boundaries for that histogram are described by bucket_bounds. This defines
+     * size(bucket_bounds) + 1 (= N) buckets. The boundaries for bucket index i are:
+     *
+     * <ul>
+     *   <li>{@code (-infinity, bucket_bounds[i]) for i == 0}
+     *   <li>{@code [bucket_bounds[i-1], bucket_bounds[i]) for 0 < i < N-2}
+     *   <li>{@code [bucket_bounds[i-1], +infinity) for i == N-1}
+     * </ul>
+     *
+     * <p>i.e. an underflow bucket (number 0), zero or more finite buckets (1 through N - 2, and an
+     * overflow bucket (N - 1), with inclusive lower bounds and exclusive upper bounds.
+     *
+     * <p>If bucket_bounds has no elements (zero size), then there is no histogram associated with
+     * the Distribution. If bucket_bounds has only one element, there are no finite buckets, and
+     * that single element is the common boundary of the overflow and underflow buckets. The values
+     * must be monotonically increasing.
+     *
+     * <p>The returned list is immutable, an {@link UnsupportedOperationException} will be thrown
+     * when trying to modify it.
+     *
+     * @return the bucket boundaries of this distribution.
+     * @since 0.15
+     */
+    public abstract List<Double> getBucketBoundaries();
+
+    /**
+     * Returns the the aggregated histogram {@link Bucket}s. The returned list is immutable, trying
+     * to update it will throw an {@code UnsupportedOperationException}.
+     *
+     * @return the the aggregated histogram buckets.
+     * @since 0.15
+     */
+    public abstract List<Bucket> getBuckets();
+
+    /**
+     * The range of the population values.
+     *
+     * @since 0.15
+     */
+    @AutoValue
+    @Immutable
+    public abstract static class Range {
+
+      Range() {}
+
+      /**
+       * Creates a {@link Range}.
+       *
+       * @param min the minimum of the population values.
+       * @param max the maximum of the population values.
+       * @return a {@code Range}.
+       * @since 0.15
+       */
+      public static Range create(double min, double max) {
+        if (min != Double.POSITIVE_INFINITY || max != Double.NEGATIVE_INFINITY) {
+          Utils.checkArgument(min <= max, "max should be greater or equal to min.");
+        }
+        return new AutoValue_Value_DistributionValue_Range(min, max);
+      }
+
+      /**
+       * Returns the minimum of the population values.
+       *
+       * @return the minimum of the population values.
+       * @since 0.15
+       */
+      public abstract double getMin();
+
+      /**
+       * Returns the maximum of the population values.
+       *
+       * @return the maximum of the population values.
+       * @since 0.15
+       */
+      public abstract double getMax();
+    }
+
+    /**
+     * The histogram bucket of the population values.
+     *
+     * @since 0.15
+     */
+    @AutoValue
+    @Immutable
+    public abstract static class Bucket {
+
+      Bucket() {}
+
+      /**
+       * Creates a {@link Bucket}.
+       *
+       * @param count the number of values in each bucket of the histogram.
+       * @return a {@code Bucket}.
+       * @since 0.15
+       */
+      public static Bucket create(long count) {
+        Utils.checkArgument(count >= 0, "bucket count should be non-negative.");
+        return new AutoValue_Value_DistributionValue_Bucket(count);
+      }
+
+      /**
+       * Returns the number of values in each bucket of the histogram.
+       *
+       * @return the number of values in each bucket of the histogram.
+       * @since 0.15
+       */
+      public abstract long getCount();
+
+      // TODO(songya): add support for exemplars.
+    }
+  }
+
+  // TODO(songya): Add support for Summary type.
+  // This is an aggregation that produces percentiles directly.
+}

--- a/metrics/src/main/java/io/opencensus/metrics/Value.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Value.java
@@ -182,6 +182,7 @@ public abstract class Value {
           sumOfSquaredDeviations >= 0, "sum of squared deviations should be non-negative.");
       if (count == 0) {
         Utils.checkArgument(range == null, "range should not be present if count is 0.");
+        Utils.checkArgument(mean == 0, "mean should be 0 if count is 0.");
         Utils.checkArgument(
             sumOfSquaredDeviations == 0, "sum of squared deviations should be 0 if count is 0.");
       } else {

--- a/metrics/src/test/java/io/opencensus/metrics/DistributionTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/DistributionTest.java
@@ -1,0 +1,216 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.opencensus.metrics.Distribution.Bucket;
+import io.opencensus.metrics.Distribution.Range;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Value}. */
+@RunWith(JUnit4.class)
+public class DistributionTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void createAndGet_Range() {
+    Range range = Range.create(-5.5, 6.6);
+    assertThat(range.getMax()).isEqualTo(6.6);
+    assertThat(range.getMin()).isEqualTo(-5.5);
+  }
+
+  @Test
+  public void createAndGet_Bucket() {
+    Bucket bucket = Bucket.create(98);
+    assertThat(bucket.getCount()).isEqualTo(98);
+  }
+
+  @Test
+  public void createAndGet_Distribution() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
+    Distribution distribution = Distribution.create(6.6, 10, 678.54, range, bucketBounds, buckets);
+    assertThat(distribution.getMean()).isEqualTo(6.6);
+    assertThat(distribution.getCount()).isEqualTo(10);
+    assertThat(distribution.getSumOfSquaredDeviations()).isEqualTo(678.54);
+    assertThat(distribution.getRange()).isEqualTo(range);
+    assertThat(distribution.getBucketBoundaries())
+        .containsExactlyElementsIn(bucketBounds)
+        .inOrder();
+    assertThat(distribution.getBuckets()).containsExactlyElementsIn(buckets).inOrder();
+  }
+
+  @Test
+  public void createRange_MinGreaterThanMax() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("max should be greater or equal to min.");
+    Range.create(1.0, -1.0);
+  }
+
+  @Test
+  public void createBucket_NegativeCount() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("bucket count should be non-negative.");
+    Bucket.create(-5);
+  }
+
+  @Test
+  public void createDistribution_NegativeCount() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("count should be non-negative.");
+    Distribution.create(6.6, -10, 678.54, range, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_NegativeSumOfSquaredDeviations() {
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("sum of squared deviations should be non-negative.");
+    Distribution.create(6.6, 0, -678.54, null, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_ZeroCountAndNonNullRange() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("range should not be present if count is 0.");
+    Distribution.create(0, 0, 0, range, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_ZeroCountAndPositiveMean() {
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("mean should be 0 if count is 0.");
+    Distribution.create(6.6, 0, 0, null, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_ZeroCountAndSumOfSquaredDeviations() {
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("sum of squared deviations should be 0 if count is 0.");
+    Distribution.create(0, 0, 678.54, null, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_PositiveCountAndNullRange() {
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(0), Bucket.create(1), Bucket.create(0), Bucket.create(0));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("range should be present if count is not 0.");
+    Distribution.create(6.6, 1, 0, null, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_NullBucketBounds() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("bucketBoundaries list should not be null.");
+    Distribution.create(6.6, 10, 678.54, range, null, buckets);
+  }
+
+  @Test
+  public void createDistribution_UnorderedBucketBounds() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(0.0, -1.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("bucket boundaries not sorted.");
+    Distribution.create(6.6, 10, 678.54, range, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_NullBucketList() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("bucket list should not be null.");
+    Distribution.create(6.6, 10, 678.54, range, bucketBounds, null);
+  }
+
+  @Test
+  public void createDistribution_NullBucket() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), null, Bucket.create(4));
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("bucket should not be null.");
+    Distribution.create(6.6, 10, 678.54, range, bucketBounds, buckets);
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            Distribution.create(
+                10,
+                10,
+                1,
+                Range.create(1, 5),
+                Arrays.asList(-5.0, 0.0, 5.0),
+                Arrays.asList(
+                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))),
+            Distribution.create(
+                10,
+                10,
+                1,
+                Range.create(1, 5),
+                Arrays.asList(-5.0, 0.0, 5.0),
+                Arrays.asList(
+                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))))
+        .addEqualityGroup(
+            Distribution.create(
+                -7,
+                10,
+                23.456,
+                Range.create(-19.1, 19.2),
+                Arrays.asList(-5.0, 0.0, 5.0),
+                Arrays.asList(
+                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))))
+        .testEquals();
+  }
+}

--- a/metrics/src/test/java/io/opencensus/metrics/PointTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/PointTest.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.opencensus.common.Timestamp;
+import io.opencensus.metrics.Value.DistributionValue;
+import io.opencensus.metrics.Value.DistributionValue.Bucket;
+import io.opencensus.metrics.Value.DistributionValue.Range;
+import io.opencensus.metrics.Value.DoubleValue;
+import io.opencensus.metrics.Value.LongValue;
+import java.util.Arrays;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Point}. */
+@RunWith(JUnit4.class)
+public class PointTest {
+
+  private static final DoubleValue DOUBLE_VALUE = DoubleValue.create(55.5);
+  private static final LongValue LONG_VALUE = LongValue.create(9876543210L);
+  private static final DistributionValue DISTRIBUTION_VALUE =
+      DistributionValue.create(
+          6.6,
+          10,
+          678.54,
+          Range.create(-3.4, 5.6),
+          Arrays.asList(-1.0, 0.0, 1.0),
+          Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4)));
+  private static final Timestamp TIMESTAMP_1 = Timestamp.create(1, 2);
+  private static final Timestamp TIMESTAMP_2 = Timestamp.create(3, 4);
+  private static final Timestamp TIMESTAMP_3 = Timestamp.create(5, 6);
+
+  @Test
+  public void testGet() {
+    Point point = Point.create(DOUBLE_VALUE, TIMESTAMP_1);
+    assertThat(point.getValue()).isEqualTo(DOUBLE_VALUE);
+    assertThat(point.getTimestamp()).isEqualTo(TIMESTAMP_1);
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            Point.create(DOUBLE_VALUE, TIMESTAMP_1), Point.create(DOUBLE_VALUE, TIMESTAMP_1))
+        .addEqualityGroup(Point.create(LONG_VALUE, TIMESTAMP_1))
+        .addEqualityGroup(Point.create(LONG_VALUE, TIMESTAMP_2))
+        .addEqualityGroup(
+            Point.create(DISTRIBUTION_VALUE, TIMESTAMP_2),
+            Point.create(DISTRIBUTION_VALUE, TIMESTAMP_2))
+        .addEqualityGroup(Point.create(DISTRIBUTION_VALUE, TIMESTAMP_3))
+        .testEquals();
+  }
+}

--- a/metrics/src/test/java/io/opencensus/metrics/PointTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/PointTest.java
@@ -20,11 +20,8 @@ import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Timestamp;
-import io.opencensus.metrics.Value.DistributionValue;
-import io.opencensus.metrics.Value.DistributionValue.Bucket;
-import io.opencensus.metrics.Value.DistributionValue.Range;
-import io.opencensus.metrics.Value.DoubleValue;
-import io.opencensus.metrics.Value.LongValue;
+import io.opencensus.metrics.Distribution.Bucket;
+import io.opencensus.metrics.Distribution.Range;
 import java.util.Arrays;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,16 +31,18 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class PointTest {
 
-  private static final DoubleValue DOUBLE_VALUE = DoubleValue.create(55.5);
-  private static final LongValue LONG_VALUE = LongValue.create(9876543210L);
-  private static final DistributionValue DISTRIBUTION_VALUE =
-      DistributionValue.create(
-          6.6,
-          10,
-          678.54,
-          Range.create(-3.4, 5.6),
-          Arrays.asList(-1.0, 0.0, 1.0),
-          Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4)));
+  private static final Value DOUBLE_VALUE = Value.doubleValue(55.5);
+  private static final Value LONG_VALUE = Value.longValue(9876543210L);
+  private static final Value DISTRIBUTION_VALUE =
+      Value.distributionValue(
+          Distribution.create(
+              6.6,
+              10,
+              678.54,
+              Range.create(-3.4, 5.6),
+              Arrays.asList(-1.0, 0.0, 1.0),
+              Arrays.asList(
+                  Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))));
   private static final Timestamp TIMESTAMP_1 = Timestamp.create(1, 2);
   private static final Timestamp TIMESTAMP_2 = Timestamp.create(3, 4);
   private static final Timestamp TIMESTAMP_3 = Timestamp.create(5, 6);

--- a/metrics/src/test/java/io/opencensus/metrics/ValueTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/ValueTest.java
@@ -125,7 +125,17 @@ public class ValueTest {
         Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("range should not be present if count is 0.");
-    DistributionValue.create(6.6, 0, 0, range, bucketBounds, buckets);
+    DistributionValue.create(0, 0, 0, range, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_ZeroCountAndPositiveMean() {
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("mean should be 0 if count is 0.");
+    DistributionValue.create(6.6, 0, 0, null, bucketBounds, buckets);
   }
 
   @Test
@@ -135,7 +145,7 @@ public class ValueTest {
         Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("sum of squared deviations should be 0 if count is 0.");
-    DistributionValue.create(6.6, 0, 678.54, null, bucketBounds, buckets);
+    DistributionValue.create(0, 0, 678.54, null, bucketBounds, buckets);
   }
 
   @Test

--- a/metrics/src/test/java/io/opencensus/metrics/ValueTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/ValueTest.java
@@ -21,17 +21,15 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Function;
 import io.opencensus.common.Functions;
-import io.opencensus.metrics.Value.DistributionValue;
-import io.opencensus.metrics.Value.DistributionValue.Bucket;
-import io.opencensus.metrics.Value.DistributionValue.Range;
-import io.opencensus.metrics.Value.DoubleValue;
-import io.opencensus.metrics.Value.LongValue;
+import io.opencensus.metrics.Distribution.Bucket;
+import io.opencensus.metrics.Distribution.Range;
+import io.opencensus.metrics.Value.ValueDistribution;
+import io.opencensus.metrics.Value.ValueDouble;
+import io.opencensus.metrics.Value.ValueLong;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -39,191 +37,53 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class ValueTest {
 
-  @Rule public final ExpectedException thrown = ExpectedException.none();
+  private static final Distribution DISTRIBUTION =
+      Distribution.create(
+          10,
+          10,
+          1,
+          Range.create(1, 5),
+          Arrays.asList(-5.0, 0.0, 5.0),
+          Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4)));
 
   @Test
-  public void createAndGet_DoubleValue() {
-    assertThat(DoubleValue.create(-34.56).getValue()).isEqualTo(-34.56);
+  public void createAndGet_ValueDouble() {
+    Value value = Value.doubleValue(-34.56);
+    assertThat(value).isInstanceOf(ValueDouble.class);
+    assertThat(((ValueDouble) value).getValue()).isEqualTo(-34.56);
   }
 
   @Test
-  public void createAndGet_LongValue() {
-    assertThat(LongValue.create(123456789).getValue()).isEqualTo(123456789);
+  public void createAndGet_ValueLong() {
+    Value value = Value.longValue(123456789);
+    assertThat(value).isInstanceOf(ValueLong.class);
+    assertThat(((ValueLong) value).getValue()).isEqualTo(123456789);
   }
 
   @Test
-  public void createAndGet_Range() {
-    Range range = Range.create(-5.5, 6.6);
-    assertThat(range.getMax()).isEqualTo(6.6);
-    assertThat(range.getMin()).isEqualTo(-5.5);
-  }
-
-  @Test
-  public void createAndGet_Bucket() {
-    Bucket bucket = Bucket.create(98);
-    assertThat(bucket.getCount()).isEqualTo(98);
-  }
-
-  @Test
-  public void createAndGet_DistributionValue() {
-    Range range = Range.create(-3.4, 5.6);
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
-    DistributionValue distributionValue =
-        DistributionValue.create(6.6, 10, 678.54, range, bucketBounds, buckets);
-    assertThat(distributionValue.getMean()).isEqualTo(6.6);
-    assertThat(distributionValue.getCount()).isEqualTo(10);
-    assertThat(distributionValue.getSumOfSquaredDeviations()).isEqualTo(678.54);
-    assertThat(distributionValue.getRange()).isEqualTo(range);
-    assertThat(distributionValue.getBucketBoundaries())
-        .containsExactlyElementsIn(bucketBounds)
-        .inOrder();
-    assertThat(distributionValue.getBuckets()).containsExactlyElementsIn(buckets).inOrder();
-  }
-
-  @Test
-  public void createRange_MinGreaterThanMax() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("max should be greater or equal to min.");
-    Range.create(1.0, -1.0);
-  }
-
-  @Test
-  public void createBucket_NegativeCount() {
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("bucket count should be non-negative.");
-    Bucket.create(-5);
-  }
-
-  @Test
-  public void createDistribution_NegativeCount() {
-    Range range = Range.create(-3.4, 5.6);
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("count should be non-negative.");
-    DistributionValue.create(6.6, -10, 678.54, range, bucketBounds, buckets);
-  }
-
-  @Test
-  public void createDistribution_NegativeSumOfSquaredDeviations() {
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("sum of squared deviations should be non-negative.");
-    DistributionValue.create(6.6, 0, -678.54, null, bucketBounds, buckets);
-  }
-
-  @Test
-  public void createDistribution_ZeroCountAndNonNullRange() {
-    Range range = Range.create(-3.4, 5.6);
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("range should not be present if count is 0.");
-    DistributionValue.create(0, 0, 0, range, bucketBounds, buckets);
-  }
-
-  @Test
-  public void createDistribution_ZeroCountAndPositiveMean() {
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("mean should be 0 if count is 0.");
-    DistributionValue.create(6.6, 0, 0, null, bucketBounds, buckets);
-  }
-
-  @Test
-  public void createDistribution_ZeroCountAndSumOfSquaredDeviations() {
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(0), Bucket.create(0), Bucket.create(0), Bucket.create(0));
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("sum of squared deviations should be 0 if count is 0.");
-    DistributionValue.create(0, 0, 678.54, null, bucketBounds, buckets);
-  }
-
-  @Test
-  public void createDistribution_PositiveCountAndNullRange() {
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(0), Bucket.create(1), Bucket.create(0), Bucket.create(0));
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("range should be present if count is not 0.");
-    DistributionValue.create(6.6, 1, 0, null, bucketBounds, buckets);
-  }
-
-  @Test
-  public void createDistribution_NullBucketBounds() {
-    Range range = Range.create(-3.4, 5.6);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("bucketBoundaries list should not be null.");
-    DistributionValue.create(6.6, 10, 678.54, range, null, buckets);
-  }
-
-  @Test
-  public void createDistribution_UnorderedBucketBounds() {
-    Range range = Range.create(-3.4, 5.6);
-    List<Double> bucketBounds = Arrays.asList(0.0, -1.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
-    thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("bucket boundaries not sorted.");
-    DistributionValue.create(6.6, 10, 678.54, range, bucketBounds, buckets);
-  }
-
-  @Test
-  public void createDistribution_NullBucketList() {
-    Range range = Range.create(-3.4, 5.6);
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("bucket list should not be null.");
-    DistributionValue.create(6.6, 10, 678.54, range, bucketBounds, null);
-  }
-
-  @Test
-  public void createDistribution_NullBucket() {
-    Range range = Range.create(-3.4, 5.6);
-    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
-    List<Bucket> buckets =
-        Arrays.asList(Bucket.create(3), Bucket.create(1), null, Bucket.create(4));
-    thrown.expect(NullPointerException.class);
-    thrown.expectMessage("bucket should not be null.");
-    DistributionValue.create(6.6, 10, 678.54, range, bucketBounds, buckets);
+  public void createAndGet_ValueDistribution() {
+    Value value = Value.distributionValue(DISTRIBUTION);
+    assertThat(value).isInstanceOf(ValueDistribution.class);
+    assertThat(((ValueDistribution) value).getValue()).isEqualTo(DISTRIBUTION);
   }
 
   @Test
   public void testEquals() {
     new EqualsTester()
-        .addEqualityGroup(DoubleValue.create(1.0), DoubleValue.create(1.0))
-        .addEqualityGroup(DoubleValue.create(-1.0))
-        .addEqualityGroup(LongValue.create(1), LongValue.create(1))
-        .addEqualityGroup(LongValue.create(-1))
+        .addEqualityGroup(Value.doubleValue(1.0), Value.doubleValue(1.0))
+        .addEqualityGroup(Value.doubleValue(2.0))
+        .addEqualityGroup(Value.longValue(1L))
+        .addEqualityGroup(Value.longValue(2L))
         .addEqualityGroup(
-            DistributionValue.create(
-                10,
-                10,
-                1,
-                Range.create(1, 5),
-                Arrays.asList(-5.0, 0.0, 5.0),
-                Arrays.asList(
-                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))))
-        .addEqualityGroup(
-            DistributionValue.create(
-                -7,
-                10,
-                23.456,
-                Range.create(-19.1, 19.2),
-                Arrays.asList(-5.0, 0.0, 5.0),
-                Arrays.asList(
-                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))))
+            Value.distributionValue(
+                Distribution.create(
+                    -7,
+                    10,
+                    23.456,
+                    Range.create(-19.1, 19.2),
+                    Arrays.asList(-5.0, 0.0, 5.0),
+                    Arrays.asList(
+                        Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4)))))
         .testEquals();
   }
 
@@ -231,39 +91,29 @@ public class ValueTest {
   public void testMatch() {
     List<Value> values =
         Arrays.asList(
-            DoubleValue.create(1.0),
-            LongValue.create(-1),
-            DistributionValue.create(
-                -7,
-                10,
-                23.456,
-                Range.create(-19.1, 19.2),
-                Arrays.asList(-5.0, 0.0, 5.0),
-                Arrays.asList(
-                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))));
+            ValueDouble.create(1.0), ValueLong.create(-1), ValueDistribution.create(DISTRIBUTION));
     List<Number> expected =
-        Arrays.<Number>asList(
-            1.0, -1L, -7.0, 10L, 23.456, -19.1, 19.2, -5.0, 0.0, 5.0, 3L, 1L, 2L, 4L);
+        Arrays.<Number>asList(1.0, -1L, 10.0, 10L, 1.0, 1.0, 5.0, -5.0, 0.0, 5.0, 3L, 1L, 2L, 4L);
     final List<Number> actual = new ArrayList<Number>();
     for (Value value : values) {
       value.match(
-          new Function<DoubleValue, Object>() {
+          new Function<Double, Object>() {
             @Override
-            public Object apply(DoubleValue arg) {
-              actual.add(arg.getValue());
+            public Object apply(Double arg) {
+              actual.add(arg);
               return null;
             }
           },
-          new Function<LongValue, Object>() {
+          new Function<Long, Object>() {
             @Override
-            public Object apply(LongValue arg) {
-              actual.add(arg.getValue());
+            public Object apply(Long arg) {
+              actual.add(arg);
               return null;
             }
           },
-          new Function<DistributionValue, Object>() {
+          new Function<Distribution, Object>() {
             @Override
-            public Object apply(DistributionValue arg) {
+            public Object apply(Distribution arg) {
               actual.add(arg.getMean());
               actual.add(arg.getCount());
               actual.add(arg.getSumOfSquaredDeviations());

--- a/metrics/src/test/java/io/opencensus/metrics/ValueTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/ValueTest.java
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.opencensus.common.Function;
+import io.opencensus.common.Functions;
+import io.opencensus.metrics.Value.DistributionValue;
+import io.opencensus.metrics.Value.DistributionValue.Bucket;
+import io.opencensus.metrics.Value.DistributionValue.Range;
+import io.opencensus.metrics.Value.DoubleValue;
+import io.opencensus.metrics.Value.LongValue;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Value}. */
+@RunWith(JUnit4.class)
+public class ValueTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private static final double EPSILON = 1e-7;
+
+  @Test
+  public void createAndGet_DoubleValue() {
+    assertThat(DoubleValue.create(-34.56).getValue()).isWithin(EPSILON).of(-34.56);
+  }
+
+  @Test
+  public void createAndGet_LongValue() {
+    assertThat(LongValue.create(123456789).getValue()).isEqualTo(123456789);
+  }
+
+  @Test
+  public void createAndGet_Range() {
+    Range range = Range.create(-5.5, 6.6);
+    assertThat(range.getMax()).isWithin(EPSILON).of(6.6);
+    assertThat(range.getMin()).isWithin(EPSILON).of(-5.5);
+  }
+
+  @Test
+  public void createAndGet_Bucket() {
+    Bucket bucket = Bucket.create(98);
+    assertThat(bucket.getCount()).isEqualTo(98);
+  }
+
+  @Test
+  public void createAndGet_DistributionValue() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
+    DistributionValue distributionValue =
+        DistributionValue.create(6.6, 10, 678.54, range, bucketBounds, buckets);
+    assertThat(distributionValue.getMean()).isWithin(EPSILON).of(6.6);
+    assertThat(distributionValue.getCount()).isEqualTo(10);
+    assertThat(distributionValue.getSumOfSquaredDeviations()).isWithin(EPSILON).of(678.54);
+    assertThat(distributionValue.getRange()).isEqualTo(range);
+    assertThat(distributionValue.getBucketBoundaries())
+        .containsExactlyElementsIn(bucketBounds)
+        .inOrder();
+    assertThat(distributionValue.getBuckets()).containsExactlyElementsIn(buckets).inOrder();
+  }
+
+  @Test
+  public void createRange_InitialImpossibleValue() {
+    Range range = Range.create(Double.POSITIVE_INFINITY, Double.NEGATIVE_INFINITY);
+    assertThat(range.getMax()).isNegativeInfinity();
+    assertThat(range.getMin()).isPositiveInfinity();
+  }
+
+  @Test
+  public void createRange_MinGreaterThanMax() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("max should be greater or equal to min.");
+    Range.create(1.0, -1.0);
+  }
+
+  @Test
+  public void createBucket_NegativeCount() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("bucket count should be non-negative.");
+    Bucket.create(-5);
+  }
+
+  @Test
+  public void createDistribution_NegativeCount() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("count should be non-negative.");
+    DistributionValue.create(6.6, -10, 678.54, range, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_NullBucketBounds() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("bucketBoundaries list should not be null.");
+    DistributionValue.create(6.6, 10, 678.54, range, null, buckets);
+  }
+
+  @Test
+  public void createDistribution_UnorderedBucketBounds() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(0.0, -1.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("bucket boundaries not sorted.");
+    DistributionValue.create(6.6, 10, 678.54, range, bucketBounds, buckets);
+  }
+
+  @Test
+  public void createDistribution_NullBucketList() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("bucket list should not be null.");
+    DistributionValue.create(6.6, 10, 678.54, range, bucketBounds, null);
+  }
+
+  @Test
+  public void createDistribution_NullBucket() {
+    Range range = Range.create(-3.4, 5.6);
+    List<Double> bucketBounds = Arrays.asList(-1.0, 0.0, 1.0);
+    List<Bucket> buckets =
+        Arrays.asList(Bucket.create(3), Bucket.create(1), null, Bucket.create(4));
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("bucket should not be null.");
+    DistributionValue.create(6.6, 10, 678.54, range, bucketBounds, buckets);
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(DoubleValue.create(1.0), DoubleValue.create(1.0))
+        .addEqualityGroup(DoubleValue.create(-1.0))
+        .addEqualityGroup(LongValue.create(1), LongValue.create(1))
+        .addEqualityGroup(LongValue.create(-1))
+        .addEqualityGroup(
+            DistributionValue.create(
+                10,
+                10,
+                1,
+                Range.create(1, 5),
+                Arrays.asList(-5.0, 0.0, 5.0),
+                Arrays.asList(
+                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))))
+        .addEqualityGroup(
+            DistributionValue.create(
+                -7,
+                10,
+                23.456,
+                Range.create(-19.1, 19.2),
+                Arrays.asList(-5.0, 0.0, 5.0),
+                Arrays.asList(
+                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))))
+        .testEquals();
+  }
+
+  @Test
+  public void testMatch() {
+    List<Value> values =
+        Arrays.asList(
+            DoubleValue.create(1.0),
+            LongValue.create(-1),
+            DistributionValue.create(
+                -7,
+                10,
+                23.456,
+                Range.create(-19.1, 19.2),
+                Arrays.asList(-5.0, 0.0, 5.0),
+                Arrays.asList(
+                    Bucket.create(3), Bucket.create(1), Bucket.create(2), Bucket.create(4))));
+    List<Number> expected =
+        Arrays.<Number>asList(
+            1.0, -1L, -7.0, 10L, 23.456, -19.1, 19.2, -5.0, 0.0, 5.0, 3L, 1L, 2L, 4L);
+    final List<Number> actual = new ArrayList<Number>();
+    for (Value value : values) {
+      value.match(
+          new Function<DoubleValue, Object>() {
+            @Override
+            public Object apply(DoubleValue arg) {
+              actual.add(arg.getValue());
+              return null;
+            }
+          },
+          new Function<LongValue, Object>() {
+            @Override
+            public Object apply(LongValue arg) {
+              actual.add(arg.getValue());
+              return null;
+            }
+          },
+          new Function<DistributionValue, Object>() {
+            @Override
+            public Object apply(DistributionValue arg) {
+              actual.add(arg.getMean());
+              actual.add(arg.getCount());
+              actual.add(arg.getSumOfSquaredDeviations());
+              actual.add(arg.getRange().getMin());
+              actual.add(arg.getRange().getMax());
+              actual.addAll(arg.getBucketBoundaries());
+              for (Bucket bucket : arg.getBuckets()) {
+                actual.add(bucket.getCount());
+              }
+              return null;
+            }
+          },
+          Functions.throwAssertionError());
+    }
+    assertThat(actual).containsExactlyElementsIn(expected).inOrder();
+  }
+}


### PR DESCRIPTION
~~Blocked by https://github.com/census-instrumentation/opencensus-java/pull/1261.~~

From [metrics.proto](https://github.com/census-instrumentation/opencensus-proto/blob/master/opencensus/proto/stats/metrics/metrics.proto):
```
// A timestamped measurement.
message Point {
  // The moment when this point was recorded.
  google.protobuf.Timestamp timestamp = 1; // required

  // The actual point value.
  oneof value {
    // A 64-bit integer.
    int64 int64_value = 2;

    // A 64-bit double-precision floating-point number.
    double double_value = 3;

    // A distribution value.
    DistributionValue distribution_value = 4;

    // TODO: Add support for Summary type. This is an aggregation that produces
    // percentiles directly.
    //
    // See also: https://prometheus.io/docs/concepts/metric_types/#summary
  }
}

// Distribution contains summary statistics for a population of values. It
// optionally contains a histogram representing the distribution of those
// values across a set of buckets.
message DistributionValue {
  // The number of values in the population. Must be non-negative. This value
  // must equal the sum of the values in bucket_counts if a histogram is
  // provided.
  int64 count = 1;

  // The arithmetic mean of the values in the population. If count is zero
  // then this field must be zero.
  double mean = 2;

  // The sum of squared deviations from the mean of the values in the
  // population. For values x_i this is:
  //
  //     Sum[i=1..n]((x_i - mean)^2)
  //
  // Knuth, "The Art of Computer Programming", Vol. 2, page 323, 3rd edition
  // describes Welford's method for accumulating this sum in one pass.
  //
  // If count is zero then this field must be zero.
  double sum_of_squared_deviation = 3;

  // The range of the population values.
  message Range {
    // The minimum of the population values.
    double min = 1;

    // The maximum of the population values.
    double max = 2;
  }

  // If specified, contains the range of the population values. The field
  // must not be present if the count is zero.
  Range range = 4;

  // A Distribution may optionally contain a histogram of the values in the
  // population. The bucket boundaries for that histogram are described by
  // bucket_bounds. This defines size(bucket_bounds) + 1 (= N)
  // buckets. The boundaries for bucket index i are:
  //
  // (-infinity, bucket_bounds[i]) for i == 0
  // [bucket_bounds[i-1], bucket_bounds[i]) for 0 < i < N-2
  // [bucket_bounds[i-1], +infinity) for i == N-1
  //
  // i.e. an underflow bucket (number 0), zero or more finite buckets (1
  // through N - 2, and an overflow bucket (N - 1), with inclusive lower
  // bounds and exclusive upper bounds.
  //
  // If bucket_bounds has no elements (zero size), then there is no
  // histogram associated with the Distribution. If bucket_bounds has only
  // one element, there are no finite buckets, and that single element is the
  // common boundary of the overflow and underflow buckets. The values must
  // be monotonically increasing.
  //
  // Don't change bucket boundaries within a timeseries if your backend
  // doesn't support this.
  repeated double bucket_bounds = 5;

  message Bucket {
    // The number of values in each bucket of the histogram, as described in
    // bucket_bounds.
    int64 count = 1;

    // TODO: Add support for exemplars.
  }

  // If the distribution does not have a histogram, then omit this field.
  // If there is a histogram, then the sum of the values in the Bucket counts
  // must equal the value in the count field of the distribution.
  repeated Bucket buckets = 6;
}

```