### PR TITLE
Make jmh available for all subprojects.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -119,6 +119,36 @@ such as
 `Disallowed import - edu.umd.cs.findbugs.annotations.SuppressFBWarnings. [ImportControl]`
 could mean that `import-control.xml` needs to be updated.
 
+## Benchmarks
+
+### Invoke all benchmarks on a sub-project
+
+```bash
+$ ./gradlew clean :opencensus-impl-core:jmh
+```
+
+### Invoke on a single benchmark class
+
+```bash
+./gradlew -PjmhIncludeSingleClass=BinaryFormatImplBenchmark clean :opencensus-impl-core:jmh
+```
+
+### Debug compilation errors
+When you make incompatible changes in the Benchmarks classes you may get compilation errors which
+are related to the old code not being compatible with the new code. Some of the reasons are:
+* Any plugin cannot delete the generated code (jmh generates code) because if the user configured
+the directory as the same as source code the plugin will delete users source code.
+* After you run jmh, a gradle daemon will stay alive which may cache the generated code in memory
+and use use that generated code even if the files were changed. This is an issue for classes
+generated with auto-value.
+
+Run this commands to clean the Gradle's cache:
+```bash
+./gradlew --stop
+rm -fr .gradle/
+rm -fr benchmarks/build
+```
+
 ## Proposing changes
 
 Create a Pull Request with your changes. Please add any user-visible changes to

--- a/all/build.gradle
+++ b/all/build.gradle
@@ -1,11 +1,5 @@
 description = "OpenCensus All"
 
