### PR TITLE
Improve handling of null project ID in Stackdriver log correlation.

### DIFF
--- a/checker-framework/stubs/google-cloud-java.astub
+++ b/checker-framework/stubs/google-cloud-java.astub
@@ -1,0 +1,8 @@
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+package com.google.cloud;
+
+class ServiceOptions<ServiceT extends Service<OptionsT>, OptionsT extends ServiceOptions<ServiceT, OptionsT>> {
+  @Nullable
+  static String getDefaultProjectId();
+}

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -42,7 +42,7 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
   public static final String PROJECT_ID_PROPERTY_NAME =
       "io.opencensus.contrib.logcorrelation.stackdriver.OpenCensusTraceLoggingEnhancer.projectId";
 
-  private final String projectId;
+  @Nullable private final String projectId;
 
   // This field caches the prefix used for the LogEntry.trace field and is derived from projectId.
   private final String tracePrefix;
@@ -65,10 +65,11 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
 
   // visible for testing
   OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
-    this.projectId = projectId == null ? "" : projectId;
-    this.tracePrefix = "projects/" + this.projectId + "/traces/";
+    this.projectId = projectId;
+    this.tracePrefix = "projects/" + (projectId == null ? "" : projectId) + "/traces/";
   }
 
+  @Nullable
   private static String lookUpProjectId() {
     String projectIdProperty = lookUpProperty(PROJECT_ID_PROPERTY_NAME);
     return projectIdProperty == null || projectIdProperty.isEmpty()
@@ -85,6 +86,7 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
   }
 
   // visible for testing
+  @Nullable
   String getProjectId() {
     return projectId;
   }

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -304,7 +304,12 @@ public final class StackdriverStatsExporter {
       @Nullable MonitoredResource monitoredResource,
       @Nullable String metricNamePrefix)
       throws IOException {
-    projectId = projectId == null ? ServiceOptions.getDefaultProjectId() : projectId;
+    projectId =
+        projectId == null
+
+            // TODO(sebright): Handle null default project ID.
+            ? castNonNull(ServiceOptions.getDefaultProjectId())
+            : projectId;
     exportInterval = exportInterval == null ? DEFAULT_INTERVAL : exportInterval;
     monitoredResource = monitoredResource == null ? DEFAULT_RESOURCE : monitoredResource;
     synchronized (monitor) {
@@ -330,6 +335,12 @@ public final class StackdriverStatsExporter {
               metricNamePrefix);
       exporter.workerThread.start();
     }
+  }
+
+  // TODO(sebright): Remove this method.
+  @SuppressWarnings("nullness")
+  private static <T> T castNonNull(@javax.annotation.Nullable T arg) {
+    return arg;
   }
 
   // Resets exporter to null. Used only for unit tests.

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverExporter.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverExporter.java
@@ -109,8 +109,16 @@ public final class StackdriverExporter {
     StackdriverTraceExporter.createAndRegister(
         StackdriverTraceConfiguration.builder()
             .setCredentials(GoogleCredentials.getApplicationDefault())
-            .setProjectId(ServiceOptions.getDefaultProjectId())
+
+            // TODO(sebright): Handle null default project ID.
+            .setProjectId(castNonNull(ServiceOptions.getDefaultProjectId()))
             .build());
+  }
+
+  // TODO(sebright): Remove this method.
+  @SuppressWarnings("nullness")
+  private static <T> T castNonNull(@javax.annotation.Nullable T arg) {
+    return arg;
   }
 
   /**

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceExporter.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceExporter.java
@@ -78,7 +78,9 @@ public final class StackdriverTraceExporter {
       checkState(handler == null, "Stackdriver exporter is already registered.");
       Credentials credentials = configuration.getCredentials();
       String projectId = configuration.getProjectId();
-      projectId = projectId != null ? projectId : ServiceOptions.getDefaultProjectId();
+
+      // TODO(sebright): Handle null default project ID.
+      projectId = projectId != null ? projectId : castNonNull(ServiceOptions.getDefaultProjectId());
 
       StackdriverV2ExporterHandler handler;
       TraceServiceStub stub = configuration.getTraceServiceStub();
@@ -93,6 +95,12 @@ public final class StackdriverTraceExporter {
 
       registerInternal(handler);
     }
+  }
+
+  // TODO(sebright): Remove this method.
+  @SuppressWarnings("nullness")
+  private static <T> T castNonNull(@javax.annotation.Nullable T arg) {
+    return arg;
   }
 
   private static void registerInternal(Handler newHandler) {


### PR DESCRIPTION
This commit stores null instead of an empty string when the project ID can't be
found, which allows distinguishing between null and empty project IDs.

This commit also improves null safety by adding a Nullable annotation to
com.google.cloud.ServiceOptions.getDefaultProjectId(), which can return null
when no project ID is available.  I had to suppress three warnings and add TODOs
where the result was already assumed to be non-null.

_____________________________________________________________________________

I'm planning to open an issue to fix the TODOs after this PR is merged.