### PR TITLE
Changing compareTo to compareToIgnoreCase.

### DIFF
--- a/api/src/main/java/io/opencensus/stats/View.java
+++ b/api/src/main/java/io/opencensus/stats/View.java
@@ -48,7 +48,7 @@ public abstract class View {
       new Comparator<TagKey>() {
         @Override
         public int compare(TagKey key1, TagKey key2) {
-          return key1.getName().compareTo(key2.getName());
+          return key1.getName().compareToIgnoreCase(key2.getName());
         }
       };
 


### PR DESCRIPTION
Changing compareTo to compareToIgnoreCase so that keys are sorted ignoring case.  Capitalized tag keys should not go before lower case tag keys, it should be based on the lexicographic order of the letter itself.