### PR TITLE
 Update all targets to at least java7 and android14

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,7 +6,8 @@ dependencies {
 
     compileOnly libraries.auto_value
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }
 
 javadoc.exclude 'io/opencensus/internal/**'

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -6,8 +6,8 @@ dependencies {
 
     compileOnly libraries.auto_value
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
 javadoc.exclude 'io/opencensus/internal/**'

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   compile libraries.findbugs_annotations
   compile libraries.guava
 
-  signature 'org.codehaus.mojo.signature:java17:+@signature'
+  signature 'org.codehaus.mojo.signature:java17:1.0@signature'
 }
 
 jar {

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -29,7 +29,7 @@ dependencies {
   compile libraries.findbugs_annotations
   compile libraries.guava
 
-  signature 'org.codehaus.mojo.signature:java16:+@signature'
+  signature 'org.codehaus.mojo.signature:java17:+@signature'
 }
 
 jar {

--- a/contrib/exemplar_util/build.gradle
+++ b/contrib/exemplar_util/build.gradle
@@ -10,5 +10,6 @@ apply plugin: 'java'
 dependencies {
     compile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/contrib/exemplar_util/build.gradle
+++ b/contrib/exemplar_util/build.gradle
@@ -10,6 +10,6 @@ apply plugin: 'java'
 dependencies {
     compile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/contrib/grpc_metrics/build.gradle
+++ b/contrib/grpc_metrics/build.gradle
@@ -10,5 +10,6 @@ apply plugin: 'java'
 dependencies {
     compile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/contrib/grpc_metrics/build.gradle
+++ b/contrib/grpc_metrics/build.gradle
@@ -10,6 +10,6 @@ apply plugin: 'java'
 dependencies {
     compile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/contrib/grpc_util/build.gradle
+++ b/contrib/grpc_util/build.gradle
@@ -21,6 +21,6 @@ dependencies {
         exclude group: 'io.opencensus', module: 'opencensus-api'
     }
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/contrib/grpc_util/build.gradle
+++ b/contrib/grpc_util/build.gradle
@@ -21,5 +21,6 @@ dependencies {
         exclude group: 'io.opencensus', module: 'opencensus-api'
     }
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/contrib/http_util/build.gradle
+++ b/contrib/http_util/build.gradle
@@ -11,5 +11,6 @@ dependencies {
     compile project(':opencensus-api'),
             libraries.guava
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/contrib/http_util/build.gradle
+++ b/contrib/http_util/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     compile project(':opencensus-api'),
             libraries.guava
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/contrib/log_correlation/stackdriver/build.gradle
+++ b/contrib/log_correlation/stackdriver/build.gradle
@@ -8,6 +8,6 @@ dependencies {
 
     testCompile libraries.guava
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/contrib/log_correlation/stackdriver/build.gradle
+++ b/contrib/log_correlation/stackdriver/build.gradle
@@ -8,5 +8,6 @@ dependencies {
 
     testCompile libraries.guava
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/contrib/monitored_resource_util/build.gradle
+++ b/contrib/monitored_resource_util/build.gradle
@@ -10,5 +10,6 @@ apply plugin: 'java'
 dependencies {
     compileOnly libraries.auto_value
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/contrib/monitored_resource_util/build.gradle
+++ b/contrib/monitored_resource_util/build.gradle
@@ -10,6 +10,6 @@ apply plugin: 'java'
 dependencies {
     compileOnly libraries.auto_value
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/contrib/spring/build.gradle
+++ b/contrib/spring/build.gradle
@@ -17,5 +17,5 @@ dependencies {
             libraries.aspectj,
             libraries.spring_test
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
 }

--- a/contrib/spring/build.gradle
+++ b/contrib/spring/build.gradle
@@ -17,5 +17,5 @@ dependencies {
             libraries.aspectj,
             libraries.spring_test
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }

--- a/exporters/stats/prometheus/build.gradle
+++ b/exporters/stats/prometheus/build.gradle
@@ -13,6 +13,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/exporters/stats/prometheus/build.gradle
+++ b/exporters/stats/prometheus/build.gradle
@@ -14,4 +14,5 @@ dependencies {
     testCompile project(':opencensus-api')
 
     signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollector.java
+++ b/exporters/stats/prometheus/src/main/java/io/opencensus/exporter/stats/prometheus/PrometheusStatsCollector.java
@@ -101,7 +101,8 @@ public final class PrometheusStatsCollector extends Collector implements Collect
             .setRecordEvents(true)
             .startSpan();
     span.addAnnotation("Collect Prometheus Metric Samples.");
-    try (Scope scope = tracer.withSpan(span)) {
+    Scope scope = tracer.withSpan(span);
+    try {
       for (View view : viewManager.getAllExportedViews()) {
         if (containsDisallowedLeLabelForHistogram(
             convertToLabelNames(view.getColumns()),
@@ -125,6 +126,7 @@ public final class PrometheusStatsCollector extends Collector implements Collect
       }
       span.addAnnotation("Finish collecting Prometheus Metric Samples.");
     } finally {
+      scope.close();
       span.end();
     }
     return samples;
@@ -140,7 +142,8 @@ public final class PrometheusStatsCollector extends Collector implements Collect
             .setRecordEvents(true)
             .startSpan();
     span.addAnnotation("Describe Prometheus Metrics.");
-    try (Scope scope = tracer.withSpan(span)) {
+    Scope scope = tracer.withSpan(span);
+    try {
       for (View view : viewManager.getAllExportedViews()) {
         try {
           samples.add(PrometheusExportUtils.createDescribableMetricFamilySamples(view));
@@ -153,6 +156,7 @@ public final class PrometheusStatsCollector extends Collector implements Collect
       }
       span.addAnnotation("Finish describing Prometheus Metrics.");
     } finally {
+      scope.close();
       span.end();
     }
     return samples;

--- a/exporters/stats/signalfx/build.gradle
+++ b/exporters/stats/signalfx/build.gradle
@@ -18,4 +18,5 @@ dependencies {
     testCompile project(':opencensus-api')
 
     signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/exporters/stats/signalfx/build.gradle
+++ b/exporters/stats/signalfx/build.gradle
@@ -17,6 +17,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThread.java
+++ b/exporters/stats/signalfx/src/main/java/io/opencensus/exporter/stats/signalfx/SignalFxStatsExporterWorkerThread.java
@@ -69,8 +69,9 @@ final class SignalFxStatsExporterWorkerThread extends Thread {
   }
 
   @VisibleForTesting
-  void export() {
-    try (Session session = sender.createSession()) {
+  void export() throws IOException {
+    Session session = sender.createSession();
+    try {
       for (View view : views.getAllExportedViews()) {
         ViewData data = views.getView(view.getName());
         if (data == null) {
@@ -81,8 +82,8 @@ final class SignalFxStatsExporterWorkerThread extends Thread {
           session.setDatapoint(datapoint);
         }
       }
-    } catch (IOException e) {
-      // Does not happen, flush/close errors are communicated through the sender's error handlers.
+    } finally {
+      session.close();
     }
   }
 

--- a/exporters/stats/stackdriver/build.gradle
+++ b/exporters/stats/stackdriver/build.gradle
@@ -25,5 +25,5 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }

--- a/exporters/stats/stackdriver/build.gradle
+++ b/exporters/stats/stackdriver/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     testCompile project(':opencensus-api')
 
     signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/exporters/stats/stackdriver/build.gradle
+++ b/exporters/stats/stackdriver/build.gradle
@@ -26,5 +26,4 @@ dependencies {
     testCompile project(':opencensus-api')
 
     signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/exporters/trace/instana/build.gradle
+++ b/exporters/trace/instana/build.gradle
@@ -10,6 +10,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/exporters/trace/instana/build.gradle
+++ b/exporters/trace/instana/build.gradle
@@ -10,5 +10,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/exporters/trace/jaeger/build.gradle
+++ b/exporters/trace/jaeger/build.gradle
@@ -19,17 +19,18 @@ sourceSets {
 dependencies {
     compile project(':opencensus-api')
 
-    compile (libraries.jaeger_reporter) {
+    compile(libraries.jaeger_reporter) {
         // Prefer library version.
         exclude group: 'com.google.guava', module: 'guava'
     }
 
     testCompile project(':opencensus-api'),
-                'org.testcontainers:testcontainers:1.7.0',
-                'com.google.http-client:google-http-client-gson:1.23.0'
+            'org.testcontainers:testcontainers:1.7.0',
+            'com.google.http-client:google-http-client-gson:1.23.0'
 
     // Unless linked to impl, spans will be blank and not exported during integration tests.
     testRuntime project(':opencensus-impl')
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/exporters/trace/jaeger/build.gradle
+++ b/exporters/trace/jaeger/build.gradle
@@ -31,6 +31,6 @@ dependencies {
     // Unless linked to impl, spans will be blank and not exported during integration tests.
     testRuntime project(':opencensus-impl')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/exporters/trace/logging/build.gradle
+++ b/exporters/trace/logging/build.gradle
@@ -6,6 +6,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/exporters/trace/logging/build.gradle
+++ b/exporters/trace/logging/build.gradle
@@ -6,5 +6,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/exporters/trace/stackdriver/build.gradle
+++ b/exporters/trace/stackdriver/build.gradle
@@ -26,4 +26,5 @@ dependencies {
     testCompile project(':opencensus-api')
 
     signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/exporters/trace/stackdriver/build.gradle
+++ b/exporters/trace/stackdriver/build.gradle
@@ -25,6 +25,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/exporters/trace/zipkin/build.gradle
+++ b/exporters/trace/zipkin/build.gradle
@@ -12,6 +12,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/exporters/trace/zipkin/build.gradle
+++ b/exporters/trace/zipkin/build.gradle
@@ -12,5 +12,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/impl/build.gradle
+++ b/impl/build.gradle
@@ -15,7 +15,7 @@ dependencies {
     testCompile project(':opencensus-api'),
             project(':opencensus-impl-core')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }
 
 javadoc.exclude 'io/opencensus/internal/**'

--- a/impl_core/build.gradle
+++ b/impl_core/build.gradle
@@ -9,8 +9,8 @@ dependencies {
     testCompile project(':opencensus-api'),
             project(':opencensus-testing')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
 javadoc.exclude 'io/opencensus/internal/**'

--- a/impl_core/build.gradle
+++ b/impl_core/build.gradle
@@ -9,7 +9,8 @@ dependencies {
     testCompile project(':opencensus-api'),
             project(':opencensus-testing')
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }
 
 javadoc.exclude 'io/opencensus/internal/**'

--- a/impl_lite/build.gradle
+++ b/impl_lite/build.gradle
@@ -7,6 +7,6 @@ dependencies {
     testCompile project(':opencensus-api'),
             project(':opencensus-impl-core')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/impl_lite/build.gradle
+++ b/impl_lite/build.gradle
@@ -7,5 +7,6 @@ dependencies {
     testCompile project(':opencensus-api'),
             project(':opencensus-impl-core')
 
+    signature "org.codehaus.mojo.signature:java17:+@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -5,6 +5,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java17:+@signature"
-    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -5,5 +5,6 @@ dependencies {
 
     testCompile project(':opencensus-api')
 
-    signature "org.codehaus.mojo.signature:java16:+@signature"
+    signature "org.codehaus.mojo.signature:java17:+@signature"
+    signature "net.sf.androidscents.signature:android-api-level-14:+@signature"
 }


### PR DESCRIPTION
gRPC updated to java7/android14 for io.context and all their artifacts see https://github.com/grpc/grpc-java/pull/4727

Currently we still cannot use try-with-resources (android 19) or ThreadLocalRandom (android 21).