### PR TITLE
Remove warning about Stackdriver log correlation being experimental.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,10 @@
 - Add an util artifact `opencensus-contrib-dropwizard` to translate Dropwizard metrics to
   OpenCensus.
 - Add Gauges (`DoubleGauge`, `LongGauge`, `DerivedDoubleGauge`, `DerivedLongGauge`) APIs.
-- Update `opencensus-contrib-log-correlation-log4j2` to match the
-  [OpenCensus log correlation spec](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/LogCorrelation.md).
+- Update `opencensus-contrib-log-correlation-log4j2` and
+  `opencensus-contrib-log-correlation-stackdriver` to match the
+  [OpenCensus log correlation spec](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/LogCorrelation.md)
+  and remove all `ExperimentalApi` annotations.
 - The histogram bucket boundaries (`BucketBoundaries`) and values (`Count` and `Sum`) are no longer
   supported for negative values. The Record API drops the negative `value` and logs the warning.
   This could be a breaking change if you are recording negative value for any `measure`.

--- a/contrib/log_correlation/stackdriver/README.md
+++ b/contrib/log_correlation/stackdriver/README.md
@@ -1,10 +1,5 @@
 # OpenCensus Stackdriver Log Correlation
 
-This subproject is currently experimental, so it may be redesigned or removed in the future.  It
-will remain experimental until we have a specification for a log correlation feature in
-[opencensus-specs](https://github.com/census-instrumentation/opencensus-specs/)
-(issue [#123](https://github.com/census-instrumentation/opencensus-specs/issues/123)).
-
 The `opencensus-contrib-log-correlation-stackdriver` artifact provides a
 [Stackdriver Logging](https://cloud.google.com/logging/)
 [`LoggingEnhancer`](http://googlecloudplatform.github.io/google-cloud-java/google-cloud-clients/apidocs/com/google/cloud/logging/LoggingEnhancer.html)

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -19,7 +19,6 @@ package io.opencensus.contrib.logcorrelation.stackdriver;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.LoggingEnhancer;
-import io.opencensus.common.ExperimentalApi;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.TraceId;
@@ -30,11 +29,8 @@ import javax.annotation.Nullable;
 /**
  * Stackdriver {@link LoggingEnhancer} that adds OpenCensus tracing data to log entries.
  *
- * <p>This feature is currently experimental.
- *
  * @since 0.15
  */
-@ExperimentalApi
 public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
   private static final String SAMPLED_LABEL_KEY = "opencensusTraceSampled";
 


### PR DESCRIPTION
opencensus-contrib-log-correlation-stackdriver is consistent with the log
correlation spec, so it no longer needs to be labeled experimental.

___________________________________________________________________________

This PR depends on #1532.