### PR TITLE
Metrics: Add MetricDescriptor.

### DIFF
--- a/metrics/src/main/java/io/opencensus/metrics/MetricDescriptor.java
+++ b/metrics/src/main/java/io/opencensus/metrics/MetricDescriptor.java
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * {@link MetricDescriptor} defines a {@code Metric} type and its schema.
+ *
+ * @since 0.16
+ */
+@ExperimentalApi
+@Immutable
+@AutoValue
+public abstract class MetricDescriptor {
+
+  MetricDescriptor() {}
+
+  /**
+   * Creates a {@link MetricDescriptor}.
+   *
+   * @param name name of {@code MetricDescriptor}.
+   * @param description description of {@code MetricDescriptor}.
+   * @param unit the metric unit.
+   * @param type type of {@code MetricDescriptor}.
+   * @param labelKeys the label keys associated with the {@code MetricDescriptor}.
+   * @return a {@code MetricDescriptor}.
+   * @since 0.16
+   */
+  public static MetricDescriptor create(
+      String name, String description, String unit, Type type, List<LabelKey> labelKeys) {
+    Utils.checkNotNull(labelKeys, "labelKeys");
+    Utils.checkListElementNotNull(labelKeys, "labelKey");
+    return new AutoValue_MetricDescriptor(
+        name,
+        description,
+        unit,
+        type,
+        Collections.unmodifiableList(new ArrayList<LabelKey>(labelKeys)));
+  }
+
+  /**
+   * Returns the metric descriptor name.
+   *
+   * @return the metric descriptor name.
+   * @since 0.16
+   */
+  public abstract String getName();
+
+  /**
+   * Returns the description of this metric descriptor.
+   *
+   * @return the description of this metric descriptor.
+   * @since 0.16
+   */
+  public abstract String getDescription();
+
+  /**
+   * Returns the unit of this metric descriptor.
+   *
+   * @return the unit of this metric descriptor.
+   * @since 0.16
+   */
+  public abstract String getUnit();
+
+  /**
+   * Returns the type of this metric descriptor.
+   *
+   * @return the type of this metric descriptor.
+   * @since 0.16
+   */
+  public abstract Type getType();
+
+  /**
+   * Returns the label keys associated with this metric descriptor.
+   *
+   * @return the label keys associated with this metric descriptor.
+   * @since 0.16
+   */
+  public abstract List<LabelKey> getLabelKeys();
+
+  /**
+   * The kind of metric. It describes how the data is reported.
+   *
+   * <p>A gauge is an instantaneous measurement of a value.
+   *
+   * <p>A cumulative measurement is a value accumulated over a time interval. In a time series,
+   * cumulative measurements should have the same start time and increasing end times, until an
+   * event resets the cumulative value to zero and sets a new start time for the following points.
+   *
+   * @since 0.16
+   */
+  public enum Type {
+    /**
+     * Unspecified type. Do not use this as default value.
+     *
+     * @since 0.16
+     */
+    UNSPECIFIED,
+
+    /**
+     * An instantaneous measurement of an int64 value.
+     *
+     * @since 0.16
+     */
+    GAUGE_INT64,
+
+    /**
+     * An instantaneous measurement of a double value.
+     *
+     * @since 0.16
+     */
+    GAUGE_DOUBLE,
+
+    /**
+     * An cumulative measurement of an int64 value.
+     *
+     * @since 0.16
+     */
+    CUMULATIVE_INT64,
+
+    /**
+     * An cumulative measurement of a double value.
+     *
+     * @since 0.16
+     */
+    CUMULATIVE_DOUBLE,
+
+    /**
+     * An cumulative measurement of a distribution value.
+     *
+     * @since 0.16
+     */
+    CUMULATIVE_DISTRIBUTION,
+  }
+}

--- a/metrics/src/main/java/io/opencensus/metrics/MetricDescriptor.java
+++ b/metrics/src/main/java/io/opencensus/metrics/MetricDescriptor.java
@@ -110,12 +110,6 @@ public abstract class MetricDescriptor {
    * @since 0.16
    */
   public enum Type {
-    /**
-     * Unspecified type. Do not use this as default value.
-     *
-     * @since 0.16
-     */
-    UNSPECIFIED,
 
     /**
      * An instantaneous measurement of an int64 value.

--- a/metrics/src/test/java/io/opencensus/metrics/MetricDescriptorTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/MetricDescriptorTest.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.opencensus.metrics.MetricDescriptor.Type;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link MetricDescriptor}. */
+@RunWith(JUnit4.class)
+public class MetricDescriptorTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private static final String METRIC_NAME_1 = "metric1";
+  private static final String METRIC_NAME_2 = "metric2";
+  private static final String DESCRIPTION = "Metric description.";
+  private static final String UNIT = "kb/s";
+  private static final LabelKey KEY_1 = LabelKey.create("key1", "some key");
+  private static final LabelKey KEY_2 = LabelKey.create("key2", "some other key");
+
+  @Test
+  public void testGet() {
+    MetricDescriptor metricDescriptor =
+        MetricDescriptor.create(
+            METRIC_NAME_1, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, Arrays.asList(KEY_1, KEY_2));
+    assertThat(metricDescriptor.getName()).isEqualTo(METRIC_NAME_1);
+    assertThat(metricDescriptor.getDescription()).isEqualTo(DESCRIPTION);
+    assertThat(metricDescriptor.getUnit()).isEqualTo(UNIT);
+    assertThat(metricDescriptor.getType()).isEqualTo(Type.GAUGE_DOUBLE);
+    assertThat(metricDescriptor.getLabelKeys()).containsExactly(KEY_1, KEY_2).inOrder();
+  }
+
+  @Test
+  public void preventNullLabelKeyList() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelKeys");
+    MetricDescriptor.create(METRIC_NAME_1, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, null);
+  }
+
+  @Test
+  public void preventNullLabelKey() {
+    List<LabelKey> keys = Arrays.asList(KEY_1, null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelKey");
+    MetricDescriptor.create(METRIC_NAME_1, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, keys);
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            MetricDescriptor.create(
+                METRIC_NAME_1, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, Arrays.asList(KEY_1, KEY_2)),
+            MetricDescriptor.create(
+                METRIC_NAME_1, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, Arrays.asList(KEY_1, KEY_2)))
+        .addEqualityGroup(
+            MetricDescriptor.create(
+                METRIC_NAME_2, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, Arrays.asList(KEY_1, KEY_2)))
+        .addEqualityGroup(
+            MetricDescriptor.create(
+                METRIC_NAME_2, DESCRIPTION, UNIT, Type.GAUGE_INT64, Arrays.asList(KEY_1, KEY_2)))
+        .addEqualityGroup(
+            MetricDescriptor.create(
+                METRIC_NAME_1,
+                DESCRIPTION,
+                UNIT,
+                Type.CUMULATIVE_DISTRIBUTION,
+                Arrays.asList(KEY_1, KEY_2)))
+        .addEqualityGroup(
+            MetricDescriptor.create(
+                METRIC_NAME_1,
+                DESCRIPTION,
+                UNIT,
+                Type.CUMULATIVE_DISTRIBUTION,
+                Arrays.asList(KEY_1)))
+        .testEquals();
+  }
+}

