### PR TITLE
Fix incorrect argument to Checker Framework, and fix nullness warnings.

### DIFF
--- a/api/src/main/java/io/opencensus/common/ServerStatsFieldEnums.java
+++ b/api/src/main/java/io/opencensus/common/ServerStatsFieldEnums.java
@@ -17,6 +17,7 @@
 package io.opencensus.common;
 
 import java.util.TreeMap;
+import javax.annotation.Nullable;
 
 /**
  * A Enum representation for Ids and Size for attributes of {@code ServerStats}.
@@ -85,8 +86,9 @@ public final class ServerStatsFieldEnums {
      * @return the numerical value of the id. null if the id is not valid
      * @since 0.16
      */
+    @Nullable
     public static Id valueOf(int value) {
-      return (Id) map.get(value);
+      return map.get(value);
     }
   }
 

--- a/api/src/main/java/io/opencensus/trace/SpanBuilder.java
+++ b/api/src/main/java/io/opencensus/trace/SpanBuilder.java
@@ -335,7 +335,7 @@ public abstract class SpanBuilder {
     }
 
     @Override
-    public SpanBuilder setSpanKind(Span.Kind spanKind) {
+    public SpanBuilder setSpanKind(@Nullable Span.Kind spanKind) {
       return this;
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -410,7 +410,7 @@ subprojects {
                     compile.options.compilerArgs += [
                         '-Xmaxerrs', '10000',
                         "-Xbootclasspath/p:${configurations.checkerFrameworkAnnotatedJDK.asPath}",
-                        "-AskipDefs=[\\.AutoValue_|\\.TraceIdProto]",
+                        "-AskipDefs=\\.AutoValue_|^io.opencensus.contrib.appengine.standard.util.TraceIdProto\$|^io.opencensus.contrib.appengine.standard.util.TraceProto\$",
                         "-AinvariantArrays"
                     ]
                     options.fork = true

--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -157,14 +157,15 @@
              <message key="ws.notPreceded"
              value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
         </module>
-        <module name="Indentation">
-            <property name="basicOffset" value="2"/>
-            <property name="braceAdjustment" value="0"/>
-            <property name="caseIndent" value="2"/>
-            <property name="throwsIndent" value="4"/>
-            <property name="lineWrappingIndentation" value="4"/>
-            <property name="arrayInitIndent" value="2"/>
-        </module>
+        <!-- <!-\- Checkstyle indentation rules conflict with google-java-format: -\-> -->
+        <!-- <module name="Indentation"> -->
+        <!--     <property name="basicOffset" value="2"/> -->
+        <!--     <property name="braceAdjustment" value="0"/> -->
+        <!--     <property name="caseIndent" value="2"/> -->
+        <!--     <property name="throwsIndent" value="4"/> -->
+        <!--     <property name="lineWrappingIndentation" value="4"/> -->
+        <!--     <property name="arrayInitIndent" value="2"/> -->
+        <!-- </module> -->
         <module name="AbbreviationAsWordInName">
             <property name="ignoreFinal" value="false"/>
             <property name="allowedAbbreviationLength" value="1"/>

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -151,6 +151,7 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
 
   // An OpenCensusTraceLoggingEnhancer property can be set with a logging property or a system
   // property.
+  @Nullable
   private static String lookUpProperty(String name) {
     String property = LogManager.getLogManager().getProperty(name);
     return property == null || property.isEmpty() ? System.getProperty(name) : property;

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/CensusSpringAspect.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/CensusSpringAspect.java
@@ -57,6 +57,9 @@ public final class CensusSpringAspect {
     Method method = signature.getMethod();
 
     Traced annotation = method.getAnnotation(Traced.class);
+    if (annotation == null) {
+      return call.proceed();
+    }
     String spanName = annotation.name();
     if (spanName.isEmpty()) {
       spanName = method.getName();

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/Handler.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/Handler.java
@@ -42,7 +42,9 @@ final class Handler {
 
     } catch (Throwable t) {
       Map<String, AttributeValue> attributes = new HashMap<String, AttributeValue>();
-      attributes.put("message", AttributeValue.stringAttributeValue(t.getMessage()));
+      String message = t.getMessage();
+      attributes.put(
+          "message", AttributeValue.stringAttributeValue(message == null ? "null" : message));
       attributes.put("type", AttributeValue.stringAttributeValue(t.getClass().toString()));
 
       Span span = tracer.getCurrentSpan();

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -374,8 +374,8 @@ final class StackdriverExportUtils {
             return builder.build();
           }
         },
-        Functions.</*@Nullable*/ TimeInterval>throwIllegalArgumentException(),
-        Functions.</*@Nullable*/ TimeInterval>throwIllegalArgumentException());
+        Functions.<TimeInterval>throwIllegalArgumentException(),
+        Functions.<TimeInterval>throwIllegalArgumentException());
   }
 
   // Create a TypedValue using AggregationData and Aggregation

--- a/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterHandler.java
+++ b/exporters/trace/zipkin/src/main/java/io/opencensus/exporter/trace/zipkin/ZipkinExporterHandler.java
@@ -172,8 +172,8 @@ final class ZipkinExporterHandler extends SpanExporter.Handler {
 
   // The return type needs to be nullable when this function is used as an argument to 'match' in
   // attributeValueToString, because 'match' doesn't allow covariant return types.
-  private static final Function<Object, /*@Nullable*/ String> returnToString =
-      new Function<Object, /*@Nullable*/ String>() {
+  private static final Function<Object, String> returnToString =
+      new Function<Object, String>() {
         @Override
         public String apply(Object input) {
           return input.toString();

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableAggregation.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableAggregation.java
@@ -348,9 +348,10 @@ abstract class MutableAggregation {
         this.bucketCounts[i] += bucketCounts[i];
       }
 
-      if (exemplars != null) {
-        for (int i = 0; i < mutableDistribution.getExemplars().length; i++) {
-          Exemplar exemplar = mutableDistribution.getExemplars()[i];
+      Exemplar[] otherExemplars = mutableDistribution.getExemplars();
+      if (exemplars != null && otherExemplars != null) {
+        for (int i = 0; i < otherExemplars.length; i++) {
+          Exemplar exemplar = otherExemplars[i];
           // Assume other is always newer than this, because we combined interval buckets in time
           // order.
           // If there's a newer exemplar, overwrite current value.

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/RecordUtils.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/RecordUtils.java
@@ -143,7 +143,7 @@ final class RecordUtils {
     return measurement.match(
         GET_VALUE_FROM_MEASUREMENT_DOUBLE,
         GET_VALUE_FROM_MEASUREMENT_LONG,
-        Functions.</*@Nullable*/ Double>throwAssertionError());
+        Functions.<Double>throwAssertionError());
   }
 
   // static inner Function classes
@@ -263,8 +263,9 @@ final class RecordUtils {
         boxedBucketCounts.add(bucketCount);
       }
       List<Exemplar> exemplars = new ArrayList<Exemplar>();
-      if (arg.getExemplars() != null) {
-        for (Exemplar exemplar : arg.getExemplars()) {
+      Exemplar[] exemplarArray = arg.getExemplars();
+      if (exemplarArray != null) {
+        for (Exemplar exemplar : exemplarArray) {
           if (exemplar != null) {
             exemplars.add(exemplar);
           }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/SpanBuilderImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/SpanBuilderImpl.java
@@ -241,7 +241,7 @@ final class SpanBuilderImpl extends SpanBuilder {
   }
 
   @Override
-  public SpanBuilderImpl setSpanKind(Kind kind) {
+  public SpanBuilderImpl setSpanKind(@Nullable Kind kind) {
     this.kind = kind;
     return this;
   }


### PR DESCRIPTION
709d97aa321d5729988fd63b960bbece04cfba10 modified the -AskipDefs argument to the
Checker Framework (a regular expression) in a way that caused it to skip
checking all files.  This commit fixes the regular expression and the new
Checker Framework warnings.