### PR TITLE
Add helper functions for base16 encoding.

### DIFF
--- a/api/src/main/java/io/opencensus/trace/TraceId.java
+++ b/api/src/main/java/io/opencensus/trace/TraceId.java
@@ -59,25 +59,16 @@ public final class TraceId implements Comparable<TraceId> {
   /**
    * Returns a {@code TraceId} built from a byte representation.
    *
-   * <p>Equivalent with:
-   *
-   * <pre>{@code
-   * TraceId.fromBytes(buffer, 0);
-   * }</pre>
-   *
-   * @param buffer the representation of the {@code TraceId}.
-   * @return a {@code TraceId} whose representation is given by the {@code buffer} parameter.
-   * @throws NullPointerException if {@code buffer} is null.
-   * @throws IllegalArgumentException if {@code buffer.length} is not {@link TraceId#SIZE}.
+   * @param src the representation of the {@code TraceId}.
+   * @return a {@code TraceId} whose representation is given by the {@code src} parameter.
+   * @throws NullPointerException if {@code src} is null.
+   * @throws IllegalArgumentException if {@code src.length} is not {@link TraceId#SIZE}.
    * @since 0.5
    */
-  public static TraceId fromBytes(byte[] buffer) {
-    Utils.checkNotNull(buffer, "buffer");
-    Utils.checkArgument(
-        buffer.length == SIZE, "Invalid size: expected %s, got %s", SIZE, buffer.length);
-    return new TraceId(
-        BigendianEncoding.longFromByteArray(buffer, 0),
-        BigendianEncoding.longFromByteArray(buffer, BigendianEncoding.LONG_BYTES));
+  public static TraceId fromBytes(byte[] src) {
+    Utils.checkNotNull(src, "src");
+    Utils.checkArgument(src.length == SIZE, "Invalid size: expected %s, got %s", SIZE, src.length);
+    return fromBytes(src, 0);
   }
 
   /**
@@ -94,6 +85,7 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.5
    */
   public static TraceId fromBytes(byte[] src, int srcOffset) {
+    Utils.checkNotNull(src, "src");
     return new TraceId(
         BigendianEncoding.longFromByteArray(src, srcOffset),
         BigendianEncoding.longFromByteArray(src, srcOffset + BigendianEncoding.LONG_BYTES));
@@ -110,14 +102,32 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.11
    */
   public static TraceId fromLowerBase16(CharSequence src) {
+    Utils.checkNotNull(src, "src");
     Utils.checkArgument(
         src.length() == BASE16_SIZE,
         "Invalid size: expected %s, got %s",
         BASE16_SIZE,
         src.length());
+    return fromLowerBase16(src, 0);
+  }
+
+  /**
+   * Returns a {@code TraceId} built from a lowercase base16 representation.
+   *
+   * @param src the lowercase base16 representation.
+   * @param srcOffset the offset in the buffer where the representation of the {@code TraceId}
+   *     begins.
+   * @return a {@code TraceId} built from a lowercase base16 representation.
+   * @throws NullPointerException if {@code src} is null.
+   * @throws IllegalArgumentException if not enough characters in the {@code src} from the {@code
+   *     srcOffset}.
+   * @since 0.11
+   */
+  public static TraceId fromLowerBase16(CharSequence src, int srcOffset) {
+    Utils.checkNotNull(src, "src");
     return new TraceId(
-        BigendianEncoding.longFromBase16String(src, 0),
-        BigendianEncoding.longFromBase16String(src, BigendianEncoding.LONG_BASE16));
+        BigendianEncoding.longFromBase16String(src, srcOffset),
+        BigendianEncoding.longFromBase16String(src, srcOffset + BigendianEncoding.LONG_BASE16));
   }
 
   /**
@@ -154,12 +164,6 @@ public final class TraceId implements Comparable<TraceId> {
    * Copies the byte array representations of the {@code TraceId} into the {@code dest} beginning at
    * the {@code destOffset} offset.
    *
-   * <p>Equivalent with (but faster because it avoids any new allocations):
-   *
-   * <pre>{@code
-   * System.arraycopy(getBytes(), 0, dest, destOffset, TraceId.SIZE);
-   * }</pre>
-   *
    * @param dest the destination buffer.
    * @param destOffset the starting offset in the destination buffer.
    * @throws NullPointerException if {@code dest} is null.
@@ -170,6 +174,21 @@ public final class TraceId implements Comparable<TraceId> {
   public void copyBytesTo(byte[] dest, int destOffset) {
     BigendianEncoding.longToByteArray(idHi, dest, destOffset);
     BigendianEncoding.longToByteArray(idLo, dest, destOffset + BigendianEncoding.LONG_BYTES);
+  }
+
+  /**
+   * Copies the lowercase base16 representations of the {@code TraceId} into the {@code dest}
+   * beginning at the {@code destOffset} offset.
+   *
+   * @param dest the destination buffer.
+   * @param destOffset the starting offset in the destination buffer.
+   * @throws IndexOutOfBoundsException if {@code destOffset + 2 * TraceId.SIZE} is greater than
+   *     {@code dest.length}.
+   * @since 0.18
+   */
+  public void copyLowerBase16To(char[] dest, int destOffset) {
+    BigendianEncoding.longToBase16String(idHi, dest, destOffset);
+    BigendianEncoding.longToBase16String(idLo, dest, destOffset + BASE16_SIZE / 2);
   }
 
   /**
@@ -190,10 +209,9 @@ public final class TraceId implements Comparable<TraceId> {
    * @since 0.11
    */
   public String toLowerBase16() {
-    StringBuilder stringBuilder = new StringBuilder(BASE16_SIZE);
-    BigendianEncoding.longToBase16String(idHi, stringBuilder);
-    BigendianEncoding.longToBase16String(idLo, stringBuilder);
-    return stringBuilder.toString();
+    char[] chars = new char[BASE16_SIZE];
+    copyLowerBase16To(chars, 0);
+    return new String(chars);
   }
 
   /**

--- a/api/src/main/java/io/opencensus/trace/TraceOptions.java
+++ b/api/src/main/java/io/opencensus/trace/TraceOptions.java
@@ -43,6 +43,8 @@ public final class TraceOptions {
    */
   public static final int SIZE = 1;
 
+  private static final int BASE16_SIZE = 2 * SIZE;
+
   /**
    * The default {@code TraceOptions}.
    *
@@ -115,6 +117,22 @@ public final class TraceOptions {
   }
 
   /**
+   * Returns a {@code TraceOption} built from a lowercase base16 representation.
+   *
+   * @param src the lowercase base16 representation.
+   * @param srcOffset the offset in the buffer where the representation of the {@code TraceOptions}
+   *     begins.
+   * @return a {@code TraceOption} built from a lowercase base16 representation.
+   * @throws NullPointerException if {@code src} is null.
+   * @throws IllegalArgumentException if {@code src.length} is not {@code 2 * TraceOption.SIZE} OR
+   *     if the {@code str} has invalid characters.
+   * @since 0.18
+   */
+  public static TraceOptions fromLowerBase16(CharSequence src, int srcOffset) {
+    return new TraceOptions(BigendianEncoding.byteFromBase16String(src, srcOffset));
+  }
+
+  /**
    * Returns the one byte representation of the {@code TraceOptions}.
    *
    * @return the one byte representation of the {@code TraceOptions}.
@@ -158,6 +176,32 @@ public final class TraceOptions {
   public void copyBytesTo(byte[] dest, int destOffset) {
     Utils.checkIndex(destOffset, dest.length);
     dest[destOffset] = options;
+  }
+
+  /**
+   * Copies the lowercase base16 representations of the {@code TraceId} into the {@code dest}
+   * beginning at the {@code destOffset} offset.
+   *
+   * @param dest the destination buffer.
+   * @param destOffset the starting offset in the destination buffer.
+   * @throws IndexOutOfBoundsException if {@code destOffset + 2} is greater than {@code
+   *     dest.length}.
+   * @since 0.18
+   */
+  public void copyLowerBase16To(char[] dest, int destOffset) {
+    BigendianEncoding.byteToBase16String(options, dest, destOffset);
+  }
+
+  /**
+   * Returns the lowercase base16 encoding of this {@code TraceOptions}.
+   *
+   * @return the lowercase base16 encoding of this {@code TraceOptions}.
+   * @since 0.18
+   */
+  public String toLowerBase16() {
+    char[] chars = new char[BASE16_SIZE];
+    copyLowerBase16To(chars, 0);
+    return new String(chars);
   }
 
   /**

--- a/api/src/test/java/io/opencensus/trace/BigendianEncodingTest.java
+++ b/api/src/test/java/io/opencensus/trace/BigendianEncodingTest.java
@@ -123,18 +123,18 @@ public class BigendianEncodingTest {
 
   @Test
   public void longToBase16String() {
-    StringBuilder result1 = new StringBuilder(BigendianEncoding.LONG_BASE16);
-    BigendianEncoding.longToBase16String(FIRST_LONG, result1);
-    assertThat(result1.toString()).isEqualTo(new String(FIRST_CHAR_ARRAY));
+    char[] chars1 = new char[BigendianEncoding.LONG_BASE16];
+    BigendianEncoding.longToBase16String(FIRST_LONG, chars1, 0);
+    assertThat(chars1).isEqualTo(FIRST_CHAR_ARRAY);
 
-    StringBuilder result2 = new StringBuilder(BigendianEncoding.LONG_BASE16);
-    BigendianEncoding.longToBase16String(SECOND_LONG, result2);
-    assertThat(result2.toString()).isEqualTo(new String(SECOND_CHAR_ARRAY));
+    char[] chars2 = new char[BigendianEncoding.LONG_BASE16];
+    BigendianEncoding.longToBase16String(SECOND_LONG, chars2, 0);
+    assertThat(chars2).isEqualTo(SECOND_CHAR_ARRAY);
 
-    StringBuilder result3 = new StringBuilder(2 * BigendianEncoding.LONG_BASE16);
-    BigendianEncoding.longToBase16String(FIRST_LONG, result3);
-    BigendianEncoding.longToBase16String(SECOND_LONG, result3);
-    assertThat(result3.toString()).isEqualTo(new String(BOTH_CHAR_ARRAY));
+    char[] chars3 = new char[2 * BigendianEncoding.LONG_BASE16];
+    BigendianEncoding.longToBase16String(FIRST_LONG, chars3, 0);
+    BigendianEncoding.longToBase16String(SECOND_LONG, chars3, BigendianEncoding.LONG_BASE16);
+    assertThat(chars3).isEqualTo(BOTH_CHAR_ARRAY);
   }
 
   @Test
@@ -187,8 +187,8 @@ public class BigendianEncodingTest {
   }
 
   private static void toFromBase16StringValidate(long value) {
-    StringBuilder dest = new StringBuilder(BigendianEncoding.LONG_BASE16);
-    BigendianEncoding.longToBase16String(value, dest);
-    assertThat(BigendianEncoding.longFromBase16String(dest.toString(), 0)).isEqualTo(value);
+    char[] dest = new char[BigendianEncoding.LONG_BASE16];
+    BigendianEncoding.longToBase16String(value, dest, 0);
+    assertThat(BigendianEncoding.longFromBase16String(CharBuffer.wrap(dest), 0)).isEqualTo(value);
   }
 }

--- a/api/src/test/java/io/opencensus/trace/SpanIdTest.java
+++ b/api/src/test/java/io/opencensus/trace/SpanIdTest.java
@@ -52,6 +52,13 @@ public class SpanIdTest {
   }
 
   @Test
+  public void fromLowerBase16_WithOffset() {
+    assertThat(SpanId.fromLowerBase16("XX0000000000000000AA", 2)).isEqualTo(SpanId.INVALID);
+    assertThat(SpanId.fromLowerBase16("YY0000000000000061BB", 2)).isEqualTo(first);
+    assertThat(SpanId.fromLowerBase16("ZZff00000000000041CC", 2)).isEqualTo(second);
+  }
+
+  @Test
   public void toLowerBase16() {
     assertThat(SpanId.INVALID.toLowerBase16()).isEqualTo("0000000000000000");
     assertThat(first.toLowerBase16()).isEqualTo("0000000000000061");

--- a/api/src/test/java/io/opencensus/trace/TraceIdTest.java
+++ b/api/src/test/java/io/opencensus/trace/TraceIdTest.java
@@ -67,6 +67,15 @@ public class TraceIdTest {
   }
 
   @Test
+  public void fromLowerBase16_WithOffset() {
+    assertThat(TraceId.fromLowerBase16("XX00000000000000000000000000000000CC", 2))
+        .isEqualTo(TraceId.INVALID);
+    assertThat(TraceId.fromLowerBase16("YY00000000000000000000000000000061AA", 2)).isEqualTo(first);
+    assertThat(TraceId.fromLowerBase16("ZZff000000000000000000000000000041BB", 2))
+        .isEqualTo(second);
+  }
+
+  @Test
   public void toLowerBase16() {
     assertThat(TraceId.INVALID.toLowerBase16()).isEqualTo("00000000000000000000000000000000");
     assertThat(first.toLowerBase16()).isEqualTo("00000000000000000000000000000061");

--- a/api/src/test/java/io/opencensus/trace/TraceOptionsTest.java
+++ b/api/src/test/java/io/opencensus/trace/TraceOptionsTest.java
@@ -56,6 +56,13 @@ public class TraceOptionsTest {
   }
 
   @Test
+  public void toFromBase16() {
+    assertThat(TraceOptions.fromLowerBase16("ff", 0).toLowerBase16()).isEqualTo("ff");
+    assertThat(TraceOptions.fromLowerBase16("01", 0).toLowerBase16()).isEqualTo("01");
+    assertThat(TraceOptions.fromLowerBase16("06", 0).toLowerBase16()).isEqualTo("06");
+  }
+
+  @Test
   @SuppressWarnings("deprecation")
   public void deprecated_fromBytes() {
     assertThat(TraceOptions.fromBytes(new byte[] {FIRST_BYTE}).getByte()).isEqualTo(FIRST_BYTE);


### PR DESCRIPTION
Split from https://github.com/census-instrumentation/opencensus-java/pull/1401 to simplify the review process.

Also improves the toLowerBase16 by avoiding one extra allocation of the StringBuilder.