### PR TITLE
Replace OpenCensusTraceLoggingEnhancer(String) constructor with factory method.

### DIFF
--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -63,6 +63,11 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
     this(lookUpProjectId());
   }
 
+  private OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
+    this.projectId = projectId == null ? "" : projectId;
+    this.tracePrefix = "projects/" + this.projectId + "/traces/";
+  }
+
   /**
    * Returns a {@code OpenCensusTraceLoggingEnhancer} with the given project ID.
    *
@@ -72,11 +77,6 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
    */
   public static OpenCensusTraceLoggingEnhancer create(@Nullable String projectId) {
     return new OpenCensusTraceLoggingEnhancer(projectId);
-  }
-
-  private OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
-    this.projectId = projectId == null ? "" : projectId;
-    this.tracePrefix = "projects/" + this.projectId + "/traces/";
   }
 
   private static String lookUpProjectId() {

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -64,12 +64,17 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
   }
 
   /**
-   * Constructs a {@code OpenCensusTraceLoggingEnhancer} with the given project ID.
+   * Returns a {@code OpenCensusTraceLoggingEnhancer} with the given project ID.
    *
-   * @param projectId the project ID for this instance.
+   * @param projectId the project ID to be used by the logging enhancer.
+   * @return a {@code OpenCensusTraceLoggingEnhancer} with the given project ID.
    * @since 0.17
    */
-  public OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
+  public static OpenCensusTraceLoggingEnhancer create(@Nullable String projectId) {
+    return new OpenCensusTraceLoggingEnhancer(projectId);
+  }
+
+  private OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
     this.projectId = projectId == null ? "" : projectId;
     this.tracePrefix = "projects/" + this.projectId + "/traces/";
   }

--- a/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
+++ b/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
@@ -60,7 +60,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddSampledSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            new OpenCensusTraceLoggingEnhancer("my-test-project-3"),
+            OpenCensusTraceLoggingEnhancer.create("my-test-project-3"),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("4c6af40c499951eb7de2777ba1e4fefa"),
@@ -76,7 +76,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddNonSampledSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            new OpenCensusTraceLoggingEnhancer("my-test-project-6"),
+            OpenCensusTraceLoggingEnhancer.create("my-test-project-6"),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("72c905c76f99e99974afd84dc053a480"),
@@ -92,7 +92,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddBlankSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            new OpenCensusTraceLoggingEnhancer("my-test-project-7"), BlankSpan.INSTANCE);
+            OpenCensusTraceLoggingEnhancer.create("my-test-project-7"), BlankSpan.INSTANCE);
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-7/traces/00000000000000000000000000000000");
     assertThat(logEntry.getSpanId()).isEqualTo("0000000000000000");
@@ -102,7 +102,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_ConvertNullProjectIdToEmptyString() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            new OpenCensusTraceLoggingEnhancer(null),
+            OpenCensusTraceLoggingEnhancer.create(null),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("bfb4248a24325a905873a1d43001d9a0"),


### PR DESCRIPTION
opencensus-contrib-log-correlation-stackdriver is still experimental, so this is
a good time to improve the API.