### PR TITLE
Revert "Temporarily disable example-bazel build for Travis CI. (#1229)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,11 +60,6 @@ matrix:
   - env: TASK=BUILD
     os: osx
 
-  # TODO: don't allow failure for this build once bazel is stable.
-  - jdk: oraclejdk8
-    env: TASK=BUILD_EXAMPLES_BAZEL
-    os: linux
-
 before_install:
   - git log --oneline --decorate --graph -30
   - if \[ "$TASK" == "BUILD_EXAMPLES_BAZEL" \]; then


### PR DESCRIPTION
This reverts commit 8ab1628f4daad0489c41f2c9ac96085a7948e84d.

The Bazel build is passing again, so this commit removes it from
'allow_failures'.  Fixes #1228.