### PR TITLE
Testing: Add a fake implementation of TraceService.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -189,6 +189,8 @@ subprojects {
                 google_cloud_monitoring: "com.google.cloud:google-cloud-monitoring:${googleCloudGaVersion}",
                 grpc_context: "io.grpc:grpc-context:${grpcVersion}",
                 grpc_core: "io.grpc:grpc-core:${grpcVersion}",
+                grpc_netty: "io.grpc:grpc-netty:${grpcVersion}",
+                grpc_stub: "io.grpc:grpc-stub:${grpcVersion}",
                 guava: "com.google.guava:guava:${guavaVersion}",
                 jsr305: "com.google.code.findbugs:jsr305:${findBugsJsr305Version}",
                 signalfx_java: "com.signalfx.public:signalfx-java:${signalfxVersion}",

--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -170,6 +170,7 @@ General guidelines on imports:
       </subpackage>
       <subpackage name="ocagent">
         <allow pkg="com.google.protobuf"/>
+        <allow pkg="io.grpc"/>
         <allow pkg="io.opencensus.contrib.monitoredresource.util"/>
         <allow pkg="io.opencensus.contrib.opencensus.proto.util"/>
         <allow pkg="io.opencensus.exporter.trace.ocagent"/>

--- a/exporters/trace/ocagent/build.gradle
+++ b/exporters/trace/ocagent/build.gradle
@@ -10,6 +10,9 @@ dependencies {
 
     compile project(':opencensus-api'),
             project(':opencensus-contrib-monitored-resource-util'),
+            libraries.grpc_core,
+            libraries.grpc_netty,
+            libraries.grpc_stub,
             libraries.opencensus_proto
 
     testCompile project(':opencensus-api')

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/FakeOcAgentTraceServiceGrpcImpl.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/FakeOcAgentTraceServiceGrpcImpl.java
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.ocagent;
+
+import com.google.common.util.concurrent.MoreExecutors;
+import io.grpc.Server;
+import io.grpc.ServerBuilder;
+import io.grpc.netty.NettyServerBuilder;
+import io.grpc.stub.StreamObserver;
+import io.opencensus.proto.agent.trace.v1.CurrentLibraryConfig;
+import io.opencensus.proto.agent.trace.v1.ExportTraceServiceRequest;
+import io.opencensus.proto.agent.trace.v1.ExportTraceServiceResponse;
+import io.opencensus.proto.agent.trace.v1.TraceServiceGrpc;
+import io.opencensus.proto.agent.trace.v1.UpdatedLibraryConfig;
+import io.opencensus.proto.trace.v1.ConstantSampler;
+import io.opencensus.proto.trace.v1.TraceConfig;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+
+/** Fake implementation of {@link TraceServiceGrpc}. */
+final class FakeOcAgentTraceServiceGrpcImpl extends TraceServiceGrpc.TraceServiceImplBase {
+
+  private static final Logger logger =
+      Logger.getLogger(FakeOcAgentTraceServiceGrpcImpl.class.getName());
+
+  // Default updatedLibraryConfig uses an always sampler.
+  private UpdatedLibraryConfig updatedLibraryConfig =
+      UpdatedLibraryConfig.newBuilder()
+          .setConfig(
+              TraceConfig.newBuilder()
+                  .setConstantSampler(ConstantSampler.newBuilder().setDecision(true).build())
+                  .build())
+          .build();
+
+  private final List<CurrentLibraryConfig> currentLibraryConfigs = new ArrayList<>();
+  private final List<ExportTraceServiceRequest> exportTraceServiceRequests = new ArrayList<>();
+
+  private final AtomicReference<StreamObserver<UpdatedLibraryConfig>> updatedConfigObserverRef =
+      new AtomicReference<>();
+
+  private final StreamObserver<CurrentLibraryConfig> currentConfigObserver =
+      new StreamObserver<CurrentLibraryConfig>() {
+        @Override
+        public void onNext(CurrentLibraryConfig value) {
+          currentLibraryConfigs.add(value);
+          @Nullable
+          StreamObserver<UpdatedLibraryConfig> updatedConfigObserver =
+              updatedConfigObserverRef.get();
+          if (updatedConfigObserver != null) {
+            updatedConfigObserver.onNext(updatedLibraryConfig);
+          }
+        }
+
+        @Override
+        public void onError(Throwable t) {
+          logger.warning("Exception thrown for config stream: " + t);
+        }
+
+        @Override
+        public void onCompleted() {}
+      };
+
+  private final StreamObserver<ExportTraceServiceRequest> exportRequestObserver =
+      new StreamObserver<ExportTraceServiceRequest>() {
+        @Override
+        public void onNext(ExportTraceServiceRequest value) {
+          exportTraceServiceRequests.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+          logger.warning("Exception thrown for export stream: " + t);
+        }
+
+        @Override
+        public void onCompleted() {}
+      };
+
+  @Override
+  public StreamObserver<CurrentLibraryConfig> config(
+      StreamObserver<UpdatedLibraryConfig> updatedLibraryConfigStreamObserver) {
+    updatedConfigObserverRef.set(updatedLibraryConfigStreamObserver);
+    return currentConfigObserver;
+  }
+
+  @Override
+  public StreamObserver<ExportTraceServiceRequest> export(
+      StreamObserver<ExportTraceServiceResponse> exportTraceServiceResponseStreamObserver) {
+    return exportRequestObserver;
+  }
+
+  // Returns the stored CurrentLibraryConfigs.
+  List<CurrentLibraryConfig> getCurrentLibraryConfigs() {
+    return currentLibraryConfigs;
+  }
+
+  // Returns the stored ExportTraceServiceRequests.
+  List<ExportTraceServiceRequest> getExportTraceServiceRequests() {
+    return exportTraceServiceRequests;
+  }
+
+  // Sets the UpdatedLibraryConfig that will be passed to client.
+  void setUpdatedLibraryConfig(UpdatedLibraryConfig updatedLibraryConfig) {
+    this.updatedLibraryConfig = updatedLibraryConfig;
+  }
+
+  // Gets the UpdatedLibraryConfig that will be passed to client.
+  UpdatedLibraryConfig getUpdatedLibraryConfig() {
+    return updatedLibraryConfig;
+  }
+
+  static void startServer(String endPoint) throws IOException {
+    ServerBuilder<?> builder = NettyServerBuilder.forAddress(parseEndpoint(endPoint));
+    Executor executor = MoreExecutors.directExecutor();
+    builder.executor(executor);
+    final Server server = builder.addService(new FakeOcAgentTraceServiceGrpcImpl()).build();
+    server.start();
+    logger.info("Server started at " + endPoint);
+
+    Runtime.getRuntime()
+        .addShutdownHook(
+            new Thread() {
+              @Override
+              public void run() {
+                server.shutdown();
+              }
+            });
+
+    try {
+      server.awaitTermination();
+    } catch (InterruptedException e) {
+      logger.warning("Thread interrupted: " + e.getMessage());
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  private static InetSocketAddress parseEndpoint(String endPoint) {
+    try {
+      int colonIndex = endPoint.indexOf(":");
+      String host = endPoint.substring(0, colonIndex);
+      int port = Integer.parseInt(endPoint.substring(colonIndex + 1));
+      return new InetSocketAddress(host, port);
+    } catch (RuntimeException e) {
+      logger.warning("Unexpected format of end point: " + endPoint + ", use default end point.");
+      return new InetSocketAddress("localhost", 55678);
+    }
+  }
+}

--- a/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/FakeOcAgentTraceServiceGrpcImpl.java
+++ b/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/FakeOcAgentTraceServiceGrpcImpl.java
@@ -31,6 +31,7 @@ import io.opencensus.proto.trace.v1.TraceConfig;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicReference;
@@ -111,12 +112,12 @@ final class FakeOcAgentTraceServiceGrpcImpl extends TraceServiceGrpc.TraceServic
 
   // Returns the stored CurrentLibraryConfigs.
   List<CurrentLibraryConfig> getCurrentLibraryConfigs() {
-    return currentLibraryConfigs;
+    return Collections.unmodifiableList(currentLibraryConfigs);
   }
 
   // Returns the stored ExportTraceServiceRequests.
   List<ExportTraceServiceRequest> getExportTraceServiceRequests() {
-    return exportTraceServiceRequests;
+    return Collections.unmodifiableList(exportTraceServiceRequests);
   }
 
   // Sets the UpdatedLibraryConfig that will be passed to client.

--- a/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/FakeOcAgentTraceServiceGrpcImplTest.java
+++ b/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/FakeOcAgentTraceServiceGrpcImplTest.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.ocagent;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.stub.StreamObserver;
+import io.opencensus.proto.agent.trace.v1.CurrentLibraryConfig;
+import io.opencensus.proto.agent.trace.v1.ExportTraceServiceRequest;
+import io.opencensus.proto.agent.trace.v1.ExportTraceServiceResponse;
+import io.opencensus.proto.agent.trace.v1.UpdatedLibraryConfig;
+import io.opencensus.proto.trace.v1.ConstantSampler;
+import io.opencensus.proto.trace.v1.TraceConfig;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link FakeOcAgentTraceServiceGrpcImpl}. */
+@RunWith(JUnit4.class)
+public class FakeOcAgentTraceServiceGrpcImplTest {
+
+  private final List<UpdatedLibraryConfig> updatedLibraryConfigs = new ArrayList<>();
+
+  private final StreamObserver<UpdatedLibraryConfig> updatedConfigObserver =
+      new StreamObserver<UpdatedLibraryConfig>() {
+
+        @Override
+        public void onNext(UpdatedLibraryConfig value) {
+          updatedLibraryConfigs.add(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onCompleted() {}
+      };
+
+  private final StreamObserver<ExportTraceServiceResponse> exportResponseObserver =
+      new StreamObserver<ExportTraceServiceResponse>() {
+        @Override
+        public void onNext(ExportTraceServiceResponse value) {}
+
+        @Override
+        public void onError(Throwable t) {}
+
+        @Override
+        public void onCompleted() {}
+      };
+
+  private static final UpdatedLibraryConfig neverSampledLibraryConfig =
+      UpdatedLibraryConfig.newBuilder()
+          .setConfig(
+              TraceConfig.newBuilder()
+                  .setConstantSampler(ConstantSampler.newBuilder().setDecision(false).build())
+                  .build())
+          .build();
+
+  @Test
+  public void export() {
+    FakeOcAgentTraceServiceGrpcImpl traceServiceGrpc = new FakeOcAgentTraceServiceGrpcImpl();
+    StreamObserver<ExportTraceServiceRequest> exportRequestObserver =
+        traceServiceGrpc.export(exportResponseObserver);
+    ExportTraceServiceRequest request = ExportTraceServiceRequest.getDefaultInstance();
+    exportRequestObserver.onNext(request);
+    assertThat(traceServiceGrpc.getExportTraceServiceRequests()).containsExactly(request);
+  }
+
+  @Test
+  public void config() {
+    FakeOcAgentTraceServiceGrpcImpl traceServiceGrpc = new FakeOcAgentTraceServiceGrpcImpl();
+    StreamObserver<CurrentLibraryConfig> currentConfigObsever =
+        traceServiceGrpc.config(updatedConfigObserver);
+    CurrentLibraryConfig currentLibraryConfig = CurrentLibraryConfig.getDefaultInstance();
+    currentConfigObsever.onNext(currentLibraryConfig);
+    assertThat(traceServiceGrpc.getCurrentLibraryConfigs()).containsExactly(currentLibraryConfig);
+    assertThat(updatedLibraryConfigs).containsExactly(traceServiceGrpc.getUpdatedLibraryConfig());
+    updatedLibraryConfigs.clear();
+  }
+
+  @Test
+  public void config_WithNeverSampler() {
+    FakeOcAgentTraceServiceGrpcImpl traceServiceGrpc = new FakeOcAgentTraceServiceGrpcImpl();
+    traceServiceGrpc.setUpdatedLibraryConfig(neverSampledLibraryConfig);
+    StreamObserver<CurrentLibraryConfig> currentConfigObsever =
+        traceServiceGrpc.config(updatedConfigObserver);
+    CurrentLibraryConfig currentLibraryConfig = CurrentLibraryConfig.getDefaultInstance();
+    currentConfigObsever.onNext(currentLibraryConfig);
+    assertThat(traceServiceGrpc.getCurrentLibraryConfigs()).containsExactly(currentLibraryConfig);
+    assertThat(updatedLibraryConfigs).containsExactly(neverSampledLibraryConfig);
+    updatedLibraryConfigs.clear();
+  }
+}


### PR DESCRIPTION
This fake server will be used to test against the clients in https://github.com/census-instrumentation/opencensus-java/pull/1476.

Equivalent to https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/blob/master/mock_agent_test.go.