### PR TITLE
Export cumulative buckets for Prometheus

### DIFF
--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
@@ -190,7 +190,7 @@ final class PrometheusExportUtils {
             List<Double> boundaries = distribution.getBucketBoundaries().getBoundaries();
             List<String> labelNamesWithLe = new ArrayList<String>(labelNames);
             labelNamesWithLe.add(LABEL_NAME_BUCKET_BOUND);
-            long sum = 0;
+            long cumulativeCount = 0;
             for (int i = 0; i < arg.getBucketCounts().size(); i++) {
               List<String> labelValuesWithLe = new ArrayList<String>(labelValues);
               // The label value of "le" is the upper inclusive bound.
@@ -199,13 +199,13 @@ final class PrometheusExportUtils {
                   doubleToGoString(
                       i < boundaries.size() ? boundaries.get(i) : Double.POSITIVE_INFINITY);
               labelValuesWithLe.add(bucketBoundary);
-              sum += arg.getBucketCounts().get(i);
+              cumulativeCount += arg.getBucketCounts().get(i);
               samples.add(
                   new MetricFamilySamples.Sample(
                       name + SAMPLE_SUFFIX_BUCKET,
                       labelNamesWithLe,
                       labelValuesWithLe,
-                      sum));
+                      cumulativeCount));
             }
 
             samples.add(

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtils.java
@@ -190,6 +190,7 @@ final class PrometheusExportUtils {
             List<Double> boundaries = distribution.getBucketBoundaries().getBoundaries();
             List<String> labelNamesWithLe = new ArrayList<String>(labelNames);
             labelNamesWithLe.add(LABEL_NAME_BUCKET_BOUND);
+            long sum = 0;
             for (int i = 0; i < arg.getBucketCounts().size(); i++) {
               List<String> labelValuesWithLe = new ArrayList<String>(labelValues);
               // The label value of "le" is the upper inclusive bound.
@@ -198,12 +199,13 @@ final class PrometheusExportUtils {
                   doubleToGoString(
                       i < boundaries.size() ? boundaries.get(i) : Double.POSITIVE_INFINITY);
               labelValuesWithLe.add(bucketBoundary);
+              sum += arg.getBucketCounts().get(i);
               samples.add(
                   new MetricFamilySamples.Sample(
                       name + SAMPLE_SUFFIX_BUCKET,
                       labelNamesWithLe,
                       labelValuesWithLe,
-                      arg.getBucketCounts().get(i)));
+                      sum));
             }
 
             samples.add(

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusExportUtilsTest.java
@@ -211,9 +211,9 @@ public class PrometheusExportUtilsTest {
             new Sample(
                 SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "0.0"), 2),
             new Sample(
-                SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "5.0"), 2),
+                SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "5.0"), 4),
             new Sample(
-                SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "+Inf"), 1),
+                SAMPLE_NAME + "_bucket", Arrays.asList("k1", "le"), Arrays.asList("v1", "+Inf"), 5),
             new Sample(SAMPLE_NAME + "_count", Arrays.asList("k1"), Arrays.asList("v1"), 5),
             new Sample(SAMPLE_NAME + "_sum", Arrays.asList("k1"), Arrays.asList("v1"), 22.0))
         .inOrder();
@@ -303,12 +303,12 @@ public class PrometheusExportUtilsTest {
                     new Sample(
                         "view_3_bucket", Arrays.asList("k1", "le"), Arrays.asList("v-3", "0.0"), 2),
                     new Sample(
-                        "view_3_bucket", Arrays.asList("k1", "le"), Arrays.asList("v-3", "5.0"), 2),
+                        "view_3_bucket", Arrays.asList("k1", "le"), Arrays.asList("v-3", "5.0"), 4),
                     new Sample(
                         "view_3_bucket",
                         Arrays.asList("k1", "le"),
                         Arrays.asList("v-3", "+Inf"),
-                        1),
+                        5),
                     new Sample("view_3_count", Arrays.asList("k1"), Arrays.asList("v-3"), 5),
                     new Sample("view_3_sum", Arrays.asList("k1"), Arrays.asList("v-3"), 22.0))));
     assertThat(

--- a/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollectorTest.java
+++ b/exporters/stats/prometheus/src/test/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollectorTest.java
@@ -122,12 +122,12 @@ public class PrometheusStatsCollectorTest {
                         name + "_bucket",
                         Arrays.asList("k1", "k2", "le"),
                         Arrays.asList("v1", "v2", "5.0"),
-                        2),
+                        4),
                     new Sample(
                         name + "_bucket",
                         Arrays.asList("k1", "k2", "le"),
                         Arrays.asList("v1", "v2", "+Inf"),
-                        1),
+                        5),
                     new Sample(
                         name + "_count", Arrays.asList("k1", "k2"), Arrays.asList("v1", "v2"), 5),
                     new Sample(


### PR DESCRIPTION
Fixing #1307.

Prometheus uses cumulative values in the histogram buckets thus the buckets from OpenCensus `Distribution` needs to be summarized as they are exported to Prometheus. Otherwise the built-in functions in Prometheus, e.g., `histogram_quantile`, wont work as expected.