### PR TITLE
Add opencensus-contrib-log-correlation-log4j2 to the list of released artifacts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 - Add get/from{Byte} methods on TraceOptions and deprecate get/from{Bytes}.
 - Add an API to `StackdriverTraceConfiguration` to allow setting a
   `TraceServiceStub` instance to be used for export RPC calls.
+- Add an experimental artifact, `opencensus-contrib-log-correlation-log4j2`, for
+  adding tracing data to Log4j 2 LogEvents.
 
 ## 0.15.1 - 2018-08-28
 - Improve propagation performance by avoiding doing string formatting when calling checkArgument.

--- a/build.gradle
+++ b/build.gradle
@@ -384,10 +384,7 @@ subprojects {
                  'opencensus-contrib-grpc-metrics',
                  'opencensus-contrib-grpc-util',
                  'opencensus-contrib-http-util',
-
-                 // TODO(sebright): Uncomment opencensus-contrib-log-correlation-log4j when it is complete.
-                 // 'opencensus-contrib-log-correlation-log4j',
-
+                 'opencensus-contrib-log-correlation-log4j2',
                  'opencensus-contrib-log-correlation-stackdriver',
                  'opencensus-contrib-monitored-resource-util',
                  'opencensus-contrib-spring',


### PR DESCRIPTION
This pull request depends on #1413 and #1414.