### PR TITLE
Contrib/agent: detach() should take the context returned from attach().

### DIFF
--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
@@ -18,7 +18,6 @@ package io.opencensus.contrib.agent.instrumentation;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.base.Preconditions;
 import io.grpc.Context;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -115,10 +114,7 @@ public class ThreadInstrumentationIT {
             // been wrapped in a different context (by automatic instrumentation of
             // Executor#execute), that context will be attached when executing the Runnable.
             Context context2 = Context.current().withValue(KEY, "wrong context");
-            // Work around findbugs warning. Context.attach() is marked as @CheckReturnValue so we
-            // need to check the return
-            // value here, otherwise findbugs will fail.
-            Preconditions.checkNotNull(context2.attach(), "context2.attach()");
+            Context context3 = context2.attach();
             Thread thread = new Thread(command);
             thread.start();
             try {
@@ -126,7 +122,7 @@ public class ThreadInstrumentationIT {
             } catch (InterruptedException ex) {
               Thread.currentThread().interrupt();
             }
-            context2.detach(context);
+            context2.detach(context3);
           }
         };
 

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
@@ -129,19 +129,16 @@ public class ThreadInstrumentationIT {
         };
 
     final AtomicReference<Context> newThreadCtx = new AtomicReference<Context>();
-    final AtomicReference<String> newThreadCtxVal = new AtomicReference<String>();
     newThreadExecutor.execute(
         new Runnable() {
           @Override
           public void run() {
             newThreadCtx.set(Context.current());
-            newThreadCtxVal.set(KEY.get());
           }
         });
 
     // Assert that the automatic context propagation added by ThreadInstrumentation did not
     // interfere with the automatically propagated context from Executor#execute.
     assertThat(newThreadCtx.get()).isSameAs(context);
-    assertThat(newThreadCtxVal.get()).isEqualTo("myvalue");
   }
 }

--- a/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
+++ b/contrib/agent/src/integration-test/java/io/opencensus/contrib/agent/instrumentation/ThreadInstrumentationIT.java
@@ -115,14 +115,17 @@ public class ThreadInstrumentationIT {
             // Executor#execute), that context will be attached when executing the Runnable.
             Context context2 = Context.current().withValue(KEY, "wrong context");
             Context context3 = context2.attach();
-            Thread thread = new Thread(command);
-            thread.start();
             try {
-              thread.join();
-            } catch (InterruptedException ex) {
-              Thread.currentThread().interrupt();
+              Thread thread = new Thread(command);
+              thread.start();
+              try {
+                thread.join();
+              } catch (InterruptedException ex) {
+                Thread.currentThread().interrupt();
+              }
+            } finally {
+              context2.detach(context3);
             }
-            context2.detach(context3);
           }
         };
 


### PR DESCRIPTION
Part of https://github.com/census-instrumentation/opencensus-java/issues/1407.