### PR TITLE
Stackdriver log correlation: Use lowercase c in "openCensusTraceSampled" field.

### DIFF
--- a/contrib/log_correlation/stackdriver/README.md
+++ b/contrib/log_correlation/stackdriver/README.md
@@ -12,7 +12,7 @@ that automatically adds tracing data to log entries. The class name is
 `OpenCensusTraceLoggingEnhancer`. `OpenCensusTraceLoggingEnhancer` adds the current trace and span
 ID to each log entry, which allows Stackdriver to display the log entries associated with each
 trace, or filter logs based on trace or span ID. It currently also adds the sampling decision using
-the label "`openCensusTraceSampled`".
+the label "`opencensusTraceSampled`".
 
 ## Instructions
 

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  */
 @ExperimentalApi
 public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
-  private static final String SAMPLED_LABEL_KEY = "openCensusTraceSampled";
+  private static final String SAMPLED_LABEL_KEY = "opencensusTraceSampled";
   private static final SpanSelection DEFAULT_SPAN_SELECTION = SpanSelection.ALL_SPANS;
 
   /**

--- a/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
+++ b/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
@@ -82,7 +82,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
                     SpanId.fromLowerBase16("592ae363e92cb3dd"),
                     TraceOptions.builder().setIsSampled(true).build(),
                     EMPTY_TRACESTATE)));
-    assertThat(logEntry.getLabels()).containsEntry("openCensusTraceSampled", "true");
+    assertThat(logEntry.getLabels()).containsEntry("opencensusTraceSampled", "true");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-2/traces/4c9874d0b41224cce77ff74ee10f5ee6");
     assertThat(logEntry.getSpanId()).isEqualTo("592ae363e92cb3dd");
@@ -99,7 +99,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
                     SpanId.fromLowerBase16("de52e84d13dd232d"),
                     TraceOptions.builder().setIsSampled(true).build(),
                     EMPTY_TRACESTATE)));
-    assertThat(logEntry.getLabels()).containsEntry("openCensusTraceSampled", "true");
+    assertThat(logEntry.getLabels()).containsEntry("opencensusTraceSampled", "true");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-3/traces/4c6af40c499951eb7de2777ba1e4fefa");
     assertThat(logEntry.getSpanId()).isEqualTo("de52e84d13dd232d");
@@ -144,7 +144,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
                     SpanId.fromLowerBase16("731e102335b7a5a0"),
                     TraceOptions.builder().setIsSampled(false).build(),
                     EMPTY_TRACESTATE)));
-    assertThat(logEntry.getLabels()).containsEntry("openCensusTraceSampled", "false");
+    assertThat(logEntry.getLabels()).containsEntry("opencensusTraceSampled", "false");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-6/traces/72c905c76f99e99974afd84dc053a480");
     assertThat(logEntry.getSpanId()).isEqualTo("731e102335b7a5a0");
@@ -156,7 +156,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
         getEnhancedLogEntry(
             new OpenCensusTraceLoggingEnhancer("my-test-project-7", SpanSelection.ALL_SPANS),
             BlankSpan.INSTANCE);
-    assertThat(logEntry.getLabels().get("openCensusTraceSampled")).isEqualTo("false");
+    assertThat(logEntry.getLabels().get("opencensusTraceSampled")).isEqualTo("false");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-7/traces/00000000000000000000000000000000");
     assertThat(logEntry.getSpanId()).isEqualTo("0000000000000000");
@@ -188,7 +188,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   }
 
   private static void assertContainsNoTracingData(LogEntry logEntry) {
-    assertThat(logEntry.getLabels()).doesNotContainKey("openCensusTraceSampled");
+    assertThat(logEntry.getLabels()).doesNotContainKey("opencensusTraceSampled");
     assertThat(logEntry.getTrace()).isNull();
     assertThat(logEntry.getSpanId()).isNull();
   }


### PR DESCRIPTION
This change is consistent with the change to Log4j log correlation context key
names in #1414.