### PR TITLE
Implement CurrentStatsState using atomic variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
   tracing.
 - Allow custom prefix for Stackdriver metrics in `StackdriverStatsConfiguration`.
 - Add support to handle the Tracestate in the SpanContext.
+- Remove global synchronization from the get current stats state.
 
 ## 0.15.0 - 2018-06-20
 - Expose the factory methods of MonitoredResource.

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -41,6 +41,11 @@
     <Class name="io.opencensus.contrib.appengine.standard.util.TraceIdProto$Builder"/>
     <Method name="maybeForceBuilderInitialization"/>
   </Match>
+  <Match>
+    <!-- Reason: The synchronization in the setState is for the side effects not for the state. -->
+    <Bug pattern="UG_SYNC_SET_UNSYNC_GET"/>
+    <Class name="io.opencensus.implcore.stats.StatsComponentImplBase"/>
+  </Match>
 
   <!-- Suppress some FindBugs warnings related to performance or robustness -->
   <!-- in test classes, where those issues are less important. -->

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsComponentImplBase.java
@@ -67,7 +67,7 @@ public class StatsComponentImplBase extends StatsComponent {
 
   @Override
   @SuppressWarnings("deprecation")
-  public void setState(StatsCollectionState newState) {
+  public synchronized void setState(StatsCollectionState newState) {
     boolean stateChanged = state.set(Preconditions.checkNotNull(newState, "newState"));
     if (stateChanged) {
       if (newState == StatsCollectionState.DISABLED) {


### PR DESCRIPTION
Alternative implementation of the https://github.com/census-instrumentation/opencensus-java/pull/1376 that does not change the API behavior.

Also this PR fixes an undefined behavior when setState is called. Previously if 2 threads call setStats the current library state and the view manager state can be inconsistent.