-buildscript {
-    repositories {
-        mavenCentral()
-    }
-}
-
 def subprojects = [
         project(':opencensus-api'),
         project(':opencensus-impl-core'),

--- a/api/build.gradle
+++ b/api/build.gradle
@@ -9,5 +9,7 @@ dependencies {
     signature "net.sf.androidscents.signature:android-api-level-14:4.0_r4@signature"
 }
 
-javadoc.exclude 'io/opencensus/internal/**'
-javadoc.exclude 'io/opencensus/trace/internal/**'
+javadoc {
+    exclude 'io/opencensus/internal/**'
+    exclude 'io/opencensus/trace/internal/**'
+}

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,22 +1,3 @@
 # OpenCensus Benchmarks
 
-## To run the benchmark use
-
-```
-$ ./gradlew :opencensus-benchmarks:jmh
-```
-
-## To debug compilation errors
-When you make incompatible changes in the Benchmarks classes you may get compilation errors which
-are related to the old code not being compatible with the new code. Some of the reasons are:
-* Any plugin cannot delete the generated code (jmh generates code) because if the user configured
-the directory as the same as source code the plugin will delete users source code.
-* After you run jmh a gradle demon will stay alive which may cache the generated code in memory and 
-generates the same code even if the files were changed.
-
-Run this commands to clean the Gradle's cache:
-```bash
-./gradlew --stop
-rm -fr .gradle/
-rm -fr benchmarks/build
-```
+See [here](../CONTRIBUTING.md#benchmarks) for how to run and debug issues with benchmarks.

--- a/benchmarks/build.gradle
+++ b/benchmarks/build.gradle
@@ -1,47 +1,10 @@
 description = 'OpenCensus Benchmarks'
 
-buildscript {
-    repositories {
-        jcenter()
-        maven {
-            url "https://plugins.gradle.org/m2/"
-        }
-    }
-    dependencies {
-        classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.7"
-        classpath "gradle.plugin.io.morethan.jmhreport:gradle-jmh-report:0.7.0"
-    }
-}
-
-apply plugin: "me.champeau.gradle.jmh"
-apply plugin: "io.morethan.jmhreport"
-
-jmh {
-    jmhVersion = '1.20'
-    warmupIterations = 10
-    iterations = 10
-    fork = 1
-    failOnError = true
-    resultFormat = 'JSON'
-}
-
 dependencies {
     compile project(':opencensus-api'),
             project(':opencensus-impl-core'),
             project(':opencensus-impl-lite'),
             project(':opencensus-impl')
-}
-
-compileJmhJava {
-    options.compilerArgs = compileJava.options.compilerArgs
-}
-
-// Generate html report for findbugsJmh.
-findbugsJmh {
-    reports {
-        xml.enabled = false
-        html.enabled = true
-    }
 }
 
 jmhReport {

--- a/build.gradle
+++ b/build.gradle
@@ -12,6 +12,8 @@ buildscript {
         classpath "net.ltgt.gradle:gradle-apt-plugin:0.10"
         classpath 'com.github.ben-manes:gradle-versions-plugin:0.17.0'
         classpath "gradle.plugin.com.github.sherter.google-java-format:google-java-format-gradle-plugin:0.7.1"
+        classpath "me.champeau.gradle:jmh-gradle-plugin:0.4.7"
+        classpath "gradle.plugin.io.morethan.jmhreport:gradle-jmh-report:0.7.0"
     }
 }
 
@@ -35,6 +37,8 @@ subprojects {
     apply plugin: 'ru.vyarus.animalsniffer'
     apply plugin: 'findbugs'
     apply plugin: 'net.ltgt.apt'
+    apply plugin: "me.champeau.gradle.jmh"
+    apply plugin: "io.morethan.jmhreport"
     // Plugins that require java8
     if (JavaVersion.current().isJava8Compatible()) {
         if (useErrorProne) {
@@ -65,7 +69,7 @@ subprojects {
         }
     }
 
-    [compileJava, compileTestJava].each() {
+    [compileJava, compileTestJava, compileJmhJava].each() {
         // We suppress the "try" warning because it disallows managing an auto-closeable with
         // try-with-resources without referencing the auto-closeable within the try block.
         // We suppress the "processing" warning as suggested in
@@ -272,6 +276,12 @@ subprojects {
             html.enabled = true
         }
     }
+    findbugsJmh {
+        reports {
+            xml.enabled = false
+            html.enabled = true
+        }
+    }
 
     checkstyle {
         configFile = file("$rootDir/buildscripts/checkstyle.xml")
@@ -286,6 +296,7 @@ subprojects {
     // Disable checkstyle if no java8.
     checkstyleMain.enabled = JavaVersion.current().isJava8Compatible()
     checkstyleTest.enabled = JavaVersion.current().isJava8Compatible()
+    checkstyleJmh.enabled = JavaVersion.current().isJava8Compatible()
 
     // Google formatter works only on java8.
     if (JavaVersion.current().isJava8Compatible()) {
@@ -324,6 +335,29 @@ subprojects {
     artifacts {
         archives javadocJar, sourcesJar
     }
+
+    jmh {
+        jmhVersion = '1.20'
+        warmupIterations = 10
+        iterations = 10
+        fork = 1
+        failOnError = true
+        resultFormat = 'JSON'
+        // Allow to run single benchmark class like:
+        // ./gradlew -PjmhIncludeSingleClass=StatsTraceContextBenchmark clean :grpc-core:jmh
+        if (project.hasProperty('jmhIncludeSingleClass')) {
+            include = [
+                    project.property('jmhIncludeSingleClass')
+            ]
+        }
+    }
+
+    jmhReport {
+        jmhResultPath = project.file("${project.buildDir}/reports/jmh/results.json")
+        jmhReportOutput = project.file("${project.buildDir}/reports/jmh")
+    }
+
+    tasks.jmh.finalizedBy tasks.jmhReport
 
     uploadArchives {
         repositories {

--- a/contrib/agent/build.gradle
+++ b/contrib/agent/build.gradle
@@ -1,7 +1,5 @@
 plugins {
   id 'com.github.johnrengelman.shadow' version '2.0.2'
-  id 'me.champeau.gradle.jmh' version '0.4.5'
-  id 'io.morethan.jmhreport' version '0.7.0'
 }
 
 description = 'OpenCensus Agent'
@@ -234,17 +232,6 @@ dependencies {
   jmh libraries.grpc_context
 }
 
-// Disable checkstyle for JMH benchmarks if not java8.
-checkstyleJmh.enabled = JavaVersion.current().isJava8Compatible()
-
-// Generate html report for findbugsJmh.
-findbugsJmh {
-  reports {
-    xml.enabled = false
-    html.enabled = true
-  }
-}
-
 // Make the agent JAR available using a fixed file name so that we don't have to modify the JMH
 // benchmarks whenever the version changes.
 task agentJar(type: Copy) {
@@ -257,19 +244,3 @@ task agentJar(type: Copy) {
 
 jmhJar.dependsOn agentJar
 jmhJar.dependsOn integrationTest
-
-jmh {
-  jmhVersion = '1.19'
-  warmupIterations = 10
-  iterations = 10
-  fork = 1
-  failOnError = true
-  resultFormat = 'JSON'
-}
-
-jmhReport {
-  jmhResultPath = project.file("${project.buildDir}/reports/jmh/results.json")
-  jmhReportOutput = project.file("${project.buildDir}/reports/jmh")
-}
-
-tasks.jmh.finalizedBy tasks.jmhReport

--- a/impl_core/src/jmh/java/io/opencensus/implcore/trace/propagation/B3FormatImplBenchmark.java
+++ b/impl_core/src/jmh/java/io/opencensus/implcore/trace/propagation/B3FormatImplBenchmark.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package io.opencensus.benchmarks.trace.propagation;
+package io.opencensus.implcore.trace.propagation;
 
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.TraceId;
 import io.opencensus.trace.TraceOptions;
 import io.opencensus.trace.Tracestate;
-import io.opencensus.trace.Tracing;
 import io.opencensus.trace.propagation.SpanContextParseException;
 import io.opencensus.trace.propagation.TextFormat;
 import io.opencensus.trace.propagation.TextFormat.Getter;
@@ -49,7 +48,7 @@ public class B3FormatImplBenchmark {
 
     @Setup
     public void setup() {
-      textFormatBase = new TextFormatBenchmarkBase(Tracing.getPropagationComponent().getB3Format());
+      textFormatBase = new TextFormatBenchmarkBase(new B3Format());
       Random random = new Random(1234);
       spanContext =
           SpanContext.create(

--- a/impl_core/src/jmh/java/io/opencensus/implcore/trace/propagation/BinaryFormatImplBenchmark.java
+++ b/impl_core/src/jmh/java/io/opencensus/implcore/trace/propagation/BinaryFormatImplBenchmark.java
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package io.opencensus.benchmarks.trace.propagation;
+package io.opencensus.implcore.trace.propagation;
 
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.SpanId;
 import io.opencensus.trace.TraceId;
 import io.opencensus.trace.TraceOptions;
 import io.opencensus.trace.Tracestate;
-import io.opencensus.trace.Tracing;
 import io.opencensus.trace.propagation.BinaryFormat;
 import io.opencensus.trace.propagation.SpanContextParseException;
 import java.util.Random;
@@ -45,7 +44,7 @@ public class BinaryFormatImplBenchmark {
 
     @Setup
     public void setup() {
-      binaryFormat = Tracing.getPropagationComponent().getBinaryFormat();
+      binaryFormat = new BinaryFormatImpl();
       Random random = new Random(1234);
       spanContext =
           SpanContext.create(

--- a/impl_core/src/jmh/java/io/opencensus/implcore/trace/propagation/TextFormatBenchmarkBase.java
+++ b/impl_core/src/jmh/java/io/opencensus/implcore/trace/propagation/TextFormatBenchmarkBase.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.opencensus.benchmarks.trace.propagation;
+package io.opencensus.implcore.trace.propagation;
 
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.propagation.SpanContextParseException;


### PR DESCRIPTION
Main pros:
* Use the same version across all artifacts (for example agent was using jmh 1.19);
* Allow to easily create/add benchmarks in every artifact (allows access to package protected classes for example the propagation implementations);