### PR TITLE
Stats: Add new MeasureMap.record() APIs that take a string map for recording exemplars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Add APIs to register gRPC client and server views separately.
+- Add new MeasureMap.record() APIs that take a string map for recording exemplars.
 
 ## 0.15.0 - 2018-06-20
 - Expose the factory methods of MonitoredResource.

--- a/api/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/api/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -19,6 +19,7 @@ package io.opencensus.stats;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.tags.TagContext;
+import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -61,6 +62,17 @@ public abstract class MeasureMap {
   public abstract void record();
 
   /**
+   * Records all of the measures at the same time, with the current {@link TagContext} and given
+   * contextual information of an {@code Exemplar}.
+   *
+   * <p>This method records all of the stats in the {@code MeasureMap} every time it is called.
+   *
+   * @param attachments contextual information of an {@code Exemplar}.
+   * @since 0.16
+   */
+  public abstract void record(Map<String, String> attachments);
+
+  /**
    * Records all of the measures at the same time, with an explicit {@link TagContext}.
    *
    * <p>This method records all of the stats in the {@code MeasureMap} every time it is called.
@@ -69,4 +81,16 @@ public abstract class MeasureMap {
    * @since 0.8
    */
   public abstract void record(TagContext tags);
+
+  /**
+   * Records all of the measures at the same time, with an explicit {@link TagContext} and given
+   * contextual information of an {@code Exemplar}.
+   *
+   * <p>This method records all of the stats in the {@code MeasureMap} every time it is called.
+   *
+   * @param tags the tags associated with the measurements.
+   * @param attachments contextual information of an {@code Exemplar}.
+   * @since 0.16
+   */
+  public abstract void record(TagContext tags, Map<String, String> attachments);
 }

