### PR TITLE
Metrics: Add TimeSeries.

### DIFF
--- a/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
+++ b/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
@@ -99,6 +99,8 @@ public abstract class TimeSeries {
       // Fail fast on null lists to prevent NullPointerException when copying the lists.
       Utils.checkNotNull(labelValues, "labelValues");
       Utils.checkNotNull(points, "points");
+      Utils.checkListElementNotNull(labelValues, "labelValue");
+      Utils.checkListElementNotNull(points, "point");
       return new AutoValue_TimeSeries_TimeSeriesGauge(
           Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
           Collections.unmodifiableList(new ArrayList<Point>(points)));
@@ -140,6 +142,8 @@ public abstract class TimeSeries {
       // Fail fast on null lists to prevent NullPointerException when copying the lists.
       Utils.checkNotNull(labelValues, "labelValues");
       Utils.checkNotNull(points, "points");
+      Utils.checkListElementNotNull(labelValues, "labelValue");
+      Utils.checkListElementNotNull(points, "point");
       return new AutoValue_TimeSeries_TimeSeriesCumulative(
           Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
           Collections.unmodifiableList(new ArrayList<Point>(points)),

--- a/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
+++ b/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import io.opencensus.common.Function;
+import io.opencensus.common.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A collection of data points that describes the time-varying values of a {@code Metric}.
+ *
+ * @since 0.16
+ */
+@ExperimentalApi
+@Immutable
+public abstract class TimeSeries {
+
+  TimeSeries() {}
+
+  /**
+   * Returns the set of {@link LabelValue}s that uniquely identify this {@link TimeSeries}.
+   *
+   * <p>Apply to all {@link Point}s.
+   *
+   * <p>The order of {@link LabelValue}s must match that of {@link LabelKey}s in the {@code
+   * MetricDescriptor}.
+   *
+   * @return the {@code LabelValue}s.
+   * @since 0.16
+   */
+  public abstract List<LabelValue> getLabelValues();
+
+  /**
+   * Returns the data {@link Point}s of this {@link TimeSeries}.
+   *
+   * @return the data {@code Point}s.
+   * @since 0.16
+   */
+  public abstract List<Point> getPoints();
+
+  /**
+   * Applies the given match function to the underlying data type.
+   *
+   * @since 0.16
+   */
+  public abstract <T> T match(
+      Function<? super GaugeTimeSeries, T> p0,
+      Function<? super CumulativeTimeSeries, T> p1,
+      Function<? super TimeSeries, T> defaultFunction);
+
+  /**
+   * A collection of data points that describes the time-varying values of a gauge {@code Metric}.
+   *
+   * @since 0.16
+   */
+  @ExperimentalApi
+  @Immutable
+  @AutoValue
+  public abstract static class GaugeTimeSeries extends TimeSeries {
+
+    GaugeTimeSeries() {}
+
+    @Override
+    public final <T> T match(
+        Function<? super GaugeTimeSeries, T> p0,
+        Function<? super CumulativeTimeSeries, T> p1,
+        Function<? super TimeSeries, T> defaultFunction) {
+      return p0.apply(this);
+    }
+
+    /**
+     * Creates a {@link GaugeTimeSeries}.
+     *
+     * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
+     * @param points the data {@code Point}s of this {@code TimeSeries}.
+     * @return a {@code GaugeTimeSeries}.
+     * @since 0.16
+     */
+    public static GaugeTimeSeries create(List<LabelValue> labelValues, List<Point> points) {
+      return new AutoValue_TimeSeries_GaugeTimeSeries(
+          Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
+          Collections.unmodifiableList(new ArrayList<Point>(points)));
+    }
+  }
+
+  /**
+   * A collection of data points that describes the time-varying values of a cumulative {@code
+   * Metric}.
+   *
+   * @since 0.16
+   */
+  @ExperimentalApi
+  @Immutable
+  @AutoValue
+  public abstract static class CumulativeTimeSeries extends TimeSeries {
+
+    CumulativeTimeSeries() {}
+
+    @Override
+    public final <T> T match(
+        Function<? super GaugeTimeSeries, T> p0,
+        Function<? super CumulativeTimeSeries, T> p1,
+        Function<? super TimeSeries, T> defaultFunction) {
+      return p1.apply(this);
+    }
+
+    /**
+     * Creates a {@link CumulativeTimeSeries}.
+     *
+     * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
+     * @param points the data {@code Point}s of this {@code TimeSeries}.
+     * @param startTimestamp the start {@code Timestamp} of this {@code CumulativeTimeSeries}.
+     * @return a {@code CumulativeTimeSeries}.
+     * @since 0.16
+     */
+    public static CumulativeTimeSeries create(
+        List<LabelValue> labelValues, List<Point> points, Timestamp startTimestamp) {
+      return new AutoValue_TimeSeries_CumulativeTimeSeries(
+          Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
+          Collections.unmodifiableList(new ArrayList<Point>(points)),
+          startTimestamp);
+    }
+
+    /**
+     * Returns the start {@link Timestamp} of this {@link CumulativeTimeSeries}.
+     *
+     * @return the start {@code Timestamp}.
+     * @since 0.16
+     */
+    public abstract Timestamp getStartTimestamp();
+  }
+}

--- a/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
+++ b/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
@@ -63,8 +63,8 @@ public abstract class TimeSeries {
    * @since 0.16
    */
   public abstract <T> T match(
-      Function<? super GaugeTimeSeries, T> p0,
-      Function<? super CumulativeTimeSeries, T> p1,
+      Function<? super TimeSeriesGauge, T> p0,
+      Function<? super TimeSeriesCumulative, T> p1,
       Function<? super TimeSeries, T> defaultFunction);
 
   /**
@@ -75,28 +75,28 @@ public abstract class TimeSeries {
   @ExperimentalApi
   @Immutable
   @AutoValue
-  public abstract static class GaugeTimeSeries extends TimeSeries {
+  public abstract static class TimeSeriesGauge extends TimeSeries {
 
-    GaugeTimeSeries() {}
+    TimeSeriesGauge() {}
 
     @Override
     public final <T> T match(
-        Function<? super GaugeTimeSeries, T> p0,
-        Function<? super CumulativeTimeSeries, T> p1,
+        Function<? super TimeSeriesGauge, T> p0,
+        Function<? super TimeSeriesCumulative, T> p1,
         Function<? super TimeSeries, T> defaultFunction) {
       return p0.apply(this);
     }
 
     /**
-     * Creates a {@link GaugeTimeSeries}.
+     * Creates a {@link TimeSeriesGauge}.
      *
      * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
      * @param points the data {@code Point}s of this {@code TimeSeries}.
-     * @return a {@code GaugeTimeSeries}.
+     * @return a {@code TimeSeriesGauge}.
      * @since 0.16
      */
-    public static GaugeTimeSeries create(List<LabelValue> labelValues, List<Point> points) {
-      return new AutoValue_TimeSeries_GaugeTimeSeries(
+    public static TimeSeriesGauge create(List<LabelValue> labelValues, List<Point> points) {
+      return new AutoValue_TimeSeries_TimeSeriesGauge(
           Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
           Collections.unmodifiableList(new ArrayList<Point>(points)));
     }
@@ -111,37 +111,37 @@ public abstract class TimeSeries {
   @ExperimentalApi
   @Immutable
   @AutoValue
-  public abstract static class CumulativeTimeSeries extends TimeSeries {
+  public abstract static class TimeSeriesCumulative extends TimeSeries {
 
-    CumulativeTimeSeries() {}
+    TimeSeriesCumulative() {}
 
     @Override
     public final <T> T match(
-        Function<? super GaugeTimeSeries, T> p0,
-        Function<? super CumulativeTimeSeries, T> p1,
+        Function<? super TimeSeriesGauge, T> p0,
+        Function<? super TimeSeriesCumulative, T> p1,
         Function<? super TimeSeries, T> defaultFunction) {
       return p1.apply(this);
     }
 
     /**
-     * Creates a {@link CumulativeTimeSeries}.
+     * Creates a {@link TimeSeriesCumulative}.
      *
      * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
      * @param points the data {@code Point}s of this {@code TimeSeries}.
-     * @param startTimestamp the start {@code Timestamp} of this {@code CumulativeTimeSeries}.
-     * @return a {@code CumulativeTimeSeries}.
+     * @param startTimestamp the start {@code Timestamp} of this {@code TimeSeriesCumulative}.
+     * @return a {@code TimeSeriesCumulative}.
      * @since 0.16
      */
-    public static CumulativeTimeSeries create(
+    public static TimeSeriesCumulative create(
         List<LabelValue> labelValues, List<Point> points, Timestamp startTimestamp) {
-      return new AutoValue_TimeSeries_CumulativeTimeSeries(
+      return new AutoValue_TimeSeries_TimeSeriesCumulative(
           Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
           Collections.unmodifiableList(new ArrayList<Point>(points)),
           startTimestamp);
     }
 
     /**
-     * Returns the start {@link Timestamp} of this {@link CumulativeTimeSeries}.
+     * Returns the start {@link Timestamp} of this {@link TimeSeriesCumulative}.
      *
      * @return the start {@code Timestamp}.
      * @since 0.16

--- a/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
+++ b/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
@@ -96,6 +96,9 @@ public abstract class TimeSeries {
      * @since 0.16
      */
     public static TimeSeriesGauge create(List<LabelValue> labelValues, List<Point> points) {
+      // Fail fast on null lists to prevent NullPointerException when copying the lists.
+      Utils.checkNotNull(labelValues, "labelValues");
+      Utils.checkNotNull(points, "points");
       return new AutoValue_TimeSeries_TimeSeriesGauge(
           Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
           Collections.unmodifiableList(new ArrayList<Point>(points)));
@@ -134,6 +137,9 @@ public abstract class TimeSeries {
      */
     public static TimeSeriesCumulative create(
         List<LabelValue> labelValues, List<Point> points, Timestamp startTimestamp) {
+      // Fail fast on null lists to prevent NullPointerException when copying the lists.
+      Utils.checkNotNull(labelValues, "labelValues");
+      Utils.checkNotNull(points, "points");
       return new AutoValue_TimeSeries_TimeSeriesCumulative(
           Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
           Collections.unmodifiableList(new ArrayList<Point>(points)),

--- a/metrics/src/main/java/io/opencensus/metrics/Utils.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Utils.java
@@ -20,6 +20,8 @@ package io.opencensus.metrics;
 import org.checkerframework.checker.nullness.qual.NonNull;
 */
 
+import java.util.List;
+
 /** General internal utility methods. */
 // TODO(songya): remove this class and use shared Utils instead.
 final class Utils {
@@ -52,5 +54,20 @@ final class Utils {
       throw new NullPointerException(message);
     }
     return arg;
+  }
+
+  /**
+   * Throws a {@link NullPointerException} if any of the list elements is null.
+   *
+   * @param list the argument list to check for null.
+   * @param message the message to use for the exception.
+   */
+  static <T /*>>> extends @NonNull Object*/> void checkListElementNotNull(
+      List<T> list, String message) {
+    for (T element : list) {
+      if (element == null) {
+        throw new NullPointerException(message);
+      }
+    }
   }
 }

--- a/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
@@ -25,8 +25,11 @@ import io.opencensus.metrics.TimeSeries.TimeSeriesCumulative;
 import io.opencensus.metrics.TimeSeries.TimeSeriesGauge;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -34,8 +37,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class TimeSeriesTest {
 
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
   private static final LabelValue LABEL_VALUE_1 = LabelValue.create("value1");
-  private static final LabelValue LABEL_VALUE_2 = LabelValue.create("value1");
+  private static final LabelValue LABEL_VALUE_2 = LabelValue.create("value2");
   private static final LabelValue LABEL_VALUE_EMPTY = LabelValue.create("");
   private static final Value VALUE_LONG = Value.longValue(12345678);
   private static final Value VALUE_DOUBLE = Value.doubleValue(-345.77);
@@ -66,6 +71,36 @@ public class TimeSeriesTest {
         .containsExactly(LABEL_VALUE_1, LABEL_VALUE_EMPTY)
         .inOrder();
     assertThat(cumulativeTimeSeries.getPoints()).containsExactly(POINT_1).inOrder();
+  }
+
+  @Test
+  public void create_WithNullLabelValueList() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    TimeSeriesCumulative.create(null, Collections.<Point>emptyList(), TIMESTAMP_1);
+  }
+
+  @Test
+  public void create_WithNullLabelValue() {
+    List<LabelValue> labelValues = Arrays.asList(LABEL_VALUE_1, null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    TimeSeriesCumulative.create(labelValues, Collections.<Point>emptyList(), TIMESTAMP_1);
+  }
+
+  @Test
+  public void create_WithNullPointList() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("points");
+    TimeSeriesCumulative.create(Collections.<LabelValue>emptyList(), null, TIMESTAMP_1);
+  }
+
+  @Test
+  public void create_WithNullPoint() {
+    List<Point> points = Arrays.asList(POINT_1, null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("point");
+    TimeSeriesCumulative.create(Collections.<LabelValue>emptyList(), points, TIMESTAMP_1);
   }
 
   @Test

--- a/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.opencensus.common.Functions;
+import io.opencensus.common.Timestamp;
+import io.opencensus.metrics.TimeSeries.CumulativeTimeSeries;
+import io.opencensus.metrics.TimeSeries.GaugeTimeSeries;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TimeSeries}. */
+@RunWith(JUnit4.class)
+public class TimeSeriesTest {
+
+  private static final LabelValue LABEL_VALUE_1 = LabelValue.create("value1");
+  private static final LabelValue LABEL_VALUE_2 = LabelValue.create("value1");
+  private static final LabelValue LABEL_VALUE_EMPTY = LabelValue.create("");
+  private static final Value VALUE_LONG = Value.longValue(12345678);
+  private static final Value VALUE_DOUBLE = Value.doubleValue(-345.77);
+  private static final Timestamp TIMESTAMP_1 = Timestamp.fromMillis(1000);
+  private static final Timestamp TIMESTAMP_2 = Timestamp.fromMillis(2000);
+  private static final Timestamp TIMESTAMP_3 = Timestamp.fromMillis(3000);
+  private static final Point POINT_1 = Point.create(VALUE_DOUBLE, TIMESTAMP_2);
+  private static final Point POINT_2 = Point.create(VALUE_LONG, TIMESTAMP_3);
+
+  @Test
+  public void testGet_GaugeTimeSeries() {
+    GaugeTimeSeries gaugeTimeSeries =
+        GaugeTimeSeries.create(
+            Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2));
+    assertThat(gaugeTimeSeries.getLabelValues())
+        .containsExactly(LABEL_VALUE_1, LABEL_VALUE_2)
+        .inOrder();
+    assertThat(gaugeTimeSeries.getPoints()).containsExactly(POINT_1, POINT_2).inOrder();
+  }
+
+  @Test
+  public void testGet_CumulativeTimeSeries() {
+    CumulativeTimeSeries cumulativeTimeSeries =
+        CumulativeTimeSeries.create(
+            Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY), Arrays.asList(POINT_1), TIMESTAMP_1);
+    assertThat(cumulativeTimeSeries.getStartTimestamp()).isEqualTo(TIMESTAMP_1);
+    assertThat(cumulativeTimeSeries.getLabelValues())
+        .containsExactly(LABEL_VALUE_1, LABEL_VALUE_EMPTY)
+        .inOrder();
+    assertThat(cumulativeTimeSeries.getPoints()).containsExactly(POINT_1).inOrder();
+  }
+
+  @Test
+  public void testMatch() {
+    List<TimeSeries> timeSeriesList =
+        Arrays.asList(
+            GaugeTimeSeries.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)),
+            CumulativeTimeSeries.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
+                Arrays.asList(POINT_1),
+                TIMESTAMP_1));
+    List<String> expected = Arrays.asList("Gauge", "Cumulative");
+    List<String> actual = new ArrayList<String>();
+    for (TimeSeries timeSeries : timeSeriesList) {
+      actual.add(
+          timeSeries.match(
+              Functions.returnConstant("Gauge"),
+              Functions.returnConstant("Cumulative"),
+              Functions.<String>throwAssertionError()));
+    }
+    assertThat(actual).containsExactlyElementsIn(expected).inOrder();
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            GaugeTimeSeries.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)),
+            GaugeTimeSeries.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)))
+        .addEqualityGroup(
+            GaugeTimeSeries.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1)))
+        .addEqualityGroup(
+            GaugeTimeSeries.create(Arrays.asList(LABEL_VALUE_1), Arrays.asList(POINT_1)))
+        .addEqualityGroup(
+            CumulativeTimeSeries.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
+                Arrays.asList(POINT_1),
+                TIMESTAMP_1))
+        .addEqualityGroup(
+            CumulativeTimeSeries.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
+                Arrays.asList(POINT_1),
+                TIMESTAMP_2))
+        .testEquals();
+  }
+}

