### PR TITLE
Stats: Add API MeasureMap.putAttachment() for recording exemplars.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## Unreleased
 - Add APIs to register gRPC client and server views separately.
+- Add API MeasureMap.withAttachments() for recording exemplars.
 
 ## 0.15.0 - 2018-06-20
 - Expose the factory methods of MonitoredResource.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 - Add APIs to register gRPC client and server views separately.
-- Add API MeasureMap.withAttachments() for recording exemplars.
+- Add an API MeasureMap.putAttachment() for recording exemplars.
 
 ## 0.15.0 - 2018-06-20
 - Expose the factory methods of MonitoredResource.

--- a/api/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/api/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -19,6 +19,7 @@ package io.opencensus.stats;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.tags.TagContext;
+import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -50,6 +51,17 @@ public abstract class MeasureMap {
    * @since 0.8
    */
   public abstract MeasureMap put(MeasureLong measure, long value);
+
+  /**
+   * Associate the contextual information of an {@code Exemplar} to this {@link MeasureMap}.
+   *
+   * <p>If this method is called multiple times, only the last string map will be kept.
+   *
+   * @param attachments contextual information of an {@code Exemplar}.
+   * @return this
+   * @since 0.16
+   */
+  public abstract MeasureMap withAttachments(Map<String, String> attachments);
 
   /**
    * Records all of the measures at the same time, with the current {@link TagContext}.

--- a/api/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/api/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.stats;
 
+import io.opencensus.internal.Utils;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.tags.TagContext;
@@ -55,13 +56,19 @@ public abstract class MeasureMap {
   /**
    * Associate the contextual information of an {@code Exemplar} to this {@link MeasureMap}.
    *
-   * <p>If this method is called multiple times, only the last string map will be kept.
+   * <p>If this method is called multiple times, the string maps should be merged. If there are
+   * multiple values with the same key in the maps, only the last value will be kept. I.e equivalent
+   * to {@code new HashMap<>().putAll(map1).putAll(map2)}.
    *
    * @param attachments contextual information of an {@code Exemplar}.
    * @return this
    * @since 0.16
    */
-  public abstract MeasureMap withAttachments(Map<String, String> attachments);
+  public MeasureMap putAttachments(Map<String, String> attachments) {
+    // Provides a default no-op implementation to avoid breaking other existing sub-classes.
+    Utils.checkNotNull(attachments, "attachments");
+    return this;
+  }
 
   /**
    * Records all of the measures at the same time, with the current {@link TagContext}.

--- a/api/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/api/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -63,7 +63,8 @@ public abstract class MeasureMap {
    * @return this
    * @since 0.16
    */
-  public MeasureMap putAttachement(String key, String value) {
+  // TODO(songya): make this method abstract in the 0.17 release.
+  public MeasureMap putAttachment(String key, String value) {
     // Provides a default no-op implementation to avoid breaking other existing sub-classes.
     Utils.checkNotNull(key, "key");
     Utils.checkNotNull(value, "value");

--- a/api/src/main/java/io/opencensus/stats/MeasureMap.java
+++ b/api/src/main/java/io/opencensus/stats/MeasureMap.java
@@ -20,7 +20,6 @@ import io.opencensus.internal.Utils;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.tags.TagContext;
-import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
 
 /**
@@ -55,18 +54,19 @@ public abstract class MeasureMap {
 
   /**
    * Associate the contextual information of an {@code Exemplar} to this {@link MeasureMap}.
+   * Contextual information is represented as {@code String} key-value pairs.
    *
-   * <p>If this method is called multiple times, the string maps should be merged. If there are
-   * multiple values with the same key in the maps, only the last value will be kept. I.e equivalent
-   * to {@code new HashMap<>().putAll(map1).putAll(map2)}.
+   * <p>If this method is called multiple times with the same key, only the last value will be kept.
    *
-   * @param attachments contextual information of an {@code Exemplar}.
+   * @param key the key of contextual information of an {@code Exemplar}.
+   * @param value the string representation of contextual information of an {@code Exemplar}.
    * @return this
    * @since 0.16
    */
-  public MeasureMap putAttachments(Map<String, String> attachments) {
+  public MeasureMap putAttachement(String key, String value) {
     // Provides a default no-op implementation to avoid breaking other existing sub-classes.
-    Utils.checkNotNull(attachments, "attachments");
+    Utils.checkNotNull(key, "key");
+    Utils.checkNotNull(value, "value");
     return this;
   }
 

--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -135,12 +135,6 @@ final class NoopStats {
     }
 
     @Override
-    public MeasureMap withAttachments(Map<String, String> attachments) {
-      Utils.checkNotNull(attachments, "attachments");
-      return this;
-    }
-
-    @Override
     public void record() {}
 
     @Override

--- a/api/src/main/java/io/opencensus/stats/NoopStats.java
+++ b/api/src/main/java/io/opencensus/stats/NoopStats.java
@@ -135,6 +135,12 @@ final class NoopStats {
     }
 
     @Override
+    public MeasureMap withAttachments(Map<String, String> attachments) {
+      Utils.checkNotNull(attachments, "attachments");
+      return this;
+    }
+
+    @Override
     public void record() {}
 
     @Override

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -94,11 +94,19 @@ public final class NoopStatsTest {
   }
 
   @Test
-  public void noopStatsRecorder_WithNullStringMap() {
+  public void noopStatsRecorder_PutAttachmentNullKey() {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("attachments");
-    measureMap.putAttachments(null);
+    thrown.expectMessage("key");
+    measureMap.putAttachement(null, "value");
+  }
+
+  @Test
+  public void noopStatsRecorder_PutAttachmentNullValue() {
+    MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("value");
+    measureMap.putAttachement("key", null);
   }
 
   // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -98,7 +98,7 @@ public final class NoopStatsTest {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("attachments");
-    measureMap.withAttachments(null);
+    measureMap.putAttachments(null);
   }
 
   // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -98,7 +98,7 @@ public final class NoopStatsTest {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("key");
-    measureMap.putAttachement(null, "value");
+    measureMap.putAttachment(null, "value");
   }
 
   @Test
@@ -106,7 +106,7 @@ public final class NoopStatsTest {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("value");
-    measureMap.putAttachement("key", null);
+    measureMap.putAttachment("key", null);
   }
 
   // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an

--- a/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
+++ b/api/src/test/java/io/opencensus/stats/NoopStatsTest.java
@@ -93,6 +93,14 @@ public final class NoopStatsTest {
     noopStatsComponent.setState(StatsCollectionState.ENABLED);
   }
 
+  @Test
+  public void noopStatsRecorder_WithNullStringMap() {
+    MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("attachments");
+    measureMap.withAttachments(null);
+  }
+
   // The NoopStatsRecorder should do nothing, so this test just checks that record doesn't throw an
   // exception.
   @Test
@@ -111,6 +119,7 @@ public final class NoopStatsTest {
   public void noopStatsRecorder_Record_DisallowNullTagContext() {
     MeasureMap measureMap = NoopStats.getNoopStatsRecorder().newMeasureMap();
     thrown.expect(NullPointerException.class);
+    thrown.expectMessage("tags");
     measureMap.record(null);
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
@@ -21,7 +21,6 @@ import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.stats.MeasureMap;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.unsafe.ContextUtils;
-import java.util.Map;
 
 /** Implementation of {@link MeasureMap}. */
 final class MeasureMapImpl extends MeasureMap {
@@ -49,8 +48,8 @@ final class MeasureMapImpl extends MeasureMap {
   }
 
   @Override
-  public MeasureMap putAttachments(Map<String, String> attachments) {
-    builder.putAttachments(attachments);
+  public MeasureMap putAttachement(String key, String value) {
+    builder.putAttachment(key, value);
     return this;
   }
 

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
@@ -21,6 +21,7 @@ import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.stats.MeasureMap;
 import io.opencensus.tags.TagContext;
 import io.opencensus.tags.unsafe.ContextUtils;
+import java.util.Map;
 
 /** Implementation of {@link MeasureMap}. */
 final class MeasureMapImpl extends MeasureMap {
@@ -44,6 +45,12 @@ final class MeasureMapImpl extends MeasureMap {
   @Override
   public MeasureMapImpl put(MeasureLong measure, long value) {
     builder.put(measure, value);
+    return this;
+  }
+
+  @Override
+  public MeasureMap withAttachments(Map<String, String> attachments) {
+    builder.withAttachments(attachments);
     return this;
   }
 

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
@@ -49,8 +49,8 @@ final class MeasureMapImpl extends MeasureMap {
   }
 
   @Override
-  public MeasureMap withAttachments(Map<String, String> attachments) {
-    builder.withAttachments(attachments);
+  public MeasureMap putAttachments(Map<String, String> attachments) {
+    builder.putAttachments(attachments);
     return this;
   }
 

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
@@ -48,7 +48,7 @@ final class MeasureMapImpl extends MeasureMap {
   }
 
   @Override
-  public MeasureMap putAttachement(String key, String value) {
+  public MeasureMap putAttachment(String key, String value) {
     builder.putAttachment(key, value);
     return this;
   }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapInternal.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapInternal.java
@@ -90,8 +90,11 @@ final class MeasureMapInternal {
       return this;
     }
 
-    Builder withAttachments(Map<String, String> attachments) {
-      this.attachments = attachments;
+    Builder putAttachments(Map<String, String> attachments) {
+      if (this.attachments == null) {
+        this.attachments = new HashMap<String, String>();
+      }
+      this.attachments.putAll(attachments);
       return this;
     }
 

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapInternal.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapInternal.java
@@ -21,8 +21,12 @@ import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.stats.Measurement;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import javax.annotation.Nullable;
 
 // TODO(songya): consider combining MeasureMapImpl and this class.
 /** A map from {@link Measure}'s to measured values. */
@@ -41,10 +45,21 @@ final class MeasureMapInternal {
     return new MeasureMapInternalIterator();
   }
 
-  private final ArrayList<Measurement> measurements;
+  // Returns the contextual information associated with an example value.
+  Map<String, String> getAttachments() {
+    return attachments;
+  }
 
-  private MeasureMapInternal(ArrayList<Measurement> measurements) {
+  private final ArrayList<Measurement> measurements;
+  @Nullable private final Map<String, String> attachments;
+
+  private MeasureMapInternal(
+      ArrayList<Measurement> measurements, @Nullable Map<String, String> attachments) {
     this.measurements = measurements;
+    this.attachments =
+        attachments == null
+            ? null
+            : Collections.unmodifiableMap(new HashMap<String, String>(attachments));
   }
 
   /** Builder for the {@link MeasureMapInternal} class. */
@@ -75,6 +90,11 @@ final class MeasureMapInternal {
       return this;
     }
 
+    Builder withAttachments(Map<String, String> attachments) {
+      this.attachments = attachments;
+      return this;
+    }
+
     /** Constructs a {@link MeasureMapInternal} from the current measurements. */
     MeasureMapInternal build() {
       // Note: this makes adding measurements quadratic but is fastest for the sizes of
@@ -88,10 +108,11 @@ final class MeasureMapInternal {
           }
         }
       }
-      return new MeasureMapInternal(measurements);
+      return new MeasureMapInternal(measurements, attachments);
     }
 
     private final ArrayList<Measurement> measurements = new ArrayList<Measurement>();
+    @Nullable private Map<String, String> attachments;
 
     private Builder() {}
   }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapInternal.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapInternal.java
@@ -90,11 +90,11 @@ final class MeasureMapInternal {
       return this;
     }
 
-    Builder putAttachments(Map<String, String> attachments) {
+    Builder putAttachment(String key, String value) {
       if (this.attachments == null) {
         this.attachments = new HashMap<String, String>();
       }
-      this.attachments.putAll(attachments);
+      this.attachments.put(key, value);
       return this;
     }
 

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -146,6 +146,7 @@ final class MeasureToViewMap {
   // Records stats with a set of tags.
   synchronized void record(TagContext tags, MeasureMapInternal stats, Timestamp timestamp) {
     Iterator<Measurement> iterator = stats.iterator();
+    Map<String, String> attachments = stats.getAttachments();
     while (iterator.hasNext()) {
       Measurement measurement = iterator.next();
       Measure measure = measurement.getMeasure();
@@ -156,8 +157,8 @@ final class MeasureToViewMap {
       Collection<MutableViewData> views = mutableMap.get(measure.getName());
       for (MutableViewData view : views) {
         measurement.match(
-            new RecordDoubleValueFunc(tags, view, timestamp),
-            new RecordLongValueFunc(tags, view, timestamp),
+            new RecordDoubleValueFunc(tags, view, timestamp, attachments),
+            new RecordLongValueFunc(tags, view, timestamp, attachments),
             Functions.</*@Nullable*/ Void>throwAssertionError());
       }
     }
@@ -184,36 +185,48 @@ final class MeasureToViewMap {
   private static final class RecordDoubleValueFunc implements Function<MeasurementDouble, Void> {
     @Override
     public Void apply(MeasurementDouble arg) {
-      view.record(tags, arg.getValue(), timestamp);
+      view.record(tags, arg.getValue(), timestamp, attachments);
       return null;
     }
 
     private final TagContext tags;
     private final MutableViewData view;
     private final Timestamp timestamp;
+    @javax.annotation.Nullable private final Map<String, String> attachments;
 
-    private RecordDoubleValueFunc(TagContext tags, MutableViewData view, Timestamp timestamp) {
+    private RecordDoubleValueFunc(
+        TagContext tags,
+        MutableViewData view,
+        Timestamp timestamp,
+        @javax.annotation.Nullable Map<String, String> attachments) {
       this.tags = tags;
       this.view = view;
       this.timestamp = timestamp;
+      this.attachments = attachments;
     }
   }
 
   private static final class RecordLongValueFunc implements Function<MeasurementLong, Void> {
     @Override
     public Void apply(MeasurementLong arg) {
-      view.record(tags, arg.getValue(), timestamp);
+      view.record(tags, arg.getValue(), timestamp, attachments);
       return null;
     }
 
     private final TagContext tags;
     private final MutableViewData view;
     private final Timestamp timestamp;
+    @javax.annotation.Nullable private final Map<String, String> attachments;
 
-    private RecordLongValueFunc(TagContext tags, MutableViewData view, Timestamp timestamp) {
+    private RecordLongValueFunc(
+        TagContext tags,
+        MutableViewData view,
+        Timestamp timestamp,
+        @javax.annotation.Nullable Map<String, String> attachments) {
       this.tags = tags;
       this.view = view;
       this.timestamp = timestamp;
+      this.attachments = attachments;
     }
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -101,6 +101,7 @@ abstract class MutableViewData {
   }
 
   /** Record double stats with the given tags. */
+  // TODO(songya): store the attachments in MutableDistribution.
   abstract void record(
       TagContext context,
       double value,

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -101,12 +101,20 @@ abstract class MutableViewData {
   }
 
   /** Record double stats with the given tags. */
-  abstract void record(TagContext context, double value, Timestamp timestamp);
+  abstract void record(
+      TagContext context,
+      double value,
+      Timestamp timestamp,
+      @javax.annotation.Nullable Map<String, String> attachments);
 
   /** Record long stats with the given tags. */
-  void record(TagContext tags, long value, Timestamp timestamp) {
+  void record(
+      TagContext tags,
+      long value,
+      Timestamp timestamp,
+      @javax.annotation.Nullable Map<String, String> attachments) {
     // TODO(songya): shall we check for precision loss here?
-    record(tags, (double) value, timestamp);
+    record(tags, (double) value, timestamp, attachments);
   }
 
   /** Convert this {@link MutableViewData} to {@link ViewData}. */
@@ -206,7 +214,11 @@ abstract class MutableViewData {
     }
 
     @Override
-    void record(TagContext context, double value, Timestamp timestamp) {
+    void record(
+        TagContext context,
+        double value,
+        Timestamp timestamp,
+        @javax.annotation.Nullable Map<String, String> attachments) {
       List</*@Nullable*/ TagValue> tagValues =
           getTagValues(getTagMap(context), super.view.getColumns());
       if (!tagValueAggregationMap.containsKey(tagValues)) {
@@ -300,7 +312,11 @@ abstract class MutableViewData {
     }
 
     @Override
-    void record(TagContext context, double value, Timestamp timestamp) {
+    void record(
+        TagContext context,
+        double value,
+        Timestamp timestamp,
+        @javax.annotation.Nullable Map<String, String> attachments) {
       List</*@Nullable*/ TagValue> tagValues =
           getTagValues(getTagMap(context), super.view.getColumns());
       refreshBucketList(timestamp);


### PR DESCRIPTION
Add a builder API that supports attaching contextual information of exemplars to measure maps. This should make the API easier to use, compared to overloading and having multiple versions of record (https://github.com/census-instrumentation/opencensus-java/pull/1284).

To do next (in another PR): add the Exemplar class, record and store Exemplars in impl.

/cc @rghetia 