### PR TITLE
 Metrics: Add Metric.

### DIFF
--- a/metrics/src/main/java/io/opencensus/metrics/Metric.java
+++ b/metrics/src/main/java/io/opencensus/metrics/Metric.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A {@link Metric} with one or more {@link TimeSeries}.
+ *
+ * @since 0.16
+ */
+@ExperimentalApi
+@Immutable
+@AutoValue
+public abstract class Metric {
+
+  Metric() {}
+
+  /**
+   * Creates a {@link Metric}.
+   *
+   * @param metricDescriptor the {@link MetricDescriptor}.
+   * @param timeSeries the {@link TimeSeries} for this metric.
+   * @return a {@code Metric}.
+   * @since 0.16
+   */
+  public static Metric create(MetricDescriptor metricDescriptor, List<TimeSeries> timeSeries) {
+    Utils.checkNotNull(timeSeries, "timeSeriesList");
+    Utils.checkListElementNotNull(timeSeries, "timeSeries");
+    return new AutoValue_Metric(
+        metricDescriptor, Collections.unmodifiableList(new ArrayList<TimeSeries>(timeSeries)));
+  }
+
+  /**
+   * Returns the {@link MetricDescriptor} of this metric.
+   *
+   * @return the {@code MetricDescriptor} of this metric.
+   * @since 0.16
+   */
+  public abstract MetricDescriptor getMetricDescriptor();
+
+  /**
+   * Returns the {@link TimeSeries}s for this metric.
+   *
+   * <p>Each {@link TimeSeries} has one or more {@link Point}.
+   *
+   * <p>The type of the {@link TimeSeries}s must match {@link MetricDescriptor.Type}, so the list
+   * should only contains either {@link TimeSeries.TimeSeriesCumulative} or {@link
+   * TimeSeries.TimeSeriesGauge}.
+   *
+   * @return the {@code TimeSeries}s for this metric.
+   * @since 0.16
+   */
+  public abstract List<TimeSeries> getTimeSeries();
+}

--- a/metrics/src/test/java/io/opencensus/metrics/MetricTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/MetricTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.opencensus.common.Timestamp;
+import io.opencensus.metrics.MetricDescriptor.Type;
+import io.opencensus.metrics.TimeSeries.TimeSeriesCumulative;
+import io.opencensus.metrics.TimeSeries.TimeSeriesGauge;
+import java.util.Arrays;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link Metric}. */
+@RunWith(JUnit4.class)
+public class MetricTest {
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  private static final String METRIC_NAME_1 = "metric1";
+  private static final String METRIC_NAME_2 = "metric2";
+  private static final String DESCRIPTION = "Metric description.";
+  private static final String UNIT = "kb/s";
+  private static final LabelKey KEY_1 = LabelKey.create("key1", "some key");
+  private static final LabelKey KEY_2 = LabelKey.create("key1", "some other key");
+  private static final MetricDescriptor METRIC_DESCRIPTOR_1 =
+      MetricDescriptor.create(
+          METRIC_NAME_1, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, Arrays.asList(KEY_1, KEY_2));
+  private static final MetricDescriptor METRIC_DESCRIPTOR_2 =
+      MetricDescriptor.create(
+          METRIC_NAME_2, DESCRIPTION, UNIT, Type.CUMULATIVE_INT64, Arrays.asList(KEY_1));
+  private static final LabelValue LABEL_VALUE_1 = LabelValue.create("value1");
+  private static final LabelValue LABEL_VALUE_2 = LabelValue.create("value1");
+  private static final LabelValue LABEL_VALUE_EMPTY = LabelValue.create("");
+  private static final Value VALUE_LONG = Value.longValue(12345678);
+  private static final Value VALUE_DOUBLE_1 = Value.doubleValue(-345.77);
+  private static final Value VALUE_DOUBLE_2 = Value.doubleValue(133.79);
+  private static final Timestamp TIMESTAMP_1 = Timestamp.fromMillis(1000);
+  private static final Timestamp TIMESTAMP_2 = Timestamp.fromMillis(2000);
+  private static final Timestamp TIMESTAMP_3 = Timestamp.fromMillis(3000);
+  private static final Point POINT_1 = Point.create(VALUE_DOUBLE_1, TIMESTAMP_2);
+  private static final Point POINT_2 = Point.create(VALUE_DOUBLE_2, TIMESTAMP_3);
+  private static final Point POINT_3 = Point.create(VALUE_LONG, TIMESTAMP_3);
+  private static final TimeSeries GAUGE_TIME_SERIES_1 =
+      TimeSeriesGauge.create(Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1));
+  private static final TimeSeries GAUGE_TIME_SERIES_2 =
+      TimeSeriesGauge.create(Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_2));
+  private static final TimeSeries CUMULATIVE_TIME_SERIES =
+      TimeSeriesCumulative.create(
+          Arrays.asList(LABEL_VALUE_EMPTY), Arrays.asList(POINT_3), TIMESTAMP_1);
+
+  @Test
+  public void testGet() {
+    Metric metric = Metric.create(METRIC_DESCRIPTOR_1, Arrays.asList(GAUGE_TIME_SERIES_1));
+    assertThat(metric.getMetricDescriptor()).isEqualTo(METRIC_DESCRIPTOR_1);
+    assertThat(metric.getTimeSeries()).containsExactly(GAUGE_TIME_SERIES_1);
+  }
+
+  @Test
+  public void preventNullTimeSeriesList() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("timeSeriesList");
+    Metric.create(METRIC_DESCRIPTOR_1, null);
+  }
+
+  @Test
+  public void preventNullTimeSeries() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("timeSeries");
+    Metric.create(METRIC_DESCRIPTOR_1, Arrays.asList(GAUGE_TIME_SERIES_1, null));
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            Metric.create(METRIC_DESCRIPTOR_1, Arrays.asList(GAUGE_TIME_SERIES_1)),
+            Metric.create(METRIC_DESCRIPTOR_1, Arrays.asList(GAUGE_TIME_SERIES_1)))
+        .addEqualityGroup(Metric.create(METRIC_DESCRIPTOR_1, Arrays.asList(GAUGE_TIME_SERIES_2)))
+        .addEqualityGroup(
+            Metric.create(
+                METRIC_DESCRIPTOR_1, Arrays.asList(GAUGE_TIME_SERIES_1, GAUGE_TIME_SERIES_2)))
+        .addEqualityGroup(Metric.create(METRIC_DESCRIPTOR_2, Arrays.asList(CUMULATIVE_TIME_SERIES)))
+        .testEquals();
+  }
+}

