### PR TITLE
 Exporter/Metrics/OcAgent: Add export RPC handler and tests.

### DIFF
--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsServiceExportRpcHandler.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsServiceExportRpcHandler.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.metrics.ocagent;
+
+import com.google.common.annotations.VisibleForTesting;
+import io.grpc.Status;
+import io.grpc.StatusRuntimeException;
+import io.grpc.stub.StreamObserver;
+import io.opencensus.proto.agent.metrics.v1.ExportMetricsServiceRequest;
+import io.opencensus.proto.agent.metrics.v1.ExportMetricsServiceResponse;
+import io.opencensus.proto.agent.metrics.v1.MetricsServiceGrpc.MetricsServiceStub;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+/** Handler of export service RPC. */
+@ThreadSafe
+final class OcAgentMetricsServiceExportRpcHandler {
+
+  private static final Logger logger =
+      Logger.getLogger(OcAgentMetricsServiceExportRpcHandler.class.getName());
+
+  // A reference to the exportRequestObserver returned from stub.
+  @GuardedBy("this")
+  @Nullable
+  private StreamObserver<ExportMetricsServiceRequest> exportRequestObserver;
+
+  // The RPC status when this stream finishes/disconnects. Null if the stream is still connected.
+  @GuardedBy("this")
+  @Nullable
+  private Status terminateStatus;
+
+  private OcAgentMetricsServiceExportRpcHandler() {}
+
+  private synchronized void setExportRequestObserver(
+      StreamObserver<ExportMetricsServiceRequest> exportRequestObserver) {
+    this.exportRequestObserver = exportRequestObserver;
+  }
+
+  // Creates an OcAgentMetricsServiceExportRpcHandler. Tries to initiate the export stream with the
+  // given MetricsServiceStub.
+  static OcAgentMetricsServiceExportRpcHandler create(MetricsServiceStub stub) {
+    OcAgentMetricsServiceExportRpcHandler exportRpcHandler =
+        new OcAgentMetricsServiceExportRpcHandler();
+    ExportResponseObserver exportResponseObserver = new ExportResponseObserver(exportRpcHandler);
+    try {
+      StreamObserver<ExportMetricsServiceRequest> exportRequestObserver =
+          stub.export(exportResponseObserver);
+      exportRpcHandler.setExportRequestObserver(exportRequestObserver);
+    } catch (StatusRuntimeException e) {
+      exportRpcHandler.onComplete(e);
+    }
+    return exportRpcHandler;
+  }
+
+  // Sends the export request to Agent if the stream is still connected, otherwise do nothing.
+  synchronized void onExport(ExportMetricsServiceRequest request) {
+    if (isCompleted() || exportRequestObserver == null) {
+      return;
+    }
+    try {
+      exportRequestObserver.onNext(request);
+    } catch (Exception e) { // Catch client side exceptions.
+      onComplete(e);
+    }
+  }
+
+  // Marks this export stream as completed with an optional error.
+  // Once onComplete is called, this OcAgentMetricsServiceExportRpcHandler instance can be discarded
+  // and GC'ed in the worker thread.
+  synchronized void onComplete(@javax.annotation.Nullable Throwable error) {
+    if (isCompleted()) {
+      return;
+    }
+    // TODO(songya): add Runnable
+    Status status;
+    if (error == null) {
+      status = Status.OK;
+    } else if (error instanceof StatusRuntimeException) {
+      status = ((StatusRuntimeException) error).getStatus();
+    } else {
+      status = Status.UNKNOWN;
+    }
+    terminateStatus = status;
+  }
+
+  synchronized boolean isCompleted() {
+    return terminateStatus != null;
+  }
+
+  @Nullable
+  synchronized Status getTerminateStatus() {
+    return terminateStatus;
+  }
+
+  @VisibleForTesting
+  static class ExportResponseObserver implements StreamObserver<ExportMetricsServiceResponse> {
+
+    private final OcAgentMetricsServiceExportRpcHandler exportRpcHandler;
+
+    ExportResponseObserver(OcAgentMetricsServiceExportRpcHandler exportRpcHandler) {
+      this.exportRpcHandler = exportRpcHandler;
+    }
+
+    @Override
+    public void onNext(ExportMetricsServiceResponse value) {
+      // Do nothing since ExportMetricsServiceResponse is an empty message.
+    }
+
+    @Override
+    public void onError(Throwable t) {
+      logger.log(Level.WARNING, "Export stream is disconnected.", t);
+      exportRpcHandler.onComplete(t);
+    }
+
+    @Override
+    public void onCompleted() {
+      exportRpcHandler.onComplete(null);
+    }
+  }
+}

