### PR TITLE
Tracing: Reduce default limit on Links to 32.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Improve the styling of Rpcz, Statsz, Tracez, and Traceconfigz pages.
 - Add an artifact `opencensus-contrib-exemplar-util` that has helper utilities 
   on recording exemplars.
+- Reduce the default limit on `Link`s per `Span` to 32 (was 128 before).
 
 ## 0.15.0 - 2018-06-20
 - Expose the factory methods of MonitoredResource.

--- a/api/src/main/java/io/opencensus/trace/config/TraceParams.java
+++ b/api/src/main/java/io/opencensus/trace/config/TraceParams.java
@@ -40,7 +40,7 @@ public abstract class TraceParams {
   private static final int DEFAULT_SPAN_MAX_NUM_ATTRIBUTES = 32;
   private static final int DEFAULT_SPAN_MAX_NUM_ANNOTATIONS = 32;
   private static final int DEFAULT_SPAN_MAX_NUM_MESSAGE_EVENTS = 128;
-  private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 128;
+  private static final int DEFAULT_SPAN_MAX_NUM_LINKS = 32;
 
   /**
    * Default {@code TraceParams}.

--- a/api/src/test/java/io/opencensus/trace/config/TraceParamsTest.java
+++ b/api/src/test/java/io/opencensus/trace/config/TraceParamsTest.java
@@ -33,7 +33,7 @@ public class TraceParamsTest {
     assertThat(TraceParams.DEFAULT.getMaxNumberOfAnnotations()).isEqualTo(32);
     assertThat(TraceParams.DEFAULT.getMaxNumberOfNetworkEvents()).isEqualTo(128);
     assertThat(TraceParams.DEFAULT.getMaxNumberOfMessageEvents()).isEqualTo(128);
-    assertThat(TraceParams.DEFAULT.getMaxNumberOfLinks()).isEqualTo(128);
+    assertThat(TraceParams.DEFAULT.getMaxNumberOfLinks()).isEqualTo(32);
   }
 
   @Test(expected = NullPointerException.class)


### PR DESCRIPTION
Per Specs: https://github.com/census-instrumentation/opencensus-specs/pull/139.