### PR TITLE
Fix bug: Dropwizard Meter should have non-null start Timestamp

### DIFF
--- a/contrib/dropwizard/src/main/java/io/opencensus/contrib/dropwizard/DropWizardMetrics.java
+++ b/contrib/dropwizard/src/main/java/io/opencensus/contrib/dropwizard/DropWizardMetrics.java
@@ -162,7 +162,7 @@ public class DropWizardMetrics extends MetricProducer {
         TimeSeries.createWithOnePoint(
             Collections.<LabelValue>emptyList(),
             Point.create(Value.longValue(meter.getCount()), clock.now()),
-            null);
+            cumulativeStartTimestamp);
 
     return Metric.createWithOneTimeSeries(metricDescriptor, timeSeries);
   }

--- a/contrib/dropwizard/src/main/java/io/opencensus/contrib/dropwizard/DropWizardMetrics.java
+++ b/contrib/dropwizard/src/main/java/io/opencensus/contrib/dropwizard/DropWizardMetrics.java
@@ -72,6 +72,9 @@ public class DropWizardMetrics extends MetricProducer {
         Utils.checkNotNull(metricRegistryList, "metricRegistryList"), "metricRegistry");
     this.metricRegistryList = metricRegistryList;
     clock = MillisClock.getInstance();
+
+    // TODO(mayurkale): consider to add cache map<string, CacheEntry> where CacheEntry is
+    // {MetricDescriptor, startTime}
     cumulativeStartTimestamp = clock.now();
   }
 

--- a/contrib/dropwizard/src/test/java/io/opencensus/contrib/dropwizard/DropWizardMetricsTest.java
+++ b/contrib/dropwizard/src/test/java/io/opencensus/contrib/dropwizard/DropWizardMetricsTest.java
@@ -252,7 +252,7 @@ public class DropWizardMetricsTest {
         .isEqualTo(
             MetricDescriptor.create(
                 "codahale_result_histogram",
-                "Collected from codahale (metric=result, " + "type=com.codahale.metrics.Histogram)",
+                "Collected from codahale (metric=result, type=com.codahale.metrics.Histogram)",
                 DEFAULT_UNIT,
                 Type.SUMMARY,
                 Collections.<LabelKey>emptyList()));

--- a/contrib/dropwizard/src/test/java/io/opencensus/contrib/dropwizard/DropWizardMetricsTest.java
+++ b/contrib/dropwizard/src/test/java/io/opencensus/contrib/dropwizard/DropWizardMetricsTest.java
@@ -237,7 +237,7 @@ public class DropWizardMetricsTest {
     assertThat(metrics.get(0).getTimeSeriesList().get(0).getPoints().size()).isEqualTo(1);
     assertThat(metrics.get(0).getTimeSeriesList().get(0).getPoints().get(0).getValue())
         .isEqualTo(Value.longValue(2));
-    assertThat(metrics.get(0).getTimeSeriesList().get(0).getStartTimestamp()).isNull();
+    assertThat(metrics.get(0).getTimeSeriesList().get(0).getStartTimestamp()).isNotNull();
   }
 
   @Test


### PR DESCRIPTION
startTimestamp: Must be non-null for cumulative points.