### PR TITLE
Remove guava dependency from the API artifact.

### DIFF
--- a/api/build.gradle
+++ b/api/build.gradle
@@ -1,8 +1,7 @@
 description = 'OpenCensus API'
 
 dependencies {
-    compile libraries.grpc_context,
-            libraries.guava
+    compile libraries.grpc_context
 
     compileOnly libraries.auto_value
 

--- a/api/src/main/java/io/opencensus/trace/SpanId.java
+++ b/api/src/main/java/io/opencensus/trace/SpanId.java
@@ -16,8 +16,8 @@
 
 package io.opencensus.trace;
 
-import com.google.common.io.BaseEncoding;
 import io.opencensus.internal.Utils;
+import io.opencensus.trace.internal.LowerCaseBase16Encoding;
 import java.util.Arrays;
 import java.util.Random;
 import javax.annotation.Nullable;
@@ -109,8 +109,7 @@ public final class SpanId implements Comparable<SpanId> {
   public static SpanId fromLowerBase16(CharSequence src) {
     Utils.checkArgument(
         src.length() == HEX_SIZE, "Invalid size: expected %s, got %s", HEX_SIZE, src.length());
-    byte[] bytes = BaseEncoding.base16().lowerCase().decode(src);
-    return new SpanId(bytes);
+    return new SpanId(LowerCaseBase16Encoding.getInstance().decodeToBytes(src));
   }
 
   /**
@@ -177,11 +176,7 @@ public final class SpanId implements Comparable<SpanId> {
    * @since 0.11
    */
   public String toLowerBase16() {
-    return toLowerBase16(bytes);
-  }
-
-  private static String toLowerBase16(byte[] bytes) {
-    return BaseEncoding.base16().lowerCase().encode(bytes);
+    return LowerCaseBase16Encoding.getInstance().encodeToString(bytes);
   }
 
   @Override
@@ -205,7 +200,7 @@ public final class SpanId implements Comparable<SpanId> {
 
   @Override
   public String toString() {
-    return "SpanId{spanId=" + toLowerBase16(bytes) + "}";
+    return "SpanId{spanId=" + toLowerBase16() + "}";
   }
 
   @Override

--- a/api/src/main/java/io/opencensus/trace/SpanId.java
+++ b/api/src/main/java/io/opencensus/trace/SpanId.java
@@ -109,7 +109,7 @@ public final class SpanId implements Comparable<SpanId> {
   public static SpanId fromLowerBase16(CharSequence src) {
     Utils.checkArgument(
         src.length() == HEX_SIZE, "Invalid size: expected %s, got %s", HEX_SIZE, src.length());
-    return new SpanId(LowerCaseBase16Encoding.getInstance().decodeToBytes(src));
+    return new SpanId(LowerCaseBase16Encoding.decodeToBytes(src));
   }
 
   /**
@@ -176,7 +176,7 @@ public final class SpanId implements Comparable<SpanId> {
    * @since 0.11
    */
   public String toLowerBase16() {
-    return LowerCaseBase16Encoding.getInstance().encodeToString(bytes);
+    return LowerCaseBase16Encoding.encodeToString(bytes);
   }
 
   @Override

--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -110,7 +110,7 @@ public final class TraceId implements Comparable<TraceId> {
   public static TraceId fromLowerBase16(CharSequence src) {
     Utils.checkArgument(
         src.length() == HEX_SIZE, "Invalid size: expected %s, got %s", HEX_SIZE, src.length());
-    return new TraceId(LowerCaseBase16Encoding.getInstance().decodeToBytes(src));
+    return new TraceId(LowerCaseBase16Encoding.decodeToBytes(src));
   }
 
   /**
@@ -177,7 +177,7 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.11
    */
   public String toLowerBase16() {
-    return LowerCaseBase16Encoding.getInstance().encodeToString(bytes);
+    return LowerCaseBase16Encoding.encodeToString(bytes);
   }
 
   /**

--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -16,9 +16,9 @@
 
 package io.opencensus.trace;
 
-import com.google.common.io.BaseEncoding;
 import io.opencensus.common.Internal;
 import io.opencensus.internal.Utils;
+import io.opencensus.trace.internal.LowerCaseBase16Encoding;
 import java.util.Arrays;
 import java.util.Random;
 import javax.annotation.Nullable;
@@ -110,8 +110,7 @@ public final class TraceId implements Comparable<TraceId> {
   public static TraceId fromLowerBase16(CharSequence src) {
     Utils.checkArgument(
         src.length() == HEX_SIZE, "Invalid size: expected %s, got %s", HEX_SIZE, src.length());
-    byte[] bytes = BaseEncoding.base16().lowerCase().decode(src);
-    return new TraceId(bytes);
+    return new TraceId(LowerCaseBase16Encoding.getInstance().decodeToBytes(src));
   }
 
   /**
@@ -178,11 +177,7 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.11
    */
   public String toLowerBase16() {
-    return toLowerBase16(bytes);
-  }
-
-  private static String toLowerBase16(byte[] bytes) {
-    return BaseEncoding.base16().lowerCase().encode(bytes);
+    return LowerCaseBase16Encoding.getInstance().encodeToString(bytes);
   }
 
   /**
@@ -227,7 +222,7 @@ public final class TraceId implements Comparable<TraceId> {
 
   @Override
   public String toString() {
-    return "TraceId{traceId=" + toLowerBase16(bytes) + "}";
+    return "TraceId{traceId=" + toLowerBase16() + "}";
   }
 
   @Override

--- a/api/src/main/java/io/opencensus/trace/internal/LowerCaseBase16Encoding.java
+++ b/api/src/main/java/io/opencensus/trace/internal/LowerCaseBase16Encoding.java
@@ -23,23 +23,28 @@ import java.util.Arrays;
 /** Internal copy of the Guava implementation of the {@code BaseEncoding.base16().lowerCase()}. */
 @Internal
 public final class LowerCaseBase16Encoding {
-  private static final LowerCaseBase16Encoding INSTANCE = new LowerCaseBase16Encoding();
   private static final String ALPHABET = "0123456789abcdef";
   private static final int ASCII_CHARACTERS = 128;
-  private final char[] encoding = new char[512];
-  private final byte[] decoding = new byte[ASCII_CHARACTERS];
+  private static final char[] ENCODING = buildEncodingArray();
+  private static final byte[] DECODING = buildDecodingArray();
 
-  private LowerCaseBase16Encoding() {
+  private static char[] buildEncodingArray() {
+    char[] encoding = new char[512];
     for (int i = 0; i < 256; ++i) {
       encoding[i] = ALPHABET.charAt(i >>> 4);
       encoding[i | 0x100] = ALPHABET.charAt(i & 0xF);
     }
+    return encoding;
+  }
 
+  private static byte[] buildDecodingArray() {
+    byte[] decoding = new byte[ASCII_CHARACTERS];
     Arrays.fill(decoding, (byte) -1);
     for (int i = 0; i < ALPHABET.length(); i++) {
       char c = ALPHABET.charAt(i);
       decoding[c] = (byte) i;
     }
+    return decoding;
   }
 
   /**
@@ -48,12 +53,12 @@ public final class LowerCaseBase16Encoding {
    * @param bytes byte array to be encoded.
    * @return the encoded {@code String}.
    */
-  public String encodeToString(byte[] bytes) {
+  public static String encodeToString(byte[] bytes) {
     StringBuilder stringBuilder = new StringBuilder(bytes.length * 2);
     for (byte byteVal : bytes) {
       int b = byteVal & 0xFF;
-      stringBuilder.append(encoding[b]);
-      stringBuilder.append(encoding[b | 0x100]);
+      stringBuilder.append(ENCODING[b]);
+      stringBuilder.append(ENCODING[b | 0x100]);
     }
     return stringBuilder.toString();
   }
@@ -66,7 +71,7 @@ public final class LowerCaseBase16Encoding {
    * @throws IllegalArgumentException if the input is not a valid encoded string according to this
    *     encoding.
    */
-  public byte[] decodeToBytes(CharSequence chars) {
+  public static byte[] decodeToBytes(CharSequence chars) {
     Utils.checkArgument(chars.length() % 2 == 0, "Invalid input length " + chars.length());
     int bytesWritten = 0;
     byte[] bytes = new byte[chars.length() / 2];
@@ -76,14 +81,13 @@ public final class LowerCaseBase16Encoding {
     return bytes;
   }
 
-  private byte decodeByte(char hi, char lo) {
-    Utils.checkArgument(lo < ASCII_CHARACTERS && decoding[lo] != -1, "Invalid character " + lo);
-    Utils.checkArgument(hi < ASCII_CHARACTERS && decoding[hi] != -1, "Invalid character " + hi);
-    int decoded = decoding[hi] << 4 | decoding[lo];
+  private static byte decodeByte(char hi, char lo) {
+    Utils.checkArgument(lo < ASCII_CHARACTERS && DECODING[lo] != -1, "Invalid character " + lo);
+    Utils.checkArgument(hi < ASCII_CHARACTERS && DECODING[hi] != -1, "Invalid character " + hi);
+    int decoded = DECODING[hi] << 4 | DECODING[lo];
     return (byte) decoded;
   }
 
-  public static LowerCaseBase16Encoding getInstance() {
-    return INSTANCE;
-  }
+  // Private constructor to disallow instances.
+  private LowerCaseBase16Encoding() {}
 }

--- a/api/src/main/java/io/opencensus/trace/internal/LowerCaseBase16Encoding.java
+++ b/api/src/main/java/io/opencensus/trace/internal/LowerCaseBase16Encoding.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.internal;
+
+import io.opencensus.common.Internal;
+import io.opencensus.internal.Utils;
+import java.util.Arrays;
+
+/** Internal copy of the Guava implementation of the {@code BaseEncoding.base16().lowerCase()}. */
+@Internal
+public final class LowerCaseBase16Encoding {
+  private static final LowerCaseBase16Encoding INSTANCE = new LowerCaseBase16Encoding();
+  private static final String ALPHABET = "0123456789abcdef";
+  private static final int ASCII_CHARACTERS = 128;
+  private final char[] encoding = new char[512];
+  private final byte[] decoding = new byte[ASCII_CHARACTERS];
+
+  private LowerCaseBase16Encoding() {
+    for (int i = 0; i < 256; ++i) {
+      encoding[i] = ALPHABET.charAt(i >>> 4);
+      encoding[i | 0x100] = ALPHABET.charAt(i & 0xF);
+    }
+
+    Arrays.fill(decoding, (byte) -1);
+    for (int i = 0; i < ALPHABET.length(); i++) {
+      char c = ALPHABET.charAt(i);
+      decoding[c] = (byte) i;
+    }
+  }
+
+  /**
+   * Encodes the specified byte array, and returns the encoded {@code String}.
+   *
+   * @param bytes byte array to be encoded.
+   * @return the encoded {@code String}.
+   */
+  public String encodeToString(byte[] bytes) {
+    StringBuilder stringBuilder = new StringBuilder(bytes.length * 2);
+    for (byte byteVal : bytes) {
+      int b = byteVal & 0xFF;
+      stringBuilder.append(encoding[b]);
+      stringBuilder.append(encoding[b | 0x100]);
+    }
+    return stringBuilder.toString();
+  }
+
+  /**
+   * Decodes the specified character sequence, and returns the resulting {@code byte[]}.
+   *
+   * @param chars the character sequence to be decoded.
+   * @return the resulting {@code byte[]}
+   * @throws IllegalArgumentException if the input is not a valid encoded string according to this
+   *     encoding.
+   */
+  public byte[] decodeToBytes(CharSequence chars) {
+    Utils.checkArgument(chars.length() % 2 == 0, "Invalid input length " + chars.length());
+    int bytesWritten = 0;
+    byte[] bytes = new byte[chars.length() / 2];
+    for (int i = 0; i < chars.length(); i += 2) {
+      bytes[bytesWritten++] = decodeByte(chars.charAt(i), chars.charAt(i + 1));
+    }
+    return bytes;
+  }
+
+  private byte decodeByte(char hi, char lo) {
+    Utils.checkArgument(lo < ASCII_CHARACTERS && decoding[lo] != -1, "Invalid character " + lo);
+    Utils.checkArgument(hi < ASCII_CHARACTERS && decoding[hi] != -1, "Invalid character " + hi);
+    int decoded = decoding[hi] << 4 | decoding[lo];
+    return (byte) decoded;
+  }
+
+  public static LowerCaseBase16Encoding getInstance() {
+    return INSTANCE;
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/internal/LowerCaseBase16EncodingTest.java
+++ b/api/src/test/java/io/opencensus/trace/internal/LowerCaseBase16EncodingTest.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.internal;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.nio.charset.Charset;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link LowerCaseBase16Encoding}. */
+@RunWith(JUnit4.class)
+public class LowerCaseBase16EncodingTest {
+  private static final Charset CHARSET = Charset.forName("UTF-8");
+
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void valid_EncodeDecode() {
+    testEncoding("", "");
+    testEncoding("f", "66");
+    testEncoding("fo", "666f");
+    testEncoding("foo", "666f6f");
+    testEncoding("foob", "666f6f62");
+    testEncoding("fooba", "666f6f6261");
+    testEncoding("foobar", "666f6f626172");
+  }
+
+  @Test
+  public void invalidDecodings_UnrecongnizedCharacters() {
+    // These contain bytes not in the decoding.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid character g");
+    LowerCaseBase16Encoding.getInstance().decodeToBytes("efhg");
+  }
+
+  @Test
+  public void invalidDecodings_InvalidInputLength() {
+    // Valid base16 strings always have an even length.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid input length 3");
+    LowerCaseBase16Encoding.getInstance().decodeToBytes("abc");
+  }
+
+  @Test
+  public void invalidDecodings_InvalidInputLengthAndCharacter() {
+    // These have a combination of invalid length and unrecognized characters.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Invalid input length 1");
+    LowerCaseBase16Encoding.getInstance().decodeToBytes("?");
+  }
+
+  private static void testEncoding(String decoded, String encoded) {
+    testEncodes(decoded, encoded);
+    testDecodes(encoded, decoded);
+  }
+
+  private static void testEncodes(String decoded, String encoded) {
+    assertThat(LowerCaseBase16Encoding.getInstance().encodeToString(decoded.getBytes(CHARSET)))
+        .isEqualTo(encoded);
+  }
+
+  private static void testDecodes(String encoded, String decoded) {
+    assertThat(LowerCaseBase16Encoding.getInstance().decodeToBytes(encoded))
+        .isEqualTo(decoded.getBytes(CHARSET));
+  }
+}

--- a/api/src/test/java/io/opencensus/trace/internal/LowerCaseBase16EncodingTest.java
+++ b/api/src/test/java/io/opencensus/trace/internal/LowerCaseBase16EncodingTest.java
@@ -48,7 +48,7 @@ public class LowerCaseBase16EncodingTest {
     // These contain bytes not in the decoding.
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid character g");
-    LowerCaseBase16Encoding.getInstance().decodeToBytes("efhg");
+    LowerCaseBase16Encoding.decodeToBytes("efhg");
   }
 
   @Test
@@ -56,7 +56,7 @@ public class LowerCaseBase16EncodingTest {
     // Valid base16 strings always have an even length.
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid input length 3");
-    LowerCaseBase16Encoding.getInstance().decodeToBytes("abc");
+    LowerCaseBase16Encoding.decodeToBytes("abc");
   }
 
   @Test
@@ -64,7 +64,7 @@ public class LowerCaseBase16EncodingTest {
     // These have a combination of invalid length and unrecognized characters.
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Invalid input length 1");
-    LowerCaseBase16Encoding.getInstance().decodeToBytes("?");
+    LowerCaseBase16Encoding.decodeToBytes("?");
   }
 
   private static void testEncoding(String decoded, String encoded) {
@@ -73,12 +73,11 @@ public class LowerCaseBase16EncodingTest {
   }
 
   private static void testEncodes(String decoded, String encoded) {
-    assertThat(LowerCaseBase16Encoding.getInstance().encodeToString(decoded.getBytes(CHARSET)))
+    assertThat(LowerCaseBase16Encoding.encodeToString(decoded.getBytes(CHARSET)))
         .isEqualTo(encoded);
   }
 
   private static void testDecodes(String encoded, String decoded) {
-    assertThat(LowerCaseBase16Encoding.getInstance().decodeToBytes(encoded))
-        .isEqualTo(decoded.getBytes(CHARSET));
+    assertThat(LowerCaseBase16Encoding.decodeToBytes(encoded)).isEqualTo(decoded.getBytes(CHARSET));
   }
 }

--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -54,9 +54,6 @@ General guidelines on imports:
     <allow pkg="io.opencensus.internal"/>
     <allow pkg="io.opencensus.trace"/>
 
-    <!-- TODO(#1081): Remove this dependency on Guava. -->
-    <allow class="com.google.common.io.BaseEncoding"/>
-
     <!-- These dependencies on impl/implcore are only needed by -->
     <!-- io.opencensus.trace.TraceComponentImpl and io.opencensus.trace.TraceComponentImplLite, -->
     <!-- which are deprecated. -->

--- a/contrib/grpc_metrics/build.gradle
+++ b/contrib/grpc_metrics/build.gradle
@@ -8,7 +8,8 @@ apply plugin: 'java'
 }
 
 dependencies {
-    compile project(':opencensus-api')
+    compile project(':opencensus-api'),
+            libraries.guava
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"

--- a/exporters/stats/prometheus/build.gradle
+++ b/exporters/stats/prometheus/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly libraries.auto_value
 
     compile project(':opencensus-api'),
+            libraries.guava,
             libraries.prometheus_simpleclient
 
     testCompile project(':opencensus-api')

--- a/exporters/stats/signalfx/build.gradle
+++ b/exporters/stats/signalfx/build.gradle
@@ -8,7 +8,8 @@ description = 'OpenCensus SignalFx Stats Exporter'
 dependencies {
     compileOnly libraries.auto_value
 
-    compile project(':opencensus-api')
+    compile project(':opencensus-api'),
+            libraries.guava
 
     compile (libraries.signalfx_java) {
         // Prefer library version.

--- a/exporters/stats/stackdriver/build.gradle
+++ b/exporters/stats/stackdriver/build.gradle
@@ -10,7 +10,8 @@ dependencies {
 
     compile project(':opencensus-api'),
             project(':opencensus-contrib-monitored-resource-util'),
-            libraries.google_auth
+            libraries.google_auth,
+            libraries.guava
 
     compile (libraries.google_cloud_monitoring) {
         // Prefer library version.

--- a/exporters/trace/instana/build.gradle
+++ b/exporters/trace/instana/build.gradle
@@ -6,7 +6,8 @@ description = 'OpenCensus Trace Instana Exporter'
 }
 
 dependencies {
-    compile project(':opencensus-api')
+    compile project(':opencensus-api'),
+            libraries.guava
 
     testCompile project(':opencensus-api')
 

--- a/exporters/trace/jaeger/build.gradle
+++ b/exporters/trace/jaeger/build.gradle
@@ -17,7 +17,8 @@ sourceSets {
 }
 
 dependencies {
-    compile project(':opencensus-api')
+    compile project(':opencensus-api'),
+            libraries.guava
 
     compile(libraries.jaeger_reporter) {
         // Prefer library version.

--- a/exporters/trace/stackdriver/build.gradle
+++ b/exporters/trace/stackdriver/build.gradle
@@ -10,7 +10,8 @@ dependencies {
 
     compile project(':opencensus-api'),
             project(':opencensus-contrib-monitored-resource-util'),
-            libraries.google_auth
+            libraries.google_auth,
+            libraries.guava
 
     compile (libraries.google_cloud_trace) {
         // Prefer library version.

--- a/exporters/trace/zipkin/build.gradle
+++ b/exporters/trace/zipkin/build.gradle
@@ -7,6 +7,7 @@ description = 'OpenCensus Trace Zipkin Exporter'
 
 dependencies {
     compile project(':opencensus-api'),
+            libraries.guava,
             libraries.zipkin_reporter,
             libraries.zipkin_urlconnection
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -1,7 +1,8 @@
 description = 'OpenCensus Testing'
 
 dependencies {
-    compile project(':opencensus-api')
+    compile project(':opencensus-api'),
+            libraries.guava
 
     testCompile project(':opencensus-api')
 


### PR DESCRIPTION
Copied the BaseEncoding class for base16 from Guava (including tests).

/cc @saturnism

EDIT: fixes https://github.com/census-instrumentation/opencensus-java/issues/1081