### PR TITLE
Stackdriver Stats Exporter: allow user to force update existing Metric with new schema.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Expose the factory methods of MonitoredResource.
+- Stackdriver Stats Exporter: allow user to force update existing Metric with new schema.
 
 ## 0.14.0 - 2018-06-04
 - Adds Tracing.getExportComponent().shutdown() for use within application shutdown hooks.

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -139,7 +139,7 @@ final class StackdriverExportUtils {
     return builder.build();
   }
 
-  private static String generateType(String viewName) {
+  static String generateType(String viewName) {
     return CUSTOM_OPENCENSUS_DOMAIN + viewName;
   }
 

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
@@ -145,8 +145,9 @@ public abstract class StackdriverStatsConfiguration {
      * Force update means delete the existing {@link com.google.api.MetricDescriptor} and create a
      * new one.
      *
-     * <p>Note that once a {@link com.google.api.MetricDescriptor} is deleted from Stackdriver, all
-     * the {@link com.google.monitoring.v3.TimeSeries} associated with it will also be deleted.
+     * <p>Historical {@link com.google.monitoring.v3.TimeSeries} associated with the old {@link
+     * com.google.api.MetricDescriptor} will not be deleted, but eventually they will expire. See
+     * https://cloud.google.com/monitoring/custom-metrics/creating-metrics#deleting_metrics.
      *
      * @param shouldOverrideExistingMetrics whether to force update existing {@link
      *     com.google.api.MetricDescriptor} or not.

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
@@ -71,6 +71,20 @@ public abstract class StackdriverStatsConfiguration {
   public abstract MonitoredResource getMonitoredResource();
 
   /**
+   * Returns {@code true} when you want to force update existing {@link
+   * com.google.api.MetricDescriptor}, returns {@code false} or {@code null} otherwise.
+   *
+   * <p>Force update means delete the existing {@link com.google.api.MetricDescriptor} and create a
+   * new one.
+   *
+   * @return {@code true} when you want to force update existing {@link
+   *     com.google.api.MetricDescriptor}, returns {@code false} or {@code null} otherwise.
+   * @since 0.15
+   */
+  @Nullable
+  public abstract Boolean getOverrideExistingMetrics();
+
+  /**
    * Returns a new {@link Builder}.
    *
    * @return a {@code Builder}.
@@ -125,6 +139,20 @@ public abstract class StackdriverStatsConfiguration {
      * @since 0.11
      */
     public abstract Builder setMonitoredResource(MonitoredResource monitoredResource);
+
+    /**
+     * Decides whether to force update existing {@link com.google.api.MetricDescriptor} or not.
+     * Force update means delete the existing {@link com.google.api.MetricDescriptor} and create a
+     * new one.
+     *
+     * <p>Note that once a {@link com.google.api.MetricDescriptor} is deleted from Stackdriver, all
+     * the {@link com.google.monitoring.v3.TimeSeries} associated with it will also be deleted.
+     *
+     * @param shouldOverrideExistingMetrics whether to force update existing {@link
+     *     com.google.api.MetricDescriptor} or not.
+     * @return this
+     */
+    public abstract Builder setOverrideExistingMetrics(Boolean shouldOverrideExistingMetrics);
 
     /**
      * Builds a new {@link StackdriverStatsConfiguration} with current settings.

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExporterWorkerTest.java
@@ -33,6 +33,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.CreateTimeSeriesRequest;
+import com.google.monitoring.v3.DeleteMetricDescriptorRequest;
 import com.google.monitoring.v3.TimeSeries;
 import com.google.protobuf.Empty;
 import io.opencensus.common.Duration;
@@ -90,6 +91,9 @@ public class StackdriverExporterWorkerTest {
   private UnaryCallable<CreateMetricDescriptorRequest, MetricDescriptor>
       mockCreateMetricDescriptorCallable;
 
+  @Mock
+  private UnaryCallable<DeleteMetricDescriptorRequest, Empty> mockDeleteMetricDescriptorCallable;
+
   @Mock private UnaryCallable<CreateTimeSeriesRequest, Empty> mockCreateTimeSeriesCallable;
 
   @Before
@@ -97,10 +101,14 @@ public class StackdriverExporterWorkerTest {
     MockitoAnnotations.initMocks(this);
 
     doReturn(mockCreateMetricDescriptorCallable).when(mockStub).createMetricDescriptorCallable();
+    doReturn(mockDeleteMetricDescriptorCallable).when(mockStub).deleteMetricDescriptorCallable();
     doReturn(mockCreateTimeSeriesCallable).when(mockStub).createTimeSeriesCallable();
     doReturn(null)
         .when(mockCreateMetricDescriptorCallable)
         .call(any(CreateMetricDescriptorRequest.class));
+    doReturn(null)
+        .when(mockDeleteMetricDescriptorCallable)
+        .call(any(DeleteMetricDescriptorRequest.class));
     doReturn(null).when(mockCreateTimeSeriesCallable).call(any(CreateTimeSeriesRequest.class));
   }
 
@@ -127,7 +135,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            false);
     worker.export();
 
     verify(mockStub, times(1)).createMetricDescriptorCallable();
@@ -170,7 +179,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            false);
 
     worker.export();
     verify(mockStub, times(1)).createMetricDescriptorCallable();
@@ -189,7 +199,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            false);
 
     assertThat(worker.registerView(view)).isFalse();
     worker.export();
@@ -198,14 +209,15 @@ public class StackdriverExporterWorkerTest {
   }
 
   @Test
-  public void skipDifferentViewWithSameName() throws IOException {
+  public void skipDifferentViewWithSameNameIfNotOverrideExistingMetrics() {
     StackdriverExporterWorker worker =
         new StackdriverExporterWorker(
             PROJECT_ID,
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            false);
     View view1 =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
     assertThat(worker.registerView(view1)).isTrue();
@@ -224,6 +236,34 @@ public class StackdriverExporterWorkerTest {
   }
 
   @Test
+  public void overrideExistingMetricsWithSameNameButDifferentAttributes() {
+    StackdriverExporterWorker worker =
+        new StackdriverExporterWorker(
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            ONE_SECOND,
+            mockViewManager,
+            DEFAULT_RESOURCE,
+            true);
+    View view1 =
+        View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
+    assertThat(worker.registerView(view1)).isTrue();
+    verify(mockStub, times(1)).createMetricDescriptorCallable();
+
+    View view2 =
+        View.create(
+            VIEW_NAME,
+            "This is a different description.",
+            MEASURE,
+            SUM,
+            Arrays.asList(KEY),
+            CUMULATIVE);
+    assertThat(worker.registerView(view2)).isTrue();
+    verify(mockStub, times(1)).deleteMetricDescriptorCallable();
+    verify(mockStub, times(2)).createMetricDescriptorCallable();
+  }
+
+  @Test
   public void doNotCreateMetricDescriptorForRegisteredView() {
     StackdriverExporterWorker worker =
         new StackdriverExporterWorker(
@@ -231,7 +271,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            false);
     View view =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), CUMULATIVE);
     assertThat(worker.registerView(view)).isTrue();
@@ -249,7 +290,8 @@ public class StackdriverExporterWorkerTest {
             new FakeMetricServiceClient(mockStub),
             ONE_SECOND,
             mockViewManager,
-            DEFAULT_RESOURCE);
+            DEFAULT_RESOURCE,
+            false);
     View view =
         View.create(VIEW_NAME, VIEW_DESCRIPTION, MEASURE, SUM, Arrays.asList(KEY), INTERVAL);
     assertThat(worker.registerView(view)).isFalse();

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
@@ -50,11 +50,13 @@ public class StackdriverStatsConfigurationTest {
             .setProjectId(PROJECT_ID)
             .setExportInterval(DURATION)
             .setMonitoredResource(RESOURCE)
+            .setOverrideExistingMetrics(true)
             .build();
     assertThat(configuration.getCredentials()).isEqualTo(FAKE_CREDENTIALS);
     assertThat(configuration.getProjectId()).isEqualTo(PROJECT_ID);
     assertThat(configuration.getExportInterval()).isEqualTo(DURATION);
     assertThat(configuration.getMonitoredResource()).isEqualTo(RESOURCE);
+    assertThat(configuration.getOverrideExistingMetrics()).isTrue();
   }
 
   @Test
@@ -64,5 +66,6 @@ public class StackdriverStatsConfigurationTest {
     assertThat(configuration.getProjectId()).isNull();
     assertThat(configuration.getExportInterval()).isNull();
     assertThat(configuration.getMonitoredResource()).isNull();
+    assertThat(configuration.getOverrideExistingMetrics()).isNull();
   }
 }


### PR DESCRIPTION
Make the Stackdriver Stats Exporter more robust by allowing schema change in Stackdriver `MetricDescriptor`. The default config is not to do force update. If a user set `StackdriverStatsConfiguration.overrideExistingMetrics` to true, when they update existing views to a different schema, the exporter will delete the existing `MetricDescriptor` from Stackdriver and create one with the new schema.

This new config will be also useful if we want to remove the opencensus-task label from existing `MetricDescriptor`s, which is a backwards-incompatible schema change.

/cc @ramonza 