### PR TITLE
Add trace exporter for Datadog.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Add ability to filter metrics collected from Dropwizard registry.
 - Add an util artifact opencensus-contrib-dropwizard5 to translate Dropwizard metrics5 to OpenCensus.
 - Add metrics util package to be shared by all metrics exporters.
+- Add Datadog Trace Exporter.
 
 ## 0.18.0 - 2018-11-27
 - Set the
@@ -48,10 +49,10 @@
 - Add an API MeasureMap.putAttachment() for recording exemplars.
 - Add Exemplar class and an API to get Exemplar list to DistributionData.
 - Improve the styling of Rpcz, Statsz, Tracez, and Traceconfigz pages.
-- Add an artifact `opencensus-contrib-exemplar-util` that has helper utilities 
+- Add an artifact `opencensus-contrib-exemplar-util` that has helper utilities
   on recording exemplars.
 - Reduce the default limit on `Link`s per `Span` to 32 (was 128 before).
-- Add Spring support for `@Traced` annotation and java.sql.PreparedStatements 
+- Add Spring support for `@Traced` annotation and java.sql.PreparedStatements
   tracing.
 - Allow custom prefix for Stackdriver metrics in `StackdriverStatsConfiguration`.
 - Add support to handle the Tracestate in the SpanContext.
@@ -114,7 +115,7 @@
 - Add `Duration.toMillis()`.
 - Make monitored resource utils a separate artifact `opencensus-contrib-monitored-resource-util`,
   so that it can be reused across exporters.
-- Add `LastValue`, `LastValueDouble` and `LastValueLong`. Also support them in 
+- Add `LastValue`, `LastValueDouble` and `LastValueLong`. Also support them in
   stats exporters and zpages. Please note that there is an API breaking change
   in methods `Aggregation.match()` and `AggregationData.match()`.
 