--- a/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
@@ -21,8 +21,8 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.common.testing.EqualsTester;
 import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
-import io.opencensus.metrics.TimeSeries.CumulativeTimeSeries;
-import io.opencensus.metrics.TimeSeries.GaugeTimeSeries;
+import io.opencensus.metrics.TimeSeries.TimeSeriesCumulative;
+import io.opencensus.metrics.TimeSeries.TimeSeriesGauge;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -46,9 +46,9 @@ public class TimeSeriesTest {
   private static final Point POINT_2 = Point.create(VALUE_LONG, TIMESTAMP_3);
 
   @Test
-  public void testGet_GaugeTimeSeries() {
-    GaugeTimeSeries gaugeTimeSeries =
-        GaugeTimeSeries.create(
+  public void testGet_TimeSeriesGauge() {
+    TimeSeriesGauge gaugeTimeSeries =
+        TimeSeriesGauge.create(
             Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2));
     assertThat(gaugeTimeSeries.getLabelValues())
         .containsExactly(LABEL_VALUE_1, LABEL_VALUE_2)
@@ -57,9 +57,9 @@ public class TimeSeriesTest {
   }
 
   @Test
-  public void testGet_CumulativeTimeSeries() {
-    CumulativeTimeSeries cumulativeTimeSeries =
-        CumulativeTimeSeries.create(
+  public void testGet_TimeSeriesCumulative() {
+    TimeSeriesCumulative cumulativeTimeSeries =
+        TimeSeriesCumulative.create(
             Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY), Arrays.asList(POINT_1), TIMESTAMP_1);
     assertThat(cumulativeTimeSeries.getStartTimestamp()).isEqualTo(TIMESTAMP_1);
     assertThat(cumulativeTimeSeries.getLabelValues())
@@ -72,9 +72,9 @@ public class TimeSeriesTest {
   public void testMatch() {
     List<TimeSeries> timeSeriesList =
         Arrays.asList(
-            GaugeTimeSeries.create(
+            TimeSeriesGauge.create(
                 Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)),
-            CumulativeTimeSeries.create(
+            TimeSeriesCumulative.create(
                 Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
                 Arrays.asList(POINT_1),
                 TIMESTAMP_1));
@@ -94,22 +94,22 @@ public class TimeSeriesTest {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            GaugeTimeSeries.create(
+            TimeSeriesGauge.create(
                 Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)),
-            GaugeTimeSeries.create(
+            TimeSeriesGauge.create(
                 Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)))
         .addEqualityGroup(
-            GaugeTimeSeries.create(
+            TimeSeriesGauge.create(
                 Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1)))
         .addEqualityGroup(
-            GaugeTimeSeries.create(Arrays.asList(LABEL_VALUE_1), Arrays.asList(POINT_1)))
+            TimeSeriesGauge.create(Arrays.asList(LABEL_VALUE_1), Arrays.asList(POINT_1)))
         .addEqualityGroup(
-            CumulativeTimeSeries.create(
+            TimeSeriesCumulative.create(
                 Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
                 Arrays.asList(POINT_1),
                 TIMESTAMP_1))
         .addEqualityGroup(
-            CumulativeTimeSeries.create(
+            TimeSeriesCumulative.create(
                 Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
                 Arrays.asList(POINT_1),
                 TIMESTAMP_2))


### PR DESCRIPTION
~~Blocked by https://github.com/census-instrumentation/opencensus-java/pull/1263.~~

[Proto definition](https://github.com/census-instrumentation/opencensus-proto/blob/master/opencensus/proto/stats/metrics/metrics.proto#L107-L132):

```
// A collection of data points that describes the time-varying values
// of a gauge metric.
message GaugeTimeSeries {
  // The set of label values that uniquely identify this timeseries. Applies to
  // all points. The order of label values must match that of label keys in the
  // metric descriptor.
  repeated LabelValue label_values = 1;

  // The data points of this timeseries. Point type MUST match the MetricDescriptor.type.
  repeated Point points = 2;
}

// A collection of data points that describes the time-varying values
// of a cumulative metric.
message CumulativeTimeSeries {
  // The time that the cumulative value was reset to zero.
  google.protobuf.Timestamp start_time = 1; // required

  // The set of label values that uniquely identify this timeseries. Applies to
  // all points. The order of label values must match that of label keys in the
  // metric descriptor.
  repeated LabelValue label_values = 2;

  // The data points of this timeseries. Point type MUST match the MetricDescriptor.type.
  repeated Point points = 3;
}
```