### PR TITLE
Avoid one extra allocation in TraceId and SpanId.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/BigendianEncoding.java
+++ b/api/src/main/java/io/opencensus/trace/BigendianEncoding.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace;
+
+import io.opencensus.internal.Utils;
+
+final class BigendianEncoding {
+  static final int LONG_BYTES = Long.SIZE / Byte.SIZE;
+
+  /**
+   * Returns the {@code long} value whose big-endian representation is stored in the first 8 bytes
+   * of {@code bytes} starting from the {@code offset}.
+   *
+   * @param bytes the byte array representation of the {@code long}.
+   * @param offset the starting offset in the byte array.
+   * @return the {@code long} value whose big-endian representation is given.
+   * @throws IllegalArgumentException if {@code bytes} has fewer than 8 elements.
+   */
+  static long longFromByteArray(byte[] bytes, int offset) {
+    Utils.checkArgument(bytes.length >= offset + LONG_BYTES, "array too small");
+    return (bytes[offset] & 0xFFL) << 56
+        | (bytes[offset + 1] & 0xFFL) << 48
+        | (bytes[offset + 2] & 0xFFL) << 40
+        | (bytes[offset + 3] & 0xFFL) << 32
+        | (bytes[offset + 4] & 0xFFL) << 24
+        | (bytes[offset + 5] & 0xFFL) << 16
+        | (bytes[offset + 6] & 0xFFL) << 8
+        | (bytes[offset + 7] & 0xFFL);
+  }
+
+  /**
+   * Stores the big-endian representation of {@code value} in the {@code dest} starting from the
+   * {@code destOffset}.
+   *
+   * @param value the value to be converted.
+   * @param dest the destination byte array.
+   * @param destOffset the starting offset in the destination byte array.
+   */
+  static void longToByteArray(long value, byte[] dest, int destOffset) {
+    Utils.checkArgument(dest.length >= destOffset + LONG_BYTES, "array too small");
+    dest[destOffset + 7] = (byte) (value & 0xFFL);
+    dest[destOffset + 6] = (byte) (value >> 8 & 0xFFL);
+    dest[destOffset + 5] = (byte) (value >> 16 & 0xFFL);
+    dest[destOffset + 4] = (byte) (value >> 24 & 0xFFL);
+    dest[destOffset + 3] = (byte) (value >> 32 & 0xFFL);
+    dest[destOffset + 2] = (byte) (value >> 40 & 0xFFL);
+    dest[destOffset + 1] = (byte) (value >> 48 & 0xFFL);
+    dest[destOffset] = (byte) (value >> 56 & 0xFFL);
+  }
+
+  private BigendianEncoding() {}
+}

--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -18,7 +18,6 @@ package io.opencensus.trace;
 
 import io.opencensus.common.Internal;
 import io.opencensus.internal.Utils;
