### PR TITLE
Update opencensus-contrib-log-correlation-stackdriver for log correlation spec.

### DIFF
--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -36,7 +36,7 @@ import javax.annotation.Nullable;
  */
 @ExperimentalApi
 public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
-  private static final String SAMPLED_LABEL_KEY = "opencensusTraceSampled";
+  private static final String SAMPLED_LABEL_KEY = "traceSampled";
   private static final SpanSelection DEFAULT_SPAN_SELECTION = SpanSelection.ALL_SPANS;
 
   /**

--- a/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
+++ b/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
@@ -82,7 +82,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
                     SpanId.fromLowerBase16("592ae363e92cb3dd"),
                     TraceOptions.builder().setIsSampled(true).build(),
                     EMPTY_TRACESTATE)));
-    assertThat(logEntry.getLabels()).containsEntry("opencensusTraceSampled", "true");
+    assertThat(logEntry.getLabels()).containsEntry("traceSampled", "true");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-2/traces/4c9874d0b41224cce77ff74ee10f5ee6");
     assertThat(logEntry.getSpanId()).isEqualTo("592ae363e92cb3dd");
@@ -99,7 +99,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
                     SpanId.fromLowerBase16("de52e84d13dd232d"),
                     TraceOptions.builder().setIsSampled(true).build(),
                     EMPTY_TRACESTATE)));
-    assertThat(logEntry.getLabels()).containsEntry("opencensusTraceSampled", "true");
+    assertThat(logEntry.getLabels()).containsEntry("traceSampled", "true");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-3/traces/4c6af40c499951eb7de2777ba1e4fefa");
     assertThat(logEntry.getSpanId()).isEqualTo("de52e84d13dd232d");
@@ -144,7 +144,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
                     SpanId.fromLowerBase16("731e102335b7a5a0"),
                     TraceOptions.builder().setIsSampled(false).build(),
                     EMPTY_TRACESTATE)));
-    assertThat(logEntry.getLabels()).containsEntry("opencensusTraceSampled", "false");
+    assertThat(logEntry.getLabels()).containsEntry("traceSampled", "false");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-6/traces/72c905c76f99e99974afd84dc053a480");
     assertThat(logEntry.getSpanId()).isEqualTo("731e102335b7a5a0");
@@ -156,7 +156,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
         getEnhancedLogEntry(
             new OpenCensusTraceLoggingEnhancer("my-test-project-7", SpanSelection.ALL_SPANS),
             BlankSpan.INSTANCE);
-    assertThat(logEntry.getLabels().get("opencensusTraceSampled")).isEqualTo("false");
+    assertThat(logEntry.getLabels().get("traceSampled")).isEqualTo("false");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-7/traces/00000000000000000000000000000000");
     assertThat(logEntry.getSpanId()).isEqualTo("0000000000000000");
@@ -188,7 +188,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   }
 
   private static void assertContainsNoTracingData(LogEntry logEntry) {
-    assertThat(logEntry.getLabels()).doesNotContainKey("opencensusTraceSampled");
+    assertThat(logEntry.getLabels()).doesNotContainKey("traceSampled");
     assertThat(logEntry.getTrace()).isNull();
     assertThat(logEntry.getSpanId()).isNull();
   }


### PR DESCRIPTION
This commit updates the trace sampled key name to match the shorter name in
https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/LogCorrelation.md.