--- a/metrics/src/test/java/io/opencensus/metrics/MetricDescriptorTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/MetricDescriptorTest.java
@@ -22,6 +22,7 @@ import com.google.common.testing.EqualsTester;
 import io.opencensus.metrics.MetricDescriptor.Type;
 import java.util.Arrays;
 import java.util.List;
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -56,7 +57,7 @@ public class MetricDescriptorTest {
   @Test
   public void preventNullLabelKeyList() {
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelKeys");
+    thrown.expectMessage(CoreMatchers.equalTo("labelKeys"));
     MetricDescriptor.create(METRIC_NAME_1, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, null);
   }
 
@@ -64,7 +65,7 @@ public class MetricDescriptorTest {
   public void preventNullLabelKey() {
     List<LabelKey> keys = Arrays.asList(KEY_1, null);
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelKey");
+    thrown.expectMessage(CoreMatchers.equalTo("labelKey"));
     MetricDescriptor.create(METRIC_NAME_1, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, keys);
   }
 

--- a/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -76,7 +77,7 @@ public class TimeSeriesTest {
   @Test
   public void create_WithNullLabelValueList() {
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValues");
+    thrown.expectMessage(CoreMatchers.equalTo("labelValues"));
     TimeSeriesCumulative.create(null, Collections.<Point>emptyList(), TIMESTAMP_1);
   }
 
@@ -84,14 +85,14 @@ public class TimeSeriesTest {
   public void create_WithNullLabelValue() {
     List<LabelValue> labelValues = Arrays.asList(LABEL_VALUE_1, null);
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("labelValue");
+    thrown.expectMessage(CoreMatchers.equalTo("labelValue"));
     TimeSeriesCumulative.create(labelValues, Collections.<Point>emptyList(), TIMESTAMP_1);
   }
 
   @Test
   public void create_WithNullPointList() {
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("points");
+    thrown.expectMessage(CoreMatchers.equalTo("points"));
     TimeSeriesCumulative.create(Collections.<LabelValue>emptyList(), null, TIMESTAMP_1);
   }
 
@@ -99,7 +100,7 @@ public class TimeSeriesTest {
   public void create_WithNullPoint() {
     List<Point> points = Arrays.asList(POINT_1, null);
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("point");
+    thrown.expectMessage(CoreMatchers.equalTo("point"));
     TimeSeriesCumulative.create(Collections.<LabelValue>emptyList(), points, TIMESTAMP_1);
   }
 


### PR DESCRIPTION
[Proto definition](https://github.com/census-instrumentation/opencensus-proto/blob/master/opencensus/proto/stats/metrics/metrics.proto#L54-L96):
```proto
// Defines a metric type and its schema.
message MetricDescriptor {
  // The metric type, including its DNS name prefix. It must be unique.
  string name = 1;

  // A detailed description of the metric, which can be used in documentation.
  string description = 2;

  // The unit in which the metric value is reported. Follows the format
  // described by http://unitsofmeasure.org/ucum.html.
  string unit = 3;

  // The kind of metric. It describes how the data is reported.
  //
  // A gauge is an instantaneous measurement of a value.
  //
  // A cumulative measurement is a value accumulated over a time interval. In
  // a time series, cumulative measurements should have the same start time and
  // increasing end times, until an event resets the cumulative value to zero
  // and sets a new start time for the following points.
  enum Type {
    // Do not use this default value.
    UNSPECIFIED = 0;

    // Integer gauge.
    GAUGE_INT64 = 1;

    // Floating point gauge.
    GAUGE_DOUBLE = 2;

    // Integer cumulative measurement.
    CUMULATIVE_INT64 = 3;

    // Floating point cumulative measurement.
    CUMULATIVE_DOUBLE = 4;

    // Distribution cumulative measurement.
    CUMULATIVE_DISTRIBUTION = 5;
  }
  Type type = 4;

  // The label keys associated with the metric descriptor.
  repeated LabelKey label_keys = 5;
}
```