### PR TITLE
Exporter/Stats/Stackdriver: Add user agent as client header. 

### DIFF
--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -145,16 +145,22 @@ public class StackdriverStatsExporterTest {
   }
 
   @Test
-  public void createMetricServiceClient_WithoutCredentials() throws IOException {
-    MetricServiceClient client;
-    synchronized (StackdriverStatsExporter.monitor) {
-      client = StackdriverStatsExporter.createMetricServiceClient(null);
+  public void createMetricServiceClient_WithoutCredentials() {
+    try {
+      MetricServiceClient client;
+      synchronized (StackdriverStatsExporter.monitor) {
+        client = StackdriverStatsExporter.createMetricServiceClient(null);
+      }
+      assertThat(client.getSettings().getCredentialsProvider())
+          .isInstanceOf(GoogleCredentialsProvider.class);
+      assertThat(client.getSettings().getTransportChannelProvider())
+          .isInstanceOf(InstantiatingGrpcChannelProvider.class);
+      // There's no way to get HeaderProvider from TransportChannelProvider.
+      assertThat(client.getSettings().getTransportChannelProvider().needsHeaders()).isFalse();
+    } catch (IOException e) {
+      // This test depends on the Application Default Credentials settings (environment variable
+      // GOOGLE_APPLICATION_CREDENTIALS). Some hosts may not have the expected environment settings
+      // and this test should be skipped in that case.
     }
-    assertThat(client.getSettings().getCredentialsProvider())
-        .isInstanceOf(GoogleCredentialsProvider.class);
-    assertThat(client.getSettings().getTransportChannelProvider())
-        .isInstanceOf(InstantiatingGrpcChannelProvider.class);
-    // There's no way to get HeaderProvider from TransportChannelProvider.
-    assertThat(client.getSettings().getTransportChannelProvider().needsHeaders()).isFalse();
   }
 }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -18,9 +18,12 @@ package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import com.google.api.gax.core.GoogleCredentialsProvider;
+import com.google.api.gax.grpc.InstantiatingGrpcChannelProvider;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.monitoring.v3.MetricServiceClient;
 import io.opencensus.common.Duration;
 import java.io.IOException;
 import java.util.Date;
@@ -125,5 +128,33 @@ public class StackdriverStatsExporterTest {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("monitoredResource");
     StackdriverStatsExporter.createAndRegisterWithMonitoredResource(ONE_SECOND, null);
+  }
+
+  @Test
+  public void createMetricServiceClient() throws IOException {
+    MetricServiceClient client;
+    synchronized (StackdriverStatsExporter.monitor) {
+      client = StackdriverStatsExporter.createMetricServiceClient(FAKE_CREDENTIALS);
+    }
+    assertThat(client.getSettings().getCredentialsProvider().getCredentials())
+        .isEqualTo(FAKE_CREDENTIALS);
+    assertThat(client.getSettings().getTransportChannelProvider())
+        .isInstanceOf(InstantiatingGrpcChannelProvider.class);
+    // There's no way to get HeaderProvider from TransportChannelProvider.
+    assertThat(client.getSettings().getTransportChannelProvider().needsHeaders()).isFalse();
+  }
+
+  @Test
+  public void createMetricServiceClient_WithoutCredentials() throws IOException {
+    MetricServiceClient client;
+    synchronized (StackdriverStatsExporter.monitor) {
+      client = StackdriverStatsExporter.createMetricServiceClient(null);
+    }
+    assertThat(client.getSettings().getCredentialsProvider())
+        .isInstanceOf(GoogleCredentialsProvider.class);
+    assertThat(client.getSettings().getTransportChannelProvider())
+        .isInstanceOf(InstantiatingGrpcChannelProvider.class);
+    // There's no way to get HeaderProvider from TransportChannelProvider.
+    assertThat(client.getSettings().getTransportChannelProvider().needsHeaders()).isFalse();
   }
 }


### PR DESCRIPTION
Equivalent to https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/blob/master/stats.go#L80-L81.

See also https://github.com/googleapis/gax-java/blob/a60bd347b69fbf725b0dd8ae18bbcf5b00b66b7b/gax-grpc/src/main/java/com/google/api/gax/grpc/GrpcHeaderInterceptor.java#L63-L67.
