### PR TITLE
Log4j log correlation: Capitalize "opencensus" as one word in context key names.

### DIFF
--- a/contrib/log_correlation/log4j2/README.md
+++ b/contrib/log_correlation/log4j2/README.md
@@ -69,16 +69,16 @@ The allowed values are:
 `opencensus-contrib-log-correlation-log4j` adds the following key-value pairs to the `LogEvent`
 context:
 
-* `openCensusTraceId` - the lowercase base16 encoding of the current trace ID
-* `openCensusSpanId` - the lowercase base16 encoding of the current span ID
-* `openCensusTraceSampled` - the sampling decision of the current span ("true" or "false")
+* `opencensusTraceId` - the lowercase base16 encoding of the current trace ID
+* `opencensusSpanId` - the lowercase base16 encoding of the current span ID
+* `opencensusTraceSampled` - the sampling decision of the current span ("true" or "false")
 
 These values can be accessed from layouts with
 [Context Map Lookup](http://logging.apache.org/log4j/2.x/manual/lookups.html#ContextMapLookup).  For
-example, the trace ID can be accessed with `$${ctx:openCensusTraceId}`.  The values can also be
+example, the trace ID can be accessed with `$${ctx:opencensusTraceId}`.  The values can also be
 accessed with the `X` conversion character in
 [`PatternLayout`](http://logging.apache.org/log4j/2.x/manual/layouts.html#PatternLayout), for
-example, `%X{openCensusTraceId}`.
+example, `%X{opencensusTraceId}`.
 
 See an example Log4j configuration file in the demo:
 https://github.com/census-ecosystem/opencensus-experiments/tree/master/java/log_correlation/log4j/src/main/resources/log4j2.xml

--- a/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
+++ b/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
@@ -50,9 +50,9 @@ import org.apache.logging.log4j.util.StringMap;
  * Layout</a>:
  *
  * <ul>
- *   <li><code>%X{openCensusTraceId}</code>
- *   <li><code>%X{openCensusSpanId}</code>
- *   <li><code>%X{openCensusTraceSampled}</code>
+ *   <li><code>%X{opencensusTraceId}</code>
+ *   <li><code>%X{opencensusSpanId}</code>
+ *   <li><code>%X{opencensusTraceSampled}</code>
  * </ul>
  *
  * <p>This feature is currently experimental.
@@ -70,21 +70,21 @@ public final class OpenCensusTraceContextDataInjector implements ContextDataInje
    *
    * @since 0.16
    */
-  public static final String TRACE_ID_CONTEXT_KEY = "openCensusTraceId";
+  public static final String TRACE_ID_CONTEXT_KEY = "opencensusTraceId";
 
   /**
    * Context key for the current span ID. The name is {@value}.
    *
    * @since 0.16
    */
-  public static final String SPAN_ID_CONTEXT_KEY = "openCensusSpanId";
+  public static final String SPAN_ID_CONTEXT_KEY = "opencensusSpanId";
 
   /**
    * Context key for the sampling decision of the current span. The name is {@value}.
    *
    * @since 0.16
    */
-  public static final String TRACE_SAMPLED_CONTEXT_KEY = "openCensusTraceSampled";
+  public static final String TRACE_SAMPLED_CONTEXT_KEY = "opencensusTraceSampled";
 
   /**
    * Name of the property that defines the {@link SpanSelection}. The name is {@value}.

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/AbstractOpenCensusLog4jLogCorrelationTest.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/AbstractOpenCensusLog4jLogCorrelationTest.java
@@ -52,8 +52,8 @@ abstract class AbstractOpenCensusLog4jLogCorrelationTest {
   private static final Tracer tracer = Tracing.getTracer();
 
   static final String TEST_PATTERN =
-      "traceId=%X{openCensusTraceId} spanId=%X{openCensusSpanId} "
-          + "sampled=%X{openCensusTraceSampled} %-5level - %msg";
+      "traceId=%X{opencensusTraceId} spanId=%X{opencensusSpanId} "
+          + "sampled=%X{opencensusTraceSampled} %-5level - %msg";
 
   static final Tracestate EMPTY_TRACESTATE = Tracestate.builder().build();
 

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjectorTest.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjectorTest.java
@@ -45,19 +45,19 @@ public final class OpenCensusTraceContextDataInjectorTest {
   @Test
   public void traceIdKey() {
     assertThat(OpenCensusTraceContextDataInjector.TRACE_ID_CONTEXT_KEY)
-        .isEqualTo("openCensusTraceId");
+        .isEqualTo("opencensusTraceId");
   }
 
   @Test
   public void spanIdKey() {
     assertThat(OpenCensusTraceContextDataInjector.SPAN_ID_CONTEXT_KEY)
-        .isEqualTo("openCensusSpanId");
+        .isEqualTo("opencensusSpanId");
   }
 
   @Test
   public void traceSampledKey() {
     assertThat(OpenCensusTraceContextDataInjector.TRACE_SAMPLED_CONTEXT_KEY)
-        .isEqualTo("openCensusTraceSampled");
+        .isEqualTo("opencensusTraceSampled");
   }
 
   @Test
@@ -106,11 +106,11 @@ public final class OpenCensusTraceContextDataInjectorTest {
             "value1",
             "property2",
             "value2",
-            "openCensusTraceId",
+            "opencensusTraceId",
             "00000000000000000000000000000000",
-            "openCensusSpanId",
+            "opencensusSpanId",
             "0000000000000000",
-            "openCensusTraceSampled",
+            "opencensusTraceSampled",
             "false");
   }
 
@@ -131,11 +131,11 @@ public final class OpenCensusTraceContextDataInjectorTest {
   private static void assertContainsOnlyDefaultTracingEntries(StringMap stringMap) {
     assertThat(toMap(stringMap))
         .containsExactly(
-            "openCensusTraceId",
+            "opencensusTraceId",
             "00000000000000000000000000000000",
-            "openCensusSpanId",
+            "opencensusSpanId",
             "0000000000000000",
-            "openCensusTraceSampled",
+            "opencensusTraceSampled",
             "false");
   }
 


### PR DESCRIPTION
For example, this commit renames "openCensusTraceId" to "opencensusTraceId".