### PR TITLE
Hide methods in OpenCensusTraceLoggingEnhancer that aren't necessary currently.

### DIFF
--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -63,20 +63,10 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
     this(lookUpProjectId());
   }
 
-  private OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
+  // visible for testing
+  OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
     this.projectId = projectId == null ? "" : projectId;
     this.tracePrefix = "projects/" + this.projectId + "/traces/";
-  }
-
-  /**
-   * Returns a {@code OpenCensusTraceLoggingEnhancer} with the given project ID.
-   *
-   * @param projectId the project ID to be used by the logging enhancer.
-   * @return a {@code OpenCensusTraceLoggingEnhancer} with the given project ID.
-   * @since 0.17
-   */
-  public static OpenCensusTraceLoggingEnhancer create(@Nullable String projectId) {
-    return new OpenCensusTraceLoggingEnhancer(projectId);
   }
 
   private static String lookUpProjectId() {
@@ -94,13 +84,8 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
     return property == null || property.isEmpty() ? System.getProperty(name) : property;
   }
 
-  /**
-   * Returns the project ID setting for this instance.
-   *
-   * @return the project ID setting for this instance.
-   * @since 0.15
-   */
-  public String getProjectId() {
+  // visible for testing
+  String getProjectId() {
     return projectId;
   }
 

--- a/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
+++ b/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
@@ -60,7 +60,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddSampledSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            OpenCensusTraceLoggingEnhancer.create("my-test-project-3"),
+            new OpenCensusTraceLoggingEnhancer("my-test-project-3"),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("4c6af40c499951eb7de2777ba1e4fefa"),
@@ -76,7 +76,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddNonSampledSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            OpenCensusTraceLoggingEnhancer.create("my-test-project-6"),
+            new OpenCensusTraceLoggingEnhancer("my-test-project-6"),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("72c905c76f99e99974afd84dc053a480"),
@@ -92,7 +92,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddBlankSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            OpenCensusTraceLoggingEnhancer.create("my-test-project-7"), BlankSpan.INSTANCE);
+            new OpenCensusTraceLoggingEnhancer("my-test-project-7"), BlankSpan.INSTANCE);
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-7/traces/00000000000000000000000000000000");
     assertThat(logEntry.getSpanId()).isEqualTo("0000000000000000");
@@ -102,7 +102,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_ConvertNullProjectIdToEmptyString() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            OpenCensusTraceLoggingEnhancer.create(null),
+            new OpenCensusTraceLoggingEnhancer(null),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("bfb4248a24325a905873a1d43001d9a0"),


### PR DESCRIPTION
Code that creates or uses OpenCensusTraceLoggingEnhancer probably won't know its
type, so it will only call the no-arg constructor and 'enhanceLogEntry'.  This
commit hides the other methods in the class, create(String) and getProjectId().
They can be re-exposed in the future if necessary.