### PR TITLE
Pass a preconfigured HttpSender to the trace exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 - Add `AttributeValueDouble` to `AttributeValue`.
 - Allow users to report metrics for their registered domain (using custom prefix). This could be a
   breaking change if you have custom prefix without (registered) domain.
+- Add `createWithSender` to `JaegerTraceExporter` to allow use of `HttpSender`
+  with extra configurations
 
 ## 0.16.0 - 2018-09-14
 - Add APIs to register gRPC client and server views separately.


### PR DESCRIPTION
There may be cases where you want to be able to configure aspects of the HttpSender, like adding headers or authentication.

This will allow the exporter to use a sender with those configurations when the default isn't enough