### PR TITLE
Gauge API : Add support for DerivedDoubleGauge

### DIFF
--- a/api/src/main/java/io/opencensus/common/ToDoubleFunction.java
+++ b/api/src/main/java/io/opencensus/common/ToDoubleFunction.java
@@ -16,6 +16,10 @@
 
 package io.opencensus.common;
 
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
 /**
  * Represents a function that produces a double-valued result. See {@link
  * io.opencensus.metrics.MetricRegistry} for an example of its use.
@@ -25,7 +29,7 @@ package io.opencensus.common;
  *
  * @since 0.16
  */
-public interface ToDoubleFunction<T> {
+public interface ToDoubleFunction</*@Nullable*/ T> {
 
   /**
    * Applies this function to the given argument.
@@ -33,5 +37,5 @@ public interface ToDoubleFunction<T> {
    * @param value the function argument.
    * @return the function result.
    */
-  double applyAsDouble(T value);
+  double applyAsDouble(/*@Nullable*/ T value);
 }

--- a/api/src/main/java/io/opencensus/metrics/DerivedDoubleGauge.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedDoubleGauge.java
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Derived Double Gauge metric, to report instantaneous measurement of a double value. Gauges can go
  * both up and down. The gauges values can be negative.
  *
- * <p>Example: Create a Gauge with a object and a callback function.
+ * <p>Example: Create a Gauge with an object and a callback function.
  *
  * <pre>{@code
  * class YourClass {

--- a/api/src/main/java/io/opencensus/metrics/DerivedDoubleGauge.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedDoubleGauge.java
@@ -81,8 +81,8 @@ public abstract class DerivedDoubleGauge {
    * @since 0.17
    */
   public abstract <T> void createTimeSeries(
-      List<LabelValue> labelValues, /*@Nullable*/
-      T obj,
+      List<LabelValue> labelValues,
+      /*@Nullable*/ T obj,
       ToDoubleFunction</*@Nullable*/ T> function);
 
   /**
@@ -133,8 +133,8 @@ public abstract class DerivedDoubleGauge {
 
     @Override
     public <T> void createTimeSeries(
-        List<LabelValue> labelValues, /*@Nullable*/
-        T obj,
+        List<LabelValue> labelValues,
+        /*@Nullable*/ T obj,
         ToDoubleFunction</*@Nullable*/ T> function) {
       Utils.checkListElementNotNull(
           Utils.checkNotNull(labelValues, "labelValues"), "labelValue element should not be null.");

--- a/api/src/main/java/io/opencensus/metrics/DerivedDoubleGauge.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedDoubleGauge.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import io.opencensus.common.ToDoubleFunction;
+import io.opencensus.internal.Utils;
+import java.lang.ref.WeakReference;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
+/**
+ * Derived Double Gauge metric, to report instantaneous measurement of a double value. Gauges can go
+ * both up and down. The gauges values can be negative.
+ *
+ * <p>Example: Create a Gauge with a object and a callback function.
+ *
+ * <pre>{@code
+ * class YourClass {
+ *
+ *   private static final MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+ *
+ *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
+ *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
+ *
+ *   // TODO(mayurkale): Plugs-in the DerivedDoubleGauge into the registry.
+ *   DerivedDoubleGauge gauge = metricRegistry.addDerivedDoubleGauge(
+ *       "queue_size", "Pending jobs in a queue", "1", labelKeys);
+ *
+ *   QueueManager queueManager = new QueueManager();
+ *   gauge.createTimeSeries(labelValues, queueManager,
+ *         new ToDoubleFunction<QueueManager>() {
+ *           {@literal @}Override
+ *           public double applyAsDouble(QueueManager queue) {
+ *             return queue.size();
+ *           }
+ *         });
+ *
+ *   void doWork() {
+ *      // Your code here.
+ *   }
+ * }
+ *
+ * }</pre>
+ *
+ * @since 0.17
+ */
+@ThreadSafe
+public abstract class DerivedDoubleGauge {
+  /**
+   * Creates a {@code TimeSeries}. The value of a single point in the TimeSeries is observed from a
+   * callback function. This function is invoked whenever metrics are collected, meaning the
+   * reported value is up-to-date. It keeps a {@link WeakReference} to the object and it is the
+   * user's responsibility to manage the lifetime of the object.
+   *
+   * @param labelValues the list of label values.
+   * @param obj the state object from which the function derives a measurement.
+   * @param function the function to be called.
+   * @param <T> the type of the object upon which the function derives a measurement.
+   * @throws NullPointerException if {@code labelValues} is null OR any element of {@code
+   *     labelValues} is null OR {@code function} is null.
+   * @throws IllegalArgumentException if different time series with the same labels already exists
+   *     OR if number of {@code labelValues}s are not equal to the label keys.
+   * @since 0.17
+   */
+  public abstract <T> void createTimeSeries(
+      List<LabelValue> labelValues, /*@Nullable*/
+      T obj,
+      ToDoubleFunction</*@Nullable*/ T> function);
+
+  /**
+   * Removes the {@code TimeSeries} from the gauge metric, if it is present.
+   *
+   * @param labelValues the list of label values.
+   * @throws NullPointerException if {@code labelValues} is null.
+   * @since 0.17
+   */
+  public abstract void removeTimeSeries(List<LabelValue> labelValues);
+
+  /**
+   * Removes all {@code TimeSeries} from the gauge metric.
+   *
+   * @since 0.17
+   */
+  public abstract void clear();
+
+  /**
+   * Returns the no-op implementation of the {@code DerivedDoubleGauge}.
+   *
+   * @return the no-op implementation of the {@code DerivedDoubleGauge}.
+   * @since 0.17
+   */
+  static DerivedDoubleGauge newNoopDerivedDoubleGauge(
+      String name, String description, String unit, List<LabelKey> labelKeys) {
+    return NoopDerivedDoubleGauge.create(name, description, unit, labelKeys);
+  }
+
+  /** No-op implementations of DerivedDoubleGauge class. */
+  private static final class NoopDerivedDoubleGauge extends DerivedDoubleGauge {
+    private final int labelKeysSize;
+
+    static NoopDerivedDoubleGauge create(
+        String name, String description, String unit, List<LabelKey> labelKeys) {
+      return new NoopDerivedDoubleGauge(name, description, unit, labelKeys);
+    }
+
+    /** Creates a new {@code NoopDerivedDoubleGauge}. */
+    NoopDerivedDoubleGauge(String name, String description, String unit, List<LabelKey> labelKeys) {
+      Utils.checkNotNull(name, "name");
+      Utils.checkNotNull(description, "description");
+      Utils.checkNotNull(unit, "unit");
+      Utils.checkListElementNotNull(
+          Utils.checkNotNull(labelKeys, "labelKeys"), "labelKey element should not be null.");
+      labelKeysSize = labelKeys.size();
+    }
+
+    @Override
+    public <T> void createTimeSeries(
+        List<LabelValue> labelValues, /*@Nullable*/
+        T obj,
+        ToDoubleFunction</*@Nullable*/ T> function) {
+      Utils.checkListElementNotNull(
+          Utils.checkNotNull(labelValues, "labelValues"), "labelValue element should not be null.");
+      Utils.checkArgument(labelKeysSize == labelValues.size(), "Incorrect number of labels.");
+      Utils.checkNotNull(function, "function");
+    }
+
+    @Override
+    public void removeTimeSeries(List<LabelValue> labelValues) {
+      Utils.checkNotNull(labelValues, "labelValues");
+    }
+
+    @Override
+    public void clear() {}
+  }
+}

--- a/api/src/main/java/io/opencensus/metrics/DerivedLongGauge.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedLongGauge.java
@@ -131,8 +131,8 @@ public abstract class DerivedLongGauge {
 
     @Override
     public <T> void createTimeSeries(
-        List<LabelValue> labelValues, /*@Nullable*/
-        T obj,
+        List<LabelValue> labelValues,
+        /*@Nullable*/ T obj,
         ToLongFunction</*@Nullable*/ T> function) {
       Utils.checkListElementNotNull(
           Utils.checkNotNull(labelValues, "labelValues"), "labelValue element should not be null.");

--- a/api/src/main/java/io/opencensus/metrics/DerivedLongGauge.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedLongGauge.java
@@ -30,7 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * Derived Long Gauge metric, to report instantaneous measurement of an int64 value. Gauges can go
  * both up and down. The gauges values can be negative.
  *
- * <p>Example: Create a Gauge with object and function.
+ * <p>Example: Create a Gauge with an object and a callback function.
  *
  * <pre>{@code
  * class YourClass {

--- a/api/src/test/java/io/opencensus/metrics/DerivedDoubleGaugeTest.java
+++ b/api/src/test/java/io/opencensus/metrics/DerivedDoubleGaugeTest.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import io.opencensus.common.ToDoubleFunction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DerivedDoubleGauge}. */
+// TODO(mayurkale): Add more tests, once DerivedDoubleGauge plugs-in into the registry.
+@RunWith(JUnit4.class)
+public class DerivedDoubleGaugeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final DerivedDoubleGauge derivedDoubleGauge =
+      DerivedDoubleGauge.newNoopDerivedDoubleGauge(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+  private static final ToDoubleFunction<Object> doubleFunction =
+      new ToDoubleFunction<Object>() {
+        @Override
+        public double applyAsDouble(Object value) {
+          return 5.0;
+        }
+      };
+
+  @Test
+  public void noopCreateTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleGauge.createTimeSeries(null, null, doubleFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue element should not be null.");
+    derivedDoubleGauge.createTimeSeries(labelValues, null, doubleFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithInvalidLabelSize() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Incorrect number of labels.");
+    derivedDoubleGauge.createTimeSeries(EMPTY_LABEL_VALUES, null, doubleFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithNullFunction() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("function");
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, null, null);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleGauge.removeTimeSeries(null);
+  }
+}

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
@@ -101,11 +101,12 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
   }
 
   @Override
+  @SuppressWarnings("rawtypes")
   public synchronized void clear() {
-    registeredPoints = Collections.emptyMap();
+    registeredPoints = Collections.<List<LabelValue>, PointWithFunction>emptyMap();
   }
 
-  @javax.annotation.Nullable
+  /*@Nullable*/
   @Override
   @SuppressWarnings("rawtypes")
   public Metric getMetric(Clock clock) {
@@ -127,7 +128,7 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
     return Metric.create(metricDescriptor, timeSeriesList);
   }
 
-  /** Implementation of {@link PointWithFunction} with a obj and function. */
+  /** Implementation of {@link PointWithFunction} with an object and a callback function. */
   public static final class PointWithFunction<T> {
     private final List<LabelValue> labelValues;
     @javax.annotation.Nullable private final WeakReference<T> ref;

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
@@ -49,7 +49,7 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
 
   @SuppressWarnings("rawtypes")
   private volatile Map<List<LabelValue>, PointWithFunction> registeredPoints =
-      Collections.emptyMap();
+      Collections.<List<LabelValue>, PointWithFunction>emptyMap();
 
   DerivedDoubleGaugeImpl(String name, String description, String unit, List<LabelKey> labelKeys) {
     labelKeysSize = labelKeys.size();
@@ -60,8 +60,8 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
   @Override
   @SuppressWarnings("rawtypes")
   public synchronized <T> void createTimeSeries(
-      List<LabelValue> labelValues, /*@Nullable*/
-      T obj,
+      List<LabelValue> labelValues,
+      /*@Nullable*/ T obj,
       ToDoubleFunction</*@Nullable*/ T> function) {
     Utils.checkListElementNotNull(
         checkNotNull(labelValues, "labelValues"), "labelValue element should not be null.");
@@ -69,7 +69,7 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
     checkNotNull(function, "function");
 
     List<LabelValue> labelValuesCopy =
-        Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues));
+        Collections.<LabelValue>unmodifiableList(new ArrayList<LabelValue>(labelValues));
 
     PointWithFunction existingPoint = registeredPoints.get(labelValuesCopy);
     if (existingPoint != null) {
@@ -134,8 +134,8 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
     private final ToDoubleFunction</*@Nullable*/ T> function;
 
     PointWithFunction(
-        List<LabelValue> labelValues, /*@Nullable*/
-        T obj,
+        List<LabelValue> labelValues,
+        /*@Nullable*/ T obj,
         ToDoubleFunction</*@Nullable*/ T> function) {
       this.labelValues = labelValues;
       ref = obj != null ? new WeakReference<T>(obj) : null;

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
@@ -1,0 +1,154 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.metrics;
+
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import io.opencensus.common.Clock;
+import io.opencensus.common.ToDoubleFunction;
+import io.opencensus.implcore.internal.Utils;
+import io.opencensus.metrics.DerivedDoubleGauge;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import io.opencensus.metrics.export.Metric;
+import io.opencensus.metrics.export.MetricDescriptor;
+import io.opencensus.metrics.export.MetricDescriptor.Type;
+import io.opencensus.metrics.export.Point;
+import io.opencensus.metrics.export.TimeSeries;
+import io.opencensus.metrics.export.Value;
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
+/** Implementation of {@link DerivedDoubleGauge}. */
+public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements Meter {
+  private final MetricDescriptor metricDescriptor;
+  private final int labelKeysSize;
+
+  @SuppressWarnings("rawtypes")
+  private volatile Map<List<LabelValue>, PointWithFunction> registeredPoints =
+      Collections.emptyMap();
+
+  DerivedDoubleGaugeImpl(String name, String description, String unit, List<LabelKey> labelKeys) {
+    labelKeysSize = labelKeys.size();
+    this.metricDescriptor =
+        MetricDescriptor.create(name, description, unit, Type.GAUGE_DOUBLE, labelKeys);
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public synchronized <T> void createTimeSeries(
+      List<LabelValue> labelValues, /*@Nullable*/
+      T obj,
+      ToDoubleFunction</*@Nullable*/ T> function) {
+    Utils.checkListElementNotNull(
+        checkNotNull(labelValues, "labelValues"), "labelValue element should not be null.");
+    checkArgument(labelKeysSize == labelValues.size(), "Incorrect number of labels.");
+    checkNotNull(function, "function");
+
+    List<LabelValue> labelValuesCopy =
+        Collections.unmodifiableList(new ArrayList<LabelValue>(labelValues));
+
+    PointWithFunction existingPoint = registeredPoints.get(labelValuesCopy);
+    if (existingPoint != null) {
+      throw new IllegalArgumentException(
+          "A different time series with the same labels already exists.");
+    }
+
+    PointWithFunction newPoint = new PointWithFunction<T>(labelValuesCopy, obj, function);
+    // Updating the map of time series happens under a lock to avoid multiple add operations
+    // to happen in the same time.
+    Map<List<LabelValue>, PointWithFunction> registeredPointsCopy =
+        new LinkedHashMap<List<LabelValue>, PointWithFunction>(registeredPoints);
+    registeredPointsCopy.put(labelValuesCopy, newPoint);
+    registeredPoints = Collections.unmodifiableMap(registeredPointsCopy);
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public synchronized void removeTimeSeries(List<LabelValue> labelValues) {
+    checkNotNull(labelValues, "labelValues");
+
+    Map<List<LabelValue>, PointWithFunction> registeredPointsCopy =
+        new LinkedHashMap<List<LabelValue>, PointWithFunction>(registeredPoints);
+    if (registeredPointsCopy.remove(labelValues) == null) {
+      // The element not present, no need to update the current map of time series.
+      return;
+    }
+    registeredPoints = Collections.unmodifiableMap(registeredPointsCopy);
+  }
+
+  @Override
+  public synchronized void clear() {
+    registeredPoints = Collections.emptyMap();
+  }
+
+  @javax.annotation.Nullable
+  @Override
+  @SuppressWarnings("rawtypes")
+  public Metric getMetric(Clock clock) {
+    Map<List<LabelValue>, PointWithFunction> currentRegisteredPoints = registeredPoints;
+    if (currentRegisteredPoints.isEmpty()) {
+      return null;
+    }
+
+    if (currentRegisteredPoints.size() == 1) {
+      PointWithFunction point = currentRegisteredPoints.values().iterator().next();
+      return Metric.createWithOneTimeSeries(metricDescriptor, point.getTimeSeries(clock));
+    }
+
+    List<TimeSeries> timeSeriesList = new ArrayList<TimeSeries>(currentRegisteredPoints.size());
+    for (Map.Entry<List<LabelValue>, PointWithFunction> entry :
+        currentRegisteredPoints.entrySet()) {
+      timeSeriesList.add(entry.getValue().getTimeSeries(clock));
+    }
+    return Metric.create(metricDescriptor, timeSeriesList);
+  }
+
+  /** Implementation of {@link PointWithFunction} with a obj and function. */
+  public static final class PointWithFunction<T> {
+    private final List<LabelValue> labelValues;
+    @javax.annotation.Nullable private final WeakReference<T> ref;
+    private final ToDoubleFunction</*@Nullable*/ T> function;
+
+    PointWithFunction(
+        List<LabelValue> labelValues, /*@Nullable*/
+        T obj,
+        ToDoubleFunction</*@Nullable*/ T> function) {
+      this.labelValues = labelValues;
+      ref = obj != null ? new WeakReference<T>(obj) : null;
+      this.function = function;
+    }
+
+    private TimeSeries getTimeSeries(Clock clock) {
+      final T obj = ref != null ? ref.get() : null;
+      double value = function.applyAsDouble(obj);
+
+      // TODO(mayurkale): OPTIMIZATION: Avoid re-evaluate the labelValues all the time (issue#1490).
+      return TimeSeries.createWithOnePoint(
+          labelValues, Point.create(Value.doubleValue(value), clock.now()), null);
+    }
+  }
+}

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedLongGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedLongGaugeImpl.java
@@ -99,11 +99,12 @@ public final class DerivedLongGaugeImpl extends DerivedLongGauge implements Mete
   }
 
   @Override
+  @SuppressWarnings("rawtypes")
   public synchronized void clear() {
-    registeredPoints = Collections.emptyMap();
+    registeredPoints = Collections.<List<LabelValue>, PointWithFunction>emptyMap();
   }
 
-  @javax.annotation.Nullable
+  /*@Nullable*/
   @Override
   @SuppressWarnings("rawtypes")
   public Metric getMetric(Clock clock) {
@@ -125,7 +126,7 @@ public final class DerivedLongGaugeImpl extends DerivedLongGauge implements Mete
     return Metric.create(metricDescriptor, timeSeriesList);
   }
 
-  /** Implementation of {@link PointWithFunction} with a obj and a callback function. */
+  /** Implementation of {@link PointWithFunction} with an object and a callback function. */
   public static final class PointWithFunction<T> {
     private final List<LabelValue> labelValues;
     @javax.annotation.Nullable private final WeakReference<T> ref;

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedLongGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedLongGaugeImpl.java
@@ -49,7 +49,7 @@ public final class DerivedLongGaugeImpl extends DerivedLongGauge implements Mete
 
   @SuppressWarnings("rawtypes")
   private volatile Map<List<LabelValue>, PointWithFunction> registeredPoints =
-      Collections.emptyMap();
+      Collections.<List<LabelValue>, PointWithFunction>emptyMap();
 
   DerivedLongGaugeImpl(String name, String description, String unit, List<LabelKey> labelKeys) {
     labelKeysSize = labelKeys.size();
@@ -132,8 +132,8 @@ public final class DerivedLongGaugeImpl extends DerivedLongGauge implements Mete
     private final ToLongFunction</*@Nullable*/ T> function;
 
     PointWithFunction(
-        List<LabelValue> labelValues, /*@Nullable*/
-        T obj,
+        List<LabelValue> labelValues,
+        /*@Nullable*/ T obj,
         ToLongFunction</*@Nullable*/ T> function) {
       this.labelValues = labelValues;
       ref = obj != null ? new WeakReference<T>(obj) : null;

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DoubleGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DoubleGaugeImpl.java
@@ -44,7 +44,8 @@ public final class DoubleGaugeImpl extends DoubleGauge implements Meter {
   @VisibleForTesting static final LabelValue UNSET_VALUE = LabelValue.create(null);
 
   private final MetricDescriptor metricDescriptor;
-  private volatile Map<List<LabelValue>, PointImpl> registeredPoints = Collections.emptyMap();
+  private volatile Map<List<LabelValue>, PointImpl> registeredPoints =
+      Collections.<List<LabelValue>, PointImpl>emptyMap();
   private final int labelKeysSize;
   private final List<LabelValue> defaultLabelValues;
 

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DoubleGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DoubleGaugeImpl.java
@@ -100,7 +100,7 @@ public final class DoubleGaugeImpl extends DoubleGauge implements Meter {
 
   @Override
   public synchronized void clear() {
-    registeredPoints = Collections.emptyMap();
+    registeredPoints = Collections.<List<LabelValue>, PointImpl>emptyMap();
   }
 
   private synchronized DoublePoint registerTimeSeries(List<LabelValue> labelValues) {

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
@@ -44,7 +44,8 @@ public final class LongGaugeImpl extends LongGauge implements Meter {
   @VisibleForTesting static final LabelValue UNSET_VALUE = LabelValue.create(null);
 
   private final MetricDescriptor metricDescriptor;
-  private volatile Map<List<LabelValue>, PointImpl> registeredPoints = Collections.emptyMap();
+  private volatile Map<List<LabelValue>, PointImpl> registeredPoints =
+      Collections.<List<LabelValue>, PointImpl>emptyMap();
   private final int labelKeysSize;
   private final List<LabelValue> defaultLabelValues;
 

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
@@ -100,7 +100,7 @@ public final class LongGaugeImpl extends LongGauge implements Meter {
 
   @Override
   public synchronized void clear() {
-    registeredPoints = Collections.emptyMap();
+    registeredPoints = Collections.<List<LabelValue>, PointImpl>emptyMap();
   }
 
   private synchronized LongPoint registerTimeSeries(List<LabelValue> labelValues) {

--- a/impl_core/src/test/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImplTest.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.implcore.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.opencensus.common.Timestamp;
+import io.opencensus.common.ToDoubleFunction;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import io.opencensus.metrics.export.Metric;
+import io.opencensus.metrics.export.MetricDescriptor;
+import io.opencensus.metrics.export.MetricDescriptor.Type;
+import io.opencensus.metrics.export.Point;
+import io.opencensus.metrics.export.TimeSeries;
+import io.opencensus.metrics.export.Value;
+import io.opencensus.testing.common.TestClock;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DerivedDoubleGaugeImpl}. */
+@RunWith(JUnit4.class)
+public class DerivedDoubleGaugeImplTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String METRIC_NAME = "name";
+  private static final String METRIC_DESCRIPTION = "description";
+  private static final String METRIC_UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelValue> LABEL_VALUES_1 =
+      Collections.singletonList(LabelValue.create("value1"));
+  private static final Timestamp TEST_TIME = Timestamp.create(1234, 123);
+  private final TestClock testClock = TestClock.create(TEST_TIME);
+  private static final MetricDescriptor METRIC_DESCRIPTOR =
+      MetricDescriptor.create(
+          METRIC_NAME, METRIC_DESCRIPTION, METRIC_UNIT, Type.GAUGE_DOUBLE, LABEL_KEY);
+
+  private final DerivedDoubleGaugeImpl derivedDoubleGauge =
+      new DerivedDoubleGaugeImpl(METRIC_NAME, METRIC_DESCRIPTION, METRIC_UNIT, LABEL_KEY);
+
+  // helper class
+  public static class QueueManager {
+    public double size() {
+      return 2.5;
+    }
+  }
+
+  private static final ToDoubleFunction<Object> doubleFunction =
+      new ToDoubleFunction<Object>() {
+        @Override
+        public double applyAsDouble(Object value) {
+          return 5.5;
+        }
+      };
+  private static final ToDoubleFunction<Object> negativeDoubleFunction =
+      new ToDoubleFunction<Object>() {
+        @Override
+        public double applyAsDouble(Object value) {
+          return -200.5;
+        }
+      };
+  private static final ToDoubleFunction<QueueManager> queueManagerFunction =
+      new ToDoubleFunction<QueueManager>() {
+        @Override
+        public double applyAsDouble(QueueManager queue) {
+          return queue.size();
+        }
+      };
+
+  @Test
+  public void createTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleGauge.createTimeSeries(null, null, doubleFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithNullElement() {
+    List<LabelKey> labelKeys =
+        Arrays.asList(LabelKey.create("key1", "desc"), LabelKey.create("key2", "desc"));
+    List<LabelValue> labelValues = Arrays.asList(LabelValue.create("value1"), null);
+    DerivedDoubleGaugeImpl derivedDoubleGauge =
+        new DerivedDoubleGaugeImpl(METRIC_NAME, METRIC_DESCRIPTION, METRIC_UNIT, labelKeys);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue element should not be null.");
+    derivedDoubleGauge.createTimeSeries(labelValues, null, doubleFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithInvalidLabelSize() {
+    List<LabelValue> labelValues =
+        Arrays.asList(LabelValue.create("value1"), LabelValue.create("value2"));
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Incorrect number of labels.");
+    derivedDoubleGauge.createTimeSeries(labelValues, null, doubleFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithNullFunction() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("function");
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, null, null);
+  }
+
+  @Test
+  public void createTimeSeries_WithObjFunction() {
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, new QueueManager(), queueManagerFunction);
+    Metric metric = derivedDoubleGauge.getMetric(testClock);
+    assertThat(metric).isNotNull();
+    assertThat(metric)
+        .isEqualTo(
+            Metric.createWithOneTimeSeries(
+                METRIC_DESCRIPTOR,
+                TimeSeries.createWithOnePoint(
+                    LABEL_VALUES, Point.create(Value.doubleValue(2.5), TEST_TIME), null)));
+  }
+
+  @Test
+  public void createTimeSeries_WithSameLabel() {
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, new QueueManager(), queueManagerFunction);
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("A different time series with the same labels already exists.");
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, null, queueManagerFunction);
+  }
+
+  @Test
+  public void addTimeSeries_WithNullObj() {
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, null, negativeDoubleFunction);
+    Metric metric = derivedDoubleGauge.getMetric(testClock);
+    assertThat(metric).isNotNull();
+    assertThat(metric)
+        .isEqualTo(
+            Metric.createWithOneTimeSeries(
+                METRIC_DESCRIPTOR,
+                TimeSeries.createWithOnePoint(
+                    LABEL_VALUES, Point.create(Value.doubleValue(-200.5), TEST_TIME), null)));
+  }
+
+  @Test
+  public void removeTimeSeries() {
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, null, doubleFunction);
+    Metric metric = derivedDoubleGauge.getMetric(testClock);
+    assertThat(metric).isNotNull();
+    assertThat(metric.getMetricDescriptor()).isEqualTo(METRIC_DESCRIPTOR);
+    assertThat(metric.getTimeSeriesList().size()).isEqualTo(1);
+    derivedDoubleGauge.removeTimeSeries(LABEL_VALUES);
+    assertThat(derivedDoubleGauge.getMetric(testClock)).isNull();
+  }
+
+  @Test
+  public void removeTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleGauge.removeTimeSeries(null);
+  }
+
+  @Test
+  public void multipleMetrics_GetMetric() {
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, null, doubleFunction);
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES_1, new QueueManager(), queueManagerFunction);
+    List<TimeSeries> expectedTimeSeriesList = new ArrayList<TimeSeries>();
+    expectedTimeSeriesList.add(
+        TimeSeries.createWithOnePoint(
+            LABEL_VALUES, Point.create(Value.doubleValue(5.5), TEST_TIME), null));
+    expectedTimeSeriesList.add(
+        TimeSeries.createWithOnePoint(
+            LABEL_VALUES_1, Point.create(Value.doubleValue(2.5), TEST_TIME), null));
+    Metric metric = derivedDoubleGauge.getMetric(testClock);
+    assertThat(metric).isNotNull();
+    assertThat(metric.getMetricDescriptor()).isEqualTo(METRIC_DESCRIPTOR);
+    assertThat(metric.getTimeSeriesList().size()).isEqualTo(2);
+    assertThat(metric.getTimeSeriesList()).containsExactlyElementsIn(expectedTimeSeriesList);
+    assertThat(metric.getTimeSeriesList().get(0).getLabelValues().size()).isEqualTo(1);
+    assertThat(metric.getTimeSeriesList().get(0).getLabelValues().get(0))
+        .isEqualTo(LabelValue.create("value"));
+    assertThat(metric.getTimeSeriesList().get(1).getLabelValues().size()).isEqualTo(1);
+    assertThat(metric.getTimeSeriesList().get(1).getLabelValues().get(0))
+        .isEqualTo(LabelValue.create("value1"));
+  }
+
+  @Test
+  public void clear() {
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES, null, doubleFunction);
+    derivedDoubleGauge.createTimeSeries(LABEL_VALUES_1, new QueueManager(), queueManagerFunction);
+    Metric metric = derivedDoubleGauge.getMetric(testClock);
+    assertThat(metric).isNotNull();
+    assertThat(metric.getMetricDescriptor()).isEqualTo(METRIC_DESCRIPTOR);
+    assertThat(metric.getTimeSeriesList().size()).isEqualTo(2);
+    derivedDoubleGauge.clear();
+    assertThat(derivedDoubleGauge.getMetric(testClock)).isNull();
+  }
+
+  @Test
+  public void empty_GetMetrics() {
+    assertThat(derivedDoubleGauge.getMetric(testClock)).isNull();
+  }
+}


### PR DESCRIPTION
This is the last installment in Gauges API. 

**Gauge API : Add LongGauge Support (Part1)**  https://github.com/census-instrumentation/opencensus-java/pull/1489

**Gauge API : Add DoubleGauge Support (Part2)** https://github.com/census-instrumentation/opencensus-java/pull/1496

**Gauge API : Add support for DerivedLongGauge (Part3)** https://github.com/census-instrumentation/opencensus-java/pull/1497