### PR TITLE
Example: Update dependency versions.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -26,7 +26,7 @@ group = "io.opencensus"
 version = "0.17.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.16.1" // LATEST_OPENCENSUS_RELEASE_VERSION
-def grpcVersion = "1.16.1" // CURRENT_GRPC_VERSION
+def grpcVersion = "1.13.1" // CURRENT_GRPC_VERSION
 def prometheusVersion = "0.5.0"
 
 tasks.withType(JavaCompile) {

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -26,8 +26,8 @@ group = "io.opencensus"
 version = "0.17.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.16.1" // LATEST_OPENCENSUS_RELEASE_VERSION
-def grpcVersion = "1.13.1" // CURRENT_GRPC_VERSION
-def prometheusVersion = "0.3.0"
+def grpcVersion = "1.16.1" // CURRENT_GRPC_VERSION
+def prometheusVersion = "0.5.0"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.8'

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- change to the version you want to use. -->
     <opencensus.version>0.16.1</opencensus.version><!-- LATEST_OPENCENSUS_RELEASE_VERSION -->
-    <grpc.version>1.16.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.13.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
   </properties>
   <dependencies>
     <dependency>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -11,7 +11,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <!-- change to the version you want to use. -->
     <opencensus.version>0.16.1</opencensus.version><!-- LATEST_OPENCENSUS_RELEASE_VERSION -->
-    <grpc.version>1.13.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.16.1</grpc.version><!-- CURRENT_GRPC_VERSION -->
   </properties>
   <dependencies>
     <dependency>
@@ -67,7 +67,7 @@
     <dependency>
       <groupId>io.prometheus</groupId>
       <artifactId>simpleclient_httpserver</artifactId>
-      <version>0.3.0</version>
+      <version>0.5.0</version>
     </dependency>
     <dependency>
       <groupId>io.opencensus</groupId>


### PR DESCRIPTION
Otherwise there will be Guava version conflict when running the examples (https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/stats/stackdriver#why-did-i-get-an-error-javalangnosuchmethoderror-comgooglecommon-like-javalangnosuchmethoderrorcomgooglecommonbasethrowablesthrowifinstanceof).