-import java.util.Arrays;
 import java.util.Random;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -218,8 +217,11 @@ public final class TraceId implements Comparable<TraceId> {
 
   @Override
   public int hashCode() {
-    // TODO: Use Objects.hashCode when switch to java17.
-    return Arrays.hashCode(new Long[] {idHi, idLo});
+    // Copied from Arrays.hashCode(long[])
+    int result = 1;
+    result = 31 * result + ((int) (idHi ^ (idHi >>> 32)));
+    result = 31 * result + ((int) (idLo ^ (idLo >>> 32)));
+    return result;
   }
 
   @Override

--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -39,19 +39,22 @@ public final class TraceId implements Comparable<TraceId> {
   public static final int SIZE = 16;
 
   private static final int HEX_SIZE = 32;
+  private static final long INVALID_ID = 0;
 
   /**
    * The invalid {@code TraceId}. All bytes are '\0'.
    *
    * @since 0.5
    */
-  public static final TraceId INVALID = new TraceId(new byte[SIZE]);
+  public static final TraceId INVALID = new TraceId(INVALID_ID, INVALID_ID);
 
   // The internal representation of the TraceId.
-  private final byte[] bytes;
+  private final long idHi;
+  private final long idLo;
 
-  private TraceId(byte[] bytes) {
-    this.bytes = bytes;
+  private TraceId(long idHi, long idLo) {
+    this.idHi = idHi;
+    this.idLo = idLo;
   }
 
   /**
@@ -73,8 +76,9 @@ public final class TraceId implements Comparable<TraceId> {
     Utils.checkNotNull(buffer, "buffer");
     Utils.checkArgument(
         buffer.length == SIZE, "Invalid size: expected %s, got %s", SIZE, buffer.length);
-    byte[] bytesCopied = Arrays.copyOf(buffer, SIZE);
-    return new TraceId(bytesCopied);
+    return new TraceId(
+        BigendianEncoding.longFromByteArray(buffer, 0),
+        BigendianEncoding.longFromByteArray(buffer, BigendianEncoding.LONG_BYTES));
   }
 
   /**
@@ -91,9 +95,9 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.5
    */
   public static TraceId fromBytes(byte[] src, int srcOffset) {
-    byte[] bytes = new byte[SIZE];
-    System.arraycopy(src, srcOffset, bytes, 0, SIZE);
-    return new TraceId(bytes);
+    return new TraceId(
+        BigendianEncoding.longFromByteArray(src, srcOffset),
+        BigendianEncoding.longFromByteArray(src, srcOffset + BigendianEncoding.LONG_BYTES));
   }
 
   /**
@@ -109,7 +113,7 @@ public final class TraceId implements Comparable<TraceId> {
   public static TraceId fromLowerBase16(CharSequence src) {
     Utils.checkArgument(
         src.length() == HEX_SIZE, "Invalid size: expected %s, got %s", HEX_SIZE, src.length());
-    return new TraceId(LowerCaseBase16Encoding.decodeToBytes(src));
+    return fromBytes(LowerCaseBase16Encoding.decodeToBytes(src));
   }
 
   /**
@@ -120,11 +124,13 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.5
    */
   public static TraceId generateRandomId(Random random) {
-    byte[] bytes = new byte[SIZE];
+    long idHi;
+    long idLo;
     do {
-      random.nextBytes(bytes);
-    } while (Arrays.equals(bytes, INVALID.bytes));
-    return new TraceId(bytes);
+      idHi = random.nextLong();
+      idLo = random.nextLong();
+    } while (idHi == INVALID_ID && idLo == INVALID_ID);
+    return new TraceId(idHi, idLo);
   }
 
   /**
@@ -134,7 +140,10 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.5
    */
   public byte[] getBytes() {
-    return Arrays.copyOf(bytes, SIZE);
+    byte[] bytes = new byte[SIZE];
+    BigendianEncoding.longToByteArray(idHi, bytes, 0);
+    BigendianEncoding.longToByteArray(idLo, bytes, BigendianEncoding.LONG_BYTES);
+    return bytes;
   }
 
   /**
@@ -155,7 +164,8 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.5
    */
   public void copyBytesTo(byte[] dest, int destOffset) {
-    System.arraycopy(bytes, 0, dest, destOffset, SIZE);
+    BigendianEncoding.longToByteArray(idHi, dest, destOffset);
+    BigendianEncoding.longToByteArray(idLo, dest, destOffset + BigendianEncoding.LONG_BYTES);
   }
 
   /**
@@ -166,7 +176,7 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.5
    */
   public boolean isValid() {
-    return !Arrays.equals(bytes, INVALID.bytes);
+    return idHi != INVALID_ID || idLo != INVALID_ID;
   }
 
   /**
@@ -176,7 +186,7 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.11
    */
   public String toLowerBase16() {
-    return LowerCaseBase16Encoding.encodeToString(bytes);
+    return LowerCaseBase16Encoding.encodeToString(getBytes());
   }
 
   /**
@@ -189,15 +199,7 @@ public final class TraceId implements Comparable<TraceId> {
    */
   @Internal
   public long getLowerLong() {
-    long result = 0;
-    for (int i = 0; i < Long.SIZE / Byte.SIZE; i++) {
-      result <<= Byte.SIZE;
-      result |= (bytes[i] & 0xff);
-    }
-    if (result < 0) {
-      return -result;
-    }
-    return result;
+    return (idHi < 0) ? -idHi : idHi;
   }
 
   @Override
@@ -211,12 +213,13 @@ public final class TraceId implements Comparable<TraceId> {
     }
 
     TraceId that = (TraceId) obj;
-    return Arrays.equals(bytes, that.bytes);
+    return idHi == that.idHi && idLo == that.idLo;
   }
 
   @Override
   public int hashCode() {
-    return Arrays.hashCode(bytes);
+    // TODO: Use Objects.hashCode when switch to java17.
+    return Arrays.hashCode(new Long[] {idHi, idLo});
   }
 
   @Override
@@ -226,11 +229,12 @@ public final class TraceId implements Comparable<TraceId> {
 
   @Override
   public int compareTo(TraceId that) {
-    for (int i = 0; i < SIZE; i++) {
-      if (bytes[i] != that.bytes[i]) {
-        return bytes[i] < that.bytes[i] ? -1 : 1;
+    if (idHi == that.idHi) {
+      if (idLo == that.idLo) {
+        return 0;
       }
+      return idLo < that.idLo ? -1 : 1;
     }
-    return 0;
+    return idHi < that.idHi ? -1 : 1;
   }
 }

--- a/api/src/test/java/io/opencensus/trace/BigendianEncodingTest.java
+++ b/api/src/test/java/io/opencensus/trace/BigendianEncodingTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link BigendianEncoding}. */
+@RunWith(JUnit4.class)
+public class BigendianEncodingTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final long FIRST_LONG = 0x1213141516171819L;
+  private static final byte[] FIRST_BYTE_ARRAY =
+      new byte[] {0x12, 0x13, 0x14, 0x15, 0x16, 0x17, 0x18, 0x19};
+  private static final long SECOND_LONG = 0xFFEEDDCCBBAA9988L;
+  private static final byte[] SECOND_BYTE_ARRAY =
+      new byte[] {
+        (byte) 0xFF, (byte) 0xEE, (byte) 0xDD, (byte) 0xCC,
+        (byte) 0xBB, (byte) 0xAA, (byte) 0x99, (byte) 0x88
+      };
+  private static final byte[] BOTH_BYTE_ARRAY =
+      new byte[] {
+        0x12,
+        0x13,
+        0x14,
+        0x15,
+        0x16,
+        0x17,
+        0x18,
+        0x19,
+        (byte) 0xFF,
+        (byte) 0xEE,
+        (byte) 0xDD,
+        (byte) 0xCC,
+        (byte) 0xBB,
+        (byte) 0xAA,
+        (byte) 0x99,
+        (byte) 0x88
+      };
+
+  @Test
+  public void longToByteArray() {
+    byte[] result1 = new byte[8];
+    BigendianEncoding.longToByteArray(FIRST_LONG, result1, 0);
+    assertThat(result1).isEqualTo(FIRST_BYTE_ARRAY);
+
+    byte[] result2 = new byte[8];
+    BigendianEncoding.longToByteArray(SECOND_LONG, result2, 0);
+    assertThat(result2).isEqualTo(SECOND_BYTE_ARRAY);
+
+    byte[] result3 = new byte[16];
+    BigendianEncoding.longToByteArray(FIRST_LONG, result3, 0);
+    BigendianEncoding.longToByteArray(SECOND_LONG, result3, 8);
+    assertThat(result3).isEqualTo(BOTH_BYTE_ARRAY);
+  }
+
+  @Test
+  public void longToByteArray_Fails() {
+    // These contain bytes not in the decoding.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("array too small");
+    BigendianEncoding.longToByteArray(123, new byte[8], 1);
+  }
+
+  @Test
+  public void longFromByteArray() {
+    assertThat(BigendianEncoding.longFromByteArray(FIRST_BYTE_ARRAY, 0)).isEqualTo(FIRST_LONG);
+
+    assertThat(BigendianEncoding.longFromByteArray(SECOND_BYTE_ARRAY, 0)).isEqualTo(SECOND_LONG);
+
+    assertThat(BigendianEncoding.longFromByteArray(BOTH_BYTE_ARRAY, 0)).isEqualTo(FIRST_LONG);
+
+    assertThat(BigendianEncoding.longFromByteArray(BOTH_BYTE_ARRAY, 8)).isEqualTo(SECOND_LONG);
+  }
+
+  @Test
+  public void toFromLong() {
+    toFromLongValidate(0x8000000000000000L);
+    toFromLongValidate(-1);
+    toFromLongValidate(0);
+    toFromLongValidate(1);
+    toFromLongValidate(0x7FFFFFFFFFFFFFFFL);
+  }
+
+  @Test
+  public void longFromByteArray_Fails() {
+    // These contain bytes not in the decoding.
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("array too small");
+    BigendianEncoding.longFromByteArray(new byte[8], 1);
+  }
+
+  private static void toFromLongValidate(long value) {
+    byte[] array = new byte[8];
+    BigendianEncoding.longToByteArray(value, array, 0);
+    assertThat(BigendianEncoding.longFromByteArray(array, 0)).isEqualTo(value);
+  }
+}


### PR DESCRIPTION
In a followup PR the LowerCaseBase16Encoding should be changed to work with longs to avoid more allocations (not doing that here to keep this PR simple).