### PR TITLE
Add opencensus-metrics to all/build.gradle.

### DIFF
--- a/all/build.gradle
+++ b/all/build.gradle
@@ -11,6 +11,7 @@ def subprojects = [
         project(':opencensus-impl-core'),
         project(':opencensus-impl'),
         project(':opencensus-impl-lite'),
+        project(':opencensus-metrics'),
         project(':opencensus-testing'),
         project(':opencensus-contrib-agent'),
         project(':opencensus-contrib-appengine-standard-util'),


### PR DESCRIPTION
I didn't add opencensus-metrics to subprojects_javadoc, because I didn't want the Javadocs to be published before the artifact is released.