### PR TITLE
Exporter/Trace/Stackdriver: Set SameProcessAsParentSpan.

### DIFF
--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
@@ -208,8 +208,9 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
     if (spanData.getParentSpanId() != null && spanData.getParentSpanId().isValid()) {
       spanBuilder.setParentSpanId(spanData.getParentSpanId().toLowerBase16());
     }
-    if (spanData.getHasRemoteParent() != null) {
-      spanBuilder.setSameProcessAsParentSpan(BoolValue.of(!spanData.getHasRemoteParent()));
+    /*@Nullable*/ Boolean hasRemoteParent = spanData.getHasRemoteParent();
+    if (hasRemoteParent != null) {
+      spanBuilder.setSameProcessAsParentSpan(BoolValue.of(!hasRemoteParent));
     }
     return spanBuilder.build();
   }

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
@@ -35,6 +35,7 @@ import com.google.devtools.cloudtrace.v2.Span.TimeEvent;
 import com.google.devtools.cloudtrace.v2.Span.TimeEvent.MessageEvent;
 import com.google.devtools.cloudtrace.v2.SpanName;
 import com.google.devtools.cloudtrace.v2.TruncatableString;
+import com.google.protobuf.BoolValue;
 import com.google.protobuf.Int32Value;
 import com.google.rpc.Status;
 import io.opencensus.common.Function;
@@ -207,7 +208,9 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
     if (spanData.getParentSpanId() != null && spanData.getParentSpanId().isValid()) {
       spanBuilder.setParentSpanId(spanData.getParentSpanId().toLowerBase16());
     }
-
+    if (spanData.getHasRemoteParent() != null) {
+      spanBuilder.setSameProcessAsParentSpan(BoolValue.of(!spanData.getHasRemoteParent()));
+    }
     return spanBuilder.build();
   }
 

--- a/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandlerProtoTest.java
+++ b/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandlerProtoTest.java
@@ -309,7 +309,7 @@ public final class StackdriverV2ExporterHandlerProtoTest {
     assertThat(span.getLinks()).isEqualTo(spanLinks);
     assertThat(span.getStatus()).isEqualTo(spanStatus);
     assertThat(span.getSameProcessAsParentSpan())
-        .isEqualTo(com.google.protobuf.BoolValue.newBuilder().build());
+        .isEqualTo(com.google.protobuf.BoolValue.of(false));
     assertThat(span.getChildSpanCount())
         .isEqualTo(Int32Value.newBuilder().setValue(CHILD_SPAN_COUNT).build());
   }


### PR DESCRIPTION
Chatted with @rghetia today, I found that in the Stackdriver Trace Exporter we never set the `SameProcessAsParentSpan` field for `Span`s, while this field is already available in cloudtrace.v2 proto: https://github.com/googleapis/google-cloud-java/blob/master/google-api-grpc/proto-google-cloud-trace-v2/src/main/proto/google/devtools/cloudtrace/v2/trace.proto#L232.

I'm not sure if this is intentional or we just forgot to set it.