### PR TITLE
Fix ClassCastException in opencensus-contrib-log-correlation-log4j2.

### DIFF
--- a/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/ContextDataUtils.java
+++ b/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/ContextDataUtils.java
@@ -129,6 +129,10 @@ final class ContextDataUtils {
       stringMap = new SortedArrayStringMap(contextData.size() + 3);
       stringMap.putAll(contextData);
     }
+    // TODO(sebright): Move the calls to TraceId.toLowerBase16() and SpanId.toLowerBase16() out of
+    // the critical path by wrapping the trace and span IDs in objects that call toLowerBase16() in
+    // their toString() methods, after there is a fix for
+    // https://github.com/census-instrumentation/opencensus-java/issues/1436.
     stringMap.putValue(
         OpenCensusTraceContextDataInjector.TRACE_ID_CONTEXT_KEY,
         spanContext.getTraceId().toLowerBase16());

--- a/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/ContextDataUtils.java
+++ b/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/ContextDataUtils.java
@@ -19,8 +19,6 @@ package io.opencensus.contrib.logcorrelation.log4j2;
 import io.opencensus.contrib.logcorrelation.log4j2.OpenCensusTraceContextDataInjector.SpanSelection;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
-import io.opencensus.trace.SpanId;
-import io.opencensus.trace.TraceId;
 import io.opencensus.trace.unsafe.ContextUtils;
 import java.util.Collection;
 import java.util.Collections;
@@ -133,10 +131,10 @@ final class ContextDataUtils {
     }
     stringMap.putValue(
         OpenCensusTraceContextDataInjector.TRACE_ID_CONTEXT_KEY,
-        new TraceIdToLowerBase16Formatter(spanContext.getTraceId()));
+        spanContext.getTraceId().toLowerBase16());
     stringMap.putValue(
         OpenCensusTraceContextDataInjector.SPAN_ID_CONTEXT_KEY,
-        new SpanIdToLowerBase16Formatter(spanContext.getSpanId()));
+        spanContext.getSpanId().toLowerBase16());
     stringMap.putValue(
         OpenCensusTraceContextDataInjector.TRACE_SAMPLED_CONTEXT_KEY,
         spanContext.getTraceOptions().isSampled() ? "true" : "false");
@@ -146,32 +144,6 @@ final class ContextDataUtils {
   private static SpanContext getCurrentSpanContext() {
     Span span = ContextUtils.CONTEXT_SPAN_KEY.get();
     return span == null ? SpanContext.INVALID : span.getContext();
-  }
-
-  private static final class TraceIdToLowerBase16Formatter {
-    private final TraceId traceId;
-
-    private TraceIdToLowerBase16Formatter(TraceId traceId) {
-      this.traceId = traceId;
-    }
-
-    @Override
-    public String toString() {
-      return traceId.toLowerBase16();
-    }
-  }
-
-  private static final class SpanIdToLowerBase16Formatter {
-    private final SpanId spanId;
-
-    private SpanIdToLowerBase16Formatter(SpanId spanId) {
-      this.spanId = spanId;
-    }
-
-    @Override
-    public String toString() {
-      return spanId.toLowerBase16();
-    }
   }
 
   @Immutable


### PR DESCRIPTION
Fixes #1436.

Log4j's SortedArrayStringMap can contain Object values, but
`SortedArrayStringMap.getValue` has signature `<V> V getValue(String key)` and
unsafely casts the Objects to type `V`.  When the OpenCensus ContextDataInjector
returned a SortedArrayStringMap, and then a Log4j ContextMapLookup looked up
values as Strings to insert them into log entries
(https://github.com/apache/logging-log4j2/blob/fa27894c13c3890e4ae545f6b6365ea2e159757c/log4j-core/src/main/java/org/apache/logging/log4j/core/lookup/ContextMapLookup.java#L58),
it resulted in a ClassCastException.

This commit fixes the ClassCastException by only inserting String values into
the Log4j SortedArrayStringMap.