### PR TITLE
Change getState to be non-cacheable.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   tracing.
 - Allow custom prefix for Stackdriver metrics in `StackdriverStatsConfiguration`.
 - Add support to handle the Tracestate in the SpanContext.
+- Behavior change for getState/setState. The result of getState cannot be cached anymore.
 
 ## 0.15.0 - 2018-06-20
 - Expose the factory methods of MonitoredResource.

--- a/api/src/main/java/io/opencensus/stats/StatsComponent.java
+++ b/api/src/main/java/io/opencensus/stats/StatsComponent.java
@@ -45,8 +45,8 @@ public abstract class StatsComponent {
    * <p>When no implementation is available, {@code getState} always returns {@link
    * StatsCollectionState#DISABLED}.
    *
-   * <p>Once {@link #getState()} is called, subsequent calls to {@link
-   * #setState(StatsCollectionState)} will throw an {@code IllegalStateException}.
+   * <p>IMPORTANT: The returned value cannot be cached because subsequent calls to {@link
+   * #setState(StatsCollectionState)} can change the current value.
    *
    * @return the current {@code StatsCollectionState}.
    * @since 0.8
@@ -62,11 +62,9 @@ public abstract class StatsComponent {
    * recorded will be cleared.
    *
    * @param state the new {@code StatsCollectionState}.
-   * @throws IllegalStateException if {@link #getState()} was previously called.
    * @deprecated This method is deprecated because other libraries could cache the result of {@link
    *     #getState()}, use a stale value, and behave incorrectly. It is only safe to call early in
-   *     initialization. This method throws {@link IllegalStateException} after {@code getState()}
-   *     has been called, in order to limit changes to the result of {@code getState()}.
+   *     initialization.
    * @since 0.8
    */
   @Deprecated

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -41,6 +41,11 @@
     <Class name="io.opencensus.contrib.appengine.standard.util.TraceIdProto$Builder"/>
     <Method name="maybeForceBuilderInitialization"/>
   </Match>
+  <Match>
+    <!-- Reason: The synchronization in the setState is for the side effects not for the state. -->
+    <Bug pattern="UG_SYNC_SET_UNSYNC_GET"/>
+    <Class name="io.opencensus.implcore.stats.StatsComponentImplBase"/>
+  </Match>
 
   <!-- Suppress some FindBugs warnings related to performance or robustness -->
   <!-- in test classes, where those issues are less important. -->

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/CurrentStatsState.java
@@ -40,7 +40,7 @@ final class CurrentStatsState {
 
   // Sets current state to the given state. Returns true if the current state is changed, false
   // otherwise.
-  boolean set(StatsCollectionState state) {
-    return state != currentState.getAndSet(checkNotNull(state, "state"));
+  boolean set(StatsCollectionState newState) {
+    return newState != currentState.getAndSet(checkNotNull(newState, "newState"));
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -70,7 +70,8 @@ public class StatsComponentImplBase extends StatsComponent {
   @SuppressWarnings("deprecation")
   public synchronized void setState(StatsCollectionState newState) {
     // Synchronized because needs to ensure that the call to resume/clear are happening atomically
-    // with the change of the state.
+    // with the change of the state. Use a different object to make sure that if this class needs
+    // synchronization in the future this logic does not contend with that.
     synchronized (setStateLock) {
       boolean stateChanged = currentState.set(newState);
       if (stateChanged) {

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -55,7 +55,7 @@ final class StatsManager {
 
   @Nullable
   ViewData getView(View.Name viewName) {
-    return measureToViewMap.getView(viewName, clock, state.getInternal());
+    return measureToViewMap.getView(viewName, clock, state.get());
   }
 
   Set<View> getExportedViews() {
@@ -65,13 +65,13 @@ final class StatsManager {
   void record(TagContext tags, MeasureMapInternal measurementValues) {
     // TODO(songya): consider exposing No-op MeasureMap and use it when stats state is DISABLED, so
     // that we don't need to create actual MeasureMapImpl.
-    if (state.getInternal() == StatsCollectionState.ENABLED) {
+    if (state.get() == StatsCollectionState.ENABLED) {
       queue.enqueue(new StatsEvent(this, tags, measurementValues));
     }
   }
 
   Collection<Metric> getMetrics() {
-    return measureToViewMap.getMetrics(clock, state.getInternal());
+    return measureToViewMap.getMetrics(clock, state.get());
   }
 
   void clearStats() {

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
@@ -50,7 +50,7 @@ public final class CurrentStatsStateTest {
   public void preventNull() {
     CurrentStatsState state = new CurrentStatsState();
     thrown.expect(NullPointerException.class);
-    thrown.expectMessage("state");
+    thrown.expectMessage("newState");
     state.set(null);
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/CurrentStatsStateTest.java
@@ -40,9 +40,9 @@ public final class CurrentStatsStateTest {
   public void setState() {
     CurrentStatsState state = new CurrentStatsState();
     assertThat(state.set(StatsCollectionState.DISABLED)).isTrue();
-    assertThat(state.getInternal()).isEqualTo(StatsCollectionState.DISABLED);
+    assertThat(state.get()).isEqualTo(StatsCollectionState.DISABLED);
     assertThat(state.set(StatsCollectionState.ENABLED)).isTrue();
-    assertThat(state.getInternal()).isEqualTo(StatsCollectionState.ENABLED);
+    assertThat(state.get()).isEqualTo(StatsCollectionState.ENABLED);
     assertThat(state.set(StatsCollectionState.ENABLED)).isFalse();
   }
 
@@ -52,14 +52,5 @@ public final class CurrentStatsStateTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("state");
     state.set(null);
-  }
-
-  @Test
-  public void preventSettingStateAfterReadingState() {
-    CurrentStatsState state = new CurrentStatsState();
-    state.get();
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("State was already read, cannot set state.");
-    state.set(StatsCollectionState.DISABLED);
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsComponentImplBaseTest.java
@@ -51,8 +51,9 @@ public final class StatsComponentImplBaseTest {
 
   @Test
   @SuppressWarnings("deprecation")
-  public void setState_Enabled() {
+  public void setState_ReEnabled() {
     statsComponent.setState(StatsCollectionState.DISABLED);
+    assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.DISABLED);
     statsComponent.setState(StatsCollectionState.ENABLED);
     assertThat(statsComponent.getState()).isEqualTo(StatsCollectionState.ENABLED);
   }
@@ -63,15 +64,5 @@ public final class StatsComponentImplBaseTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("newState");
     statsComponent.setState(null);
-  }
-
-  @Test
-  @SuppressWarnings("deprecation")
-  public void preventSettingStateAfterGettingState() {
-    statsComponent.setState(StatsCollectionState.DISABLED);
-    statsComponent.getState();
-    thrown.expect(IllegalStateException.class);
-    thrown.expectMessage("State was already read, cannot set state.");
-    statsComponent.setState(StatsCollectionState.ENABLED);
   }
 }


### PR DESCRIPTION
This is a behavior change compared to previous comments, but it should be fine because:
1) If previously a ENABLE value is cached and the current value is DISABLE the stats will not be recorded anyway, only downside is the extra overhead on the library that caches the value to call record.
2) If previously a DISABLE value is cached and the library makes a decision of not recording stats based on this, the result will be that even if the current state is change to ENABLE the stats will not be recorded which is consistent with the previous behavior. The only difference will be that the call to setState from DISABLE -> ENABLE will not throw an exception anymore.

Not throwing a runtime exception (IllegalStateException) is backwards compatible.

This simplifies the logic of the current state and removes a global serialization point from the stats library.

Also this PR fixes an undefined behavior when setState is called. Previously if 2 threads call setStats the current library state and the view manager state can be inconsistent.