### PR TITLE
Metrics: Move TimeSeriesCumulative and TimeSeriesGauge to top level. Hide TimeSeries.

### DIFF
--- a/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
+++ b/metrics/src/main/java/io/opencensus/metrics/TimeSeries.java
@@ -16,23 +16,12 @@
 
 package io.opencensus.metrics;
 
-import com.google.auto.value.AutoValue;
-import io.opencensus.common.ExperimentalApi;
-import io.opencensus.common.Function;
-import io.opencensus.common.Timestamp;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import javax.annotation.concurrent.Immutable;
 
-/**
- * A collection of data points that describes the time-varying values of a {@code Metric}.
- *
- * @since 0.16
- */
-@ExperimentalApi
+/** A collection of data points that describes the time-varying values of a {@code Metric}. */
 @Immutable
-public abstract class TimeSeries {
+abstract class TimeSeries {
 
   TimeSeries() {}
 
@@ -56,106 +45,4 @@ public abstract class TimeSeries {
    * @since 0.16
    */
   public abstract List<Point> getPoints();
-
-  /**
-   * Applies the given match function to the underlying data type.
-   *
-   * @since 0.16
-   */
-  public abstract <T> T match(
-      Function<? super TimeSeriesGauge, T> p0,
-      Function<? super TimeSeriesCumulative, T> p1,
-      Function<? super TimeSeries, T> defaultFunction);
-
-  /**
-   * A collection of data points that describes the time-varying values of a gauge {@code Metric}.
-   *
-   * @since 0.16
-   */
-  @ExperimentalApi
-  @Immutable
-  @AutoValue
-  public abstract static class TimeSeriesGauge extends TimeSeries {
-
-    TimeSeriesGauge() {}
-
-    @Override
-    public final <T> T match(
-        Function<? super TimeSeriesGauge, T> p0,
-        Function<? super TimeSeriesCumulative, T> p1,
-        Function<? super TimeSeries, T> defaultFunction) {
-      return p0.apply(this);
-    }
-
-    /**
-     * Creates a {@link TimeSeriesGauge}.
-     *
-     * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
-     * @param points the data {@code Point}s of this {@code TimeSeries}.
-     * @return a {@code TimeSeriesGauge}.
-     * @since 0.16
-     */
-    public static TimeSeriesGauge create(List<LabelValue> labelValues, List<Point> points) {
-      // Fail fast on null lists to prevent NullPointerException when copying the lists.
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkNotNull(points, "points");
-      Utils.checkListElementNotNull(labelValues, "labelValue");
-      Utils.checkListElementNotNull(points, "point");
-      return new AutoValue_TimeSeries_TimeSeriesGauge(
-          Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
-          Collections.unmodifiableList(new ArrayList<Point>(points)));
-    }
-  }
-
-  /**
-   * A collection of data points that describes the time-varying values of a cumulative {@code
-   * Metric}.
-   *
-   * @since 0.16
-   */
-  @ExperimentalApi
-  @Immutable
-  @AutoValue
-  public abstract static class TimeSeriesCumulative extends TimeSeries {
-
-    TimeSeriesCumulative() {}
-
-    @Override
-    public final <T> T match(
-        Function<? super TimeSeriesGauge, T> p0,
-        Function<? super TimeSeriesCumulative, T> p1,
-        Function<? super TimeSeries, T> defaultFunction) {
-      return p1.apply(this);
-    }
-
-    /**
-     * Creates a {@link TimeSeriesCumulative}.
-     *
-     * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
-     * @param points the data {@code Point}s of this {@code TimeSeries}.
-     * @param startTimestamp the start {@code Timestamp} of this {@code TimeSeriesCumulative}.
-     * @return a {@code TimeSeriesCumulative}.
-     * @since 0.16
-     */
-    public static TimeSeriesCumulative create(
-        List<LabelValue> labelValues, List<Point> points, Timestamp startTimestamp) {
-      // Fail fast on null lists to prevent NullPointerException when copying the lists.
-      Utils.checkNotNull(labelValues, "labelValues");
-      Utils.checkNotNull(points, "points");
-      Utils.checkListElementNotNull(labelValues, "labelValue");
-      Utils.checkListElementNotNull(points, "point");
-      return new AutoValue_TimeSeries_TimeSeriesCumulative(
-          Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
-          Collections.unmodifiableList(new ArrayList<Point>(points)),
-          startTimestamp);
-    }
-
-    /**
-     * Returns the start {@link Timestamp} of this {@link TimeSeriesCumulative}.
-     *
-     * @return the start {@code Timestamp}.
-     * @since 0.16
-     */
-    public abstract Timestamp getStartTimestamp();
-  }
 }

--- a/metrics/src/main/java/io/opencensus/metrics/TimeSeriesCumulative.java
+++ b/metrics/src/main/java/io/opencensus/metrics/TimeSeriesCumulative.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import io.opencensus.common.Timestamp;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A collection of data points that describes the time-varying values of a cumulative {@code
+ * Metric}.
+ *
+ * @since 0.16
+ */
+@ExperimentalApi
+@Immutable
+@AutoValue
+public abstract class TimeSeriesCumulative extends TimeSeries {
+
+  TimeSeriesCumulative() {}
+
+  /**
+   * Creates a {@link TimeSeriesCumulative}.
+   *
+   * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
+   * @param points the data {@code Point}s of this {@code TimeSeries}.
+   * @param startTimestamp the start {@code Timestamp} of this {@code TimeSeriesCumulative}.
+   * @return a {@code TimeSeriesCumulative}.
+   * @since 0.16
+   */
+  public static TimeSeriesCumulative create(
+      List<LabelValue> labelValues, List<Point> points, Timestamp startTimestamp) {
+    // Fail fast on null lists to prevent NullPointerException when copying the lists.
+    Utils.checkNotNull(labelValues, "labelValues");
+    Utils.checkNotNull(points, "points");
+    Utils.checkListElementNotNull(labelValues, "labelValue");
+    Utils.checkListElementNotNull(points, "point");
+    return new AutoValue_TimeSeriesCumulative(
+        Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
+        Collections.unmodifiableList(new ArrayList<Point>(points)),
+        startTimestamp);
+  }
+
+  /**
+   * Returns the start {@link Timestamp} of this {@link TimeSeriesCumulative}.
+   *
+   * @return the start {@code Timestamp}.
+   * @since 0.16
+   */
+  public abstract Timestamp getStartTimestamp();
+}

--- a/metrics/src/main/java/io/opencensus/metrics/TimeSeriesGauge.java
+++ b/metrics/src/main/java/io/opencensus/metrics/TimeSeriesGauge.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * A collection of data points that describes the time-varying values of a gauge {@code Metric}.
+ *
+ * @since 0.16
+ */
+@ExperimentalApi
+@Immutable
+@AutoValue
+public abstract class TimeSeriesGauge extends TimeSeries {
+
+  TimeSeriesGauge() {}
+
+  /**
+   * Creates a {@link TimeSeriesGauge}.
+   *
+   * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
+   * @param points the data {@code Point}s of this {@code TimeSeries}.
+   * @return a {@code TimeSeriesGauge}.
+   * @since 0.16
+   */
+  public static TimeSeriesGauge create(List<LabelValue> labelValues, List<Point> points) {
+    // Fail fast on null lists to prevent NullPointerException when copying the lists.
+    Utils.checkNotNull(labelValues, "labelValues");
+    Utils.checkNotNull(points, "points");
+    Utils.checkListElementNotNull(labelValues, "labelValue");
+    Utils.checkListElementNotNull(points, "point");
+    return new AutoValue_TimeSeriesGauge(
+        Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues)),
+        Collections.unmodifiableList(new ArrayList<Point>(points)));
+  }
+}

