### PR TITLE
Stats: Only include the simple class name in the error message for ViewData.check methods.

### DIFF
--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -232,9 +232,9 @@ public abstract class ViewData {
       View.AggregationWindow window, AggregationWindowData windowData) {
     return "AggregationWindow and AggregationWindowData types mismatch. "
         + "AggregationWindow: "
-        + window
+        + window.getClass().getSimpleName()
         + " AggregationWindowData: "
-        + windowData;
+        + windowData.getClass().getSimpleName();
   }
 
   private static void checkAggregation(
@@ -331,9 +331,9 @@ public abstract class ViewData {
       Aggregation aggregation, AggregationData aggregationData) {
     return "Aggregation and AggregationData types mismatch. "
         + "Aggregation: "
-        + aggregation
+        + aggregation.getClass().getSimpleName()
         + " AggregationData: "
-        + aggregationData;
+        + aggregationData.getClass().getSimpleName();
   }
 
   /**

--- a/api/src/main/java/io/opencensus/stats/ViewData.java
+++ b/api/src/main/java/io/opencensus/stats/ViewData.java
@@ -209,7 +209,7 @@ public abstract class ViewData {
         new Function<View.AggregationWindow.Cumulative, Void>() {
           @Override
           public Void apply(View.AggregationWindow.Cumulative arg) {
-            checkWindow(
+            throwIfWindowMismatch(
                 windowData instanceof AggregationWindowData.CumulativeData, arg, windowData);
             return null;
           }
@@ -217,14 +217,15 @@ public abstract class ViewData {
         new Function<View.AggregationWindow.Interval, Void>() {
           @Override
           public Void apply(View.AggregationWindow.Interval arg) {
-            checkWindow(windowData instanceof AggregationWindowData.IntervalData, arg, windowData);
+            throwIfWindowMismatch(
+                windowData instanceof AggregationWindowData.IntervalData, arg, windowData);
             return null;
           }
         },
         Functions.</*@Nullable*/ Void>throwAssertionError());
   }
 
