### PR TITLE
Exporter/Metrics/OcAgent: Add MetricsProtoUtils.

### DIFF
--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/MetricsProtoUtils.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/MetricsProtoUtils.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.metrics.ocagent;
+
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Int64Value;
+import io.opencensus.common.Function;
+import io.opencensus.common.Functions;
+import io.opencensus.common.Timestamp;
+import io.opencensus.metrics.export.Distribution;
+import io.opencensus.metrics.export.Summary;
+import io.opencensus.proto.metrics.v1.DistributionValue;
+import io.opencensus.proto.metrics.v1.LabelKey;
+import io.opencensus.proto.metrics.v1.LabelValue;
+import io.opencensus.proto.metrics.v1.Metric;
+import io.opencensus.proto.metrics.v1.MetricDescriptor;
+import io.opencensus.proto.metrics.v1.Point;
+import io.opencensus.proto.metrics.v1.SummaryValue;
+import io.opencensus.proto.metrics.v1.TimeSeries;
+import io.opencensus.proto.resource.v1.Resource;
+import javax.annotation.Nullable;
+
+/** Utilities for converting Metrics APIs in OpenCensus Java to OpenCensus Metrics Proto. */
+final class MetricsProtoUtils {
+
+  static Metric toMetricProto(
+      io.opencensus.metrics.export.Metric metric,
+      @Nullable io.opencensus.resource.Resource resource,
+      boolean alreadySent) {
+    Metric.Builder builder = Metric.newBuilder();
+    if (alreadySent) {
+      builder.setName(metric.getMetricDescriptor().getName());
+    } else {
+      builder.setMetricDescriptor(toMetricDescriptorProto(metric.getMetricDescriptor()));
+    }
+    for (io.opencensus.metrics.export.TimeSeries timeSeries : metric.getTimeSeriesList()) {
+      builder.addTimeseries(toTimeSeriesProto(timeSeries));
+    }
+    if (resource != null) {
+      builder.setResource(toResourceProto(resource));
+    }
+    return builder.build();
+  }
+
+  private static MetricDescriptor toMetricDescriptorProto(
+      io.opencensus.metrics.export.MetricDescriptor metricDescriptor) {
+    MetricDescriptor.Builder builder = MetricDescriptor.newBuilder();
+    builder
+        .setName(metricDescriptor.getName())
+        .setDescription(metricDescriptor.getDescription())
+        .setUnit(metricDescriptor.getUnit())
+        .setType(toTypeProto(metricDescriptor.getType()));
+    for (io.opencensus.metrics.LabelKey labelKey : metricDescriptor.getLabelKeys()) {
+      builder.addLabelKeys(toLabelKeyProto(labelKey));
+    }
+    return builder.build();
+  }
+
+  private static MetricDescriptor.Type toTypeProto(
+      io.opencensus.metrics.export.MetricDescriptor.Type type) {
+    switch (type) {
+      case CUMULATIVE_INT64:
+        return MetricDescriptor.Type.CUMULATIVE_INT64;
+      case CUMULATIVE_DOUBLE:
+        return MetricDescriptor.Type.CUMULATIVE_DOUBLE;
+      case CUMULATIVE_DISTRIBUTION:
+        return MetricDescriptor.Type.CUMULATIVE_DISTRIBUTION;
+      case GAUGE_INT64:
+        return MetricDescriptor.Type.GAUGE_INT64;
+      case GAUGE_DOUBLE:
+        return MetricDescriptor.Type.GAUGE_DOUBLE;
+      case GAUGE_DISTRIBUTION:
+        return MetricDescriptor.Type.GAUGE_DISTRIBUTION;
+      case SUMMARY:
+        return MetricDescriptor.Type.SUMMARY;
+    }
+    return MetricDescriptor.Type.UNRECOGNIZED;
+  }
+
+  private static LabelKey toLabelKeyProto(io.opencensus.metrics.LabelKey labelKey) {
+    return LabelKey.newBuilder()
+        .setKey(labelKey.getKey())
+        .setDescription(labelKey.getDescription())
+        .build();
+  }
+
+  private static Resource toResourceProto(io.opencensus.resource.Resource resource) {
+    Resource.Builder builder = Resource.newBuilder();
+    if (resource.getType() != null) {
+      builder.setType(resource.getType());
+    }
+    builder.putAllLabels(resource.getLabels());
+    return builder.build();
+  }
+
+  private static TimeSeries toTimeSeriesProto(io.opencensus.metrics.export.TimeSeries timeSeries) {
+    TimeSeries.Builder builder = TimeSeries.newBuilder();
+    if (timeSeries.getStartTimestamp() != null) {
+      builder.setStartTimestamp(toTimestampProto(timeSeries.getStartTimestamp()));
+    }
+    for (io.opencensus.metrics.LabelValue labelValue : timeSeries.getLabelValues()) {
+      builder.addLabelValues(toLabelValueProto(labelValue));
+    }
+    for (io.opencensus.metrics.export.Point point : timeSeries.getPoints()) {
+      builder.addPoints(toPointProto(point));
+    }
+    return builder.build();
+  }
+
+  private static LabelValue toLabelValueProto(io.opencensus.metrics.LabelValue labelValue) {
+    LabelValue.Builder builder = LabelValue.newBuilder();
+    if (labelValue.getValue() == null) {
+      builder.setHasValue(false);
+    } else {
+      builder.setHasValue(true).setValue(labelValue.getValue());
+    }
+    return builder.build();
+  }
+
+  private static Point toPointProto(io.opencensus.metrics.export.Point point) {
+    final Point.Builder builder = Point.newBuilder();
+    builder.setTimestamp(toTimestampProto(point.getTimestamp()));
+    point
+        .getValue()
+        .match(
+            new Function<Double, Void>() {
+              @Override
+              public Void apply(Double arg) {
+                builder.setDoubleValue(arg);
+                return null;
+              }
+            },
+            new Function<Long, Void>() {
+              @Override
+              public Void apply(Long arg) {
+                builder.setInt64Value(arg);
+                return null;
+              }
+            },
+            new Function<Distribution, Void>() {
+              @Override
+              public Void apply(Distribution arg) {
+                builder.setDistributionValue(toDistributionProto(arg));
+                return null;
+              }
+            },
+            new Function<Summary, Void>() {
+              @Override
+              public Void apply(Summary arg) {
+                builder.setSummaryValue(toSummaryProto(arg));
+                return null;
+              }
+            },
+            Functions.<Void>throwAssertionError());
+    return builder.build();
+  }
+
+  private static DistributionValue toDistributionProto(
+      io.opencensus.metrics.export.Distribution distribution) {
+    DistributionValue.Builder builder = DistributionValue.newBuilder();
+    builder
+        .setSum(distribution.getSum())
+        .setCount(distribution.getCount())
+        .setSumOfSquaredDeviation(distribution.getSumOfSquaredDeviations());
+    if (distribution.getBucketOptions() != null) {
+      builder.setBucketOptions(toBucketOptionsProto(distribution.getBucketOptions()));
+    }
+    for (io.opencensus.metrics.export.Distribution.Bucket bucket : distribution.getBuckets()) {
+      builder.addBuckets(toBucketProto(bucket));
+    }
+    return builder.build();
+  }
+
+  private static DistributionValue.BucketOptions toBucketOptionsProto(
+      Distribution.BucketOptions bucketOptions) {
+    final DistributionValue.BucketOptions.Builder builder =
+        DistributionValue.BucketOptions.newBuilder();
+    bucketOptions.match(
+        new Function<Distribution.BucketOptions.ExplicitOptions, Void>() {
+          @Override
+          public Void apply(Distribution.BucketOptions.ExplicitOptions arg) {
+            builder.setExplicit(
+                DistributionValue.BucketOptions.Explicit.newBuilder()
+                    .addAllBounds(arg.getBucketBoundaries())
+                    .build());
+            return null;
+          }
+        },
+        Functions.<Void>throwAssertionError());
+    return builder.build();
+  }
+
+  private static DistributionValue.Bucket toBucketProto(
+      io.opencensus.metrics.export.Distribution.Bucket bucket) {
+    DistributionValue.Bucket.Builder builder =
+        DistributionValue.Bucket.newBuilder().setCount(bucket.getCount());
+    io.opencensus.metrics.export.Distribution.Exemplar exemplar = bucket.getExemplar();
+    if (exemplar != null) {
+      builder.setExemplar(toExemplarProto(exemplar));
+    }
+    return builder.build();
+  }
+
+  private static DistributionValue.Exemplar toExemplarProto(
+      io.opencensus.metrics.export.Distribution.Exemplar exemplar) {
+    return DistributionValue.Exemplar.newBuilder()
+        .setValue(exemplar.getValue())
+        .setTimestamp(toTimestampProto(exemplar.getTimestamp()))
+        .putAllAttachments(exemplar.getAttachments())
+        .build();
+  }
+
+  private static SummaryValue toSummaryProto(io.opencensus.metrics.export.Summary summary) {
+    SummaryValue.Builder builder = SummaryValue.newBuilder();
+    if (summary.getSum() != null) {
+      builder.setSum(DoubleValue.of(summary.getSum()));
+    }
+    if (summary.getCount() != null) {
+      builder.setCount(Int64Value.of(summary.getCount()));
+    }
+    builder.setSnapshot(toSnapshotProto(summary.getSnapshot()));
+    return builder.build();
+  }
+
+  private static SummaryValue.Snapshot toSnapshotProto(
+      io.opencensus.metrics.export.Summary.Snapshot snapshot) {
+    SummaryValue.Snapshot.Builder builder = SummaryValue.Snapshot.newBuilder();
+    if (snapshot.getSum() != null) {
+      builder.setSum(DoubleValue.of(snapshot.getSum()));
+    }
+    if (snapshot.getCount() != null) {
+      builder.setCount(Int64Value.of(snapshot.getCount()));
+    }
+    for (io.opencensus.metrics.export.Summary.Snapshot.ValueAtPercentile valueAtPercentile :
+        snapshot.getValueAtPercentiles()) {
+      builder.addPercentileValues(
+          SummaryValue.Snapshot.ValueAtPercentile.newBuilder()
+              .setValue(valueAtPercentile.getValue())
+              .setPercentile(valueAtPercentile.getPercentile())
+              .build());
+    }
+    return builder.build();
+  }
+
+  static com.google.protobuf.Timestamp toTimestampProto(Timestamp timestamp) {
+    return com.google.protobuf.Timestamp.newBuilder()
+        .setSeconds(timestamp.getSeconds())
+        .setNanos(timestamp.getNanos())
+        .build();
+  }
+
+  private MetricsProtoUtils() {}
+}

