### PR TITLE
Avoid using internal org.apache.logging.log4j.core.impl package.

### DIFF
--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -96,6 +96,7 @@ General guidelines on imports:
     </subpackage>
     <subpackage name="logcorrelation.log4j2">
       <allow pkg="io.opencensus.trace"/>
+      <disallow pkg="org.apache.logging.log4j.core.impl"/>
       <allow pkg="org.apache.logging.log4j"/>
     </subpackage>
     <subpackage name="logcorrelation.stackdriver">

--- a/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
+++ b/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
@@ -20,6 +20,7 @@ import io.opencensus.common.ExperimentalApi;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.unsafe.ContextUtils;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -28,7 +29,6 @@ import org.apache.logging.log4j.core.ContextDataInjector;
 import org.apache.logging.log4j.core.Layout;
 import org.apache.logging.log4j.core.LogEvent;
 import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.core.impl.ThreadContextDataInjector;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
 
@@ -176,9 +176,15 @@ public final class OpenCensusTraceContextDataInjector implements ContextDataInje
       return rawContextData();
     }
     // Context data has precedence over configuration properties.
-    ThreadContextDataInjector.copyProperties(properties, reusable);
+    putProperties(properties, reusable);
     reusable.putAll(rawContextData());
     return reusable;
+  }
+
+  private static void putProperties(Collection<Property> properties, StringMap stringMap) {
+    for (Property property : properties) {
+      stringMap.putValue(property.getName(), property.getValue());
+    }
   }
 
   // This method avoids getting the current span when the feature is disabled, for efficiency.


### PR DESCRIPTION
This commit adds the internal package to import-control.xml and removes the use
of org.apache.logging.log4j.core.impl.ThreadContextDataInjector.