### PR TITLE
Update opencensus-contrib-log-correlation-log4j2 to match log correlation spec.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Add an util artifact `opencensus-contrib-dropwizard` to translate Dropwizard metrics to
   OpenCensus.
 - Add Gauges (`DoubleGauge`, `LongGauge`, `DerivedDoubleGauge`, `DerivedLongGauge`) APIs.
+- Update `opencensus-contrib-log-correlation-log4j2` to match the
+  [OpenCensus log correlation spec](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/LogCorrelation.md).
 
 ## 0.16.1 - 2018-09-18
 - Fix ClassCastException in Log4j log correlation

--- a/contrib/log_correlation/log4j2/README.md
+++ b/contrib/log_correlation/log4j2/README.md
@@ -1,10 +1,5 @@
 # OpenCensus Log4j 2 Log Correlation
 
-This subproject is currently experimental, so it may be redesigned or removed in the future.  It
-will remain experimental until we have a specification for a log correlation feature in
-[opencensus-specs](https://github.com/census-instrumentation/opencensus-specs/)
-(issue [#123](https://github.com/census-instrumentation/opencensus-specs/issues/123)).
-
 The `opencensus-contrib-log-correlation-log4j2` artifact provides a
 [Log4j 2](https://logging.apache.org/log4j/2.x/)
 [`ContextDataInjector`](https://logging.apache.org/log4j/2.x/manual/extending.html#Custom_ContextDataInjector)
@@ -69,16 +64,16 @@ The allowed values are:
 `opencensus-contrib-log-correlation-log4j2` adds the following key-value pairs to the `LogEvent`
 context:
 
-* `opencensusTraceId` - the lowercase base16 encoding of the current trace ID
-* `opencensusSpanId` - the lowercase base16 encoding of the current span ID
-* `opencensusTraceSampled` - the sampling decision of the current span ("true" or "false")
+* `traceId` - the lowercase base16 encoding of the current trace ID
+* `spanId` - the lowercase base16 encoding of the current span ID
+* `traceSampled` - the sampling decision of the current span ("true" or "false")
 
 These values can be accessed from layouts with
 [Context Map Lookup](http://logging.apache.org/log4j/2.x/manual/lookups.html#ContextMapLookup).  For
-example, the trace ID can be accessed with `$${ctx:opencensusTraceId}`.  The values can also be
-accessed with the `X` conversion character in
+example, the trace ID can be accessed with `$${ctx:traceId}`.  The values can also be accessed with
+the `X` conversion character in
 [`PatternLayout`](http://logging.apache.org/log4j/2.x/manual/layouts.html#PatternLayout), for
-example, `%X{opencensusTraceId}`.
+example, `%X{traceId}`.
 
 See an example Log4j configuration file in the demo:
 https://github.com/census-ecosystem/opencensus-experiments/tree/master/java/log_correlation/log4j2/src/main/resources/log4j2.xml

--- a/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
+++ b/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
@@ -44,9 +44,9 @@ import org.apache.logging.log4j.util.StringMap;
  * Layout</a>:
  *
  * <ul>
- *   <li><code>%X{opencensusTraceId}</code>
- *   <li><code>%X{opencensusSpanId}</code>
- *   <li><code>%X{opencensusTraceSampled}</code>
+ *   <li><code>%X{traceId}</code>
+ *   <li><code>%X{spanId}</code>
+ *   <li><code>%X{traceSampled}</code>
  * </ul>
  *
  * <p>This feature is currently experimental.
@@ -64,21 +64,21 @@ public final class OpenCensusTraceContextDataInjector implements ContextDataInje
    *
    * @since 0.16
    */
-  public static final String TRACE_ID_CONTEXT_KEY = "opencensusTraceId";
+  public static final String TRACE_ID_CONTEXT_KEY = "traceId";
 
   /**
    * Context key for the current span ID. The name is {@value}.
    *
    * @since 0.16
    */
-  public static final String SPAN_ID_CONTEXT_KEY = "opencensusSpanId";
+  public static final String SPAN_ID_CONTEXT_KEY = "spanId";
 
   /**
    * Context key for the sampling decision of the current span. The name is {@value}.
    *
    * @since 0.16
    */
-  public static final String TRACE_SAMPLED_CONTEXT_KEY = "opencensusTraceSampled";
+  public static final String TRACE_SAMPLED_CONTEXT_KEY = "traceSampled";
 
   /**
    * Name of the property that defines the {@link SpanSelection}. The name is {@value}.

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/AbstractOpenCensusLog4jLogCorrelationTest.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/AbstractOpenCensusLog4jLogCorrelationTest.java
@@ -45,8 +45,7 @@ abstract class AbstractOpenCensusLog4jLogCorrelationTest {
   private static final Tracer tracer = Tracing.getTracer();
 
   static final String TEST_PATTERN =
-      "traceId=%X{opencensusTraceId} spanId=%X{opencensusSpanId} "
-          + "sampled=%X{opencensusTraceSampled} %-5level - %msg";
+      "traceId=%X{traceId} spanId=%X{spanId} sampled=%X{traceSampled} %-5level - %msg";
 
   static final Tracestate EMPTY_TRACESTATE = Tracestate.builder().build();
 

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusLog4jLogCorrelationAllSpansTest.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusLog4jLogCorrelationAllSpansTest.java
@@ -114,7 +114,7 @@ public final class OpenCensusLog4jLogCorrelationAllSpansTest
   public void preserveOtherKeyValuePairs() {
     String log =
         logWithSpanAndLog4jConfiguration(
-            "%X{opencensusTraceId} %X{myTestKey} %-5level - %msg",
+            "%X{traceId} %X{myTestKey} %-5level - %msg",
             SpanContext.create(
                 TraceId.fromLowerBase16("c95329bb6b7de41afbc51a231c128f97"),
                 SpanId.fromLowerBase16("bf22ea74d38eddad"),

--- a/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjectorTest.java
+++ b/contrib/log_correlation/log4j2/src/test/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjectorTest.java
@@ -53,20 +53,18 @@ public final class OpenCensusTraceContextDataInjectorTest {
 
   @Test
   public void traceIdKey() {
-    assertThat(OpenCensusTraceContextDataInjector.TRACE_ID_CONTEXT_KEY)
-        .isEqualTo("opencensusTraceId");
+    assertThat(OpenCensusTraceContextDataInjector.TRACE_ID_CONTEXT_KEY).isEqualTo("traceId");
   }
 
   @Test
   public void spanIdKey() {
-    assertThat(OpenCensusTraceContextDataInjector.SPAN_ID_CONTEXT_KEY)
-        .isEqualTo("opencensusSpanId");
+    assertThat(OpenCensusTraceContextDataInjector.SPAN_ID_CONTEXT_KEY).isEqualTo("spanId");
   }
 
   @Test
   public void traceSampledKey() {
     assertThat(OpenCensusTraceContextDataInjector.TRACE_SAMPLED_CONTEXT_KEY)
-        .isEqualTo("opencensusTraceSampled");
+        .isEqualTo("traceSampled");
   }
 
   @Test
@@ -115,11 +113,11 @@ public final class OpenCensusTraceContextDataInjectorTest {
             "value1",
             "property2",
             "value2",
-            "opencensusTraceId",
+            "traceId",
             "00000000000000000000000000000000",
-            "opencensusSpanId",
+            "spanId",
             "0000000000000000",
-            "opencensusTraceSampled",
+            "traceSampled",
             "false");
   }
 
@@ -140,11 +138,11 @@ public final class OpenCensusTraceContextDataInjectorTest {
   private static void assertContainsOnlyDefaultTracingEntries(StringMap stringMap) {
     assertThat(stringMap.toMap())
         .containsExactly(
-            "opencensusTraceId",
+            "traceId",
             "00000000000000000000000000000000",
-            "opencensusSpanId",
+            "spanId",
             "0000000000000000",
-            "opencensusTraceSampled",
+            "traceSampled",
             "false");
   }
 
@@ -167,11 +165,11 @@ public final class OpenCensusTraceContextDataInjectorTest {
             .containsExactly(
                 "myTestKey",
                 "myTestValue",
-                "opencensusTraceId",
+                "traceId",
                 "e17944156660f55b8cae5ce3f45d4a40",
-                "opencensusSpanId",
+                "spanId",
                 "fc3d2ba0d283b66a",
-                "opencensusTraceSampled",
+                "traceSampled",
                 "true");
       } finally {
         ThreadContext.remove(key);


### PR DESCRIPTION
This commit updates the context key names to match the shorter names in
https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/LogCorrelation.md.
It also removes the warning about the library being experimental.