### PR TITLE
Tags: Add two new APIs defaultTagContext() and defaultBuilder().

### DIFF
--- a/.vscode/launch.test.json
+++ b/.vscode/launch.test.json
@@ -1,0 +1,462 @@
+{
+    "run": {
+        "default": "",
+        "items": [
+            {
+                "name": "opencensus-impl-lite",
+                "projectName": "opencensus-impl-lite",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/impl_lite",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-logging",
+                "projectName": "opencensus-exporter-trace-logging",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/logging",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-metrics",
+                "projectName": "opencensus-metrics",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/metrics",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-stats-prometheus",
+                "projectName": "opencensus-exporter-stats-prometheus",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/stats/prometheus",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-instana",
+                "projectName": "opencensus-exporter-trace-instana",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/instana",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-impl-core",
+                "projectName": "opencensus-impl-core",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/impl_core",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-stats-stackdriver",
+                "projectName": "opencensus-exporter-stats-stackdriver",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/stats/stackdriver",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-jaeger",
+                "projectName": "opencensus-exporter-trace-jaeger",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/jaeger",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-grpc-util",
+                "projectName": "opencensus-contrib-grpc-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/grpc_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-stats-signalfx",
+                "projectName": "opencensus-exporter-stats-signalfx",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/stats/signalfx",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-zpages",
+                "projectName": "opencensus-contrib-zpages",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/zpages",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-zipkin",
+                "projectName": "opencensus-exporter-trace-zipkin",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/zipkin",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-all",
+                "projectName": "opencensus-all",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/all",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-monitored-resource-util",
+                "projectName": "opencensus-contrib-monitored-resource-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/monitored_resource_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-http-util",
+                "projectName": "opencensus-contrib-http-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/http_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-impl",
+                "projectName": "opencensus-impl",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/impl",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-exemplar-util",
+                "projectName": "opencensus-contrib-exemplar-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/exemplar_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-stackdriver",
+                "projectName": "opencensus-exporter-trace-stackdriver",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/stackdriver",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-agent",
+                "projectName": "opencensus-contrib-agent",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/agent",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-api",
+                "projectName": "opencensus-api",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/api",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-log-correlation-stackdriver",
+                "projectName": "opencensus-contrib-log-correlation-stackdriver",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/log_correlation/stackdriver",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-benchmarks",
+                "projectName": "opencensus-benchmarks",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/benchmarks",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-appengine-standard-util",
+                "projectName": "opencensus-contrib-appengine-standard-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/appengine_standard_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-grpc-metrics",
+                "projectName": "opencensus-contrib-grpc-metrics",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/grpc_metrics",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-testing",
+                "projectName": "opencensus-testing",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/testing",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            }
+        ]
+    },
+    "debug": {
+        "default": "",
+        "items": [
+            {
+                "name": "opencensus-impl-lite",
+                "projectName": "opencensus-impl-lite",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/impl_lite",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-logging",
+                "projectName": "opencensus-exporter-trace-logging",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/logging",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-metrics",
+                "projectName": "opencensus-metrics",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/metrics",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-stats-prometheus",
+                "projectName": "opencensus-exporter-stats-prometheus",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/stats/prometheus",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-instana",
+                "projectName": "opencensus-exporter-trace-instana",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/instana",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-impl-core",
+                "projectName": "opencensus-impl-core",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/impl_core",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-stats-stackdriver",
+                "projectName": "opencensus-exporter-stats-stackdriver",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/stats/stackdriver",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-jaeger",
+                "projectName": "opencensus-exporter-trace-jaeger",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/jaeger",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-grpc-util",
+                "projectName": "opencensus-contrib-grpc-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/grpc_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-stats-signalfx",
+                "projectName": "opencensus-exporter-stats-signalfx",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/stats/signalfx",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-zpages",
+                "projectName": "opencensus-contrib-zpages",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/zpages",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-zipkin",
+                "projectName": "opencensus-exporter-trace-zipkin",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/zipkin",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-all",
+                "projectName": "opencensus-all",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/all",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-monitored-resource-util",
+                "projectName": "opencensus-contrib-monitored-resource-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/monitored_resource_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-http-util",
+                "projectName": "opencensus-contrib-http-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/http_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-impl",
+                "projectName": "opencensus-impl",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/impl",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-exemplar-util",
+                "projectName": "opencensus-contrib-exemplar-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/exemplar_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-exporter-trace-stackdriver",
+                "projectName": "opencensus-exporter-trace-stackdriver",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/exporters/trace/stackdriver",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-agent",
+                "projectName": "opencensus-contrib-agent",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/agent",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-api",
+                "projectName": "opencensus-api",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/api",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-log-correlation-stackdriver",
+                "projectName": "opencensus-contrib-log-correlation-stackdriver",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/log_correlation/stackdriver",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-benchmarks",
+                "projectName": "opencensus-benchmarks",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/benchmarks",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-appengine-standard-util",
+                "projectName": "opencensus-contrib-appengine-standard-util",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/appengine_standard_util",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-contrib-grpc-metrics",
+                "projectName": "opencensus-contrib-grpc-metrics",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/contrib/grpc_metrics",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            },
+            {
+                "name": "opencensus-testing",
+                "projectName": "opencensus-testing",
+                "workingDirectory": "/Users/songya/Google/opencensus-java/testing",
+                "args": [],
+                "vmargs": [],
+                "env": {},
+                "preLaunchTask": ""
+            }
+        ]
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add an artifact `opencensus-contrib-exemplar-util` that has helper utilities 
   on recording exemplars.
 - Reduce the default limit on `Link`s per `Span` to 32 (was 128 before).
+- Add two new APIs `defaultTagContext()` and `defaultBuilder()` to `Tagger`.
 
 ## 0.15.0 - 2018-06-20
 - Expose the factory methods of MonitoredResource.

--- a/api/src/main/java/io/opencensus/tags/Tagger.java
+++ b/api/src/main/java/io/opencensus/tags/Tagger.java
@@ -41,6 +41,16 @@ public abstract class Tagger {
   public abstract TagContext empty();
 
   /**
+   * Returns the default {@code TagContext}.
+   *
+   * @return the default {@code TagContext}.
+   * @since 0.16
+   */
+  public TagContext defaultTagContext() {
+    return empty();
+  }
+
+  /**
    * Returns the current {@code TagContext}.
    *
    * @return the current {@code TagContext}.
@@ -55,6 +65,16 @@ public abstract class Tagger {
    * @since 0.8
    */
   public abstract TagContextBuilder emptyBuilder();
+
+  /**
+   * Returns a new {@code Builder} for default {@code TagContext}.
+   *
+   * @return a new {@code Builder} for default {@code TagContext}.
+   * @since 0.16
+   */
+  public TagContextBuilder defaultBuilder() {
+    return emptyBuilder();
+  }
 
   /**
    * Returns a builder based on this {@code TagContext}.

--- a/api/src/test/java/io/opencensus/tags/NoopTagsTest.java
+++ b/api/src/test/java/io/opencensus/tags/NoopTagsTest.java
@@ -89,8 +89,10 @@ public final class NoopTagsTest {
   public void noopTagger() {
     Tagger noopTagger = NoopTags.getNoopTagger();
     assertThat(noopTagger.empty()).isSameAs(NoopTags.getNoopTagContext());
+    assertThat(noopTagger.defaultTagContext()).isSameAs(NoopTags.getNoopTagContext());
     assertThat(noopTagger.getCurrentTagContext()).isSameAs(NoopTags.getNoopTagContext());
     assertThat(noopTagger.emptyBuilder()).isSameAs(NoopTags.getNoopTagContextBuilder());
+    assertThat(noopTagger.defaultBuilder()).isSameAs(NoopTags.getNoopTagContextBuilder());
     assertThat(noopTagger.toBuilder(TAG_CONTEXT)).isSameAs(NoopTags.getNoopTagContextBuilder());
     assertThat(noopTagger.currentBuilder()).isSameAs(NoopTags.getNoopTagContextBuilder());
     assertThat(noopTagger.withTagContext(TAG_CONTEXT)).isSameAs(NoopScope.getInstance());


### PR DESCRIPTION
It's important to differentiate between empty and default `TagContext`, since they are not always the same in different implementations. Currently we're using `Tagger.empty()` and `Tagger.emptyBuilder()` to get the default `TagContext`s and that has caused some problems.

Adding two new APIs `defaultTagContext()` and `defaultBuilder()`. By default they are the same as `empty()` and `emptyBuilder()` but implementations can override them to have different behaviors.

/cc @zhangkun83