### PR TITLE
Example: Fix Bazel Build.

### DIFF
--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,6 +1,7 @@
 workspace(name = "opencensus_examples")
 
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 git_repository(
     name = "grpc_java",

--- a/examples/WORKSPACE
+++ b/examples/WORKSPACE
@@ -1,5 +1,7 @@
 workspace(name = "opencensus_examples")
 
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+
 git_repository(
     name = "grpc_java",
     remote = "https://github.com/grpc/grpc-java.git",


### PR DESCRIPTION
> The native git_repository rule is deprecated. load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository") for a replacement.

See https://travis-ci.org/census-instrumentation/opencensus-java/jobs/462666269#L567.