### PR TITLE
gRPC metrics: Add measures and views for real-time metrics in streaming RPCs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
   [`trace_sampled` field](https://github.com/googleapis/googleapis/blob/8027f17420d5a323c7dfef1ae0e57d82f3b97430/google/logging/v2/log_entry.proto#L143-L149)
   in the Stackdriver `LogEntry` protocol buffer in `opencensus-contrib-log-correlation-stackdriver`.
 - Add support for w3c/distributed-tracing propagation format.
+- Add gRPC measures and views for real-time metrics in streaming RPCs.
 
 ## 0.17.0 - 2018-11-02
 - Add `AttributeValueDouble` to `AttributeValue`.

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -255,6 +255,48 @@ public final class RpcMeasureConstants {
           BYTE);
 
   /**
+   * {@link Measure} for total bytes sent per method, recorded real-time as bytes are sent.
+   *
+   * @since 0.18
+   */
+  public static final MeasureDouble GRPC_CLIENT_SENT_BYTES_PER_METHOD =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/sent_bytes_per_method",
+          "Total bytes sent per method, recorded real-time as bytes are sent.",
+          BYTE);
+
+  /**
+   * {@link Measure} for total bytes received per method, recorded real-time as bytes are received.
+   *
+   * @since 0.18
+   */
+  public static final MeasureDouble GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/received_bytes_per_method",
+          "Total bytes received per method, recorded real-time as bytes are received.",
+          BYTE);
+
+  /**
+   * {@link Measure} for total client sent messages.
+   *
+   * @since 0.18
+   */
+  public static final MeasureLong GRPC_CLIENT_SENT_MESSAGES_PER_METHOD =
+      Measure.MeasureLong.create(
+          "grpc.io/client/sent_messages_per_method", "Total messages sent per method.", COUNT);
+
+  /**
+   * {@link Measure} for total client received messages.
+   *
+   * @since 0.18
+   */
+  public static final MeasureLong GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD =
+      Measure.MeasureLong.create(
+          "grpc.io/client/received_messages_per_method",
+          "Total messages received per method.",
+          COUNT);
+
+  /**
    * {@link Measure} for gRPC client roundtrip latency in milliseconds.
    *
    * @since 0.13
@@ -448,6 +490,48 @@ public final class RpcMeasureConstants {
           "grpc.io/server/received_bytes_per_rpc",
           "Total bytes received across all messages per RPC",
           BYTE);
+
+  /**
+   * {@link Measure} for total bytes sent per method, recorded real-time as bytes are sent.
+   *
+   * @since 0.18
+   */
+  public static final MeasureDouble GRPC_SERVER_SENT_BYTES_PER_METHOD =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/sent_bytes_per_method",
+          "Total bytes sent per method, recorded real-time as bytes are sent.",
+          BYTE);
+
+  /**
+   * {@link Measure} for total bytes received per method, recorded real-time as bytes are received.
+   *
+   * @since 0.18
+   */
+  public static final MeasureDouble GRPC_SERVER_RECEIVED_BYTES_PER_METHOD =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/received_bytes_per_method",
+          "Total bytes received per method, recorded real-time as bytes are received.",
+          BYTE);
+
+  /**
+   * {@link Measure} for total server sent messages.
+   *
+   * @since 0.18
+   */
+  public static final MeasureLong GRPC_SERVER_SENT_MESSAGES_PER_METHOD =
+      Measure.MeasureLong.create(
+          "grpc.io/server/sent_messages_per_method", "Total messages sent per method.", COUNT);
+
+  /**
+   * {@link Measure} for total server received messages.
+   *
+   * @since 0.18
+   */
+  public static final MeasureLong GRPC_SERVER_RECEIVED_MESSAGES_PER_METHOD =
+      Measure.MeasureLong.create(
+          "grpc.io/server/received_messages_per_method",
+          "Total messages received per method.",
+          COUNT);
 
   /**
    * {@link Measure} for number of messages sent in each RPC.

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -17,18 +17,26 @@
 package io.opencensus.contrib.grpc.metrics;
 
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_METHOD;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STATUS;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_METHOD;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS;
@@ -63,6 +71,7 @@ import io.opencensus.common.Duration;
 import io.opencensus.stats.Aggregation;
 import io.opencensus.stats.Aggregation.Count;
 import io.opencensus.stats.Aggregation.Distribution;
+import io.opencensus.stats.Aggregation.Sum;
 import io.opencensus.stats.BucketBoundaries;
 import io.opencensus.stats.View;
 import java.util.Arrays;
@@ -125,6 +134,7 @@ public final class RpcViewConstants {
   // Use Aggregation.Mean to record sum and count stats at the same time.
   @VisibleForTesting static final Aggregation MEAN = Aggregation.Mean.create();
   @VisibleForTesting static final Aggregation COUNT = Count.create();
+  @VisibleForTesting static final Aggregation SUM = Sum.create();
 
   @VisibleForTesting
   static final Aggregation AGGREGATION_WITH_BYTES_HISTOGRAM =
@@ -411,6 +421,58 @@ public final class RpcViewConstants {
           Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
+   * {@link View} for client sent bytes per method.
+   *
+   * @since 0.18
+   */
+  public static final View GRPC_CLIENT_SENT_BYTES_PER_METHOD_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/sent_bytes_per_method"),
+          "Sent bytes per method",
+          GRPC_CLIENT_SENT_BYTES_PER_METHOD,
+          SUM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client received bytes per method.
+   *
+   * @since 0.18
+   */
+  public static final View GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/received_bytes_per_method"),
+          "Received bytes per method",
+          GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD,
+          SUM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client sent messages.
+   *
+   * @since 0.18
+   */
+  public static final View GRPC_CLIENT_SENT_MESSAGES_PER_METHOD_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/sent_messages_per_method"),
+          "Number of messages sent",
+          GRPC_CLIENT_SENT_MESSAGES_PER_METHOD,
+          COUNT,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client received messages.
+   *
+   * @since 0.18
+   */
+  public static final View GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/received_messages_per_method"),
+          "Number of messages received",
+          GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD,
+          COUNT,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
    * {@link View} for completed client RPCs.
    *
    * <p>This {@code View} uses measure {@code GRPC_CLIENT_ROUNDTRIP_LATENCY}, since completed RPCs