--- a/metrics/src/test/java/io/opencensus/metrics/MetricTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/MetricTest.java
@@ -24,6 +24,7 @@ import io.opencensus.metrics.MetricDescriptor.Type;
 import io.opencensus.metrics.TimeSeries.TimeSeriesCumulative;
 import io.opencensus.metrics.TimeSeries.TimeSeriesGauge;
 import java.util.Arrays;
+import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -78,14 +79,14 @@ public class MetricTest {
   @Test
   public void preventNullTimeSeriesList() {
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("timeSeriesList");
+    thrown.expectMessage(CoreMatchers.equalTo("timeSeriesList"));
     Metric.create(METRIC_DESCRIPTOR_1, null);
   }
 
   @Test
   public void preventNullTimeSeries() {
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("timeSeries");
+    thrown.expectMessage(CoreMatchers.equalTo("timeSeries"));
     Metric.create(METRIC_DESCRIPTOR_1, Arrays.asList(GAUGE_TIME_SERIES_1, null));
   }
 


### PR DESCRIPTION
~~Depend on https://github.com/census-instrumentation/opencensus-java/pull/1291.~~

[Proto definition](https://github.com/census-instrumentation/opencensus-proto/blob/master/opencensus/proto/stats/metrics/metrics.proto#L32-L45):

```proto

// Defines a Metric which has one or more timeseries.
message Metric {
  // The definition of the Metric. For now, we send the full MetricDescriptor
  // every time in order to keep the protocol stateless, but this is one of the
  // places where we can make future changes to make the protocol more
  // efficient.
  MetricDescriptor metric_descriptor = 1;

  // One or more timeseries for a single metric, where each timeseries has
  // one or more points. The type of the timeseries must match
  // metric_descriptor.type, so only one of the two should be populated.
  repeated GaugeTimeSeries gauge_timeseries = 2;
  repeated CumulativeTimeSeries cumulative_timeseries = 3;
}
```

EDIT: `MerticSet` is removed, per https://github.com/census-instrumentation/opencensus-proto/pull/66.