--- a/metrics/src/test/java/io/opencensus/metrics/TimeSeriesCumulativeTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/TimeSeriesCumulativeTest.java
@@ -30,15 +30,14 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Unit tests for {@link TimeSeries}. */
+/** Unit tests for {@link TimeSeriesCumulative}. */
 @RunWith(JUnit4.class)
-public class TimeSeriesTest {
+public class TimeSeriesCumulativeTest {
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   private static final LabelValue LABEL_VALUE_1 = LabelValue.create("value1");
   private static final LabelValue LABEL_VALUE_2 = LabelValue.create("value2");
-  private static final LabelValue LABEL_VALUE_EMPTY = LabelValue.create("");
   private static final Value VALUE_LONG = Value.longValue(12345678);
   private static final Value VALUE_DOUBLE = Value.doubleValue(-345.77);
   private static final Timestamp TIMESTAMP_1 = Timestamp.fromMillis(1000);
@@ -48,24 +47,13 @@ public class TimeSeriesTest {
   private static final Point POINT_2 = Point.create(VALUE_LONG, TIMESTAMP_3);
 
   @Test
-  public void testGet_TimeSeriesGauge() {
-    TimeSeriesGauge gaugeTimeSeries =
-        TimeSeriesGauge.create(
-            Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2));
-    assertThat(gaugeTimeSeries.getLabelValues())
-        .containsExactly(LABEL_VALUE_1, LABEL_VALUE_2)
-        .inOrder();
-    assertThat(gaugeTimeSeries.getPoints()).containsExactly(POINT_1, POINT_2).inOrder();
-  }
-
-  @Test
   public void testGet_TimeSeriesCumulative() {
     TimeSeriesCumulative cumulativeTimeSeries =
         TimeSeriesCumulative.create(
-            Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY), Arrays.asList(POINT_1), TIMESTAMP_1);
+            Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1), TIMESTAMP_1);
     assertThat(cumulativeTimeSeries.getStartTimestamp()).isEqualTo(TIMESTAMP_1);
     assertThat(cumulativeTimeSeries.getLabelValues())