@@ -681,6 +743,58 @@ public final class RpcViewConstants {
           "Number of response messages received in each RPC",
           GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC,
           AGGREGATION_WITH_COUNT_HISTOGRAM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for total server sent bytes per method.
+   *
+   * @since 0.18
+   */
+  public static final View GRPC_SERVER_SENT_BYTES_PER_METHOD_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/sent_bytes_per_method"),
+          "Sent bytes per method",
+          GRPC_SERVER_SENT_BYTES_PER_METHOD,
+          SUM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for total server received bytes per method.
+   *
+   * @since 0.18
+   */
+  public static final View GRPC_SERVER_RECEIVED_BYTES_PER_METHOD_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/received_bytes_per_method"),
+          "Received bytes per method",
+          GRPC_SERVER_RECEIVED_BYTES_PER_METHOD,
+          SUM,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for server sent messages.
+   *
+   * @since 0.18
+   */
+  public static final View GRPC_SERVER_SENT_MESSAGES_PER_METHOD_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/sent_messages_per_method"),
+          "Number of messages sent",
+          GRPC_SERVER_SENT_MESSAGES_PER_METHOD,
+          COUNT,
+          Arrays.asList(GRPC_SERVER_METHOD));
+
+  /**
+   * {@link View} for server received messages.
+   *
+   * @since 0.18
+   */
+  public static final View GRPC_SERVER_RECEIVED_MESSAGES_PER_METHOD_VIEW =
+      View.create(
+          View.Name.create("grpc.io/server/received_messages_per_method"),
+          "Number of messages received",
+          GRPC_SERVER_RECEIVED_MESSAGES_PER_METHOD,
+          COUNT,
           Arrays.asList(GRPC_SERVER_METHOD));
 
   /**

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -126,6 +126,18 @@ public final class RpcViews {
           RpcViewConstants.RPC_SERVER_STARTED_COUNT_HOUR_VIEW,
           RpcViewConstants.RPC_SERVER_FINISHED_COUNT_HOUR_VIEW);
 
+  @VisibleForTesting
+  static final ImmutableSet<View> RPC_REAL_TIME_METRICS_VIEWS_SET =
+      ImmutableSet.of(
+          RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD_VIEW,
+          RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD_VIEW,
+          RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_METHOD_VIEW,
+          RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD_VIEW,
+          RpcViewConstants.GRPC_SERVER_SENT_BYTES_PER_METHOD_VIEW,
+          RpcViewConstants.GRPC_SERVER_RECEIVED_BYTES_PER_METHOD_VIEW,
+          RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_METHOD_VIEW,
+          RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_METHOD_VIEW);
+
   /**
    * Registers all standard gRPC views.
    *
@@ -244,6 +256,22 @@ public final class RpcViews {
   static void registerAllViews(ViewManager viewManager) {
     registerAllCumulativeViews(viewManager);
     registerAllIntervalViews(viewManager);
+  }
+
+  /**
+   * Registers views for real time metrics reporting for streaming RPCs.
+   *
+   * @since 0.18
+   */
+  public static void registerRealTimeMetricsViews() {
+    registerRealTimeMetricsViews(Stats.getViewManager());
+  }
+
+  @VisibleForTesting
+  static void registerRealTimeMetricsViews(ViewManager viewManager) {
+    for (View view : RPC_REAL_TIME_METRICS_VIEWS_SET) {
+      viewManager.registerView(view);
+    }
   }
 
   private RpcViews() {}

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
@@ -52,6 +52,8 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS).isNotNull();
@@ -72,6 +74,8 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_SENT_BYTES_PER_METHOD).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_METHOD).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_SERVER_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_SERVER_STARTED_RPCS).isNotNull();
   }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -107,6 +107,10 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_METHOD_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_SERVER_LATENCY_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW).isNotNull();
 
@@ -124,6 +128,10 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_RPC_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_SENT_BYTES_PER_METHOD_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_BYTES_PER_METHOD_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_SENT_MESSAGES_PER_METHOD_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_SERVER_RECEIVED_MESSAGES_PER_METHOD_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW).isNotNull();
 

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
@@ -91,6 +91,14 @@ public class RpcViewsTest {
         .containsExactlyElementsIn(RpcViews.GRPC_SERVER_VIEWS_SET);
   }
 
+  @Test
+  public void registerRealTimeMetricsViews() {
+    FakeViewManager fakeViewManager = new FakeViewManager();
+    RpcViews.registerRealTimeMetricsViews(fakeViewManager);
+    assertThat(fakeViewManager.getRegisteredViews())
+        .containsExactlyElementsIn(RpcViews.RPC_REAL_TIME_METRICS_VIEWS_SET);
+  }
+
   // TODO(bdrutu): Test with reflection that all defined gRPC views are registered.
 
   private static final class FakeViewManager extends ViewManager {


### PR DESCRIPTION
~~Blocked waiting on https://github.com/census-instrumentation/opencensus-specs/pull/206.~~

The new views won't be included in the default view set and need to be registered separately.