### PR TITLE
Update and add imports to examples in readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,23 @@ For the complete example, see
 [here](https://github.com/census-instrumentation/opencensus-java/blob/master/examples/src/main/java/io/opencensus/examples/helloworld/QuickStart.java).
 
 ```java
-public final class QuickStart {
+import io.opencensus.common.Scope;
+import io.opencensus.stats.Aggregation;
+import io.opencensus.stats.BucketBoundaries;
+import io.opencensus.stats.Measure.MeasureLong;
+import io.opencensus.stats.Stats;
+import io.opencensus.stats.StatsRecorder;
+import io.opencensus.stats.View;
+import io.opencensus.stats.ViewData;
+import io.opencensus.stats.ViewManager;
+import io.opencensus.tags.TagKey;
+import io.opencensus.tags.TagValue;
+import io.opencensus.tags.Tagger;
+import io.opencensus.tags.Tags;
+import java.util.Arrays;
+import java.util.Collections;
+
+public final class MyClassWithStats {
   private static final Tagger tagger = Tags.getTagger();
   private static final ViewManager viewManager = Stats.getViewManager();
   private static final StatsRecorder statsRecorder = Stats.getStatsRecorder();
@@ -125,32 +141,33 @@ public final class QuickStart {
   private static final TagKey FRONTEND_KEY = TagKey.create("myorg_keys_frontend");
 
   // videoSize will measure the size of processed videos.
-  private static final MeasureLong VIDEO_SIZE = MeasureLong.create(
-      "my.org/measure/video_size", "size of processed videos", "By");
+  private static final MeasureLong VIDEO_SIZE =
+      MeasureLong.create("my.org/measure/video_size", "size of processed videos", "By");
 
   // Create view to see the processed video size distribution broken down by frontend.
   // The view has bucket boundaries (0, 256, 65536) that will group measure values into
   // histogram buckets.
   private static final View.Name VIDEO_SIZE_VIEW_NAME = View.Name.create("my.org/views/video_size");
-  private static final View VIDEO_SIZE_VIEW = View.create(
-      VIDEO_SIZE_VIEW_NAME,
-      "processed video size over time",
-      VIDEO_SIZE,
-      Aggregation.Distribution.create(BucketBoundaries.create(Arrays.asList(0.0, 256.0, 65536.0))),
-      Collections.singletonList(FRONTEND_KEY),
-      Cumulative.create());
+  private static final View VIDEO_SIZE_VIEW =
+      View.create(
+          VIDEO_SIZE_VIEW_NAME,
+          "processed video size over time",
+          VIDEO_SIZE,
+          Aggregation.Distribution.create(
+              BucketBoundaries.create(Arrays.asList(0.0, 256.0, 65536.0))),
+          Collections.singletonList(FRONTEND_KEY));
 
-  private static void initialize() {
+  public static void initialize() {
     // ...
     viewManager.registerView(VIDEO_SIZE_VIEW);
   }
 
-  private static void processVideo() {
+  public static void processVideo() {
     try (Scope scopedTags =
-           tagger
-             .currentBuilder()
-             .put(FRONTEND_KEY, TagValue.create("mobile-ios9.3.5"))
-             .buildScoped()) {
+        tagger
+            .currentBuilder()
+            .put(FRONTEND_KEY, TagValue.create("mobile-ios9.3.5"))
+            .buildScoped()) {
       // Processing video.
       // ...
 
@@ -159,10 +176,10 @@ public final class QuickStart {
     }
   }
 
-  private static void printStats() {
+  public static void printStats() {
     ViewData viewData = viewManager.getView(VIDEO_SIZE_VIEW_NAME);
     System.out.println(
-      String.format("Recorded stats for %s:\n %s", VIDEO_SIZE_VIEW_NAME.asString(), viewData));
+        String.format("Recorded stats for %s:\n %s", VIDEO_SIZE_VIEW_NAME.asString(), viewData));
   }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -64,18 +64,24 @@ annotations is possible because we propagate scope. 3rd parties libraries like S
 the same way.
 
 ```java
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.samplers.Samplers;
+
 public final class MyClassWithTracing {
   private static final Tracer tracer = Tracing.getTracer();
 
   public static void doWork() {
-    // Create a child Span of the current Span. Always record events for this span and force it to 
-    // be sampled. This makes it easier to try out the example, but unless you have a clear use 
+    // Create a child Span of the current Span. Always record events for this span and force it to
+    // be sampled. This makes it easier to try out the example, but unless you have a clear use
     // case, you don't need to explicitly set record events or sampler.
-    try (Scope ss = 
-         tracer.spanBuilder("MyChildWorkSpan")
-           .setRecordEvents(true)
-           .setSampler(Samplers.alwaysSample())
-           .startScopedSpan()) {
+    try (Scope ss =
+        tracer
+            .spanBuilder("MyChildWorkSpan")
+            .setRecordEvents(true)
+            .setSampler(Samplers.alwaysSample())
+            .startScopedSpan()) {
       doInitialWork();
       tracer.getCurrentSpan().addAnnotation("Finished initial work");
       doFinalWork();

--- a/examples/src/main/java/io/opencensus/examples/helloworld/QuickStart.java
+++ b/examples/src/main/java/io/opencensus/examples/helloworld/QuickStart.java
@@ -24,7 +24,6 @@ import io.opencensus.stats.Measure.MeasureLong;
 import io.opencensus.stats.Stats;
 import io.opencensus.stats.StatsRecorder;
 import io.opencensus.stats.View;
-import io.opencensus.stats.View.AggregationWindow.Cumulative;
 import io.opencensus.stats.ViewData;
 import io.opencensus.stats.ViewManager;
 import io.opencensus.tags.TagContextBuilder;
@@ -72,8 +71,7 @@ public final class QuickStart {
           VIDEO_SIZE,
           Aggregation.Distribution.create(
               BucketBoundaries.create(Arrays.asList(0.0, 16.0 * MiB, 256.0 * MiB))),
-          Collections.singletonList(FRONTEND_KEY),
-          Cumulative.create());
+          Collections.singletonList(FRONTEND_KEY));
 
   /** Main launcher for the QuickStart example. */
   public static void main(String[] args) throws InterruptedException {


### PR DESCRIPTION
Three commits:

#### Format and add imports to tracing example in readme.

#### Update and add imports to stats example in readme.
Changes in this commit:
- Remove use of deprecated AggregationWindow.
- Make methods public to show that they could be called by code that isn't part of the example.
- Rename the class for consistency with the tracing example.
- Run google-java-format.

#### Remove use of deprecated AggregationWindow from QuickStart.java.