### PR TITLE
Add Checker Framework stub file for gRPC Context.Key.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/CurrentSpanUtils.java
+++ b/api/src/main/java/io/opencensus/trace/CurrentSpanUtils.java
@@ -20,6 +20,7 @@ import io.grpc.Context;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.unsafe.ContextUtils;
 import java.util.concurrent.Callable;
+import javax.annotation.Nullable;
 
 /** Util methods/functionality to interact with the {@link Span} in the {@link io.grpc.Context}. */
 final class CurrentSpanUtils {
@@ -31,6 +32,7 @@ final class CurrentSpanUtils {
    *
    * @return The {@code Span} from the current context.
    */
+  @Nullable
   static Span getCurrentSpan() {
     return ContextUtils.CONTEXT_SPAN_KEY.get();
   }

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -19,6 +19,10 @@ package io.opencensus.trace.unsafe;
 import io.grpc.Context;
 import io.opencensus.trace.Span;
 
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
 /**
  * Util methods/functionality to interact with the {@link io.grpc.Context}.
  *
@@ -36,5 +40,6 @@ public final class ContextUtils {
    *
    * @since 0.5
    */
-  public static final Context.Key<Span> CONTEXT_SPAN_KEY = Context.key("opencensus-trace-span-key");
+  public static final Context.Key</*@Nullable*/ Span> CONTEXT_SPAN_KEY =
+      Context.key("opencensus-trace-span-key");
 }

--- a/checker-framework/stubs/grpc.astub
+++ b/checker-framework/stubs/grpc.astub
@@ -1,0 +1,12 @@
+package io.grpc;
+
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+class Context {
+  static <T> Key<@Nullable T> key(String name);
+  static <T> Key<T> keyWithDefault(String name, T defaultValue);
+  class Key<T> {
+    T get(Context context);
+    T get();
+  }
+}


### PR DESCRIPTION
The stub file adds Nullable annotations to indicate that Context.Key.get can
return null when the key has no default or the key has a nullable value type.