### PR TITLE
checkstyle: 8.0 -> 8.12

### DIFF
--- a/api/src/main/java/io/opencensus/common/ServerStatsFieldEnums.java
+++ b/api/src/main/java/io/opencensus/common/ServerStatsFieldEnums.java
@@ -99,19 +99,19 @@ public final class ServerStatsFieldEnums {
    */
   public enum Size {
     /**
-     * Number of bytes used to represent latency observed at Load Balancer
+     * Number of bytes used to represent latency observed at Load Balancer.
      *
      * @since 0.16
      */
     SERVER_STATS_LB_LATENCY_SIZE(8),
     /**
-     * Number of bytes used to represent latency observed at Server
+     * Number of bytes used to represent latency observed at Server.
      *
      * @since 0.16
      */
     SERVER_STATS_SERVICE_LATENCY_SIZE(8),
     /**
-     * Number of bytes used to represent Trace option
+     * Number of bytes used to represent Trace option.
      *
      * @since 0.16
      */
@@ -148,7 +148,7 @@ public final class ServerStatsFieldEnums {
   }
 
   /**
-   * Returns the total size required to encode the {@code ServerStats}
+   * Returns the total size required to encode the {@code ServerStats}.
    *
    * @return the total size required to encode all fields in {@code ServerStats}.
    * @since 0.16

--- a/api/src/main/java/io/opencensus/stats/BucketBoundaries.java
+++ b/api/src/main/java/io/opencensus/stats/BucketBoundaries.java
@@ -33,6 +33,8 @@ import javax.annotation.concurrent.Immutable;
 public abstract class BucketBoundaries {
 
   /**
+   * Returns a {@code BucketBoundaries} with the given buckets.
+   *
    * @param bucketBoundaries the boundaries for the buckets in the underlying histogram.
    * @return a new {@code BucketBoundaries} with the specified boundaries.
    * @throws NullPointerException if {@code bucketBoundaries} is null.

--- a/api/src/main/java/io/opencensus/trace/NetworkEvent.java
+++ b/api/src/main/java/io/opencensus/trace/NetworkEvent.java
@@ -118,6 +118,8 @@ public abstract class NetworkEvent extends io.opencensus.trace.BaseMessageEvent 
   public abstract long getCompressedMessageSize();
 
   /**
+   * Returns the uncompressed size in bytes of the {@code NetworkEvent}.
+   *
    * @deprecated Use {@link #getUncompressedMessageSize}.
    * @return the uncompressed size in bytes of the {@code NetworkEvent}.
    * @since 0.5
@@ -153,6 +155,8 @@ public abstract class NetworkEvent extends io.opencensus.trace.BaseMessageEvent 
     public abstract Builder setKernelTimestamp(@Nullable Timestamp kernelTimestamp);
 
     /**
+     * Sets the uncompressed message size.
+     *
      * @deprecated Use {@link #setUncompressedMessageSize}.
      * @param messageSize represents the uncompressed size in bytes of this message.
      * @return this.

--- a/api/src/main/java/io/opencensus/trace/Span.java
+++ b/api/src/main/java/io/opencensus/trace/Span.java
@@ -117,6 +117,10 @@ public abstract class Span {
   }
 
   /**
+   * Sets a set of attributes to the {@code Span}. The effect of this call is equivalent to that of
+   * calling {@link #putAttribute(String, AttributeValue)} once for each element in the specified
+   * map.
+   *
    * @deprecated Use {@link #putAttributes(Map)}
    * @param attributes the attributes that will be added and associated with the {@code Span}.
    * @since 0.5

--- a/api/src/main/java/io/opencensus/trace/TraceOptions.java
+++ b/api/src/main/java/io/opencensus/trace/TraceOptions.java
@@ -202,6 +202,8 @@ public final class TraceOptions {
     }
 
     /**
+     * Sets the sampling bit in the options to true.
+     *
      * @deprecated Use {@code Builder.setIsSampled(true)}.
      * @return this.
      * @since 0.5

--- a/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
@@ -234,63 +234,63 @@ public abstract class SampledSpanStore {
    */
   public enum LatencyBucketBoundaries {
     /**
-     * Stores finished successful requests of duration within the interval [0, 10us)
+     * Stores finished successful requests of duration within the interval [0, 10us).
      *
      * @since 0.5
      */
     ZERO_MICROSx10(0, TimeUnit.MICROSECONDS.toNanos(10)),
 
     /**
-     * Stores finished successful requests of duration within the interval [10us, 100us)
+     * Stores finished successful requests of duration within the interval [10us, 100us).
      *
      * @since 0.5
      */
     MICROSx10_MICROSx100(TimeUnit.MICROSECONDS.toNanos(10), TimeUnit.MICROSECONDS.toNanos(100)),
 
     /**
-     * Stores finished successful requests of duration within the interval [100us, 1ms)
+     * Stores finished successful requests of duration within the interval [100us, 1ms).
      *
      * @since 0.5
      */
     MICROSx100_MILLIx1(TimeUnit.MICROSECONDS.toNanos(100), TimeUnit.MILLISECONDS.toNanos(1)),
 
     /**
-     * Stores finished successful requests of duration within the interval [1ms, 10ms)
+     * Stores finished successful requests of duration within the interval [1ms, 10ms).
      *
      * @since 0.5
      */
     MILLIx1_MILLIx10(TimeUnit.MILLISECONDS.toNanos(1), TimeUnit.MILLISECONDS.toNanos(10)),
 
     /**
-     * Stores finished successful requests of duration within the interval [10ms, 100ms)
+     * Stores finished successful requests of duration within the interval [10ms, 100ms).
      *
      * @since 0.5
      */
     MILLIx10_MILLIx100(TimeUnit.MILLISECONDS.toNanos(10), TimeUnit.MILLISECONDS.toNanos(100)),
 
     /**
-     * Stores finished successful requests of duration within the interval [100ms, 1sec)
+     * Stores finished successful requests of duration within the interval [100ms, 1sec).
      *
      * @since 0.5
      */
     MILLIx100_SECONDx1(TimeUnit.MILLISECONDS.toNanos(100), TimeUnit.SECONDS.toNanos(1)),
 
     /**
-     * Stores finished successful requests of duration within the interval [1sec, 10sec)
+     * Stores finished successful requests of duration within the interval [1sec, 10sec).
      *
      * @since 0.5
      */
     SECONDx1_SECONDx10(TimeUnit.SECONDS.toNanos(1), TimeUnit.SECONDS.toNanos(10)),
 
     /**
-     * Stores finished successful requests of duration within the interval [10sec, 100sec)
+     * Stores finished successful requests of duration within the interval [10sec, 100sec).
      *
      * @since 0.5
      */
     SECONDx10_SECONDx100(TimeUnit.SECONDS.toNanos(10), TimeUnit.SECONDS.toNanos(100)),
 
     /**
-     * Stores finished successful requests of duration &gt;= 100sec
+     * Stores finished successful requests of duration &gt;= 100sec.
      *
      * @since 0.5
      */

--- a/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/BinaryFormat.java
@@ -66,6 +66,8 @@ public abstract class BinaryFormat {
   static final NoopBinaryFormat NOOP_BINARY_FORMAT = new NoopBinaryFormat();
 
   /**
+   * Serializes a {@link SpanContext} into a byte array using the binary format.
+   *
    * @deprecated use {@link #toByteArray(SpanContext)}.
    * @param spanContext the {@code SpanContext} to serialize.
    * @return the serialized binary value.
@@ -91,6 +93,8 @@ public abstract class BinaryFormat {
   }
 
   /**
+   * Parses the {@link SpanContext} from a byte array using the binary format.
+   *
    * @deprecated use {@link #fromByteArray(byte[])}.
    * @param bytes a binary encoded buffer from which the {@code SpanContext} will be parsed.
    * @return the parsed {@code SpanContext}.

--- a/build.gradle
+++ b/build.gradle
@@ -262,7 +262,7 @@ subprojects {
 
     checkstyle {
         configFile = file("$rootDir/buildscripts/checkstyle.xml")
-        toolVersion = "8.0"
+        toolVersion = "8.12"
         ignoreFailures = false
         if (rootProject.hasProperty("checkstyle.ignoreFailures")) {
             ignoreFailures = rootProject.properties["checkstyle.ignoreFailures"].toBoolean()

--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <!DOCTYPE module PUBLIC
-          "-//Puppy Crawl//DTD Check Configuration 1.3//EN"
-          "http://www.puppycrawl.com/dtds/configuration_1_3.dtd">
+          "-//Checkstyle//DTD Checkstyle Configuration 1.3//EN"
+          "https://checkstyle.org/dtds/configuration_1_3.dtd">
 
 <!--
     Checkstyle configuration that checks the Google coding conventions from Google Java Style
@@ -29,16 +29,18 @@
     <property name="fileExtensions" value="java, properties, xml"/>
     <!-- Checks for whitespace                               -->
     <!-- See http://checkstyle.sf.net/config_whitespace.html -->
-        <module name="FileTabCharacter">
-            <property name="eachLine" value="true"/>
-        </module>
+    <module name="FileTabCharacter">
+        <property name="eachLine" value="true"/>
+    </module>
 
     <module name="TreeWalker">
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
             <property name="tokens" value="STRING_LITERAL, CHAR_LITERAL"/>
-            <property name="format" value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
-            <property name="message" value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
+            <property name="format"
+             value="\\u00(09|0(a|A)|0(c|C)|0(d|D)|22|27|5(C|c))|\\(0(10|11|12|14|15|42|47)|134)"/>
+            <property name="message"
+             value="Consider using special escape sequence instead of octal value or Unicode escaped value."/>
         </module>
         <module name="AvoidEscapedUnicodeCharacters">
             <property name="allowEscapesForControlCharacters" value="true"/>
@@ -55,20 +57,23 @@
         <module name="NoLineWrap"/>
         <module name="EmptyBlock">
             <property name="option" value="TEXT"/>
-            <property name="tokens" value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
+            <property name="tokens"
+             value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
+        <module name="LeftCurly"/>
         <module name="RightCurly">
             <property name="id" value="RightCurlySame"/>
-            <property name="tokens" value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_DO"/>
+            <property name="tokens"
+             value="LITERAL_TRY, LITERAL_CATCH, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE,
+                    LITERAL_DO"/>
         </module>
         <module name="RightCurly">
             <property name="id" value="RightCurlyAlone"/>
             <property name="option" value="alone"/>
-            <property name="tokens" value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT, INSTANCE_INIT"/>
+            <property name="tokens"
+             value="CLASS_DEF, METHOD_DEF, CTOR_DEF, LITERAL_FOR, LITERAL_WHILE, STATIC_INIT,
+                    INSTANCE_INIT"/>
         </module>
         <module name="WhitespaceAround">
             <property name="allowEmptyConstructors" value="true"/>
@@ -77,14 +82,14 @@
             <property name="allowEmptyLoops" value="true"/>
             <message key="ws.notFollowed"
              value="WhitespaceAround: ''{0}'' is not followed by whitespace. Empty blocks may only be represented as '{}' when not part of a multi-block statement (4.1.3)"/>
-             <message key="ws.notPreceded"
+            <message key="ws.notPreceded"
              value="WhitespaceAround: ''{0}'' is not preceded with whitespace."/>
         </module>
         <module name="OneStatementPerLine"/>
         <module name="MultipleVariableDeclarations"/>
         <module name="ArrayTypeStyle"/>
-        <!-- This rule conflicts with Error Prone's exhaustiveness checking. -->
-	    <!-- <module name="MissingSwitchDefault"/> -->
+        <!-- <!-\- This rule conflicts with Error Prone's exhaustiveness checking. -\-> -->
+        <!-- <module name="MissingSwitchDefault"/> -->
         <module name="FallThrough"/>
         <module name="UpperEll"/>
         <module name="ModifierOrder"/>
@@ -100,6 +105,23 @@
             <property name="id" value="SeparatorWrapComma"/>
             <property name="tokens" value="COMMA"/>
             <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ELLIPSIS is EOL until https://github.com/google/styleguide/issues/258 -->
+            <property name="id" value="SeparatorWrapEllipsis"/>
+            <property name="tokens" value="ELLIPSIS"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <!-- ARRAY_DECLARATOR is EOL until https://github.com/google/styleguide/issues/259 -->
+            <property name="id" value="SeparatorWrapArrayDeclarator"/>
+            <property name="tokens" value="ARRAY_DECLARATOR"/>
+            <property name="option" value="EOL"/>
+        </module>
+        <module name="SeparatorWrap">
+            <property name="id" value="SeparatorWrapMethodRef"/>
+            <property name="tokens" value="METHOD_REF"/>
+            <property name="option" value="nl"/>
         </module>
         <module name="PackageName">
             <property name="format" value="^[a-z]+(\.[a-z][a-z0-9]*)*$"/>
@@ -119,6 +141,11 @@
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
             <message key="name.invalidPattern"
              value="Parameter name ''{0}'' must match pattern ''{1}''."/>
+        </module>
+        <module name="LambdaParameterName">
+            <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
+            <message key="name.invalidPattern"
+                     value="Lambda parameter name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="CatchParameterName">
             <property name="format" value="^[a-z]([a-z0-9][a-zA-Z0-9]*)?$"/>
@@ -150,11 +177,11 @@
         <module name="GenericWhitespace">
             <message key="ws.followed"
              value="GenericWhitespace ''{0}'' is followed by whitespace."/>
-             <message key="ws.preceded"
+            <message key="ws.preceded"
              value="GenericWhitespace ''{0}'' is preceded with whitespace."/>
-             <message key="ws.illegalFollow"
+            <message key="ws.illegalFollow"
              value="GenericWhitespace ''{0}'' should followed by whitespace."/>
-             <message key="ws.notPreceded"
+            <message key="ws.notPreceded"
              value="GenericWhitespace ''{0}'' is not preceded with whitespace."/>
         </module>
         <!-- <!-\- Checkstyle indentation rules conflict with google-java-format: -\-> -->
@@ -171,20 +198,30 @@
             <property name="allowedAbbreviationLength" value="1"/>
         </module>
         <module name="OverloadMethodsDeclarationOrder"/>
+        <!-- <!-\- Many unit tests define all variables at the start of the method. -\-> -->
+        <!-- <module name="VariableDeclarationUsageDistance"/> -->
         <module name="CustomImportOrder">
             <property name="sortImportsInGroupAlphabetically" value="true"/>
             <property name="separateLineBetweenGroups" value="true"/>
             <property name="customImportOrderRules" value="STATIC###THIRD_PARTY_PACKAGE"/>
         </module>
         <module name="MethodParamPad"/>
+        <module name="NoWhitespaceBefore">
+            <property name="tokens"
+             value="COMMA, SEMI, POST_INC, POST_DEC, DOT, ELLIPSIS, METHOD_REF"/>
+            <property name="allowLineBreaks" value="true"/>
+        </module>
         <module name="ParenPad"/>
         <module name="OperatorWrap">
             <property name="option" value="NL"/>
-            <property name="tokens" value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR, LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
+            <property name="tokens"
+             value="BAND, BOR, BSR, BXOR, DIV, EQUAL, GE, GT, LAND, LE, LITERAL_INSTANCEOF, LOR,
+                    LT, MINUS, MOD, NOT_EQUAL, PLUS, QUESTION, SL, SR, STAR, METHOD_REF "/>
         </module>
         <module name="AnnotationLocation">
             <property name="id" value="AnnotationLocationMostCases"/>
-            <property name="tokens" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
+            <property name="tokens"
+             value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF"/>
         </module>
         <module name="AnnotationLocation">
             <property name="id" value="AnnotationLocationVariables"/>
@@ -194,12 +231,14 @@
         <module name="NonEmptyAtclauseDescription"/>
         <module name="JavadocTagContinuationIndentation"/>
         <module name="SummaryJavadoc">
-            <property name="forbiddenSummaryFragments" value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
+            <property name="forbiddenSummaryFragments"
+             value="^@return the *|^This method returns |^A [{]@code [a-zA-Z0-9]+[}]( is a )"/>
         </module>
         <module name="JavadocParagraph"/>
         <module name="AtclauseOrder">
             <property name="tagOrder" value="@param, @return, @throws, @deprecated"/>
-            <property name="target" value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
+            <property name="target"
+             value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
         </module>
         <module name="JavadocMethod">
             <property name="scope" value="public"/>
@@ -207,9 +246,11 @@
             <property name="allowMissingThrowsTags" value="true"/>
             <property name="allowMissingReturnTag" value="true"/>
             <property name="minLineCount" value="2"/>
-            <!-- Too restrictive for tests -->
-            <!-- <property name="allowedAnnotations" value="Override, Test"/-->
-            <property name="allowedAnnotations" value="Override, Test, Before, After, BeforeClass, AfterClass, Setup, TearDown"/>
+            <!-- <!-\- Too restrictive for tests -\-> -->
+            <!-- <property name="allowedAnnotations" value="Override, Test"/ -->
+            <property name="allowedAnnotations"
+                      value="Override, Test, Before, After, BeforeClass, AfterClass, Setup,
+                             TearDown"/>
             <property name="allowThrowsTagsForSubclasses" value="true"/>
         </module>
         <module name="MethodName">
@@ -218,20 +259,19 @@
              value="Method name ''{0}'' must match pattern ''{1}''."/>
         </module>
         <module name="SingleLineJavadoc">
-            <!-- Wrong interpretation of the style guide; -->
-            <!-- <property name="ignoreInlineTags" value="false"/-->
+            <!-- <!-\- Wrong interpretation of the style guide; -\-> -->
+            <!-- <property name="ignoreInlineTags" value="false"/ -->
         </module>
         <module name="EmptyCatchBlock">
             <property name="exceptionVariableName" value="expected"/>
         </module>
         <module name="CommentsIndentation"/>
-        <module name="FileContentsHolder"/>
         <module name="SuppressWarningsHolder"/>
         <module name="ImportControl">
             <property name="file" value="${rootDir}/buildscripts/import-control.xml"/>
             <property name="path" value="^.*[\\/]src[\\/]main[\\/]java[\\/].*$"/>
         </module>
+        <module name="SuppressionCommentFilter"/>
     </module>
-    <module name="SuppressionCommentFilter"/>
     <module name="SuppressWarningsFilter"/>
 </module>

--- a/buildscripts/kokoro/linux_presubmit.sh
+++ b/buildscripts/kokoro/linux_presubmit.sh
@@ -64,8 +64,8 @@ case "$TASK" in
     ./gradlew clean assemble -PcheckerFramework=true
     ;;
   "CHECK_EXAMPLES_LICENSE")
-    curl -L -o checkstyle-8.0-all.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.0/checkstyle-8.0-all.jar
-    java -DrootDir=. -jar checkstyle-8.0-all.jar -c buildscripts/checkstyle.xml examples/src/
+    curl -L -o checkstyle-8.12-all.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.12/checkstyle-8.12-all.jar
+    java -DrootDir=. -jar checkstyle-8.12-all.jar -c buildscripts/checkstyle.xml examples/src/
     ;;
   "CHECK_EXAMPLES_FORMAT")
     curl -L -o google-java-format-1.5-all-deps.jar \

--- a/contrib/grpc_util/src/main/java/io/opencensus/contrib/grpc/util/StatusConverter.java
+++ b/contrib/grpc_util/src/main/java/io/opencensus/contrib/grpc/util/StatusConverter.java
@@ -17,7 +17,7 @@
 package io.opencensus.contrib.grpc.util;
 
 /**
- * Utility class to convert between {@link io.opencensus.trace.Status} and {@link io.grpc.Status}
+ * Utility class to convert between {@link io.opencensus.trace.Status} and {@link io.grpc.Status}.
  *
  * @since 0.6
  */

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/CensusSpringAspect.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/CensusSpringAspect.java
@@ -35,6 +35,8 @@ public final class CensusSpringAspect {
   private final Tracer tracer;
 
   /**
+   * Creates a {@code CensusSpringAspect} with the given tracer.
+   *
    * @param tracer the tracer responsible for building new spans
    * @since 0.16.0
    */

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/CensusSpringSqlAspect.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/CensusSpringSqlAspect.java
@@ -35,6 +35,8 @@ public final class CensusSpringSqlAspect {
   private final Tracer tracer;
 
   /**
+   * Creates a {@code CensusSpringSqlAspect} with the given tracer.
+   *
    * @param tracer the tracer responsible for building new spans
    * @since 0.16.0
    */

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/Traced.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/aop/Traced.java
@@ -32,7 +32,10 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface Traced {
+
   /**
+   * The optional custom span name.
+   *
    * @return the optional custom span name; if not specified the method name will be used as the
    *     span name
    */

--- a/scripts/travis_script
+++ b/scripts/travis_script
@@ -55,8 +55,8 @@ case "$TASK" in
     ./gradlew clean assemble -PcheckerFramework=true
     ;;
   "CHECK_EXAMPLES_LICENSE")
-    curl -L -o checkstyle-8.0-all.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.0/checkstyle-8.0-all.jar
-    java -DrootDir=. -jar checkstyle-8.0-all.jar -c buildscripts/checkstyle.xml examples/src/
+    curl -L -o checkstyle-8.12-all.jar https://github.com/checkstyle/checkstyle/releases/download/checkstyle-8.12/checkstyle-8.12-all.jar
+    java -DrootDir=. -jar checkstyle-8.12-all.jar -c buildscripts/checkstyle.xml examples/src/
     ;;
   "CHECK_EXAMPLES_FORMAT")
     curl -L -o google-java-format-1.5-all-deps.jar https://github.com/google/google-java-format/releases/download/google-java-format-1.5/google-java-format-1.5-all-deps.jar


### PR DESCRIPTION
This commit also merges new changes to checkstyle.xml and fixes new checkstyle
warnings related to Javadocs.

________________________________________________________________________________

This upgrade seems to fix a bug in parsing Javadocs where a `@value` tag is split between two lines.