### PR TITLE
Improve tests for OpenCensusTraceContextDataInjector.

### DIFF
--- a/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
+++ b/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
@@ -143,7 +143,8 @@ public final class OpenCensusTraceContextDataInjector implements ContextDataInje
     this(lookUpSpanSelectionProperty());
   }
 
-  private OpenCensusTraceContextDataInjector(SpanSelection spanSelection) {
+  // visible for testing
+  OpenCensusTraceContextDataInjector(SpanSelection spanSelection) {
     this.spanSelection = spanSelection;
   }
 

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/AbstractOpenCensusLog4jLogCorrelationTest.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/AbstractOpenCensusLog4jLogCorrelationTest.java
@@ -19,18 +19,11 @@ package io.opencensus.contrib.logcorrelation.log4j2;
 import io.opencensus.common.Function;
 import io.opencensus.common.Scope;
 import io.opencensus.contrib.logcorrelation.log4j2.OpenCensusTraceContextDataInjector.SpanSelection;
-import io.opencensus.trace.Annotation;
-import io.opencensus.trace.AttributeValue;
-import io.opencensus.trace.EndSpanOptions;
-import io.opencensus.trace.Link;
-import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracestate;
 import io.opencensus.trace.Tracing;
 import java.io.StringWriter;
-import java.util.EnumSet;
-import java.util.Map;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.core.Appender;
@@ -100,23 +93,5 @@ abstract class AbstractOpenCensusLog4jLogCorrelationTest {
     } finally {
       scope.close();
     }
-  }
-
-  private static final class TestSpan extends Span {
-    TestSpan(SpanContext context) {
-      super(context, EnumSet.of(Options.RECORD_EVENTS));
-    }
-
-    @Override
-    public void end(EndSpanOptions options) {}
-
-    @Override
-    public void addLink(Link link) {}
-
-    @Override
-    public void addAnnotation(Annotation annotation) {}
-
-    @Override
-    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
   }
 }

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjectorTest.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjectorTest.java
@@ -18,7 +18,6 @@ package io.opencensus.contrib.logcorrelation.log4j2;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import io.opencensus.common.Scope;
 import io.opencensus.contrib.logcorrelation.log4j2.OpenCensusTraceContextDataInjector.SpanSelection;
@@ -30,11 +29,8 @@ import io.opencensus.trace.Tracer;
 import io.opencensus.trace.Tracestate;
 import io.opencensus.trace.Tracing;
 import java.util.Collections;
-import java.util.Map;
 import org.apache.logging.log4j.ThreadContext;
 import org.apache.logging.log4j.core.config.Property;
-import org.apache.logging.log4j.util.BiConsumer;
-import org.apache.logging.log4j.util.ReadOnlyStringMap;
 import org.apache.logging.log4j.util.SortedArrayStringMap;
 import org.apache.logging.log4j.util.StringMap;
 import org.junit.Test;
@@ -107,13 +103,13 @@ public final class OpenCensusTraceContextDataInjectorTest {
   @Test
   public void insertConfigurationProperties() {
     assertThat(
-            toMap(
-                new OpenCensusTraceContextDataInjector(SpanSelection.ALL_SPANS)
-                    .injectContextData(
-                        Lists.newArrayList(
-                            Property.createProperty("property1", "value1"),
-                            Property.createProperty("property2", "value2")),
-                        new SortedArrayStringMap())))
+            new OpenCensusTraceContextDataInjector(SpanSelection.ALL_SPANS)
+                .injectContextData(
+                    Lists.newArrayList(
+                        Property.createProperty("property1", "value1"),
+                        Property.createProperty("property2", "value2")),
+                    new SortedArrayStringMap())
+                .toMap())
         .containsExactly(
             "property1",
             "value1",
@@ -142,7 +138,7 @@ public final class OpenCensusTraceContextDataInjectorTest {
   }
 
   private static void assertContainsOnlyDefaultTracingEntries(StringMap stringMap) {
-    assertThat(toMap(stringMap))
+    assertThat(stringMap.toMap())
         .containsExactly(
             "opencensusTraceId",
             "00000000000000000000000000000000",
@@ -167,7 +163,7 @@ public final class OpenCensusTraceContextDataInjectorTest {
       String key = "myTestKey";
       ThreadContext.put(key, "myTestValue");
       try {
-        assertThat(toMap(plugin.rawContextData()))
+        assertThat(plugin.rawContextData().toMap())
             .containsExactly(
                 "myTestKey",
                 "myTestValue",
@@ -200,24 +196,12 @@ public final class OpenCensusTraceContextDataInjectorTest {
       String key = "myTestKey";
       ThreadContext.put(key, "myTestValue");
       try {
-        assertThat(toMap(plugin.rawContextData())).containsExactly("myTestKey", "myTestValue");
+        assertThat(plugin.rawContextData().toMap()).containsExactly("myTestKey", "myTestValue");
       } finally {
         ThreadContext.remove(key);
       }
     } finally {
       scope.close();
     }
-  }
-
-  private static Map<String, String> toMap(ReadOnlyStringMap stringMap) {
-    final ImmutableMap.Builder<String, String> builder = ImmutableMap.builder();
-    stringMap.forEach(
-        new BiConsumer<String, Object>() {
-          @Override
-          public void accept(String key, Object value) {
-            builder.put(key, String.valueOf(value));
-          }
-        });
-    return builder.build();
   }
 }

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/TestSpan.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/TestSpan.java
@@ -25,6 +25,8 @@ import io.opencensus.trace.SpanContext;
 import java.util.EnumSet;
 import java.util.Map;
 
+// Simple test Span that holds a SpanContext. The tests cannot use Span directly, since it is
+// abstract.
 final class TestSpan extends Span {
   TestSpan(SpanContext context) {
     super(context, EnumSet.of(Options.RECORD_EVENTS));

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/TestSpan.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/TestSpan.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.logcorrelation.log4j2;
+
+import io.opencensus.trace.Annotation;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.EndSpanOptions;
+import io.opencensus.trace.Link;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanContext;
+import java.util.EnumSet;
+import java.util.Map;
+
+final class TestSpan extends Span {
+  TestSpan(SpanContext context) {
+    super(context, EnumSet.of(Options.RECORD_EVENTS));
+  }
+
+  @Override
+  public void end(EndSpanOptions options) {}
+
+  @Override
+  public void addLink(Link link) {}
+
+  @Override
+  public void addAnnotation(Annotation annotation) {}
+
+  @Override
+  public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
+}


### PR DESCRIPTION
This commit adds unit tests for
OpenCensusTraceContextDataInjector.rawContextData().  It also makes two
other minor improvements to the Log4j log correlation tests:

- Puts TestSpan in a separate file for reuse.
- Explicitly sets the SpanSelection in tests, where possible.

_______________________________________________________________________

~~This PR depends on #1413 and includes it.~~