--- a/build.gradle
+++ b/build.gradle
@@ -186,6 +186,7 @@ subprojects {
         zipkinReporterVersion = '2.3.2'
         jaegerReporterVersion = '0.27.0'
         opencensusProtoVersion = '0.1.0'
+        gsonVersion = '2.8.5'
         dropwizardVersion = '3.1.2'
         dropwizard5Version = '5.0.0-rc2'
 
@@ -223,6 +224,7 @@ subprojects {
                 prometheus_simpleclient: "io.prometheus:simpleclient:${prometheusVersion}",
                 protobuf: "com.google.protobuf:protobuf-java:${protobufVersion}",
                 opencensus_proto: "io.opencensus:opencensus-proto:${opencensusProtoVersion}",
+                gson: "com.google.code.gson:gson:${gsonVersion}",
 
                 // Test dependencies.
                 guava_testlib: "com.google.guava:guava-testlib:${guavaVersion}",
@@ -459,6 +461,7 @@ subprojects {
                  'opencensus-exporter-stats-prometheus',
                  'opencensus-exporter-stats-signalfx',
                  'opencensus-exporter-stats-stackdriver',
+                 'opencensus-exporter-trace-datadog',
                  'opencensus-exporter-trace-instana',
                  'opencensus-exporter-trace-logging',
                  // 'opencensus-exporter-trace-ocagent',

--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -245,6 +245,7 @@ General guidelines on imports:
         <allow pkg="io.opencensus.exporter.trace.datadog"/>
         <allow pkg="edu.umd.cs.findbugs.annotations"/>
         <allow pkg="com.google.gson"/>
+        <allow pkg="com.google.auto.value"/>
       </subpackage>
     </subpackage>
   </subpackage>

--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -241,6 +241,11 @@ General guidelines on imports:
         <allow pkg="io.opencensus.exporter.trace.zipkin"/>
         <allow pkg="zipkin2"/>
       </subpackage>
+      <subpackage name="datadog">
+        <allow pkg="io.opencensus.exporter.trace.datadog"/>
+        <allow pkg="edu.umd.cs.findbugs.annotations"/>
+        <allow pkg="com.google.gson"/>
+      </subpackage>
     </subpackage>
   </subpackage>
   <subpackage name="implcore">

--- a/exporters/trace/datadog/README.md
+++ b/exporters/trace/datadog/README.md
@@ -1,0 +1,67 @@
+# OpenCensus Datadog Trace Exporter
+[![Build Status][travis-image]][travis-url]
+[![Windows Build Status][appveyor-image]][appveyor-url]
+[![Maven Central][maven-image]][maven-url]
+
+The *OpenCensus Datadog Trace Exporter* is a trace exporter that exports data to [Datadog](https://www.datadoghq.com/).
+
+## Quickstart
+
+### Prerequisites
+
+Datadog collects traces using a local agent, which forwards them to the Datadog automatic tracing. Instructions for setting up the agent can be found [in the Datadog docs](https://docs.datadoghq.com/agent/?tab=agentv6).
+
+### Hello Stan
+
+#### Add the dependencies to your project
+
+For Maven add to your `pom.xml`:
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-api</artifactId>
+    <version>0.18.0</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-exporter-trace-datadog</artifactId>
+    <version>0.18.0</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-impl</artifactId>
+    <version>0.18.0</version>
+    <scope>runtime</scope>
+  </dependency>
+</dependencies>
+```
+
+For Gradle add to your dependencies:
+```groovy
+compile 'io.opencensus:opencensus-api:0.18.0'
+compile 'io.opencensus:opencensus-exporter-trace-instana:0.18.0'
+runtime 'io.opencensus:opencensus-impl:0.18.0'
+```
+
+#### Register the exporter
+
+```java
+public class MyMainClass {
+  public static void main(String[] args) throws Exception {
+    DatadogTraceExporter.createAndRegister("http://localhost:8126/v0.3/traces", "myService", "web");
+    // ...
+  }
+}
+```
+
+#### Java Versions
+
+Java 8 or above is required for using this exporter.
+
+[travis-image]: https://travis-ci.org/census-instrumentation/opencensus-java.svg?branch=master
+[travis-url]: https://travis-ci.org/census-instrumentation/opencensus-java
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/hxthmpkxar4jq4be/branch/master?svg=true
+[appveyor-url]: https://ci.appveyor.com/project/opencensusjavateam/opencensus-java/branch/master
+[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-exporter-trace-datadog/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-exporter-trace-datadog

--- a/exporters/trace/datadog/README.md
+++ b/exporters/trace/datadog/README.md
@@ -21,17 +21,17 @@ For Maven add to your `pom.xml`:
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-api</artifactId>
-    <version>0.18.0</version>
+    <version>0.19.0</version>
   </dependency>
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-exporter-trace-datadog</artifactId>
-    <version>0.18.0</version>
+    <version>0.19.0</version>
   </dependency>
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-impl</artifactId>
-    <version>0.18.0</version>
+    <version>0.19.0</version>
     <scope>runtime</scope>
   </dependency>
 </dependencies>
@@ -39,9 +39,9 @@ For Maven add to your `pom.xml`:
 
 For Gradle add to your dependencies:
 ```groovy
-compile 'io.opencensus:opencensus-api:0.18.0'
-compile 'io.opencensus:opencensus-exporter-trace-instana:0.18.0'
-runtime 'io.opencensus:opencensus-impl:0.18.0'
+compile 'io.opencensus:opencensus-api:0.19.0'
+compile 'io.opencensus:opencensus-exporter-trace-instana:0.19.0'
+runtime 'io.opencensus:opencensus-impl:0.19.0'
 ```
 
 #### Register the exporter

--- a/exporters/trace/datadog/README.md
+++ b/exporters/trace/datadog/README.md
@@ -49,7 +49,13 @@ runtime 'io.opencensus:opencensus-impl:0.19.0'
 ```java
 public class MyMainClass {
   public static void main(String[] args) throws Exception {
-    DatadogTraceExporter.createAndRegister("http://localhost:8126/v0.3/traces", "myService", "web");
+
+    DatadogTraceConfiguration config = DatadogTraceConfiguration.builder()
+      .setAgentEndpoint("http://localhost:8126/v0.3/traces")
+      .setService("myService")
+      .setType("web")
+      .build();
+    DatadogTraceExporter.createAndRegister(config);
     // ...
   }
 }

--- a/exporters/trace/datadog/build.gradle
+++ b/exporters/trace/datadog/build.gradle
@@ -1,0 +1,18 @@
+description = 'OpenCensus Datadog Trace Exporter'
+
+[compileJava, compileTestJava].each() {
+    it.sourceCompatibility = 1.8
+    it.targetCompatibility = 1.8
+}
+
+dependencies {
+    compileOnly libraries.findbugs_annotations
+
+    compile project(':opencensus-api'),
+        libraries.guava,
+        libraries.gson
+
+    testCompile project(':opencensus-api')
+
+    signature "org.codehaus.mojo.signature:java18:1.0@signature"
+}

--- a/exporters/trace/datadog/build.gradle
+++ b/exporters/trace/datadog/build.gradle
@@ -10,7 +10,8 @@ dependencies {
 
     compile project(':opencensus-api'),
         libraries.guava,
-        libraries.gson
+        libraries.gson, 
+        libraries.auto_value
 
     testCompile project(':opencensus-api')
 

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandler.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandler.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.datadog;
+
+import com.google.gson.FieldNamingPolicy;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import io.opencensus.common.Functions;
+import io.opencensus.common.Scope;
+import io.opencensus.common.Timestamp;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.Sampler;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.Status;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.export.SpanData;
+import io.opencensus.trace.export.SpanExporter;
+import io.opencensus.trace.samplers.Samplers;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+final class DatadogExporterHandler extends SpanExporter.Handler {
+
+  private static final Tracer tracer = Tracing.getTracer();
+  private static final Sampler probabilitySpampler = Samplers.probabilitySampler(0.0001);
+  private static Gson gson =
+      new GsonBuilder()
+          .setFieldNamingPolicy(FieldNamingPolicy.LOWER_CASE_WITH_UNDERSCORES)
+          .create();
+
+  private final URL agentEndpoint;
+  private final String service;
+  private final String type;
+
+  DatadogExporterHandler(final URL agentEndpoint, final String service, final String type) {
+    this.agentEndpoint = agentEndpoint;
+    this.service = service;
+    this.type = type;
+  }
+
+  @javax.annotation.Nullable
+  private static String attributeValueToString(AttributeValue attributeValue) {
+    return attributeValue.match(
+        Functions.returnToString(),
+        Functions.returnToString(),
+        Functions.returnToString(),
+        Functions.returnToString(),
+        Functions.returnNull());
+  }
+
+  private static Map<String, String> attributesToMeta(
+      final Map<String, AttributeValue> attributes) {
+    final HashMap<String, String> result = new HashMap<>();
+    attributes.forEach((key, value) -> result.put(key, attributeValueToString(value)));
+    return result;
+  }
+
+  private static long convertSpanId(final SpanId spanId) {
+    final byte[] bytes = spanId.getBytes();
+    long result = 0;
+    for (int i = 0; i < Long.SIZE / Byte.SIZE; i++) {
+      result <<= Byte.SIZE;
+      result |= (bytes[i] & 0xff);
+    }
+    if (result < 0) {
+      return -result;
+    }
+    return result;
+  }
+
+  private static long timestampToNanos(final Timestamp timestamp) {
+    return (timestamp == null)
+        ? 0L
+        : TimeUnit.SECONDS.toNanos(timestamp.getSeconds()) + timestamp.getNanos();
+  }
+
+  private static Integer errorCode(final Status status) {
+    if (status == Status.OK || status == Status.ALREADY_EXISTS) {
+      return 0;
+    }
+
+    return 1;
+  }
+
+  String convertToJson(Collection<SpanData> spanDataList) {
+    final ArrayList<DatadogSpan> datadogSpans = new ArrayList<>();
+    for (SpanData sd : spanDataList) {
+      SpanContext sc = sd.getContext();
+
+      final long startTime = timestampToNanos(sd.getStartTimestamp());
+      final long endTime = timestampToNanos(sd.getEndTimestamp());
+
+      Long parentId =
+          Optional.ofNullable(sd.getParentSpanId())
+              .map(DatadogExporterHandler::convertSpanId)
+              .orElse(null);
+
+      final Map<String, AttributeValue> attributes = sd.getAttributes().getAttributeMap();
+      final Map<String, String> meta =
+          attributes.isEmpty() ? new HashMap<>() : attributesToMeta(attributes);
+
+      final String resource = meta.getOrDefault("resource", "UNKNOWN");
+
+      final DatadogSpan span =
+          new DatadogSpan(
+              sc.getTraceId().getLowerLong(),
+              convertSpanId(sc.getSpanId()),
+              sd.getName(),
+              resource,
+              this.service,
+              this.type,
+              startTime,
+              endTime - startTime,
+              parentId,
+              errorCode(sd.getStatus()),
+              meta);
+      datadogSpans.add(span);
+    }
+
+    final Collection<List<DatadogSpan>> traces =
+        datadogSpans
+            .stream()
+            .collect(Collectors.groupingBy(DatadogSpan::getTraceId, Collectors.toList()))
+            .values();
+
+    return gson.toJson(traces);
+  }
+
+  @Override
+  public void export(Collection<SpanData> spanDataList) {
+    // Start a new span with explicit 1/10000 sampling probability to avoid the case when user
+    // sets the default sampler to always sample and we get the gRPC span of the datadog
+    // export call always sampled and go to an infinite loop.
+    try (Scope ss =
+        tracer
+            .spanBuilder("ExportDatadogTraces")
+            .setSampler(probabilitySpampler)
+            .startScopedSpan()) {
+
+      final String data = convertToJson(spanDataList);
+
+      final HttpURLConnection connection = (HttpURLConnection) agentEndpoint.openConnection();
+      connection.setRequestMethod("POST");
+      connection.setRequestProperty("Content-Type", "application/json");
+      connection.setDoOutput(true);
+      OutputStream outputStream = connection.getOutputStream();
+      outputStream.write(data.getBytes(Charset.defaultCharset()));
+      outputStream.flush();
+      outputStream.close();
+      if (connection.getResponseCode() != 200) {
+        tracer
+            .getCurrentSpan()
+            .setStatus(Status.UNKNOWN.withDescription("Response " + connection.getResponseCode()));
+      }
+    } catch (IOException e) {
+      tracer
+          .getCurrentSpan()
+          .setStatus(
+              Status.UNKNOWN.withDescription(
+                  e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage()));
+      // drop span batch
+    }
+  }
+}

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandler.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandler.java
@@ -108,7 +108,7 @@ final class DatadogExporterHandler extends SpanExporter.Handler {
 
   private static long timestampToNanos(@Nullable final Timestamp timestamp) {
     return (timestamp == null)
-        ? 0L
+        ? System.currentTimeMillis() * 1000 * 1000
         : TimeUnit.SECONDS.toNanos(timestamp.getSeconds()) + timestamp.getNanos();
   }
 
@@ -126,9 +126,6 @@ final class DatadogExporterHandler extends SpanExporter.Handler {
       SpanContext sc = sd.getContext();
 
       final long startTime = timestampToNanos(sd.getStartTimestamp());
-      // NB: If the span endTimestamp is null, there isn't a good way to determine the duration.
-      // Currently this will produce a meaningless negative value, since the duration field
-      // is required for Datadog to accept the trace.
       final long endTime = timestampToNanos(sd.getEndTimestamp());
       final long duration = endTime - startTime;
 

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandler.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandler.java
@@ -106,10 +106,8 @@ final class DatadogExporterHandler extends SpanExporter.Handler {
     return result;
   }
 
-  private static long timestampToNanos(@Nullable final Timestamp timestamp) {
-    return (timestamp == null)
-        ? System.currentTimeMillis() * 1000 * 1000
-        : TimeUnit.SECONDS.toNanos(timestamp.getSeconds()) + timestamp.getNanos();
+  private static long timestampToNanos(final Timestamp timestamp) {
+    return TimeUnit.SECONDS.toNanos(timestamp.getSeconds()) + timestamp.getNanos();
   }
 
   private static Integer errorCode(@Nullable final Status status) {
@@ -126,7 +124,9 @@ final class DatadogExporterHandler extends SpanExporter.Handler {
       SpanContext sc = sd.getContext();
 
       final long startTime = timestampToNanos(sd.getStartTimestamp());
-      final long endTime = timestampToNanos(sd.getEndTimestamp());
+      final Timestamp endTimestamp =
+          Optional.ofNullable(sd.getEndTimestamp()).orElseGet(() -> Tracing.getClock().now());
+      final long endTime = timestampToNanos(endTimestamp);
       final long duration = endTime - startTime;
 
       final Long parentId =

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogSpan.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogSpan.java
@@ -18,35 +18,37 @@ package io.opencensus.exporter.trace.datadog;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 @SuppressFBWarnings("URF_UNREAD_FIELD")
+@SuppressWarnings("unused")
 class DatadogSpan {
   // Required. The unique integer (64-bit unsigned) ID of the trace containing this span.
-  private long traceId;
+  private final long traceId;
   // Required. The span integer (64-bit unsigned) ID.
-  private long spanId;
+  private final long spanId;
   // Required. The span name. The span name must not be longer than 100 characters.
-  private String name;
+  private final String name;
   // Required. The resource you are tracing. The resource name must not be longer than 5000
   // characters.
   // A resource is a particular action for a service.
-  private String resource;
+  private final String resource;
   // Required. The service you are tracing. The service name must not be longer than 100 characters.
-  private String service;
+  private final String service;
   // Required. The type of request.
-  private String type;
+  private final String type;
   // Required. The start time of the request in nanoseconds from the unix epoch.
-  private long start;
+  private final long start;
   // Required. The duration of the request in nanoseconds.
-  private long duration;
+  private final long duration;
   // Optional. The span integer ID of the parent span.
-  private Long parentId;
+  @Nullable private final Long parentId;
   // Optional. Set this value to 1 to indicate if an error occured. If an error occurs, you
   // should pass additional information, such as the error message, type and stack information
   // in the meta property.
-  private Integer error;
+  @Nullable private final Integer error;
   // Optional. A dictionary of key-value metadata. e.g. tags.
-  private Map<String, String> meta;
+  @Nullable private final Map<String, String> meta;
 
   long getTraceId() {
     return traceId;
@@ -61,9 +63,9 @@ class DatadogSpan {
       final String type,
       final long start,
       final long duration,
-      final Long parentId,
-      final Integer error,
-      final Map<String, String> meta) {
+      @Nullable final Long parentId,
+      @Nullable final Integer error,
+      @Nullable final Map<String, String> meta) {
     this.traceId = traceId;
     this.spanId = spanId;
     this.name = name;

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogSpan.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogSpan.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.datadog;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Map;
+
+@SuppressFBWarnings("URF_UNREAD_FIELD")
+class DatadogSpan {
+  // Required. The unique integer (64-bit unsigned) ID of the trace containing this span.
+  private long traceId;
+  // Required. The span integer (64-bit unsigned) ID.
+  private long spanId;
+  // Required. The span name. The span name must not be longer than 100 characters.
+  private String name;
+  // Required. The resource you are tracing. The resource name must not be longer than 5000
+  // characters.
+  // A resource is a particular action for a service.
+  private String resource;
+  // Required. The service you are tracing. The service name must not be longer than 100 characters.
+  private String service;
+  // Required. The type of request.
+  private String type;
+  // Required. The start time of the request in nanoseconds from the unix epoch.
+  private long start;
+  // Required. The duration of the request in nanoseconds.
+  private long duration;
+  // Optional. The span integer ID of the parent span.
+  private Long parentId;
+  // Optional. Set this value to 1 to indicate if an error occured. If an error occurs, you
+  // should pass additional information, such as the error message, type and stack information
+  // in the meta property.
+  private Integer error;
+  // Optional. A dictionary of key-value metadata. e.g. tags.
+  private Map<String, String> meta;
+
+  long getTraceId() {
+    return traceId;
+  }
+
+  DatadogSpan(
+      final long traceId,
+      final long spanId,
+      final String name,
+      final String resource,
+      final String service,
+      final String type,
+      final long start,
+      final long duration,
+      final Long parentId,
+      final Integer error,
+      final Map<String, String> meta) {
+    this.traceId = traceId;
+    this.spanId = spanId;
+    this.name = name;
+    this.resource = resource;
+    this.service = service;
+    this.type = type;
+    this.start = start;
+    this.duration = duration;
+    this.parentId = parentId;
+    this.error = error;
+    this.meta = meta;
+  }
+}

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceConfiguration.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.datadog;
+
+import com.google.auto.value.AutoValue;
+import javax.annotation.concurrent.Immutable;
+
+/**
+ * Configuration for {@link DatadogTraceExporter}.
+ *
+ * @since 0.19
+ */
+@AutoValue
+@Immutable
+public abstract class DatadogTraceConfiguration {
+
+  DatadogTraceConfiguration() {}
+
+  /**
+   * Returns the URL of the Datadog agent.
+   *
+   * @return the URL of the Datadog agent.
+   * @since 0.19
+   */
+  public abstract String getAgentEndpoint();
+
+  /**
+   * Returns the name of the service being traced.
+   *
+   * @return the name of the service being traced.
+   * @since 0.19
+   */
+  public abstract String getService();
+
+  /**
+   * Return the type of service being traced.
+   *
+   * @return the type of service being traced.
+   * @since 0.19
+   */
+  public abstract String getType();
+
+  /**
+   * Return a new {@link Builder}.
+   *
+   * @return a {@code Builder}
+   * @since 0.19
+   */
+  public static Builder builder() {
+    return new AutoValue_DatadogTraceConfiguration.Builder();
+  }
+
+  /**
+   * Builder for {@link DatadogTraceConfiguration}.
+   *
+   * @since 0.19
+   */
+  @AutoValue.Builder
+  public abstract static class Builder {
+
+    Builder() {}
+
+    /**
+     * Sets the URL to send traces to.
+     *
+     * @param agentEndpoint the URL of the agent.
+     * @return this.
+     * @since 0.19
+     */
+    public abstract Builder setAgentEndpoint(String agentEndpoint);
+
+    /**
+     * Sets the name of service being traced.
+     *
+     * @param service the name of the service being traced.
+     * @return this.
+     * @since 0.19
+     */
+    public abstract Builder setService(String service);
+
+    /**
+     * Sets the type of the service being traced.
+     *
+     * @param type the type of service being traced.
+     * @return this.
+     * @since 0.19
+     */
+    public abstract Builder setType(String type);
+
+    public abstract DatadogTraceConfiguration build();
+  }
+}

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceExporter.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceExporter.java
@@ -21,7 +21,6 @@ import static com.google.common.base.Preconditions.checkState;
 import io.opencensus.trace.Tracing;
 import io.opencensus.trace.export.SpanExporter;
 import java.net.MalformedURLException;
-import java.net.URL;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 
@@ -54,18 +53,20 @@ public final class DatadogTraceExporter {
    * Creates and registers the Datadog Trace exporter to the OpenCensus library. Only one Datadog
    * exporter can be registered at any point.
    *
-   * @param agentEndpoint URL for the Datadog agent.
-   * @param service Name of the service being traced.
-   * @param type Type of service being traced, eg web or db.
+   * @param configuration the {@code DatadogTraceConfiguration} used to create the exporter.
+   * @throws MalformedURLException if the agent URL is invalid.
    * @since 0.19
    */
-  public static void createAndRegister(
-      final String agentEndpoint, final String service, final String type)
+  public static void createAndRegister(DatadogTraceConfiguration configuration)
       throws MalformedURLException {
     synchronized (monitor) {
       checkState(handler == null, "Datadog exporter is already registered.");
-      final URL agentUrl = new URL(agentEndpoint);
-      handler = new DatadogExporterHandler(agentUrl, service, type);
+
+      String agentEndpoint = configuration.getAgentEndpoint();
+      String service = configuration.getService();
+      String type = configuration.getType();
+
+      handler = new DatadogExporterHandler(agentEndpoint, service, type);
       Tracing.getExportComponent().getSpanExporter().registerHandler(REGISTER_NAME, handler);
     }
   }

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceExporter.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceExporter.java
@@ -31,7 +31,12 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * <pre>{@code
  * public static void main(String[] args) {
- *   DatadogTraceExporter.createAndRegister("http://localhost:8126/v0.3/traces", "myService", "web");
+ *   DatadogTraceConfiguration config = DatadogTraceConfiguration.builder()
+ * .setAgentEndpoint("http://localhost:8126/v0.3/traces")
+ * .setService("myService")
+ * .setType("web")
+ * .build();
+ * DatadogTraceExporter.createAndRegister(config);
  *   ... // Do work.
  * }
  * }</pre>
@@ -66,8 +71,12 @@ public final class DatadogTraceExporter {
       String service = configuration.getService();
       String type = configuration.getType();
 
-      handler = new DatadogExporterHandler(agentEndpoint, service, type);
-      Tracing.getExportComponent().getSpanExporter().registerHandler(REGISTER_NAME, handler);
+      final DatadogExporterHandler exporterHandler =
+          new DatadogExporterHandler(agentEndpoint, service, type);
+      handler = exporterHandler;
+      Tracing.getExportComponent()
+          .getSpanExporter()
+          .registerHandler(REGISTER_NAME, exporterHandler);
     }
   }
 

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceExporter.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceExporter.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.datadog;
+
+import static com.google.common.base.Preconditions.checkState;
+
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.export.SpanExporter;
+import java.net.MalformedURLException;
+import java.net.URL;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
+
+/**
+ * An OpenCensus span exporter implementation which exports data to Datadog.
+ *
+ * <p>Example of usage:
+ *
+ * <pre>{@code
+ * public static void main(String[] args) {
+ *   DatadogTraceExporter.createAndRegister("http://localhost:8126/v0.3/traces", "myService", "web");
+ *   ... // Do work.
+ * }
+ * }</pre>
+ *
+ * @since 0.19
+ */
+public final class DatadogTraceExporter {
+
+  private static final Object monitor = new Object();
+  private static final String REGISTER_NAME = DatadogTraceExporter.class.getName();
+
+  @GuardedBy("monitor")
+  @Nullable
+  private static SpanExporter.Handler handler = null;
+
+  private DatadogTraceExporter() {}
+
+  /**
+   * Creates and registers the Datadog Trace exporter to the OpenCensus library. Only one Datadog
+   * exporter can be registered at any point.
+   *
+   * @param agentEndpoint URL for the Datadog agent.
+   * @param service Name of the service being traced.
+   * @param type Type of service being traced, eg web or db.
+   * @since 0.19
+   */
+  public static void createAndRegister(
+      final String agentEndpoint, final String service, final String type)
+      throws MalformedURLException {
+    synchronized (monitor) {
+      checkState(handler == null, "Datadog exporter is already registered.");
+      final URL agentUrl = new URL(agentEndpoint);
+      handler = new DatadogExporterHandler(agentUrl, service, type);
+      Tracing.getExportComponent().getSpanExporter().registerHandler(REGISTER_NAME, handler);
+    }
+  }
+
+  /**
+   * Unregisters the Datadog Trace exporter from the OpenCensus library.
+   *
+   * @throws IllegalStateException if a Datadog exporter is not registered.
+   * @since 0.19
+   */
+  public static void unregister() {
+    synchronized (monitor) {
+      checkState(handler != null, "Datadog exporter is not registered.");
+      Tracing.getExportComponent().getSpanExporter().unregisterHandler(REGISTER_NAME);
+      handler = null;
+    }
+  }
+}

--- a/exporters/trace/datadog/src/test/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandlerTest.java
+++ b/exporters/trace/datadog/src/test/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandlerTest.java
@@ -124,7 +124,7 @@ public class DatadogExporterHandlerTest {
             SpanData.Links.create(Collections.emptyList(), 0),
             /* childSpanCount= */ null,
             /* status= */ null,
-            /* endTimestamp= */ null);
+            /* endTimestamp= */ Timestamp.create(1505855799, 465726528));
 
     final String expected =
         "[["
@@ -136,7 +136,7 @@ public class DatadogExporterHandlerTest {
             + "\"service\":\"service\","
             + "\"type\":\"web\","
             + "\"start\":1505855794194009601,"
-            + "\"duration\":-1505855794194009601,"
+            + "\"duration\":5271716927,"
             + "\"error\":0,"
             + "\"meta\":{"
             + "\"resource\":\"/foo\","

--- a/exporters/trace/datadog/src/test/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandlerTest.java
+++ b/exporters/trace/datadog/src/test/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandlerTest.java
@@ -124,7 +124,7 @@ public class DatadogExporterHandlerTest {
             SpanData.Links.create(Collections.emptyList(), 0),
             /* childSpanCount= */ null,
             /* status= */ null,
-            /* endTimestamp= */ Timestamp.create(1505855799, 465726528));
+            /* endTimestamp= */ null);
 
     final String expected =
         "[["
@@ -136,7 +136,7 @@ public class DatadogExporterHandlerTest {
             + "\"service\":\"service\","
             + "\"type\":\"web\","
             + "\"start\":1505855794194009601,"
-            + "\"duration\":5271716927,"
+            + "\"duration\":-1505855794194009601," // the tracer clock is set to 0 in tests
             + "\"error\":0,"
             + "\"meta\":{"
             + "\"resource\":\"/foo\","

--- a/exporters/trace/datadog/src/test/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandlerTest.java
+++ b/exporters/trace/datadog/src/test/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandlerTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.exporter.trace.datadog;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import com.google.common.collect.ImmutableMap;
+import io.opencensus.common.Timestamp;
+import io.opencensus.trace.Annotation;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.MessageEvent;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.SpanId;
+import io.opencensus.trace.Status;
+import io.opencensus.trace.TraceId;
+import io.opencensus.trace.TraceOptions;
+import io.opencensus.trace.Tracestate;
+import io.opencensus.trace.export.SpanData;
+import java.net.URL;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DatadogExporterHandler}. */
+@RunWith(JUnit4.class)
+public class DatadogExporterHandlerTest {
+  private static final String TRACE_ID = "d239036e7d5cec116b562147388b35bf";
+  private static final String SPAN_ID = "9cc1e3049173be09";
+  private static final String PARENT_SPAN_ID = "8b03ab423da481c5";
+  private static final Map<String, AttributeValue> attributes =
+      ImmutableMap.of(
+          "http.url", AttributeValue.stringAttributeValue("http://localhost/foo"),
+          "resource", AttributeValue.stringAttributeValue("/foo"));
+  private static final List<SpanData.TimedEvent<Annotation>> annotations = Collections.emptyList();
+  private static final List<SpanData.TimedEvent<MessageEvent>> messageEvents =
+      Collections.emptyList();
+
+  private DatadogExporterHandler handler;
+
+  @Before
+  public void setup() throws Exception {
+    final URL url = new URL("http://localhost");
+    this.handler = new DatadogExporterHandler(url, "service", "web");
+  }
+
+  @Test
+  public void testJsonConversion() {
+    SpanData data =
+        SpanData.create(
+            SpanContext.create(
+                TraceId.fromLowerBase16(TRACE_ID),
+                SpanId.fromLowerBase16(SPAN_ID),
+                TraceOptions.builder().setIsSampled(true).build(),
+                Tracestate.builder().build()),
+            SpanId.fromLowerBase16(PARENT_SPAN_ID),
+            true,
+            "SpanName",
+            null,
+            Timestamp.create(1505855794, 194009601) /* startTimestamp */,
+            SpanData.Attributes.create(attributes, 0),
+            SpanData.TimedEvents.create(annotations, 0),
+            SpanData.TimedEvents.create(messageEvents, 0),
+            SpanData.Links.create(Collections.emptyList(), 0),
+            null,
+            Status.OK,
+            Timestamp.create(1505855799, 465726528) /* endTimestamp */);
+
+    final String expected =
+        "[["
+            + "{"
+            + "\"trace_id\":3298601478987650031,"
+            + "\"span_id\":7151185124527981047,"
+            + "\"name\":\"SpanName\","
+            + "\"resource\":\"/foo\","
+            + "\"service\":\"service\","
+            + "\"type\":\"web\","
+            + "\"start\":1505855794194009601,"
+            + "\"duration\":5271716927,"
+            + "\"parent_id\":8429705776517054011,"
+            + "\"error\":0,"
+            + "\"meta\":{"
+            + "\"resource\":\"/foo\","
+            + "\"http.url\":\"http://localhost/foo\""
+            + "}"
+            + "}"
+            + "]]";
+
+    assertThat(handler.convertToJson(Collections.singletonList(data))).isEqualTo(expected);
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,6 +7,7 @@ include ":opencensus-impl"
 include ":opencensus-testing"
 include ":opencensus-exporter-metrics-ocagent"
 include ":opencensus-exporter-metrics-util"
+include ":opencensus-exporter-trace-datadog"
 include ":opencensus-exporter-trace-instana"
 include ":opencensus-exporter-trace-logging"
 include ":opencensus-exporter-trace-ocagent"
@@ -65,6 +66,8 @@ project(':opencensus-exporter-stats-stackdriver').projectDir =
         "$rootDir/exporters/stats/stackdriver" as File
 project(':opencensus-exporter-stats-prometheus').projectDir =
         "$rootDir/exporters/stats/prometheus" as File
+project(':opencensus-exporter-trace-datadog').projectDir =
+        "$rootDir/exporters/trace/datadog" as File
 project(':opencensus-exporter-trace-instana').projectDir =
         "$rootDir/exporters/trace/instana" as File
 project(':opencensus-exporter-trace-logging').projectDir =

--- a/settings.gradle
+++ b/settings.gradle
@@ -66,8 +66,6 @@ project(':opencensus-exporter-stats-stackdriver').projectDir =
         "$rootDir/exporters/stats/stackdriver" as File
 project(':opencensus-exporter-stats-prometheus').projectDir =
         "$rootDir/exporters/stats/prometheus" as File
-project(':opencensus-exporter-trace-datadog').projectDir =
-        "$rootDir/exporters/trace/datadog" as File
 project(':opencensus-exporter-trace-instana').projectDir =
         "$rootDir/exporters/trace/instana" as File
 project(':opencensus-exporter-trace-logging').projectDir =
@@ -91,4 +89,6 @@ if (JavaVersion.current().isJava8Compatible()) {
     project(':opencensus-benchmarks').projectDir = "$rootDir/benchmarks" as File
     project(':opencensus-contrib-zpages').projectDir = "$rootDir/contrib/zpages" as File
     project(':opencensus-contrib-dropwizard5').projectDir = "$rootDir/contrib/dropwizard5" as File
+    project(':opencensus-exporter-trace-datadog').projectDir =
+        "$rootDir/exporters/trace/datadog" as File
 }


### PR DESCRIPTION
Similar to the Instana exporter, this sends to an API that is intended to be run locally through the Datadog agent. The agent handles batching, authentication, sampling, and so on before communicating with the Datadog servers. 

AFAIK, the expected span format matches up pretty closely with OpenCensus's format. There are some fields with extra meaning which would otherwise just be attributes, which I've tried to map appropriately.