-  private static void checkWindow(
+  private static void throwIfWindowMismatch(
       boolean isValid, View.AggregationWindow window, AggregationWindowData windowData) {
     if (!isValid) {
       throw new IllegalArgumentException(createErrorMessageForWindow(window, windowData));
@@ -250,7 +251,7 @@ public abstract class ViewData {
                 new Function<MeasureDouble, Void>() {
                   @Override
                   public Void apply(MeasureDouble arg) {
-                    checkAggregation(
+                    throwIfAggregationMismatch(
                         aggregationData instanceof SumDataDouble, aggregation, aggregationData);
                     return null;
                   }
@@ -258,7 +259,7 @@ public abstract class ViewData {
                 new Function<MeasureLong, Void>() {
                   @Override
                   public Void apply(MeasureLong arg) {
-                    checkAggregation(
+                    throwIfAggregationMismatch(
                         aggregationData instanceof SumDataLong, aggregation, aggregationData);
                     return null;
                   }
@@ -270,14 +271,15 @@ public abstract class ViewData {
         new Function<Count, Void>() {
           @Override
           public Void apply(Count arg) {
-            checkAggregation(aggregationData instanceof CountData, aggregation, aggregationData);
+            throwIfAggregationMismatch(
+                aggregationData instanceof CountData, aggregation, aggregationData);
             return null;
           }
         },
         new Function<Distribution, Void>() {
           @Override
           public Void apply(Distribution arg) {
-            checkAggregation(
+            throwIfAggregationMismatch(
                 aggregationData instanceof DistributionData, aggregation, aggregationData);
             return null;
           }
@@ -289,7 +291,7 @@ public abstract class ViewData {
                 new Function<MeasureDouble, Void>() {
                   @Override
                   public Void apply(MeasureDouble arg) {
-                    checkAggregation(
+                    throwIfAggregationMismatch(
                         aggregationData instanceof LastValueDataDouble,
                         aggregation,
                         aggregationData);
@@ -299,7 +301,7 @@ public abstract class ViewData {
                 new Function<MeasureLong, Void>() {
                   @Override
                   public Void apply(MeasureLong arg) {
-                    checkAggregation(
+                    throwIfAggregationMismatch(
                         aggregationData instanceof LastValueDataLong, aggregation, aggregationData);
                     return null;
                   }
@@ -315,7 +317,7 @@ public abstract class ViewData {
             // we need to continue supporting Mean, since it could still be used by users and some
             // deprecated RPC views.
             if (arg instanceof Aggregation.Mean) {
-              checkAggregation(
+              throwIfAggregationMismatch(
                   aggregationData instanceof AggregationData.MeanData,
                   aggregation,
                   aggregationData);
@@ -326,7 +328,7 @@ public abstract class ViewData {
         });
   }
 
-  private static void checkAggregation(
+  private static void throwIfAggregationMismatch(
       boolean isValid, Aggregation aggregation, AggregationData aggregationData) {
     if (!isValid) {
       throw new IllegalArgumentException(

--- a/api/src/test/java/io/opencensus/stats/ViewDataTest.java
+++ b/api/src/test/java/io/opencensus/stats/ViewDataTest.java
@@ -160,12 +160,19 @@ public final class ViewDataTest {
 
   @Test
   public void preventWindowAndAggregationWindowDataMismatch() {
+    CumulativeData cumulativeData =
+        CumulativeData.create(Timestamp.fromMillis(1000), Timestamp.fromMillis(2000));
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("AggregationWindow and AggregationWindowData types mismatch. ");
+    thrown.expectMessage(
+        "AggregationWindow and AggregationWindowData types mismatch. "
+            + "AggregationWindow: "
+            + INTERVAL_HOUR.getClass().getSimpleName()
+            + " AggregationWindowData: "
+            + cumulativeData.getClass().getSimpleName());
     ViewData.create(
         View.create(NAME, DESCRIPTION, MEASURE_DOUBLE, DISTRIBUTION, TAG_KEYS, INTERVAL_HOUR),
         ENTRIES,
-        CumulativeData.create(Timestamp.fromMillis(1000), Timestamp.fromMillis(2000)));
+        cumulativeData);
   }
 
   @Test
@@ -213,12 +220,7 @@ public final class ViewDataTest {
   @Test
   public void preventAggregationAndAggregationDataMismatch_Distribution_Count() {
     aggregationAndAggregationDataMismatch(
-        createView(DISTRIBUTION),
-        ImmutableMap.of(
-            Arrays.asList(V1, V2),
-            DistributionData.create(1, 1, 1, 1, 0, Arrays.asList(0L, 1L, 0L)),
-            Arrays.asList(V10, V20),
-            CountData.create(100)));
+        createView(DISTRIBUTION), ImmutableMap.of(Arrays.asList(V10, V20), CountData.create(100)));
   }
 
   @Test
@@ -249,8 +251,15 @@ public final class ViewDataTest {
       View view, Map<List<TagValue>, ? extends AggregationData> entries) {
     CumulativeData cumulativeData =
         CumulativeData.create(Timestamp.fromMillis(1000), Timestamp.fromMillis(2000));
+    Aggregation aggregation = view.getAggregation();
+    AggregationData aggregationData = entries.values().iterator().next();
     thrown.expect(IllegalArgumentException.class);
-    thrown.expectMessage("Aggregation and AggregationData types mismatch. ");
+    thrown.expectMessage(
+        "Aggregation and AggregationData types mismatch. "
+            + "Aggregation: "
+            + aggregation.getClass().getSimpleName()
+            + " AggregationData: "
+            + aggregationData.getClass().getSimpleName());
     ViewData.create(view, entries, cumulativeData);
   }
 


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1265.

When there's a mismatch between `Aggregation` - `AggregationData` or `Window` - `WindowData`, all we care about is their types. Only include the subclass name in the error message instead of calling the `toString` method to reduce overhead.

/cc @steveniemitz