--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/MetricsProtoUtils.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/MetricsProtoUtils.java
@@ -37,16 +37,13 @@ import javax.annotation.Nullable;
 /** Utilities for converting Metrics APIs in OpenCensus Java to OpenCensus Metrics Proto. */
 final class MetricsProtoUtils {
 
+  // TODO(songya): determine if we should make the optimization on not sending already-existed
+  // MetricDescriptors.
   static Metric toMetricProto(
       io.opencensus.metrics.export.Metric metric,
-      @Nullable io.opencensus.resource.Resource resource,
-      boolean alreadySent) {
+      @Nullable io.opencensus.resource.Resource resource) {
     Metric.Builder builder = Metric.newBuilder();
-    if (alreadySent) {
-      builder.setName(metric.getMetricDescriptor().getName());
-    } else {
-      builder.setMetricDescriptor(toMetricDescriptorProto(metric.getMetricDescriptor()));
-    }
+    builder.setMetricDescriptor(toMetricDescriptorProto(metric.getMetricDescriptor()));
     for (io.opencensus.metrics.export.TimeSeries timeSeries : metric.getTimeSeriesList()) {
       builder.addTimeseries(toTimeSeriesProto(timeSeries));
     }
@@ -185,6 +182,8 @@ final class MetricsProtoUtils {
     return builder.build();
   }
 
+  // TODO(songya): determine if we should make the optimization on not sending already-existed
+  // BucketOptions.
   private static DistributionValue.BucketOptions toBucketOptionsProto(
       Distribution.BucketOptions bucketOptions) {
     final DistributionValue.BucketOptions.Builder builder =

--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentNodeUtils.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentNodeUtils.java
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.metrics.ocagent;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.opencensus.common.OpenCensusLibraryInformation;
+import io.opencensus.common.Timestamp;
+import io.opencensus.contrib.monitoredresource.util.MonitoredResourceUtils;
+import io.opencensus.proto.agent.common.v1.LibraryInfo;
+import io.opencensus.proto.agent.common.v1.LibraryInfo.Language;
+import io.opencensus.proto.agent.common.v1.Node;
+import io.opencensus.proto.agent.common.v1.ProcessIdentifier;
+import io.opencensus.proto.agent.common.v1.ServiceInfo;
+import io.opencensus.proto.resource.v1.Resource;
+import java.lang.management.ManagementFactory;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.security.SecureRandom;
+import java.util.Map.Entry;
+import javax.annotation.Nullable;
+
+/** Utilities for detecting and creating {@link Node}. */
+// TODO(songya): extract the utilities to a common artifact.
+final class OcAgentNodeUtils {
+
+  // The current version of the OpenCensus OC-Agent Exporter.
+  @VisibleForTesting
+  static final String OC_AGENT_EXPORTER_VERSION = "0.18.0-SNAPSHOT"; // CURRENT_OPENCENSUS_VERSION
+
+  @Nullable
+  private static final io.opencensus.resource.Resource AUTO_DETECTED_RESOURCE =
+      MonitoredResourceUtils.detectResource();
+
+  // Creates a Node with information from the OpenCensus library and environment variables.
+  static Node getNodeInfo(String serviceName) {
+    String jvmName = ManagementFactory.getRuntimeMXBean().getName();
+    Timestamp censusTimestamp = Timestamp.fromMillis(System.currentTimeMillis());
+    return Node.newBuilder()
+        .setIdentifier(getProcessIdentifier(jvmName, censusTimestamp))
+        .setLibraryInfo(getLibraryInfo(OpenCensusLibraryInformation.VERSION))
+        .setServiceInfo(getServiceInfo(serviceName))
+        .build();
+  }
+
+  // Creates process identifier with the given JVM name and start time.
+  @VisibleForTesting
+  static ProcessIdentifier getProcessIdentifier(String jvmName, Timestamp censusTimestamp) {
+    String hostname;
+    int pid;
+    // jvmName should be something like '<pid>@<hostname>', at least in Oracle and OpenJdk JVMs
+    int delimiterIndex = jvmName.indexOf('@');
+    if (delimiterIndex < 1) {
+      // Not the expected format, generate a random number.
+      try {
+        hostname = InetAddress.getLocalHost().getHostName();
+      } catch (UnknownHostException e) {
+        hostname = "localhost";
+      }
+      // Generate a random number as the PID.
+      pid = new SecureRandom().nextInt();
+    } else {
+      hostname = jvmName.substring(delimiterIndex + 1, jvmName.length());
+      try {
+        pid = Integer.parseInt(jvmName.substring(0, delimiterIndex));
+      } catch (NumberFormatException e) {
+        // Generate a random number as the PID if format is unexpected.
+        pid = new SecureRandom().nextInt();
+      }
+    }
+
+    return ProcessIdentifier.newBuilder()
+        .setHostName(hostname)
+        .setPid(pid)
+        .setStartTimestamp(MetricsProtoUtils.toTimestampProto(censusTimestamp))
+        .build();
+  }
+
+  // Creates library info with the given OpenCensus Java version.
+  @VisibleForTesting
+  static LibraryInfo getLibraryInfo(String currentOcJavaVersion) {
+    return LibraryInfo.newBuilder()
+        .setLanguage(Language.JAVA)
+        .setCoreLibraryVersion(currentOcJavaVersion)
+        .setExporterVersion(OC_AGENT_EXPORTER_VERSION)
+        .build();
+  }
+
+  // Creates service info with the given service name.
+  @VisibleForTesting
+  static ServiceInfo getServiceInfo(String serviceName) {
+    return ServiceInfo.newBuilder().setName(serviceName).build();
+  }
+
+  @Nullable
+  static Resource getAutoDetectedResourceProto() {
+    return toResourceProto(AUTO_DETECTED_RESOURCE);
+  }
+
+  // Converts a Java Resource object to a Resource proto.
+  @Nullable
+  @VisibleForTesting
+  static Resource toResourceProto(@Nullable io.opencensus.resource.Resource resource) {
+    if (resource == null || resource.getType() == null) {
+      return null;
+    } else {
+      Resource.Builder resourceProtoBuilder = Resource.newBuilder();
+      resourceProtoBuilder.setType(resource.getType());
+      for (Entry<String, String> keyValuePairs : resource.getLabels().entrySet()) {
+        resourceProtoBuilder.putLabels(keyValuePairs.getKey(), keyValuePairs.getValue());
+      }
+      return resourceProtoBuilder.build();
+    }
+  }
+
+  private OcAgentNodeUtils() {}
+}

--- a/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/MetricsProtoUtilsTests.java
+++ b/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/MetricsProtoUtilsTests.java
@@ -109,7 +109,7 @@ public class MetricsProtoUtilsTests {
       Resource.create("env", Collections.<String, String>singletonMap("env_key", "env_val"));
 
   @Test
-  public void toMetricProto_NewMetric() {
+  public void toMetricProto_Distribution() {
     Metric metric = Metric.create(DESCRIPTOR_1, Collections.singletonList(TIME_SERIES_1));
     io.opencensus.proto.metrics.v1.Metric expected =
         io.opencensus.proto.metrics.v1.Metric.newBuilder()
@@ -178,16 +178,32 @@ public class MetricsProtoUtilsTests {
                     .build())
             .build();
     io.opencensus.proto.metrics.v1.Metric actual =
-        MetricsProtoUtils.toMetricProto(metric, RESOURCE, false);
+        MetricsProtoUtils.toMetricProto(metric, RESOURCE);
     assertThat(actual).isEqualTo(expected);
   }
 
   @Test
-  public void toMetricProto_AlreadySent() {
+  public void toMetricProto_Summary() {
     Metric metric = Metric.create(DESCRIPTOR_2, Collections.singletonList(TIME_SERIES_2));
     io.opencensus.proto.metrics.v1.Metric expected =
         io.opencensus.proto.metrics.v1.Metric.newBuilder()
-            .setName(METRIC_NAME_2)
+            .setMetricDescriptor(
+                io.opencensus.proto.metrics.v1.MetricDescriptor.newBuilder()
+                    .setName(METRIC_NAME_2)
+                    .setDescription(METRIC_DESCRIPTION)
+                    .setUnit(UNIT)
+                    .setType(io.opencensus.proto.metrics.v1.MetricDescriptor.Type.SUMMARY)
+                    .addLabelKeys(
+                        io.opencensus.proto.metrics.v1.LabelKey.newBuilder()
+                            .setKey(KEY_1.getKey())
+                            .setDescription(KEY_1.getDescription())
+                            .build())
+                    .addLabelKeys(
+                        io.opencensus.proto.metrics.v1.LabelKey.newBuilder()
+                            .setKey(KEY_2.getKey())
+                            .setDescription(KEY_2.getDescription())
+                            .build())
+                    .build())
             .addTimeseries(
                 io.opencensus.proto.metrics.v1.TimeSeries.newBuilder()
                     .setStartTimestamp(MetricsProtoUtils.toTimestampProto(TIMESTAMP_5))
@@ -221,8 +237,7 @@ public class MetricsProtoUtilsTests {
                             .build())
                     .build())
             .build();
-    io.opencensus.proto.metrics.v1.Metric actual =
-        MetricsProtoUtils.toMetricProto(metric, null, true);
+    io.opencensus.proto.metrics.v1.Metric actual = MetricsProtoUtils.toMetricProto(metric, null);
     assertThat(actual).isEqualTo(expected);
   }
 }

--- a/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/MetricsProtoUtilsTests.java
+++ b/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/MetricsProtoUtilsTests.java
@@ -1,0 +1,228 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.metrics.ocagent;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.protobuf.DoubleValue;
+import com.google.protobuf.Int64Value;
+import io.opencensus.common.Timestamp;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import io.opencensus.metrics.export.Distribution;
+import io.opencensus.metrics.export.Distribution.Bucket;
+import io.opencensus.metrics.export.Distribution.BucketOptions;
+import io.opencensus.metrics.export.Distribution.Exemplar;
+import io.opencensus.metrics.export.Metric;
+import io.opencensus.metrics.export.MetricDescriptor;
+import io.opencensus.metrics.export.MetricDescriptor.Type;
+import io.opencensus.metrics.export.Point;
+import io.opencensus.metrics.export.Summary;
+import io.opencensus.metrics.export.Summary.Snapshot;
+import io.opencensus.metrics.export.Summary.Snapshot.ValueAtPercentile;
+import io.opencensus.metrics.export.TimeSeries;
+import io.opencensus.metrics.export.Value;
+import io.opencensus.proto.metrics.v1.DistributionValue;
+import io.opencensus.proto.metrics.v1.DistributionValue.BucketOptions.Explicit;
+import io.opencensus.proto.metrics.v1.SummaryValue;
+import io.opencensus.resource.Resource;
+import java.util.Arrays;
+import java.util.Collections;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link MetricsProtoUtils}. */
+@RunWith(JUnit4.class)
+public class MetricsProtoUtilsTests {
+
+  private static final LabelKey KEY_1 = LabelKey.create("key1", "");
+  private static final LabelKey KEY_2 = LabelKey.create("key2", "");
+  private static final LabelValue VALUE_1 = LabelValue.create("value1");
+  private static final LabelValue VALUE_2 = LabelValue.create("value2");
+  private static final LabelValue VALUE_NULL = LabelValue.create(null);
+  private static final String UNIT = "ms";
+  private static final String METRIC_NAME_1 = "metric1";
+  private static final String METRIC_NAME_2 = "metric2";
+  private static final String METRIC_DESCRIPTION = "description";
+  private static final MetricDescriptor DESCRIPTOR_1 =
+      MetricDescriptor.create(
+          METRIC_NAME_1,
+          METRIC_DESCRIPTION,
+          UNIT,
+          Type.CUMULATIVE_DISTRIBUTION,
+          Collections.<LabelKey>singletonList(KEY_1));
+  private static final MetricDescriptor DESCRIPTOR_2 =
+      MetricDescriptor.create(
+          METRIC_NAME_2,
+          METRIC_DESCRIPTION,
+          UNIT,
+          Type.SUMMARY,
+          Arrays.<LabelKey>asList(KEY_1, KEY_2));
+  private static final Timestamp TIMESTAMP_1 = Timestamp.create(10, 0);
+  private static final Timestamp TIMESTAMP_2 = Timestamp.create(25, 0);
+  private static final Timestamp TIMESTAMP_3 = Timestamp.create(30, 0);
+  private static final Timestamp TIMESTAMP_4 = Timestamp.create(50, 0);
+  private static final Timestamp TIMESTAMP_5 = Timestamp.create(100, 0);
+  private static final Distribution DISTRIBUTION =
+      Distribution.create(
+          5,
+          24.0,
+          321.5,
+          BucketOptions.explicitOptions(Arrays.<Double>asList(5.0, 10.0, 15.0)),
+          Arrays.<Bucket>asList(
+              Bucket.create(2),
+              Bucket.create(1),
+              Bucket.create(
+                  2, Exemplar.create(11, TIMESTAMP_1, Collections.<String, String>emptyMap())),
+              Bucket.create(0)));
+  private static final Summary SUMMARY =
+      Summary.create(
+          5L,
+          45.0,
+          Snapshot.create(
+              3L, 25.0, Arrays.<ValueAtPercentile>asList(ValueAtPercentile.create(0.4, 11))));
+  private static final Point POINT_DISTRIBUTION =
+      Point.create(Value.distributionValue(DISTRIBUTION), TIMESTAMP_2);
+  private static final Point POINT_SUMMARY = Point.create(Value.summaryValue(SUMMARY), TIMESTAMP_3);
+  private static final TimeSeries TIME_SERIES_1 =
+      TimeSeries.createWithOnePoint(
+          Collections.<LabelValue>singletonList(VALUE_1), POINT_DISTRIBUTION, TIMESTAMP_4);
+  private static final TimeSeries TIME_SERIES_2 =
+      TimeSeries.createWithOnePoint(
+          Arrays.<LabelValue>asList(VALUE_2, VALUE_NULL), POINT_SUMMARY, TIMESTAMP_5);
+  private static final Resource RESOURCE =
+      Resource.create("env", Collections.<String, String>singletonMap("env_key", "env_val"));
+
+  @Test
+  public void toMetricProto_NewMetric() {
+    Metric metric = Metric.create(DESCRIPTOR_1, Collections.singletonList(TIME_SERIES_1));
+    io.opencensus.proto.metrics.v1.Metric expected =
+        io.opencensus.proto.metrics.v1.Metric.newBuilder()
+            .setMetricDescriptor(
+                io.opencensus.proto.metrics.v1.MetricDescriptor.newBuilder()
+                    .setName(METRIC_NAME_1)
+                    .setDescription(METRIC_DESCRIPTION)
+                    .setUnit(UNIT)
+                    .setType(
+                        io.opencensus.proto.metrics.v1.MetricDescriptor.Type
+                            .CUMULATIVE_DISTRIBUTION)
+                    .addLabelKeys(
+                        io.opencensus.proto.metrics.v1.LabelKey.newBuilder()
+                            .setKey(KEY_1.getKey())
+                            .setDescription(KEY_1.getDescription())
+                            .build())
+                    .build())
+            .setResource(
+                io.opencensus.proto.resource.v1.Resource.newBuilder()
+                    .setType(RESOURCE.getType())
+                    .putAllLabels(RESOURCE.getLabels())
+                    .build())
+            .addTimeseries(
+                io.opencensus.proto.metrics.v1.TimeSeries.newBuilder()
+                    .setStartTimestamp(MetricsProtoUtils.toTimestampProto(TIMESTAMP_4))
+                    .addLabelValues(
+                        io.opencensus.proto.metrics.v1.LabelValue.newBuilder()
+                            .setHasValue(true)
+                            .setValue(VALUE_1.getValue())
+                            .build())
+                    .addPoints(
+                        io.opencensus.proto.metrics.v1.Point.newBuilder()
+                            .setTimestamp(MetricsProtoUtils.toTimestampProto(TIMESTAMP_2))
+                            .setDistributionValue(
+                                DistributionValue.newBuilder()
+                                    .setCount(5)
+                                    .setSum(24.0)
+                                    .setSumOfSquaredDeviation(321.5)
+                                    .setBucketOptions(
+                                        DistributionValue.BucketOptions.newBuilder()
+                                            .setExplicit(
+                                                Explicit.newBuilder()
+                                                    .addAllBounds(
+                                                        Arrays.<Double>asList(5.0, 10.0, 15.0))
+                                                    .build())
+                                            .build())
+                                    .addBuckets(
+                                        DistributionValue.Bucket.newBuilder().setCount(2).build())
+                                    .addBuckets(
+                                        DistributionValue.Bucket.newBuilder().setCount(1).build())
+                                    .addBuckets(
+                                        DistributionValue.Bucket.newBuilder()
+                                            .setCount(2)
+                                            .setExemplar(
+                                                DistributionValue.Exemplar.newBuilder()
+                                                    .setTimestamp(
+                                                        MetricsProtoUtils.toTimestampProto(
+                                                            TIMESTAMP_1))
+                                                    .setValue(11)
+                                                    .build())
+                                            .build())
+                                    .addBuckets(
+                                        DistributionValue.Bucket.newBuilder().setCount(0).build())
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+    io.opencensus.proto.metrics.v1.Metric actual =
+        MetricsProtoUtils.toMetricProto(metric, RESOURCE, false);
+    assertThat(actual).isEqualTo(expected);
+  }
+
+  @Test
+  public void toMetricProto_AlreadySent() {
+    Metric metric = Metric.create(DESCRIPTOR_2, Collections.singletonList(TIME_SERIES_2));
+    io.opencensus.proto.metrics.v1.Metric expected =
+        io.opencensus.proto.metrics.v1.Metric.newBuilder()
+            .setName(METRIC_NAME_2)
+            .addTimeseries(
+                io.opencensus.proto.metrics.v1.TimeSeries.newBuilder()
+                    .setStartTimestamp(MetricsProtoUtils.toTimestampProto(TIMESTAMP_5))
+                    .addLabelValues(
+                        io.opencensus.proto.metrics.v1.LabelValue.newBuilder()
+                            .setHasValue(true)
+                            .setValue(VALUE_2.getValue())
+                            .build())
+                    .addLabelValues(
+                        io.opencensus.proto.metrics.v1.LabelValue.newBuilder()
+                            .setHasValue(false)
+                            .build())
+                    .addPoints(
+                        io.opencensus.proto.metrics.v1.Point.newBuilder()
+                            .setTimestamp(MetricsProtoUtils.toTimestampProto(TIMESTAMP_3))
+                            .setSummaryValue(
+                                SummaryValue.newBuilder()
+                                    .setCount(Int64Value.of(5))
+                                    .setSum(DoubleValue.of(45.0))
+                                    .setSnapshot(
+                                        SummaryValue.Snapshot.newBuilder()
+                                            .setCount(Int64Value.of(3))
+                                            .setSum(DoubleValue.of(25.0))
+                                            .addPercentileValues(
+                                                SummaryValue.Snapshot.ValueAtPercentile.newBuilder()
+                                                    .setValue(11)
+                                                    .setPercentile(0.4)
+                                                    .build())
+                                            .build())
+                                    .build())
+                            .build())
+                    .build())
+            .build();
+    io.opencensus.proto.metrics.v1.Metric actual =
+        MetricsProtoUtils.toMetricProto(metric, null, true);
+    assertThat(actual).isEqualTo(expected);
+  }
+}


### PR DESCRIPTION
~~Blocked by https://github.com/census-instrumentation/opencensus-java/pull/1627.~~

Updates https://github.com/census-instrumentation/opencensus-java/issues/1567.
Metrics APIs and Metrics protos are one-to-one mapping.