--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -138,8 +138,19 @@ final class NoopStats {
     public void record() {}
 
     @Override
+    public void record(Map<String, String> attachments) {
+      Utils.checkNotNull(attachments, "attachments");
+    }
+
+    @Override
     public void record(TagContext tags) {
       Utils.checkNotNull(tags, "tags");
+    }
+
+    @Override
+    public void record(TagContext tags, Map<String, String> attachments) {
+      Utils.checkNotNull(tags, "tags");
+      Utils.checkNotNull(attachments, "attachments");
     }
   }
 

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -99,6 +99,7 @@ public final class NoopStatsTest {
   public void noopStatsRecorder_Record_DisallowNullTagContext() {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
+    thrown.expectMessage("tags");
     measureMap.record((TagContext) null);
   }
 
@@ -106,6 +107,7 @@ public final class NoopStatsTest {
   public void noopStatsRecorder_Record_DisallowNullAttachments() {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
+    thrown.expectMessage("attachments");
     measureMap.record((Map<String, String>) null);
   }
 
@@ -113,6 +115,7 @@ public final class NoopStatsTest {
   public void noopStatsRecorder_RecordWithAttachments_DisallowNullTagContext() {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
+    thrown.expectMessage("tags");
     measureMap.record(null, ATTACHMENTS);
   }
 
@@ -120,12 +123,12 @@ public final class NoopStatsTest {
   public void noopStatsRecorder_RecordWithAttachments_DisallowNullAttachments() {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
+    thrown.expectMessage("attachments");
     measureMap.record(tagContext, null);
   }
 
   // The NoopStatsRecorder should do nothing, so the tests below just checks that record doesn't
-  // throw an
-  // exception.
+  // throw an exception.
   @Test
   public void noopStatsRecorder_Record() {
     NoopStats.getNoopStatsRecorder().newMeasureMap().put(MEASURE, 5).record(tagContext);

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -25,6 +25,7 @@ import io.opencensus.tags.TagKey;
 import io.opencensus.tags.TagValue;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -40,6 +41,7 @@ public final class NoopStatsTest {
   private static final Tag TAG = Tag.create(TagKey.create("key"), TagValue.create("value"));
   private static final MeasureDouble MEASURE =
       Measure.MeasureDouble.create("my measure", "description", "s");
+  private static final Map<String, String> ATTACHMENTS = Collections.singletonMap("key", "value");
 
   private final TagContext tagContext =
       new TagContext() {
@@ -93,24 +95,57 @@ public final class NoopStatsTest {
     noopStatsComponent.setState(StatsCollectionState.ENABLED);
   }
 
-  // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
+  @Test
+  public void noopStatsRecorder_Record_DisallowNullTagContext() {
+    MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
+    thrown.expect(NullPointerException.class);
+    measureMap.record((TagContext) null);
+  }
+
+  @Test
+  public void noopStatsRecorder_Record_DisallowNullAttachments() {
+    MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
+    thrown.expect(NullPointerException.class);
+    measureMap.record((Map<String, String>) null);
+  }
+
+  @Test
+  public void noopStatsRecorder_RecordWithAttachments_DisallowNullTagContext() {
+    MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
+    thrown.expect(NullPointerException.class);
+    measureMap.record(null, ATTACHMENTS);
+  }
+
+  @Test
+  public void noopStatsRecorder_RecordWithAttachments_DisallowNullAttachments() {
+    MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
+    thrown.expect(NullPointerException.class);
+    measureMap.record(tagContext, null);
+  }
+
+  // The NoopStatsRecorder should do nothing, so the tests below just checks that record doesn't
+  // throw an
   // exception.
   @Test
   public void noopStatsRecorder_Record() {
     NoopStats.getNoopStatsRecorder().newMeasureMap().put(MEASURE, 5).record(tagContext);
   }
 
-  // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
-  // exception.
   @Test
   public void noopStatsRecorder_RecordWithCurrentContext() {
     NoopStats.getNoopStatsRecorder().newMeasureMap().put(MEASURE, 6).record();
   }
 
   @Test
-  public void noopStatsRecorder_Record_DisallowNullTagContext() {
-    MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
-    thrown.expect(NullPointerException.class);
-    measureMap.record(null);
+  public void noopStatsRecorder_RecordWithAttachments() {
+    NoopStats.getNoopStatsRecorder()
+        .newMeasureMap()
+        .put(MEASURE, 5)
+        .record(tagContext, ATTACHMENTS);
+  }
+
+  @Test
+  public void noopStatsRecorder_RecordWithCurrentContextAndAttachments() {
+    NoopStats.getNoopStatsRecorder().newMeasureMap().put(MEASURE, 6).record(ATTACHMENTS);
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
@@ -21,6 +21,9 @@ import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.stats.MeasureMap;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.unsafe.ContextUtils;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 /** Implementation of {@link MeasureMap}. */
 final class MeasureMapImpl extends MeasureMap {
@@ -54,7 +57,20 @@ final class MeasureMapImpl extends MeasureMap {
   }
 
   @Override
+  public void record(Map<String, String> attachments) {
+    record(ContextUtils.TAG_CONTEXT_KEY.get(), attachments);
+  }
+
+  @Override
   public void record(TagContext tags) {
     statsManager.record(tags, builder.build());
+  }
+
+  @Override
+  public void record(TagContext tags, Map<String, String> attachments) {
+    statsManager.record(
+        tags,
+        builder.build(),
+        Collections.unmodifiableMap(new HashMap<String, String>(attachments)));
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -144,7 +144,11 @@ final class MeasureToViewMap {
   }
 
   // Records stats with a set of tags.
-  synchronized void record(TagContext tags, MeasureMapInternal stats, Timestamp timestamp) {
+  synchronized void record(
+      TagContext tags,
+      MeasureMapInternal stats,
+      Timestamp timestamp,
+      @javax.annotation.Nullable Map<String, String> attachments) {
     Iterator<Measurement> iterator = stats.iterator();
     while (iterator.hasNext()) {
       Measurement measurement = iterator.next();
@@ -156,8 +160,8 @@ final class MeasureToViewMap {
       Collection<MutableViewData> views = mutableMap.get(measure.getName());
       for (MutableViewData view : views) {
         measurement.match(
-            new RecordDoubleValueFunc(tags, view, timestamp),
-            new RecordLongValueFunc(tags, view, timestamp),
+            new RecordDoubleValueFunc(tags, view, timestamp, attachments),
+            new RecordLongValueFunc(tags, view, timestamp, attachments),
             Functions.</*@Nullable*/ Void>throwAssertionError());
       }
     }
@@ -184,36 +188,48 @@ final class MeasureToViewMap {
   private static final class RecordDoubleValueFunc implements Function<MeasurementDouble, Void> {
     @Override
     public Void apply(MeasurementDouble arg) {
-      view.record(tags, arg.getValue(), timestamp);
+      view.record(tags, arg.getValue(), timestamp, attachments);
       return null;
     }
 
     private final TagContext tags;
     private final MutableViewData view;
     private final Timestamp timestamp;
+    @javax.annotation.Nullable private final Map<String, String> attachments;
 
-    private RecordDoubleValueFunc(TagContext tags, MutableViewData view, Timestamp timestamp) {
+    private RecordDoubleValueFunc(
+        TagContext tags,
+        MutableViewData view,
+        Timestamp timestamp,
+        @javax.annotation.Nullable Map<String, String> attachments) {
       this.tags = tags;
       this.view = view;
       this.timestamp = timestamp;
+      this.attachments = attachments;
     }
   }
 
   private static final class RecordLongValueFunc implements Function<MeasurementLong, Void> {
     @Override
     public Void apply(MeasurementLong arg) {
-      view.record(tags, arg.getValue(), timestamp);
+      view.record(tags, arg.getValue(), timestamp, attachments);
       return null;
     }
 
     private final TagContext tags;
     private final MutableViewData view;
     private final Timestamp timestamp;
+    @javax.annotation.Nullable private final Map<String, String> attachments;
 
-    private RecordLongValueFunc(TagContext tags, MutableViewData view, Timestamp timestamp) {
+    private RecordLongValueFunc(
+        TagContext tags,
+        MutableViewData view,
+        Timestamp timestamp,
+        @javax.annotation.Nullable Map<String, String> attachments) {
       this.tags = tags;
       this.view = view;
       this.timestamp = timestamp;
+      this.attachments = attachments;
     }
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -101,12 +101,20 @@ abstract class MutableViewData {
   }
 
   /** Record double stats with the given tags. */
-  abstract void record(TagContext context, double value, Timestamp timestamp);
+  abstract void record(
+      TagContext context,
+      double value,
+      Timestamp timestamp,
+      @javax.annotation.Nullable Map<String, String> attachments);
 
   /** Record long stats with the given tags. */
-  void record(TagContext tags, long value, Timestamp timestamp) {
+  void record(
+      TagContext tags,
+      long value,
+      Timestamp timestamp,
+      @javax.annotation.Nullable Map<String, String> attachments) {
     // TODO(songya): shall we check for precision loss here?
-    record(tags, (double) value, timestamp);
+    record(tags, (double) value, timestamp, attachments);
   }
 
   /** Convert this {@link MutableViewData} to {@link ViewData}. */
@@ -206,7 +214,11 @@ abstract class MutableViewData {
     }
 
     @Override
-    void record(TagContext context, double value, Timestamp timestamp) {
+    void record(
+        TagContext context,
+        double value,
+        Timestamp timestamp,
+        @javax.annotation.Nullable Map<String, String> attachments) {
       List</*@Nullable*/ TagValue> tagValues =
           getTagValues(getTagMap(context), super.view.getColumns());
       if (!tagValueAggregationMap.containsKey(tagValues)) {
@@ -300,7 +312,11 @@ abstract class MutableViewData {
     }
 
     @Override
-    void record(TagContext context, double value, Timestamp timestamp) {
+    void record(
+        TagContext context,
+        double value,
+        Timestamp timestamp,
+        @javax.annotation.Nullable Map<String, String> attachments) {
       List</*@Nullable*/ TagValue> tagValues =
           getTagValues(getTagMap(context), super.view.getColumns());
       refreshBucketList(timestamp);


### PR DESCRIPTION
Add two new record() APIs based on the discussion in https://github.com/census-instrumentation/opencensus-specs/pull/122.

To do next (in another PR): add the Exemplar class, record and store Exemplars in impl.

/cc @rghetia 