### PR TITLE
Split the public API from the data model.

### DIFF
--- a/api/src/main/java/io/opencensus/metrics/MetricProducer.java
+++ b/api/src/main/java/io/opencensus/metrics/MetricProducer.java
@@ -21,18 +21,20 @@ import io.opencensus.metrics.export.MetricProducerManager;
 import java.util.Collection;
 
 /**
- * A {@link io.opencensus.metrics.Metric} producer that can be registered for exporting using {@link
+ * A {@link Metric} producer that can be registered for exporting using {@link
  * MetricProducerManager}.
  *
  * <p>All implementation MUST be thread-safe.
+ *
+ * @since 0.17
  */
 @ExperimentalApi
 public abstract class MetricProducer {
 
   /**
-   * Returns a collection of produced {@link io.opencensus.metrics.Metric}s to be exported.
+   * Returns a collection of produced {@link Metric}s to be exported.
    *
-   * @return a collection of produced {@link io.opencensus.metrics.Metric}s to be exported.
+   * @return a collection of produced {@link Metric}s to be exported.
    */
   public abstract Collection<Metric> getMetrics();
 }

--- a/api/src/main/java/io/opencensus/metrics/MetricRegistry.java
+++ b/api/src/main/java/io/opencensus/metrics/MetricRegistry.java
@@ -20,19 +20,17 @@ import io.opencensus.common.ExperimentalApi;
 import io.opencensus.common.ToDoubleFunction;
 import io.opencensus.common.ToLongFunction;
 import io.opencensus.internal.Utils;
-import java.util.Collection;
-import java.util.Collections;
 import java.util.LinkedHashMap;
 
 /**
- * Creates and manages your application's set of metrics. Exporters use the metric registry to
- * iterate over the set of metrics instrumenting your application, and then further export each
- * metric to the backend of choice.
+ * Creates and manages your application's set of metrics. The default implementation of this creates
+ * a {@link MetricProducer} and registers it to the global {@link
+ * io.opencensus.metrics.export.MetricProducerManager}.
  *
- * @since 0.16
+ * @since 0.17
  */
 @ExperimentalApi
-public abstract class MetricRegistry extends MetricProducer {
+public abstract class MetricRegistry {
   /**
    * Build a new long gauge to be added to the registry.
    *
@@ -43,7 +41,7 @@ public abstract class MetricRegistry extends MetricProducer {
    * @param unit the unit of the metric.
    * @param obj the function argument.
    * @param function the function to be called.
-   * @since 0.16 @ExperimentalApi
+   * @since 0.17
    */
   public abstract <T> void addLongGauge(
       String name,
@@ -63,7 +61,7 @@ public abstract class MetricRegistry extends MetricProducer {
    * @param unit the unit of the metric.
    * @param obj the function argument.
    * @param function the function to be called.
-   * @since 0.16 @ExperimentalApi
+   * @since 0.17
    */
   public abstract <T> void addDoubleGauge(
       String name,
@@ -107,11 +105,6 @@ public abstract class MetricRegistry extends MetricProducer {
       Utils.checkNotNull(unit, "unit");
       Utils.checkNotNull(labels, "labels");
       Utils.checkNotNull(function, "function");
-    }
-
-    @Override
-    public Collection<Metric> getMetrics() {
-      return Collections.emptyList();
     }
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/MetricsComponentImplBase.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/MetricsComponentImplBase.java
@@ -18,7 +18,6 @@ package io.opencensus.implcore.metrics;
 
 import io.opencensus.common.Clock;
 import io.opencensus.implcore.metrics.export.ExportComponentImpl;
-import io.opencensus.metrics.MetricRegistry;
 import io.opencensus.metrics.MetricsComponent;
 
 /** Implementation of {@link MetricsComponent}. */
@@ -33,12 +32,13 @@ public class MetricsComponentImplBase extends MetricsComponent {
   }
 
   @Override
-  public MetricRegistry getMetricRegistry() {
+  public MetricRegistryImpl getMetricRegistry() {
     return metricRegistry;
   }
 
   protected MetricsComponentImplBase(Clock clock) {
     exportComponent = new ExportComponentImpl();
     metricRegistry = new MetricRegistryImpl(clock);
+    exportComponent.getMetricProducerManager().add(metricRegistry.getMetricProducer());
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/metrics/MetricRegistryImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/metrics/MetricRegistryImplTest.java
@@ -149,7 +149,7 @@ public class MetricRegistryImplTest {
             return 5.0;
           }
         });
-    assertThat(metricRegistry.getMetrics())
+    assertThat(metricRegistry.getMetricProducer().getMetrics())
         .containsExactly(
             Metric.create(
                 MetricDescriptor.create(
@@ -253,7 +253,7 @@ public class MetricRegistryImplTest {
             return 7;
           }
         });
-    assertThat(metricRegistry.getMetrics())
+    assertThat(metricRegistry.getMetricProducer().getMetrics())
         .containsExactly(
             Metric.create(
                 MetricDescriptor.create(
@@ -295,7 +295,7 @@ public class MetricRegistryImplTest {
             return 5.0;
           }
         });
-    assertThat(metricRegistry.getMetrics())
+    assertThat(metricRegistry.getMetricProducer().getMetrics())
         .containsExactly(
             Metric.create(
                 MetricDescriptor.create(
@@ -325,6 +325,6 @@ public class MetricRegistryImplTest {
 
   @Test
   public void empty_GetMetrics() {
-    assertThat(metricRegistry.getMetrics()).isEmpty();
+    assertThat(metricRegistry.getMetricProducer().getMetrics()).isEmpty();
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/metrics/MetricsComponentImplBaseTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/metrics/MetricsComponentImplBaseTest.java
@@ -40,4 +40,14 @@ public class MetricsComponentImplBaseTest {
   public void getMetricRegistry() {
     assertThat(metricsComponentImplBase.getMetricRegistry()).isInstanceOf(MetricRegistryImpl.class);
   }
+
+  @Test
+  public void metricRegistry_InstalledToMetricProducerManger() {
+    assertThat(
+            metricsComponentImplBase
+                .getExportComponent()
+                .getMetricProducerManager()
+                .getAllMetricProducer())
+        .containsExactly(metricsComponentImplBase.getMetricRegistry().getMetricProducer());
+  }
 }


### PR DESCRIPTION
Change MetricRegistry to not explicitly extend the MetricProducer. This way we split the public instrumentation API from the data model.

Next PR will move data model related classes to metrics/exporter to be consistent with trace and stats.