### PR TITLE
Avoid doing string formatting when calling checkArgument. (#1394)

### DIFF
--- a/api/src/main/java/io/opencensus/internal/Utils.java
+++ b/api/src/main/java/io/opencensus/internal/Utils.java
@@ -16,7 +16,7 @@
 
 package io.opencensus.internal;
 
-import javax.annotation.Nullable;
+import java.util.List;
 
 /*>>>
 import org.checkerframework.checker.nullness.qual.NonNull;
@@ -32,11 +32,38 @@ public final class Utils {
    * {@code Preconditions.checkArgument(boolean, Object)} from Guava.
    *
    * @param isValid whether the argument check passed.
-   * @param message the message to use for the exception.
+   * @param errorMessage the message to use for the exception. Will be converted to a string using
+   *     {@link String#valueOf(Object)}.
    */
-  public static void checkArgument(boolean isValid, String message) {
+  public static void checkArgument(
+      boolean isValid, @javax.annotation.Nullable Object errorMessage) {
     if (!isValid) {
-      throw new IllegalArgumentException(message);
+      throw new IllegalArgumentException(String.valueOf(errorMessage));
+    }
+  }
+
+  /**
+   * Throws an {@link IllegalArgumentException} if the argument is false. This method is similar to
+   * {@code Preconditions.checkArgument(boolean, Object)} from Guava.
+   *
+   * @param expression a boolean expression
+   * @param errorMessageTemplate a template for the exception message should the check fail. The
+   *     message is formed by replacing each {@code %s} placeholder in the template with an
+   *     argument. These are matched by position - the first {@code %s} gets {@code
+   *     errorMessageArgs[0]}, etc. Unmatched arguments will be appended to the formatted message in
+   *     square braces. Unmatched placeholders will be left as-is.
+   * @param errorMessageArgs the arguments to be substituted into the message template. Arguments
+   *     are converted to strings using {@link String#valueOf(Object)}.
+   * @throws IllegalArgumentException if {@code expression} is false
+   * @throws NullPointerException if the check fails and either {@code errorMessageTemplate} or
+   *     {@code errorMessageArgs} is null (don't let this happen)
+   */
+  public static void checkArgument(
+      boolean expression,
+      String errorMessageTemplate,
+      @javax.annotation.Nullable Object... errorMessageArgs) {
+    if (!expression) {
+      throw new IllegalArgumentException(format(errorMessageTemplate, errorMessageArgs));
     }
   }
 
@@ -45,11 +72,12 @@ public final class Utils {
    * {@code Preconditions.checkState(boolean, Object)} from Guava.
    *
    * @param isValid whether the state check passed.
-   * @param message the message to use for the exception.
+   * @param errorMessage the message to use for the exception. Will be converted to a string using
+   *     {@link String#valueOf(Object)}.
    */
-  public static void checkState(boolean isValid, String message) {
+  public static void checkState(boolean isValid, @javax.annotation.Nullable Object errorMessage) {
     if (!isValid) {
-      throw new IllegalStateException(message);
+      throw new IllegalStateException(String.valueOf(errorMessage));
     }
   }
 
@@ -76,21 +104,88 @@ public final class Utils {
    * Preconditions.checkNotNull(Object, Object)} from Guava.
    *
    * @param arg the argument to check for null.
-   * @param message the message to use for the exception.
+   * @param errorMessage the message to use for the exception. Will be converted to a string using
+   *     {@link String#valueOf(Object)}.
    * @return the argument, if it passes the null check.
    */
-  public static <T /*>>> extends @NonNull Object*/> T checkNotNull(T arg, String message) {
+  public static <T /*>>> extends @NonNull Object*/> T checkNotNull(
+      T arg, @javax.annotation.Nullable Object errorMessage) {
     if (arg == null) {
-      throw new NullPointerException(message);
+      throw new NullPointerException(String.valueOf(errorMessage));
     }
     return arg;
+  }
+
+  /**
+   * Throws a {@link NullPointerException} if any of the list elements is null.
+   *
+   * @param list the argument list to check for null.
+   * @param errorMessage the message to use for the exception. Will be converted to a string using
+   *     {@link String#valueOf(Object)}.
+   */
+  public static <T /*>>> extends @NonNull Object*/> void checkListElementNotNull(
+      List<T> list, @javax.annotation.Nullable Object errorMessage) {
+    for (T element : list) {
+      if (element == null) {
+        throw new NullPointerException(String.valueOf(errorMessage));
+      }
+    }
   }
 
   /**
    * Compares two Objects for equality. This functionality is provided by {@code
    * Objects.equal(Object, Object)} in Java 7.
    */
-  public static boolean equalsObjects(@Nullable Object x, @Nullable Object y) {
+  public static boolean equalsObjects(
+      @javax.annotation.Nullable Object x, @javax.annotation.Nullable Object y) {
     return x == null ? y == null : x.equals(y);
+  }
+
+  /**
+   * Substitutes each {@code %s} in {@code template} with an argument. These are matched by
+   * position: the first {@code %s} gets {@code args[0]}, etc. If there are more arguments than
+   * placeholders, the unmatched arguments will be appended to the end of the formatted message in
+   * square braces.
+   *
+   * <p>Copied from {@code Preconditions.format(String, Object...)} from Guava
+   *
+   * @param template a non-null string containing 0 or more {@code %s} placeholders.
+   * @param args the arguments to be substituted into the message template. Arguments are converted
+   *     to strings using {@link String#valueOf(Object)}. Arguments can be null.
+   */
+  // Note that this is somewhat-improperly used from Verify.java as well.
+  private static String format(String template, @javax.annotation.Nullable Object... args) {
+    // If no arguments return the template.
+    if (args == null) {
+      return template;
+    }
+
+    // start substituting the arguments into the '%s' placeholders
+    StringBuilder builder = new StringBuilder(template.length() + 16 * args.length);
+    int templateStart = 0;
+    int i = 0;
+    while (i < args.length) {
+      int placeholderStart = template.indexOf("%s", templateStart);
+      if (placeholderStart == -1) {
+        break;
+      }
+      builder.append(template, templateStart, placeholderStart);
+      builder.append(args[i++]);
+      templateStart = placeholderStart + 2;
+    }
+    builder.append(template, templateStart, template.length());
+
+    // if we run out of placeholders, append the extra args in square braces
+    if (i < args.length) {
+      builder.append(" [");
+      builder.append(args[i++]);
+      while (i < args.length) {
+        builder.append(", ");
+        builder.append(args[i++]);
+      }
+      builder.append(']');
+    }
+
+    return builder.toString();
   }
 }

--- a/api/src/main/java/io/opencensus/stats/Measure.java
+++ b/api/src/main/java/io/opencensus/stats/Measure.java
@@ -30,8 +30,11 @@ import javax.annotation.concurrent.Immutable;
  */
 @Immutable
 public abstract class Measure {
-
   @DefaultVisibilityForTesting static final int NAME_MAX_LENGTH = 255;
+  private static final String ERROR_MESSAGE_INVALID_NAME =
+      "Name should be a ASCII string with a length no greater than "
+          + NAME_MAX_LENGTH
+          + " characters.";
 
   /**
    * Applies the given match function to the underlying data type.
@@ -105,9 +108,7 @@ public abstract class Measure {
     public static MeasureDouble create(String name, String description, String unit) {
       Utils.checkArgument(
           StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
-          "Name should be a ASCII string with a length no greater than "
-              + NAME_MAX_LENGTH
-              + " characters.");
+          ERROR_MESSAGE_INVALID_NAME);
       return new AutoValue_Measure_MeasureDouble(name, description, unit);
     }
 
@@ -152,9 +153,7 @@ public abstract class Measure {
     public static MeasureLong create(String name, String description, String unit) {
       Utils.checkArgument(
           StringUtils.isPrintableString(name) && name.length() <= NAME_MAX_LENGTH,
-          "Name should be a ASCII string with a length no greater than "
-              + NAME_MAX_LENGTH
-              + " characters.");
+          ERROR_MESSAGE_INVALID_NAME);
       return new AutoValue_Measure_MeasureLong(name, description, unit);
     }
 

--- a/api/src/main/java/io/opencensus/tags/TagKey.java
+++ b/api/src/main/java/io/opencensus/tags/TagKey.java
@@ -60,7 +60,7 @@ public abstract class TagKey {
    * @since 0.8
    */
   public static TagKey create(String name) {
-    Utils.checkArgument(isValid(name), "Invalid TagKey name: " + name);
+    Utils.checkArgument(isValid(name), "Invalid TagKey name: %s", name);
     return new AutoValue_TagKey(name);
   }
 

--- a/api/src/main/java/io/opencensus/tags/TagValue.java
+++ b/api/src/main/java/io/opencensus/tags/TagValue.java
@@ -55,7 +55,7 @@ public abstract class TagValue {
    * @since 0.8
    */
   public static TagValue create(String value) {
-    Utils.checkArgument(isValid(value), "Invalid TagValue: " + value);
+    Utils.checkArgument(isValid(value), "Invalid TagValue: %s", value);
     return new AutoValue_TagValue(value);
   }
 

--- a/api/src/main/java/io/opencensus/trace/SpanId.java
+++ b/api/src/main/java/io/opencensus/trace/SpanId.java
@@ -38,6 +38,8 @@ public final class SpanId implements Comparable<SpanId> {
    */
   public static final int SIZE = 8;
 
+  private static final int HEX_SIZE = 2 * SIZE;
+
   /**
    * The invalid {@code SpanId}. All bytes are 0.
    *
@@ -70,8 +72,7 @@ public final class SpanId implements Comparable<SpanId> {
   public static SpanId fromBytes(byte[] buffer) {
     Utils.checkNotNull(buffer, "buffer");
     Utils.checkArgument(
-        buffer.length == SIZE,
-        String.format("Invalid size: expected %s, got %s", SIZE, buffer.length));
+        buffer.length == SIZE, "Invalid size: expected %s, got %s", SIZE, buffer.length);
     byte[] bytesCopied = Arrays.copyOf(buffer, SIZE);
     return new SpanId(bytesCopied);
   }
@@ -107,8 +108,7 @@ public final class SpanId implements Comparable<SpanId> {
    */
   public static SpanId fromLowerBase16(CharSequence src) {
     Utils.checkArgument(
-        src.length() == 2 * SIZE,
-        String.format("Invalid size: expected %s, got %s", 2 * SIZE, src.length()));
+        src.length() == HEX_SIZE, "Invalid size: expected %s, got %s", HEX_SIZE, src.length());
     byte[] bytes = BaseEncoding.base16().lowerCase().decode(src);
     return new SpanId(bytes);
   }

--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -39,6 +39,8 @@ public final class TraceId implements Comparable<TraceId> {
    */
   public static final int SIZE = 16;
 
+  private static final int HEX_SIZE = 32;
+
   /**
    * The invalid {@code TraceId}. All bytes are '\0'.
    *
@@ -71,8 +73,7 @@ public final class TraceId implements Comparable<TraceId> {
   public static TraceId fromBytes(byte[] buffer) {
     Utils.checkNotNull(buffer, "buffer");
     Utils.checkArgument(
-        buffer.length == SIZE,
-        String.format("Invalid size: expected %s, got %s", SIZE, buffer.length));
+        buffer.length == SIZE, "Invalid size: expected %s, got %s", SIZE, buffer.length);
     byte[] bytesCopied = Arrays.copyOf(buffer, SIZE);
     return new TraceId(bytesCopied);
   }
@@ -108,8 +109,7 @@ public final class TraceId implements Comparable<TraceId> {
    */
   public static TraceId fromLowerBase16(CharSequence src) {
     Utils.checkArgument(
-        src.length() == 2 * SIZE,
-        String.format("Invalid size: expected %s, got %s", 2 * SIZE, src.length()));
+        src.length() == HEX_SIZE, "Invalid size: expected %s, got %s", HEX_SIZE, src.length());
     byte[] bytes = BaseEncoding.base16().lowerCase().decode(src);
     return new TraceId(bytes);
   }

--- a/api/src/main/java/io/opencensus/trace/TraceOptions.java
+++ b/api/src/main/java/io/opencensus/trace/TraceOptions.java
@@ -76,8 +76,7 @@ public final class TraceOptions {
   public static TraceOptions fromBytes(byte[] buffer) {
     Utils.checkNotNull(buffer, "buffer");
     Utils.checkArgument(
-        buffer.length == SIZE,
-        String.format("Invalid size: expected %s, got %s", SIZE, buffer.length));
+        buffer.length == SIZE, "Invalid size: expected %s, got %s", SIZE, buffer.length);
     return new TraceOptions(buffer[0]);
   }
 

--- a/api/src/main/java/io/opencensus/trace/Tracestate.java
+++ b/api/src/main/java/io/opencensus/trace/Tracestate.java
@@ -1,0 +1,273 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace;
+
+import com.google.auto.value.AutoValue;
+import io.opencensus.common.ExperimentalApi;
+import io.opencensus.internal.Utils;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Carries tracing-system specific context in a list of key-value pairs. TraceState allows different
+ * vendors propagate additional information and inter-operate with their legacy Id formats.
+ *
+ * <p>Implementation is optimized for a small list of key-value pairs.
+ *
+ * <p>Key is opaque string up to 256 characters printable. It MUST begin with a lowercase letter,
+ * and can only contain lowercase letters a-z, digits 0-9, underscores _, dashes -, asterisks *, and
+ * forward slashes /.
+ *
+ * <p>Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the
+ * range 0x20 to 0x7E) except comma , and =.
+ *
+ * @since 0.16
+ */
+@Immutable
+@AutoValue
+@ExperimentalApi
+public abstract class Tracestate {
+  private static final int KEY_MAX_SIZE = 256;
+  private static final int VALUE_MAX_SIZE = 256;
+  private static final int MAX_KEY_VALUE_PAIRS = 32;
+
+  /**
+   * Returns the value to which the specified key is mapped, or null if this map contains no mapping
+   * for the key.
+   *
+   * @param key with which the specified value is to be associated
+   * @return the value to which the specified key is mapped, or null if this map contains no mapping
+   *     for the key.
+   * @since 0.16
+   */
+  @javax.annotation.Nullable
+  public String get(String key) {
+    for (Entry entry : getEntries()) {
+      if (entry.getKey().equals(key)) {
+        return entry.getValue();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns a {@link List} view of the mappings contained in this {@code TraceState}.
+   *
+   * @return a {@link List} view of the mappings contained in this {@code TraceState}.
+   * @since 0.16
+   */
+  public abstract List<Entry> getEntries();
+
+  /**
+   * Returns a {@code Builder} based on an empty {@code Tracestate}.
+   *
+   * @return a {@code Builder} based on an empty {@code Tracestate}.
+   * @since 0.16
+   */
+  public static Builder builder() {
+    return new Builder(Builder.EMPTY);
+  }
+
+  /**
+   * Returns a {@code Builder} based on this {@code Tracestate}.
+   *
+   * @return a {@code Builder} based on this {@code Tracestate}.
+   * @since 0.16
+   */
+  public Builder toBuilder() {
+    return new Builder(this);
+  }
+
+  /**
+   * Builder class for {@link MessageEvent}.
+   *
+   * @since 0.16
+   */
+  @ExperimentalApi
+  public static final class Builder {
+    private final Tracestate parent;
+    @javax.annotation.Nullable private ArrayList<Entry> entries;
+
+    // Needs to be in this class to avoid initialization deadlock because super class depends on
+    // subclass (the auto-value generate class).
+    private static final Tracestate EMPTY = create(Collections.<Entry>emptyList());
+
+    private Builder(Tracestate parent) {
+      Utils.checkNotNull(parent, "parent");
+      this.parent = parent;
+      this.entries = null;
+    }
+
+    /**
+     * Adds or updates the {@code Entry} that has the given {@code key} if it is present. The new
+     * {@code Entry} will always be added in the front of the list of entries.
+     *
+     * @param key the key for the {@code Entry} to be added.
+     * @param value the value for the {@code Entry} to be added.
+     * @return this.
+     * @since 0.16
+     */
+    @SuppressWarnings("nullness")
+    public Builder set(String key, String value) {
+      // Initially create the Entry to validate input.
+      Entry entry = Entry.create(key, value);
+      if (entries == null) {
+        // Copy entries from the parent.
+        entries = new ArrayList<Entry>(parent.getEntries());
+      }
+      for (int i = 0; i < entries.size(); i++) {
+        if (entries.get(i).getKey().equals(entry.getKey())) {
+          entries.remove(i);
+          // Exit now because the entries list cannot contain duplicates.
+          break;
+        }
+      }
+      // Inserts the element at the front of this list.
+      entries.add(0, entry);
+      return this;
+    }
+
+    /**
+     * Removes the {@code Entry} that has the given {@code key} if it is present.
+     *
+     * @param key the key for the {@code Entry} to be removed.
+     * @return this.
+     * @since 0.16
+     */
+    @SuppressWarnings("nullness")
+    public Builder remove(String key) {
+      Utils.checkNotNull(key, "key");
+      if (entries == null) {
+        // Copy entries from the parent.
+        entries = new ArrayList<Entry>(parent.getEntries());
+      }
+      for (int i = 0; i < entries.size(); i++) {
+        if (entries.get(i).getKey().equals(key)) {
+          entries.remove(i);
+          // Exit now because the entries list cannot contain duplicates.
+          break;
+        }
+      }
+      return this;
+    }
+
+    /**
+     * Builds a TraceState by adding the entries to the parent in front of the key-value pairs list
+     * and removing duplicate entries.
+     *
+     * @return a TraceState with the new entries.
+     * @since 0.16
+     */
+    public Tracestate build() {
+      if (entries == null) {
+        return parent;
+      }
+      return Tracestate.create(entries);
+    }
+  }
+
+  /**
+   * Immutable key-value pair for {@code Tracestate}.
+   *
+   * @since 0.16
+   */
+  @Immutable
+  @AutoValue
+  @ExperimentalApi
+  public abstract static class Entry {
+    /**
+     * Creates a new {@code Entry} for the {@code Tracestate}.
+     *
+     * @param key the Entry's key.
+     * @param value the Entry's value.
+     * @since 0.16
+     */
+    public static Entry create(String key, String value) {
+      Utils.checkNotNull(key, "key");
+      Utils.checkNotNull(value, "value");
+      Utils.checkArgument(validateKey(key), "Invalid key %s", key);
+      Utils.checkArgument(validateValue(value), "Invalid value %s", value);
+      return new AutoValue_Tracestate_Entry(key, value);
+    }
+
+    /**
+     * Returns the key {@code String}.
+     *
+     * @return the key {@code String}.
+     * @since 0.16
+     */
+    public abstract String getKey();
+
+    /**
+     * Returns the value {@code String}.
+     *
+     * @return the value {@code String}.
+     * @since 0.16
+     */
+    public abstract String getValue();
+
+    Entry() {}
+  }
+
+  // Key is opaque string up to 256 characters printable. It MUST begin with a lowercase letter, and
+  // can only contain lowercase letters a-z, digits 0-9, underscores _, dashes -, asterisks *, and
+  // forward slashes /.
+  private static boolean validateKey(String key) {
+    if (key.length() > KEY_MAX_SIZE
+        || key.isEmpty()
+        || key.charAt(0) < 'a'
+        || key.charAt(0) > 'z') {
+      return false;
+    }
+    for (int i = 1; i < key.length(); i++) {
+      char c = key.charAt(i);
+      if (!(c >= 'a' && c <= 'z')
+          && !(c >= '0' && c <= '9')
+          && c != '_'
+          && c != '-'
+          && c != '*'
+          && c != '/') {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  // Value is opaque string up to 256 characters printable ASCII RFC0020 characters (i.e., the range
+  // 0x20 to 0x7E) except comma , and =.
+  private static boolean validateValue(String value) {
+    if (value.length() > VALUE_MAX_SIZE || value.charAt(value.length() - 1) == ' ' /* '\u0020' */) {
+      return false;
+    }
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (c == ',' || c == '=' || c < ' ' /* '\u0020' */ || c > '~' /* '\u007E' */) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private static Tracestate create(List<Entry> entries) {
+    Utils.checkState(entries.size() <= MAX_KEY_VALUE_PAIRS, "Invalid size");
+    return new AutoValue_Tracestate(Collections.unmodifiableList(entries));
+  }
+
+  Tracestate() {}
+}

--- a/api/src/test/java/io/opencensus/internal/UtilsTest.java
+++ b/api/src/test/java/io/opencensus/internal/UtilsTest.java
@@ -30,6 +30,10 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public final class UtilsTest {
   private static final String TEST_MESSAGE = "test message";
+  private static final String TEST_MESSAGE_TEMPLATE = "I ate %s eggs.";
+  private static final int TEST_MESSAGE_VALUE = 2;
+  private static final String FORMATED_SIMPLE_TEST_MESSAGE = "I ate 2 eggs.";
+  private static final String FORMATED_COMPLEX_TEST_MESSAGE = "I ate 2 eggs. [2]";
 
   @Rule public ExpectedException thrown = ExpectedException.none();
 
@@ -42,6 +46,27 @@ public final class UtilsTest {
   }
 
   @Test
+  public void checkArgument_NullErrorMessage() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("null");
+    Utils.checkArgument(false, null);
+  }
+
+  @Test
+  public void checkArgument_WithSimpleFormat() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(FORMATED_SIMPLE_TEST_MESSAGE);
+    Utils.checkArgument(false, TEST_MESSAGE_TEMPLATE, TEST_MESSAGE_VALUE);
+  }
+
+  @Test
+  public void checkArgument_WithComplexFormat() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage(FORMATED_COMPLEX_TEST_MESSAGE);
+    Utils.checkArgument(false, TEST_MESSAGE_TEMPLATE, TEST_MESSAGE_VALUE, TEST_MESSAGE_VALUE);
+  }
+
+  @Test
   public void checkState() {
     Utils.checkNotNull(true, TEST_MESSAGE);
     thrown.expect(IllegalStateException.class);
@@ -50,11 +75,25 @@ public final class UtilsTest {
   }
 
   @Test
+  public void checkState_NullErrorMessage() {
+    thrown.expect(IllegalStateException.class);
+    thrown.expectMessage("null");
+    Utils.checkState(false, null);
+  }
+
+  @Test
   public void checkNotNull() {
     Utils.checkNotNull(new Object(), TEST_MESSAGE);
     thrown.expect(NullPointerException.class);
     thrown.expectMessage(TEST_MESSAGE);
     Utils.checkNotNull(null, TEST_MESSAGE);
+  }
+
+  @Test
+  public void checkNotNull_NullErrorMessage() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("null");
+    Utils.checkNotNull(null, null);
   }
 
   @Test

--- a/build.gradle
+++ b/build.gradle
@@ -251,6 +251,12 @@ subprojects {
             html.enabled = true
         }
     }
+    findbugsTest {
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
+    }
 
     checkstyle {
         configFile = file("$rootDir/buildscripts/checkstyle.xml")

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -29,6 +29,12 @@
     <Method name="checkNotNull"/>
   </Match>
   <Match>
+    <!-- Reason: This test is testing for a NPE. -->
+    <Bug pattern="NP_NONNULL_PARAM_VIOLATION"/>
+    <Class name="io.opencensus.internal.UtilsTest"/>
+    <Method name="checkNotNull_NullErrorMessage"/>
+  </Match>
+  <Match>
     <!-- Reason: It seems like FindBugs incorrectly assumes that all -->
     <!-- Throwables are subclasses of Error or Exception. -->
     <Bug pattern="BC_VACUOUS_INSTANCEOF"/>


### PR DESCRIPTION
(cherry picked from commit eabc800c3749ca6f8e3a17f057ae11c8d1385d0c)

Manual edits compared to https://github.com/census-instrumentation/opencensus-java/commit/eabc800c3749ca6f8e3a17f057ae11c8d1385d0c:
1. Remove `Tracestate` since it's not there in v0.15;
2. Use `new TraceOptions(buffer[0])` instead of `fromByte(buffer[0])`, since `fromByte` is not there in v0.15.

