### PR TITLE
Temporarily remove "traceSampled" label from Stackdriver log correlation.

### DIFF
--- a/contrib/log_correlation/stackdriver/README.md
+++ b/contrib/log_correlation/stackdriver/README.md
@@ -11,8 +11,7 @@ The `opencensus-contrib-log-correlation-stackdriver` artifact provides a
 that automatically adds tracing data to log entries. The class name is
 `OpenCensusTraceLoggingEnhancer`. `OpenCensusTraceLoggingEnhancer` adds the current trace and span
 ID to each log entry, which allows Stackdriver to display the log entries associated with each
-trace, or filter logs based on trace or span ID. It currently also adds the sampling decision using
-the label "`opencensusTraceSampled`".
+trace, or filter logs based on trace or span ID.
 
 ## Instructions
 

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -36,7 +36,6 @@ import javax.annotation.Nullable;
  */
 @ExperimentalApi
 public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
-  private static final String SAMPLED_LABEL_KEY = "opencensusTraceSampled";
 
   /**
    * Name of the property that overrides the default project ID (overrides the value returned by
@@ -120,8 +119,7 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
     builder.setTrace(formatTraceId(tracePrefix, span.getTraceId()));
     builder.setSpanId(span.getSpanId().toLowerBase16());
 
-    // TODO(sebright): Find the correct way to add the sampling decision.
-    builder.addLabel(SAMPLED_LABEL_KEY, Boolean.toString(span.getTraceOptions().isSampled()));
+    // TODO(sebright): Add the sampling decision once google-cloud-logging supports it.
   }
 
   private static String formatTraceId(String tracePrefix, TraceId traceId) {

--- a/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
+++ b/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
@@ -67,7 +67,6 @@ public class OpenCensusTraceLoggingEnhancerTest {
                     SpanId.fromLowerBase16("de52e84d13dd232d"),
                     TraceOptions.builder().setIsSampled(true).build(),
                     EMPTY_TRACESTATE)));
-    assertThat(logEntry.getLabels()).containsEntry("opencensusTraceSampled", "true");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-3/traces/4c6af40c499951eb7de2777ba1e4fefa");
     assertThat(logEntry.getSpanId()).isEqualTo("de52e84d13dd232d");
@@ -84,7 +83,6 @@ public class OpenCensusTraceLoggingEnhancerTest {
                     SpanId.fromLowerBase16("731e102335b7a5a0"),
                     TraceOptions.builder().setIsSampled(false).build(),
                     EMPTY_TRACESTATE)));
-    assertThat(logEntry.getLabels()).containsEntry("opencensusTraceSampled", "false");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-6/traces/72c905c76f99e99974afd84dc053a480");
     assertThat(logEntry.getSpanId()).isEqualTo("731e102335b7a5a0");
@@ -95,7 +93,6 @@ public class OpenCensusTraceLoggingEnhancerTest {
     LogEntry logEntry =
         getEnhancedLogEntry(
             new OpenCensusTraceLoggingEnhancer("my-test-project-7"), BlankSpan.INSTANCE);
-    assertThat(logEntry.getLabels().get("opencensusTraceSampled")).isEqualTo("false");
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-7/traces/00000000000000000000000000000000");
     assertThat(logEntry.getSpanId()).isEqualTo("0000000000000000");


### PR DESCRIPTION
Currently, opencensus-contrib-log-correlation-stackdriver adds the sampling
decision to a LogEntry as a custom label.  Once google-cloud-logging adds a
sampling decision field to its LogEntry class, we can set that field instead, so
that the value will be intepreted by Stackdriver.  However, removing the custom
label will be a breaking change.  This commit temporarily removes the custom
label so that we can make a non-experimental release of
opencensus-contrib-log-correlation-stackdriver and add the sampling decision to
the LogEntry later as a backwards-compatible change.