### PR TITLE
 Update Javadoc "since" tags in log correlation libraries.

### DIFF
--- a/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
+++ b/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/OpenCensusTraceContextDataInjector.java
@@ -48,7 +48,7 @@ import org.apache.logging.log4j.util.StringMap;
  *   <li><code>%X{traceSampled}</code>
  * </ul>
  *
- * @since 0.16
+ * @since 0.17
  * @see <a
  *     href="https://logging.apache.org/log4j/2.x/log4j-core/apidocs/org/apache/logging/log4j/core/ContextDataInjector.html">org.apache.logging.log4j.core.ContextDataInjector</a>
  */
@@ -57,28 +57,28 @@ public final class OpenCensusTraceContextDataInjector implements ContextDataInje
   /**
    * Context key for the current trace ID. The name is {@value}.
    *
-   * @since 0.16
+   * @since 0.17
    */
   public static final String TRACE_ID_CONTEXT_KEY = "traceId";
 
   /**
    * Context key for the current span ID. The name is {@value}.
    *
-   * @since 0.16
+   * @since 0.17
    */
   public static final String SPAN_ID_CONTEXT_KEY = "spanId";
 
   /**
    * Context key for the sampling decision of the current span. The name is {@value}.
    *
-   * @since 0.16
+   * @since 0.17
    */
   public static final String TRACE_SAMPLED_CONTEXT_KEY = "traceSampled";
 
   /**
    * Constructor to be called by Log4j.
    *
-   * @since 0.16
+   * @since 0.17
    */
   public OpenCensusTraceContextDataInjector() {}
 

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -63,20 +63,10 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
     this(lookUpProjectId());
   }
 
-  private OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
+  // visible for testing
+  OpenCensusTraceLoggingEnhancer(@Nullable String projectId) {
     this.projectId = projectId == null ? "" : projectId;
     this.tracePrefix = "projects/" + this.projectId + "/traces/";
-  }
-
-  /**
-   * Returns a {@code OpenCensusTraceLoggingEnhancer} with the given project ID.
-   *
-   * @param projectId the project ID to be used by the logging enhancer.
-   * @return a {@code OpenCensusTraceLoggingEnhancer} with the given project ID.
-   * @since 0.17
-   */
-  public static OpenCensusTraceLoggingEnhancer create(@Nullable String projectId) {
-    return new OpenCensusTraceLoggingEnhancer(projectId);
   }
 
   private static String lookUpProjectId() {
@@ -94,13 +84,8 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
     return property == null || property.isEmpty() ? System.getProperty(name) : property;
   }
 
-  /**
-   * Returns the project ID setting for this instance.
-   *
-   * @return the project ID setting for this instance.
-   * @since 0.15
-   */
-  public String getProjectId() {
+  // visible for testing
+  String getProjectId() {
     return projectId;
   }
 

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 /**
  * Stackdriver {@link LoggingEnhancer} that adds OpenCensus tracing data to log entries.
  *
- * @since 0.15
+ * @since 0.17
  */
 public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
 
@@ -37,7 +37,7 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
    * Name of the property that overrides the default project ID (overrides the value returned by
    * {@code com.google.cloud.ServiceOptions.getDefaultProjectId()}). The name is {@value}.
    *
-   * @since 0.15
+   * @since 0.17
    */
   public static final String PROJECT_ID_PROPERTY_NAME =
       "io.opencensus.contrib.logcorrelation.stackdriver.OpenCensusTraceLoggingEnhancer.projectId";
@@ -57,7 +57,7 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
    * can be specified with a {@link java.util.logging} property or a system property, with
    * preference given to the logging property.
    *
-   * @since 0.15
+   * @since 0.17
    */
   public OpenCensusTraceLoggingEnhancer() {
     this(lookUpProjectId());

--- a/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
+++ b/contrib/log_correlation/stackdriver/src/test/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancerTest.java
@@ -60,7 +60,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddSampledSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            OpenCensusTraceLoggingEnhancer.create("my-test-project-3"),
+            new OpenCensusTraceLoggingEnhancer("my-test-project-3"),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("4c6af40c499951eb7de2777ba1e4fefa"),
@@ -76,7 +76,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddNonSampledSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            OpenCensusTraceLoggingEnhancer.create("my-test-project-6"),
+            new OpenCensusTraceLoggingEnhancer("my-test-project-6"),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("72c905c76f99e99974afd84dc053a480"),
@@ -92,7 +92,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_AddBlankSpanToLogEntry() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            OpenCensusTraceLoggingEnhancer.create("my-test-project-7"), BlankSpan.INSTANCE);
+            new OpenCensusTraceLoggingEnhancer("my-test-project-7"), BlankSpan.INSTANCE);
     assertThat(logEntry.getTrace())
         .isEqualTo("projects/my-test-project-7/traces/00000000000000000000000000000000");
     assertThat(logEntry.getSpanId()).isEqualTo("0000000000000000");
@@ -102,7 +102,7 @@ public class OpenCensusTraceLoggingEnhancerTest {
   public void enhanceLogEntry_ConvertNullProjectIdToEmptyString() {
     LogEntry logEntry =
         getEnhancedLogEntry(
-            OpenCensusTraceLoggingEnhancer.create(null),
+            new OpenCensusTraceLoggingEnhancer(null),
             new TestSpan(
                 SpanContext.create(
                     TraceId.fromLowerBase16("bfb4248a24325a905873a1d43001d9a0"),


### PR DESCRIPTION
0.17 is the first non-experimental release, and it has some breaking changes, so
so we should reset the "since" tags to 0.17.

_______________________________________________________________

This PR includes #1538.