--- a/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/FakeOcAgentMetricsServiceGrpcImpl.java
+++ b/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/FakeOcAgentMetricsServiceGrpcImpl.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.metrics.ocagent;
+
+import io.grpc.stub.StreamObserver;
+import io.opencensus.proto.agent.metrics.v1.ExportMetricsServiceRequest;
+import io.opencensus.proto.agent.metrics.v1.ExportMetricsServiceResponse;
+import io.opencensus.proto.agent.metrics.v1.MetricsServiceGrpc;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.logging.Logger;
+import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
+
+/** Fake implementation of {@link MetricsServiceGrpc}. Used for unit tests only. */
+@ThreadSafe
+final class FakeOcAgentMetricsServiceGrpcImpl extends MetricsServiceGrpc.MetricsServiceImplBase {
+
+  private static final Logger logger =
+      Logger.getLogger(FakeOcAgentMetricsServiceGrpcImpl.class.getName());
+
+  @GuardedBy("this")
+  private final List<ExportMetricsServiceRequest> exportMetricsServiceRequests = new ArrayList<>();
+
+  @GuardedBy("this")
+  private final StreamObserver<ExportMetricsServiceRequest> exportRequestObserver =
+      new StreamObserver<ExportMetricsServiceRequest>() {
+        @Override
+        public void onNext(ExportMetricsServiceRequest value) {
+          addExportRequest(value);
+        }
+
+        @Override
+        public void onError(Throwable t) {
+          logger.warning("Exception thrown for export stream: " + t);
+        }
+
+        @Override
+        public void onCompleted() {}
+      };
+
+  @Override
+  public synchronized StreamObserver<ExportMetricsServiceRequest> export(
+      StreamObserver<ExportMetricsServiceResponse> responseObserver) {
+    return exportRequestObserver;
+  }
+
+  private synchronized void addExportRequest(ExportMetricsServiceRequest request) {
+    exportMetricsServiceRequests.add(request);
+  }
+
+  synchronized List<ExportMetricsServiceRequest> getExportMetricsServiceRequests() {
+    return Collections.unmodifiableList(exportMetricsServiceRequests);
+  }
+}

--- a/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsServiceExportRpcHandlerTest.java
+++ b/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsServiceExportRpcHandlerTest.java
@@ -1,0 +1,102 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.metrics.ocagent;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import io.grpc.ManagedChannel;
+import io.grpc.Server;
+import io.grpc.Status;
+import io.grpc.inprocess.InProcessChannelBuilder;
+import io.grpc.inprocess.InProcessServerBuilder;
+import io.opencensus.proto.agent.common.v1.LibraryInfo;
+import io.opencensus.proto.agent.common.v1.LibraryInfo.Language;
+import io.opencensus.proto.agent.common.v1.Node;
+import io.opencensus.proto.agent.metrics.v1.ExportMetricsServiceRequest;
+import io.opencensus.proto.agent.metrics.v1.MetricsServiceGrpc;
+import io.opencensus.proto.agent.metrics.v1.MetricsServiceGrpc.MetricsServiceStub;
+import java.io.IOException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link OcAgentMetricsServiceExportRpcHandler}. */
+@RunWith(JUnit4.class)
+public class OcAgentMetricsServiceExportRpcHandlerTest {
+
+  private final FakeOcAgentMetricsServiceGrpcImpl traceServiceGrpc =
+      new FakeOcAgentMetricsServiceGrpcImpl();
+  private final String serverName = InProcessServerBuilder.generateName();
+  private final Server server =
+      InProcessServerBuilder.forName(serverName)
+          .directExecutor() // directExecutor is fine for unit tests
+          .addService(traceServiceGrpc)
+          .build();
+
+  private static final Node NODE =
+      Node.newBuilder()
+          .setLibraryInfo(LibraryInfo.newBuilder().setLanguage(Language.JAVA).build())
+          .build();
+
+  @Before
+  public void setUp() throws IOException {
+    server.start();
+  }
+
+  @After
+  public void tearDown() {
+    if (!server.isTerminated()) {
+      server.shutdown();
+    }
+  }
+
+  @Test
+  public void export_createAndExport() {
+    OcAgentMetricsServiceExportRpcHandler exportRpcHandler =
+        OcAgentMetricsServiceExportRpcHandler.create(getStub(serverName));
+    ExportMetricsServiceRequest request =
+        ExportMetricsServiceRequest.newBuilder().setNode(NODE).build();
+    exportRpcHandler.onExport(request);
+    assertThat(traceServiceGrpc.getExportMetricsServiceRequests()).containsExactly(request);
+  }
+
+  @Test
+  public void export_Create_ConnectionFailed() {
+    String nonExistingServer = "unknown";
+    OcAgentMetricsServiceExportRpcHandler exportRpcHandler =
+        OcAgentMetricsServiceExportRpcHandler.create(getStub(nonExistingServer));
+    assertThat(exportRpcHandler.isCompleted()).isTrue();
+    assertThat(exportRpcHandler.getTerminateStatus().getCode()).isEqualTo(Status.Code.UNAVAILABLE);
+  }
+
+  @Test
+  public void export_Complete_Interrupted() {
+    OcAgentMetricsServiceExportRpcHandler exportRpcHandler =
+        OcAgentMetricsServiceExportRpcHandler.create(getStub(serverName));
+    assertThat(exportRpcHandler.isCompleted()).isFalse();
+    exportRpcHandler.onComplete(new InterruptedException());
+    assertThat(exportRpcHandler.isCompleted()).isTrue();
+    assertThat(exportRpcHandler.getTerminateStatus()).isEqualTo(Status.UNKNOWN);
+  }
+
+  private static MetricsServiceStub getStub(String serverName) {
+    ManagedChannel channel = InProcessChannelBuilder.forName(serverName).directExecutor().build();
+    return MetricsServiceGrpc.newStub(channel);
+  }
+}


### PR DESCRIPTION
~~Blocked by https://github.com/census-instrumentation/opencensus-java/pull/1627.~~

Updates https://github.com/census-instrumentation/opencensus-java/issues/1567.
Similar RPC handler to https://github.com/census-instrumentation/opencensus-java/pull/1570.