### PR TITLE
Metrics/Metric: Add a version of create that accepts only one timeseries.

### DIFF
--- a/api/src/main/java/io/opencensus/metrics/export/Metric.java
+++ b/api/src/main/java/io/opencensus/metrics/export/Metric.java
@@ -49,8 +49,8 @@ public abstract class Metric {
    * @since 0.17
    */
   public static Metric create(MetricDescriptor metricDescriptor, List<TimeSeries> timeSeriesList) {
-    Utils.checkNotNull(timeSeriesList, "timeSeriesList");
-    Utils.checkListElementNotNull(timeSeriesList, "timeSeries");
+    Utils.checkListElementNotNull(
+        Utils.checkNotNull(timeSeriesList, "timeSeriesList"), "timeSeries");
     return createInternal(
         metricDescriptor, Collections.unmodifiableList(new ArrayList<TimeSeries>(timeSeriesList)));
   }
@@ -65,8 +65,8 @@ public abstract class Metric {
    */
   public static Metric createWithOneTimeSeries(
       MetricDescriptor metricDescriptor, TimeSeries timeSeries) {
-    Utils.checkNotNull(timeSeries, "timeSeries");
-    return createInternal(metricDescriptor, Collections.singletonList(timeSeries));
+    return createInternal(
+        metricDescriptor, Collections.singletonList(Utils.checkNotNull(timeSeries, "timeSeries")));
   }
 
   /**

--- a/api/src/main/java/io/opencensus/metrics/export/Metric.java
+++ b/api/src/main/java/io/opencensus/metrics/export/Metric.java
@@ -49,12 +49,39 @@ public abstract class Metric {
    * @since 0.17
    */
   public static Metric create(MetricDescriptor metricDescriptor, List<TimeSeries> timeSeriesList) {
-    Utils.checkNotNull(metricDescriptor, "metricDescriptor");
     Utils.checkNotNull(timeSeriesList, "timeSeriesList");
     Utils.checkListElementNotNull(timeSeriesList, "timeSeries");
-    checkTypeMatch(metricDescriptor.getType(), timeSeriesList);
-    return new AutoValue_Metric(
+    return createInternal(
         metricDescriptor, Collections.unmodifiableList(new ArrayList<TimeSeries>(timeSeriesList)));
+  }
+
+  /**
+   * Creates a {@link Metric}.
+   *
+   * @param metricDescriptor the {@link MetricDescriptor}.
+   * @param timeSeries the single {@link TimeSeries} for this metric.
+   * @return a {@code Metric}.
+   * @since 0.17
+   */
+  public static Metric createWithOneTimeSeries(
+      MetricDescriptor metricDescriptor, TimeSeries timeSeries) {
+    Utils.checkNotNull(timeSeries, "timeSeries");
+    return createInternal(metricDescriptor, Collections.singletonList(timeSeries));
+  }
+
+  /**
+   * Creates a {@link Metric}.
+   *
+   * @param metricDescriptor the {@link MetricDescriptor}.
+   * @param timeSeriesList the {@link TimeSeries} list for this metric.
+   * @return a {@code Metric}.
+   * @since 0.17
+   */
+  private static Metric createInternal(
+      MetricDescriptor metricDescriptor, List<TimeSeries> timeSeriesList) {
+    Utils.checkNotNull(metricDescriptor, "metricDescriptor");
+    checkTypeMatch(metricDescriptor.getType(), timeSeriesList);
+    return new AutoValue_Metric(metricDescriptor, timeSeriesList);
   }
 
   /**

--- a/contrib/dropwizard/src/main/java/io/opencensus/contrib/dropwizard/DropWizardMetrics.java
+++ b/contrib/dropwizard/src/main/java/io/opencensus/contrib/dropwizard/DropWizardMetrics.java
@@ -107,7 +107,7 @@ public class DropWizardMetrics extends MetricProducer {
     TimeSeries timeSeries =
         TimeSeries.createWithOnePoint(
             Collections.<LabelValue>emptyList(), Point.create(value, clock.now()), null);
-    return Metric.create(metricDescriptor, Collections.singletonList(timeSeries));
+    return Metric.createWithOneTimeSeries(metricDescriptor, timeSeries);
   }
 
   /**
@@ -134,7 +134,7 @@ public class DropWizardMetrics extends MetricProducer {
             Collections.<LabelValue>emptyList(),
             Point.create(Value.longValue(counter.getCount()), clock.now()),
             null);
-    return Metric.create(metricDescriptor, Collections.singletonList(timeSeries));
+    return Metric.createWithOneTimeSeries(metricDescriptor, timeSeries);
   }
 
   /**
@@ -161,7 +161,7 @@ public class DropWizardMetrics extends MetricProducer {
             Point.create(Value.longValue(meter.getCount()), clock.now()),
             null);
 
-    return Metric.create(metricDescriptor, Collections.singletonList(timeSeries));
+    return Metric.createWithOneTimeSeries(metricDescriptor, timeSeries);
   }
 
   /**
@@ -231,7 +231,7 @@ public class DropWizardMetrics extends MetricProducer {
         TimeSeries.createWithOnePoint(
             Collections.<LabelValue>emptyList(), point, cumulativeStartTimestamp);
 
-    return Metric.create(metricDescriptor, Collections.singletonList(timeSeries));
+    return Metric.createWithOneTimeSeries(metricDescriptor, timeSeries);
   }
 
   @Override

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/Gauge.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/Gauge.java
@@ -37,7 +37,7 @@ abstract class Gauge {
   private final List<LabelValue> labelValues;
 
   final Metric getMetric(Clock clock) {
-    return Metric.create(metricDescriptor, Collections.singletonList(getTimeSeries(clock)));
+    return Metric.createWithOneTimeSeries(metricDescriptor, getTimeSeries(clock));
   }
 
   abstract TimeSeries getTimeSeries(Clock clock);

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
@@ -137,8 +137,9 @@ public final class LongGaugeImpl extends LongGauge implements Meter {
         timeSeriesList.add(entry.getValue().getTimeSeries(clock));
       }
 
-      // TODO(mayurkale): optimize this for 1 timeseries (issue #1491).
-      return Metric.create(metricDescriptor, timeSeriesList);
+      return pointCount == 1
+          ? Metric.createWithOneTimeSeries(metricDescriptor, timeSeriesList.get(0))
+          : Metric.create(metricDescriptor, timeSeriesList);
     }
     return null;
   }

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
@@ -129,19 +129,21 @@ public final class LongGaugeImpl extends LongGauge implements Meter {
   @Override
   public Metric getMetric(Clock clock) {
     Map<List<LabelValue>, PointImpl> currentRegisteredPoints = registeredPoints;
+    if (currentRegisteredPoints.isEmpty()) {
+      return null;
+    }
 
     int pointCount = currentRegisteredPoints.size();
-    if (pointCount > 0) {
-      List<TimeSeries> timeSeriesList = new ArrayList<TimeSeries>(pointCount);
-      for (Map.Entry<List<LabelValue>, PointImpl> entry : currentRegisteredPoints.entrySet()) {
-        timeSeriesList.add(entry.getValue().getTimeSeries(clock));
-      }
-
-      return pointCount == 1
-          ? Metric.createWithOneTimeSeries(metricDescriptor, timeSeriesList.get(0))
-          : Metric.create(metricDescriptor, timeSeriesList);
+    if (pointCount == 1) {
+      PointImpl point = currentRegisteredPoints.values().iterator().next();
+      return Metric.createWithOneTimeSeries(metricDescriptor, point.getTimeSeries(clock));
     }
-    return null;
+
+    List<TimeSeries> timeSeriesList = new ArrayList<TimeSeries>(pointCount);
+    for (Map.Entry<List<LabelValue>, PointImpl> entry : currentRegisteredPoints.entrySet()) {
+      timeSeriesList.add(entry.getValue().getTimeSeries(clock));
+    }
+    return Metric.create(metricDescriptor, timeSeriesList);
   }
 
   /** Implementation of {@link LongGauge.LongPoint}. */

--- a/impl_core/src/test/java/io/opencensus/implcore/metrics/GaugeTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/metrics/GaugeTest.java
@@ -86,25 +86,21 @@ public class GaugeTest {
   public void longGauge_GetMetric() {
     assertThat(longGauge.getMetric(testClock))
         .isEqualTo(
-            Metric.create(
+            Metric.createWithOneTimeSeries(
                 MetricDescriptor.create(NAME, DESCRIPTION, UNIT, Type.GAUGE_INT64, LABEL_KEYS),
-                Collections.singletonList(
-                    TimeSeries.createWithOnePoint(
-                        LABEL_VALUES,
-                        Point.create(Value.longValue(OBJ.hashCode()), TEST_TIME),
-                        null))));
+                TimeSeries.createWithOnePoint(
+                    LABEL_VALUES, Point.create(Value.longValue(OBJ.hashCode()), TEST_TIME), null)));
   }
 
   @Test
   public void doubleGauge_GetMetric() {
     assertThat(doubleGauge.getMetric(testClock))
         .isEqualTo(
-            Metric.create(
+            Metric.createWithOneTimeSeries(
                 MetricDescriptor.create(NAME, DESCRIPTION, UNIT, Type.GAUGE_DOUBLE, LABEL_KEYS),
-                Collections.singletonList(
-                    TimeSeries.createWithOnePoint(
-                        LABEL_VALUES,
-                        Point.create(Value.doubleValue(OBJ.hashCode()), TEST_TIME),
-                        null))));
+                TimeSeries.createWithOnePoint(
+                    LABEL_VALUES,
+                    Point.create(Value.doubleValue(OBJ.hashCode()), TEST_TIME),
+                    null)));
   }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/metrics/LongGaugeImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/metrics/LongGaugeImplTest.java
@@ -107,11 +107,10 @@ public class LongGaugeImplTest {
     assertThat(metric).isNotEqualTo(null);
     assertThat(metric)
         .isEqualTo(
-            Metric.create(
+            Metric.createWithOneTimeSeries(
                 METRIC_DESCRIPTOR,
-                Collections.singletonList(
-                    TimeSeries.createWithOnePoint(
-                        LABEL_VALUES, Point.create(Value.longValue(500), TEST_TIME), null))));
+                TimeSeries.createWithOnePoint(
+                    LABEL_VALUES, Point.create(Value.longValue(500), TEST_TIME), null)));
     new EqualsTester().addEqualityGroup(point, point1).testEquals();
   }
 
@@ -146,13 +145,10 @@ public class LongGaugeImplTest {
     assertThat(metric).isNotEqualTo(null);
     assertThat(metric)
         .isEqualTo(
-            Metric.create(
+            Metric.createWithOneTimeSeries(
                 METRIC_DESCRIPTOR,
-                Collections.singletonList(
-                    TimeSeries.createWithOnePoint(
-                        DEFAULT_LABEL_VALUES,
-                        Point.create(Value.longValue(400), TEST_TIME),
-                        null))));
+                TimeSeries.createWithOnePoint(
+                    DEFAULT_LABEL_VALUES, Point.create(Value.longValue(400), TEST_TIME), null)));
     new EqualsTester().addEqualityGroup(point, point1).testEquals();
   }
 
@@ -161,11 +157,10 @@ public class LongGaugeImplTest {
     longGaugeMetric.getOrCreateTimeSeries(LABEL_VALUES);
     assertThat(longGaugeMetric.getMetric(testClock))
         .isEqualTo(
-            Metric.create(
+            Metric.createWithOneTimeSeries(
                 METRIC_DESCRIPTOR,
-                Collections.singletonList(
-                    TimeSeries.createWithOnePoint(
-                        LABEL_VALUES, Point.create(Value.longValue(0), TEST_TIME), null))));
+                TimeSeries.createWithOnePoint(
+                    LABEL_VALUES, Point.create(Value.longValue(0), TEST_TIME), null)));
 
     longGaugeMetric.removeTimeSeries(LABEL_VALUES);
     assertThat(longGaugeMetric.getMetric(testClock)).isEqualTo(null);


### PR DESCRIPTION
Fixes #1491 