-        .containsExactly(LABEL_VALUE_1, LABEL_VALUE_EMPTY)
+        .containsExactly(LABEL_VALUE_1, LABEL_VALUE_2)
         .inOrder();
     assertThat(cumulativeTimeSeries.getPoints()).containsExactly(POINT_1).inOrder();
   }
@@ -104,25 +92,22 @@ public class TimeSeriesTest {
   public void testEquals() {
     new EqualsTester()
         .addEqualityGroup(
-            TimeSeriesGauge.create(
-                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)),
-            TimeSeriesGauge.create(
-                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)))
-        .addEqualityGroup(
-            TimeSeriesGauge.create(
-                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1)))
-        .addEqualityGroup(
-            TimeSeriesGauge.create(Arrays.asList(LABEL_VALUE_1), Arrays.asList(POINT_1)))
+            TimeSeriesCumulative.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1), TIMESTAMP_1),
+            TimeSeriesCumulative.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1), TIMESTAMP_1))
         .addEqualityGroup(
             TimeSeriesCumulative.create(
-                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
-                Arrays.asList(POINT_1),
-                TIMESTAMP_1))
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1), TIMESTAMP_2))
         .addEqualityGroup(
             TimeSeriesCumulative.create(
-                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
-                Arrays.asList(POINT_1),
-                TIMESTAMP_2))
+                Arrays.asList(LABEL_VALUE_1), Arrays.asList(POINT_1), TIMESTAMP_2))
+        .addEqualityGroup(
+            TimeSeriesCumulative.create(
+                Arrays.asList(LABEL_VALUE_1), Arrays.asList(POINT_2), TIMESTAMP_2))
+        .addEqualityGroup(
+            TimeSeriesCumulative.create(
+                Arrays.asList(LABEL_VALUE_1), Arrays.asList(POINT_1, POINT_2), TIMESTAMP_2))
         .testEquals();
   }
 }

