### PR TITLE
TimeSeries/Create: Avoid re-evaluate the labelValues all the time

### DIFF
--- a/api/src/main/java/io/opencensus/metrics/export/TimeSeries.java
+++ b/api/src/main/java/io/opencensus/metrics/export/TimeSeries.java
@@ -61,6 +61,17 @@ public abstract class TimeSeries {
    * Creates a {@link TimeSeries}.
    *
    * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
+   * @return a {@code TimeSeries}.
+   * @since 0.17
+   */
+  public static TimeSeries create(List<LabelValue> labelValues) {
+    return createInternal(labelValues, Collections.<Point>emptyList(), null);
+  }
+
+  /**
+   * Creates a {@link TimeSeries}.
+   *
+   * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
    * @param point the single data {@code Point} of this {@code TimeSeries}.
    * @param startTimestamp the start {@code Timestamp} of this {@code TimeSeries}. Must be non-null
    *     for cumulative {@code Point}s.
@@ -71,6 +82,18 @@ public abstract class TimeSeries {
       List<LabelValue> labelValues, Point point, @Nullable Timestamp startTimestamp) {
     Utils.checkNotNull(point, "point");
     return createInternal(labelValues, Collections.singletonList(point), startTimestamp);
+  }
+
+  /**
+   * Sets the {@code Point} of the {@link TimeSeries}.
+   *
+   * @param point the single data {@code Point} of this {@code TimeSeries}.
+   * @return a {@code TimeSeries}.
+   * @since 0.17
+   */
+  public TimeSeries setPoint(Point point) {
+    Utils.checkNotNull(point, "point");
+    return new AutoValue_TimeSeries(getLabelValues(), Collections.singletonList(point), null);
   }
 
   /**

--- a/api/src/main/java/io/opencensus/metrics/export/TimeSeries.java
+++ b/api/src/main/java/io/opencensus/metrics/export/TimeSeries.java
@@ -58,7 +58,7 @@ public abstract class TimeSeries {
   }
 
   /**
-   * Creates a {@link TimeSeries}.
+   * Creates a {@link TimeSeries} with empty(or no) points.
    *
    * @param labelValues the {@code LabelValue}s that uniquely identify this {@code TimeSeries}.
    * @return a {@code TimeSeries}.

--- a/api/src/test/java/io/opencensus/metrics/export/TimeSeriesTest.java
+++ b/api/src/test/java/io/opencensus/metrics/export/TimeSeriesTest.java
@@ -60,6 +60,16 @@ public class TimeSeriesTest {
   }
 
   @Test
+  public void setPoint_TimeSeries() {
+    TimeSeries timeSeries = TimeSeries.create(Arrays.asList(LABEL_VALUE_1, LABEL_VALUE_2));
+    TimeSeries timeSeries1 = timeSeries.setPoint(POINT_1);
+    assertThat(timeSeries1.getLabelValues())
+        .containsExactly(LABEL_VALUE_1, LABEL_VALUE_2)
+        .inOrder();
+    assertThat(timeSeries1.getPoints()).containsExactly(POINT_1).inOrder();
+  }
+
+  @Test
   public void create_WithNullLabelValueList() {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage(CoreMatchers.equalTo("labelValues"));

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
@@ -130,7 +130,7 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
 
   /** Implementation of {@link PointWithFunction} with an object and a callback function. */
   public static final class PointWithFunction<T> {
-    private final List<LabelValue> labelValues;
+    private final TimeSeries defaultTimeSeries;
     @javax.annotation.Nullable private final WeakReference<T> ref;
     private final ToDoubleFunction</*@Nullable*/ T> function;
 
@@ -138,7 +138,7 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
         List<LabelValue> labelValues,
         /*@Nullable*/ T obj,
         ToDoubleFunction</*@Nullable*/ T> function) {
-      this.labelValues = labelValues;
+      defaultTimeSeries = TimeSeries.create(labelValues);
       ref = obj != null ? new WeakReference<T>(obj) : null;
       this.function = function;
     }
@@ -146,10 +146,7 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
     private TimeSeries getTimeSeries(Clock clock) {
       final T obj = ref != null ? ref.get() : null;
       double value = function.applyAsDouble(obj);
-
-      // TODO(mayurkale): OPTIMIZATION: Avoid re-evaluate the labelValues all the time (issue#1490).
-      return TimeSeries.createWithOnePoint(
-          labelValues, Point.create(Value.doubleValue(value), clock.now()), null);
+      return defaultTimeSeries.setPoint(Point.create(Value.doubleValue(value), clock.now()));
     }
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedLongGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedLongGaugeImpl.java
@@ -128,7 +128,7 @@ public final class DerivedLongGaugeImpl extends DerivedLongGauge implements Mete
 
   /** Implementation of {@link PointWithFunction} with an object and a callback function. */
   public static final class PointWithFunction<T> {
-    private final List<LabelValue> labelValues;
+    private final TimeSeries defaultTimeSeries;
     @javax.annotation.Nullable private final WeakReference<T> ref;
     private final ToLongFunction</*@Nullable*/ T> function;
 
@@ -136,7 +136,7 @@ public final class DerivedLongGaugeImpl extends DerivedLongGauge implements Mete
         List<LabelValue> labelValues,
         /*@Nullable*/ T obj,
         ToLongFunction</*@Nullable*/ T> function) {
-      this.labelValues = labelValues;
+      defaultTimeSeries = TimeSeries.create(labelValues);
       ref = obj != null ? new WeakReference<T>(obj) : null;
       this.function = function;
     }
@@ -144,10 +144,7 @@ public final class DerivedLongGaugeImpl extends DerivedLongGauge implements Mete
     private TimeSeries getTimeSeries(Clock clock) {
       final T obj = ref != null ? ref.get() : null;
       long value = function.applyAsLong(obj);
-
-      // TODO(mayurkale): OPTIMIZATION: Avoid re-evaluate the labelValues all the time (issue#1490).
-      return TimeSeries.createWithOnePoint(
-          labelValues, Point.create(Value.longValue(value), clock.now()), null);
+      return defaultTimeSeries.setPoint(Point.create(Value.longValue(value), clock.now()));
     }
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DoubleGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DoubleGaugeImpl.java
@@ -151,10 +151,10 @@ public final class DoubleGaugeImpl extends DoubleGauge implements Meter {
 
     // TODO(mayurkale): Consider to use DoubleAdder here, once we upgrade to Java8.
     private final AtomicDouble value = new AtomicDouble(0);
-    private final List<LabelValue> labelValues;
+    private final TimeSeries defaultTimeSeries;
 
     PointImpl(List<LabelValue> labelValues) {
-      this.labelValues = labelValues;
+      defaultTimeSeries = TimeSeries.create(labelValues);
     }
 
     @Override
@@ -168,8 +168,7 @@ public final class DoubleGaugeImpl extends DoubleGauge implements Meter {
     }
 
     private TimeSeries getTimeSeries(Clock clock) {
-      return TimeSeries.createWithOnePoint(
-          labelValues, Point.create(Value.doubleValue(value.get()), clock.now()), null);
+      return defaultTimeSeries.setPoint(Point.create(Value.doubleValue(value.get()), clock.now()));
     }
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/LongGaugeImpl.java
@@ -151,10 +151,10 @@ public final class LongGaugeImpl extends LongGauge implements Meter {
 
     // TODO(mayurkale): Consider to use LongAdder here, once we upgrade to Java8.
     private final AtomicLong value = new AtomicLong(0);
-    private final List<LabelValue> labelValues;
+    private final TimeSeries defaultTimeSeries;
 
     PointImpl(List<LabelValue> labelValues) {
-      this.labelValues = labelValues;
+      defaultTimeSeries = TimeSeries.create(labelValues);
     }
 
     @Override
@@ -168,8 +168,7 @@ public final class LongGaugeImpl extends LongGauge implements Meter {
     }
 
     private TimeSeries getTimeSeries(Clock clock) {
-      return TimeSeries.createWithOnePoint(
-          labelValues, Point.create(Value.longValue(value.get()), clock.now()), null);
+      return defaultTimeSeries.setPoint(Point.create(Value.longValue(value.get()), clock.now()));
     }
   }
 }


### PR DESCRIPTION
Fixes #1490 