### PR TITLE
Update Google Cloud version.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -150,7 +150,8 @@ subprojects {
         grpcVersion = '1.12.0'
         guavaVersion = '20.0'
         googleAuthVersion = '0.9.1'
-        googleCloudVersion = '0.50.0-beta'
+        googleCloudBetaVersion = '0.52.0-beta'
+        googleCloudGaVersion = '1.34.0'
         signalfxVersion = '0.0.39'
         prometheusVersion = '0.4.0'
         protobufVersion = '3.5.1'
@@ -168,11 +169,11 @@ subprojects {
                 findbugs_annotations: "com.google.code.findbugs:annotations:${findBugsVersion}",
                 google_auth: "com.google.auth:google-auth-library-credentials:${googleAuthVersion}",
                 google_cloud_logging: "com.google.cloud:google-cloud-logging:1.33.0",
-                google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudVersion}",
+                google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudBetaVersion}",
                 zipkin_reporter: "io.zipkin.reporter2:zipkin-reporter:${zipkinReporterVersion}",
                 zipkin_urlconnection: "io.zipkin.reporter2:zipkin-sender-urlconnection:${zipkinReporterVersion}",
                 jaeger_reporter: "com.uber.jaeger:jaeger-core:${jaegerReporterVersion}",
-                google_cloud_monitoring: "com.google.cloud:google-cloud-monitoring:${googleCloudVersion}",
+                google_cloud_monitoring: "com.google.cloud:google-cloud-monitoring:${googleCloudGaVersion}",
                 grpc_context: "io.grpc:grpc-context:${grpcVersion}",
                 grpc_core: "io.grpc:grpc-core:${grpcVersion}",
                 guava: "com.google.guava:guava:${guavaVersion}",

--- a/build.gradle
+++ b/build.gradle
@@ -168,7 +168,7 @@ subprojects {
                 errorprone: "com.google.errorprone:error_prone_annotations:${errorProneVersion}",
                 findbugs_annotations: "com.google.code.findbugs:annotations:${findBugsVersion}",
                 google_auth: "com.google.auth:google-auth-library-credentials:${googleAuthVersion}",
-                google_cloud_logging: "com.google.cloud:google-cloud-logging:1.33.0",
+                google_cloud_logging: "com.google.cloud:google-cloud-logging:${googleCloudGaVersion}",
                 google_cloud_trace: "com.google.cloud:google-cloud-trace:${googleCloudBetaVersion}",
                 zipkin_reporter: "io.zipkin.reporter2:zipkin-reporter:${zipkinReporterVersion}",
                 zipkin_urlconnection: "io.zipkin.reporter2:zipkin-sender-urlconnection:${zipkinReporterVersion}",


### PR DESCRIPTION
Note that recently a bunch of former beta client libraries (including Cloud Monitoring) have changed to a different version set since they are moving from beta to GA:
https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22com.google.cloud%22%20AND%20a%3A%22google-cloud-monitoring%22

Also see https://github.com/GoogleCloudPlatform/google-cloud-java#google-cloud-client-library-for-java.