--- a/metrics/src/test/java/io/opencensus/metrics/TimeSeriesGaugeTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/TimeSeriesGaugeTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.testing.EqualsTester;
+import io.opencensus.common.Timestamp;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link TimeSeriesGauge}. */
+@RunWith(JUnit4.class)
+public class TimeSeriesGaugeTest {
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final LabelValue LABEL_VALUE_1 = LabelValue.create("value1");
+  private static final LabelValue LABEL_VALUE_2 = LabelValue.create("value2");
+  private static final Value VALUE_LONG = Value.longValue(12345678);
+  private static final Value VALUE_DOUBLE = Value.doubleValue(-345.77);
+  private static final Timestamp TIMESTAMP_1 = Timestamp.fromMillis(1000);
+  private static final Timestamp TIMESTAMP_2 = Timestamp.fromMillis(2000);
+  private static final Point POINT_1 = Point.create(VALUE_DOUBLE, TIMESTAMP_1);
+  private static final Point POINT_2 = Point.create(VALUE_LONG, TIMESTAMP_2);
+
+  @Test
+  public void testGet_TimeSeriesGauge() {
+    TimeSeriesGauge gaugeTimeSeries =
+        TimeSeriesGauge.create(
+            Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2));
+    assertThat(gaugeTimeSeries.getLabelValues())
+        .containsExactly(LABEL_VALUE_1, LABEL_VALUE_2)
+        .inOrder();
+    assertThat(gaugeTimeSeries.getPoints()).containsExactly(POINT_1, POINT_2).inOrder();
+  }
+
+  @Test
+  public void create_WithNullLabelValueList() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage(CoreMatchers.equalTo("labelValues"));
+    TimeSeriesGauge.create(null, Collections.<Point>emptyList());
+  }
+
+  @Test
+  public void create_WithNullLabelValue() {
+    List<LabelValue> labelValues = Arrays.asList(LABEL_VALUE_1, null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage(CoreMatchers.equalTo("labelValue"));
+    TimeSeriesGauge.create(labelValues, Collections.<Point>emptyList());
+  }
+
+  @Test
+  public void create_WithNullPointList() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage(CoreMatchers.equalTo("points"));
+    TimeSeriesGauge.create(Collections.<LabelValue>emptyList(), null);
+  }
+
+  @Test
+  public void create_WithNullPoint() {
+    List<Point> points = Arrays.asList(POINT_1, null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage(CoreMatchers.equalTo("point"));
+    TimeSeriesGauge.create(Collections.<LabelValue>emptyList(), points);
+  }
+
+  @Test
+  public void testEquals() {
+    new EqualsTester()
+        .addEqualityGroup(
+            TimeSeriesGauge.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)),
+            TimeSeriesGauge.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)))
+        .addEqualityGroup(
+            TimeSeriesGauge.create(
+                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1)))
+        .addEqualityGroup(
+            TimeSeriesGauge.create(Arrays.asList(LABEL_VALUE_1), Arrays.asList(POINT_1)))
+        .testEquals();
+  }
+}

--- a/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
+++ b/metrics/src/test/java/io/opencensus/metrics/TimeSeriesTest.java
@@ -19,11 +19,7 @@ package io.opencensus.metrics;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.google.common.testing.EqualsTester;
-import io.opencensus.common.Functions;
 import io.opencensus.common.Timestamp;
-import io.opencensus.metrics.TimeSeries.TimeSeriesCumulative;
-import io.opencensus.metrics.TimeSeries.TimeSeriesGauge;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -102,28 +98,6 @@ public class TimeSeriesTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage(CoreMatchers.equalTo("point"));
     TimeSeriesCumulative.create(Collections.<LabelValue>emptyList(), points, TIMESTAMP_1);
-  }
-
-  @Test
-  public void testMatch() {
-    List<TimeSeries> timeSeriesList =
-        Arrays.asList(
-            TimeSeriesGauge.create(
-                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2), Arrays.asList(POINT_1, POINT_2)),
-            TimeSeriesCumulative.create(
-                Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_EMPTY),
-                Arrays.asList(POINT_1),
-                TIMESTAMP_1));
-    List<String> expected = Arrays.asList("Gauge", "Cumulative");
-    List<String> actual = new ArrayList<String>();
-    for (TimeSeries timeSeries : timeSeriesList) {
-      actual.add(
-          timeSeries.match(
-              Functions.returnConstant("Gauge"),
-              Functions.returnConstant("Cumulative"),
-              Functions.<String>throwAssertionError()));
-    }
-    assertThat(actual).containsExactlyElementsIn(expected).inOrder();
   }
 
   @Test


### PR DESCRIPTION
To make APIs more consistent with the [proto definition](https://github.com/census-instrumentation/opencensus-proto/blob/master/opencensus/proto/stats/metrics/metrics.proto#L101-L126).