### PR TITLE
Adding support for JAX-RS client and server

### DIFF
--- a/contrib/http_jaxrs/README.md
+++ b/contrib/http_jaxrs/README.md
@@ -1,0 +1,39 @@
+# OpenCensus JAX-RS
+[![Build Status][travis-image]][travis-url]
+[![Windows Build Status][appveyor-image]][appveyor-url]
+[![Maven Central][maven-image]][maven-url]
+
+The *OpenCensus JAX-RS for Java* is a container and client filter  for trace instrumentation when using JAX-RS for REST implementation in Java.
+
+## Quickstart
+
+### Add the dependencies to your project
+
+For Maven add to your `pom.xml`:
+```xml
+<dependencies>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-api</artifactId>
+    <version>0.19.0</version>
+  </dependency>
+  <dependency>
+    <groupId>io.opencensus</groupId>
+    <artifactId>opencensus-contrib-http-jaxrs</artifactId>
+    <version>0.19.0</version>
+  </dependency>
+</dependencies>
+```
+
+For Gradle add to your dependencies:
+```gradle
+compile 'io.opencensus:opencensus-api:0.19.0'
+compile 'io.opencensus:opencensus-contrib-http-jaxrs:0.19.0'
+```
+
+[travis-image]: https://travis-ci.org/census-instrumentation/opencensus-java.svg?branch=master
+[travis-url]: https://travis-ci.org/census-instrumentation/opencensus-java
+[appveyor-image]: https://ci.appveyor.com/api/projects/status/hxthmpkxar4jq4be/branch/master?svg=true
+[appveyor-url]: https://ci.appveyor.com/project/opencensusjavateam/opencensus-java/branch/master
+[maven-image]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-contrib-http-jetty-client/badge.svg
+[maven-url]: https://maven-badges.herokuapp.com/maven-central/io.opencensus/opencensus-contrib-jetty-client

--- a/contrib/http_jaxrs/README.md
+++ b/contrib/http_jaxrs/README.md
@@ -31,6 +31,45 @@ compile 'io.opencensus:opencensus-api:0.19.0'
 compile 'io.opencensus:opencensus-contrib-http-jaxrs:0.19.0'
 ```
 
+### Usage
+
+#### Container Filter
+
+The container filter should be added to the JAX-RS `Application` class and endpoints should be annotated
+with `@Metrics` annotation.
+
+```java
+class MyApplication extends Application {
+  @Override
+  public Set<Class<?>> getClasses() {
+      Set<Class<?>> providers = new HashSet<>(super.getClasses());
+      providers.add(JaxrsContainerFilter.class);
+      return providers;
+  }
+}
+```
+```java
+@Metrics
+@Path("/resource")
+class MyResource {
+  @GET
+  public Response resource() {
+    ...
+  }
+}
+```
+
+The annotation may also be applied on method level.
+
+#### Client Filter
+
+Filter should be added to the `WebTarget` instance when using JAX-RS as client.
+
+```java
+WebTarget target = ClientBuilder.newClient().target("endpoint");
+target.register(JaxrsClientFilter.class);
+```
+
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-java.svg?branch=master
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-java
 [appveyor-image]: https://ci.appveyor.com/api/projects/status/hxthmpkxar4jq4be/branch/master?svg=true

--- a/contrib/http_jaxrs/README.md
+++ b/contrib/http_jaxrs/README.md
@@ -48,6 +48,24 @@ class MyApplication extends Application {
   }
 }
 ```
+
+It is possible to customize the filter by using the custom constructor. The below will
+use the `B3Format` for context propagation instead of the W3C text context format.
+
+```java
+class MyApplication extends Application {
+  @Override
+  public Set<Object> getSingletons() {
+    Set<Object> singletons = new HashSet<>(super.getSingletons());
+    singletons.add(new JaxrsContainerFilter(
+        new JaxrsContainerExtractor(),
+        Tracing.getPropagationComponent().getB3Format(),
+        /* publicEndpoint= */ true));
+    return singletons;
+  }
+}
+```
+
 ```java
 @Metrics
 @Path("/resource")
@@ -69,6 +87,18 @@ Filter should be added to the `WebTarget` instance when using JAX-RS as client.
 WebTarget target = ClientBuilder.newClient().target("endpoint");
 target.register(JaxrsClientFilter.class);
 ```
+
+It is possible to customize the filter using the custom constructor. The
+below will use the `B3Format` for context propagation instead of the default W3C
+text context format.
+
+```java
+WebTarget target = ClientBuilder.newClient().target("endpoint");
+target.register(new JaxrsClientFilter(
+    new JaxrsContainerExtractor(),
+    Tracing.getPropagationComponent().getB3Format()));
+```
+
 
 [travis-image]: https://travis-ci.org/census-instrumentation/opencensus-java.svg?branch=master
 [travis-url]: https://travis-ci.org/census-instrumentation/opencensus-java

--- a/contrib/http_jaxrs/build.gradle
+++ b/contrib/http_jaxrs/build.gradle
@@ -1,0 +1,20 @@
+plugins {
+    id 'java'
+}
+
+description = 'OpenCensus Http Servlet Plugin'
+
+[compileJava, compileTestJava].each() {
+    it.sourceCompatibility = 1.6
+    it.targetCompatibility = 1.6
+}
+
+dependencies {
+    compile project(':opencensus-api')
+    compile project(':opencensus-contrib-http-util')
+
+    // Will be provided from elsewhere
+    compileOnly('javax.ws.rs:javax.ws.rs-api:2.1')
+
+    signature "org.codehaus.mojo.signature:java17:1.0@signature"
+}

--- a/contrib/http_jaxrs/build.gradle
+++ b/contrib/http_jaxrs/build.gradle
@@ -5,8 +5,8 @@ plugins {
 description = 'OpenCensus Http Servlet Plugin'
 
 [compileJava, compileTestJava].each() {
-    it.sourceCompatibility = 1.6
-    it.targetCompatibility = 1.6
+    it.sourceCompatibility = 1.8
+    it.targetCompatibility = 1.8
 }
 
 dependencies {
@@ -16,6 +16,9 @@ dependencies {
     // Will be provided from elsewhere at runtime
     compileOnly('javax.ws.rs:javax.ws.rs-api:2.1')
     compileOnly('javax.annotation:javax.annotation-api:1.2')
+
+    testCompile('javax.ws.rs:javax.ws.rs-api:2.1')
+    testCompile('javax.annotation:javax.annotation-api:1.2')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }

--- a/contrib/http_jaxrs/build.gradle
+++ b/contrib/http_jaxrs/build.gradle
@@ -13,8 +13,9 @@ dependencies {
     compile project(':opencensus-api')
     compile project(':opencensus-contrib-http-util')
 
-    // Will be provided from elsewhere
+    // Will be provided from elsewhere at runtime
     compileOnly('javax.ws.rs:javax.ws.rs-api:2.1')
+    compileOnly('javax.annotation:javax.annotation-api:1.2')
 
     signature "org.codehaus.mojo.signature:java17:1.0@signature"
 }

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/ExtendedContainerRequest.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/ExtendedContainerRequest.java
@@ -1,17 +1,31 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opencensus.contrib.http.jaxrs;
 
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ResourceInfo;
 
-/**
- * Contains both {@link ContainerRequestContext} and {@link ResourceInfo}.
- */
+/** Contains both {@link ContainerRequestContext} and {@link ResourceInfo}. */
 class ExtendedContainerRequest {
   private final ContainerRequestContext requestContext;
   private final ResourceInfo resourceInfo;
 
-  public ExtendedContainerRequest(ContainerRequestContext requestContext,
-      ResourceInfo resourceInfo) {
+  public ExtendedContainerRequest(
+      ContainerRequestContext requestContext, ResourceInfo resourceInfo) {
     this.requestContext = requestContext;
     this.resourceInfo = resourceInfo;
   }

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/ExtendedContainerRequest.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/ExtendedContainerRequest.java
@@ -1,0 +1,26 @@
+package io.opencensus.contrib.http.jaxrs;
+
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ResourceInfo;
+
+/**
+ * Contains both {@link ContainerRequestContext} and {@link ResourceInfo}.
+ */
+class ExtendedContainerRequest {
+  private final ContainerRequestContext requestContext;
+  private final ResourceInfo resourceInfo;
+
+  public ExtendedContainerRequest(ContainerRequestContext requestContext,
+      ResourceInfo resourceInfo) {
+    this.requestContext = requestContext;
+    this.resourceInfo = resourceInfo;
+  }
+
+  public ContainerRequestContext getRequestContext() {
+    return requestContext;
+  }
+
+  public ResourceInfo getResourceInfo() {
+    return resourceInfo;
+  }
+}

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientExtractor.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientExtractor.java
@@ -1,0 +1,51 @@
+package io.opencensus.contrib.http.jaxrs;
+
+import io.opencensus.contrib.http.HttpExtractor;
+import javax.annotation.Nullable;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+
+public class JaxrsClientExtractor extends
+    HttpExtractor<ClientRequestContext, ClientResponseContext> {
+
+  @Nullable
+  @Override
+  public String getRoute(ClientRequestContext request) {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public String getUrl(ClientRequestContext request) {
+    return request.getUri().toString();
+  }
+
+  @Nullable
+  @Override
+  public String getHost(ClientRequestContext request) {
+    return request.getUri().getHost();
+  }
+
+  @Nullable
+  @Override
+  public String getMethod(ClientRequestContext request) {
+    return request.getMethod();
+  }
+
+  @Nullable
+  @Override
+  public String getPath(ClientRequestContext request) {
+    return request.getUri().getPath();
+  }
+
+  @Nullable
+  @Override
+  public String getUserAgent(ClientRequestContext request) {
+    return request.getHeaderString("user-agent");
+  }
+
+  @Override
+  public int getStatusCode(@Nullable ClientResponseContext response) {
+    return response != null ? response.getStatus() : 0;
+  }
+}

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientExtractor.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientExtractor.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opencensus.contrib.http.jaxrs;
 
 import io.opencensus.contrib.http.HttpExtractor;
@@ -5,8 +21,13 @@ import javax.annotation.Nullable;
 import javax.ws.rs.client.ClientRequestContext;
 import javax.ws.rs.client.ClientResponseContext;
 
-public class JaxrsClientExtractor extends
-    HttpExtractor<ClientRequestContext, ClientResponseContext> {
+/**
+ * Extracts information from JAX-RS client request and response.
+ *
+ * @since 0.19
+ */
+public class JaxrsClientExtractor
+    extends HttpExtractor<ClientRequestContext, ClientResponseContext> {
 
   @Nullable
   @Override

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilter.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilter.java
@@ -31,7 +31,7 @@ public class JaxrsClientFilter implements ClientRequestFilter, ClientResponseFil
   private final HttpClientHandler<ClientRequestContext, ClientResponseContext, ClientRequestContext> handler;
 
   public JaxrsClientFilter() {
-    handler = new HttpClientHandler<ClientRequestContext, ClientResponseContext, ClientRequestContext>(
+    handler = new HttpClientHandler<>(
         Tracing.getTracer(),
         new JaxrsClientExtractor(),
         Tracing.getPropagationComponent().getTraceContextFormat(),

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilter.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilter.java
@@ -1,0 +1,57 @@
+package io.opencensus.contrib.http.jaxrs;
+
+import io.opencensus.contrib.http.HttpClientHandler;
+import io.opencensus.contrib.http.HttpRequestContext;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.propagation.TextFormat.Setter;
+import java.io.IOException;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientRequestFilter;
+import javax.ws.rs.client.ClientResponseContext;
+import javax.ws.rs.client.ClientResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS client request and response filter to provide instrumentation of client calls with
+ * OpenCensus.
+ *
+ * @since 0.19
+ */
+@Provider
+public class JaxrsClientFilter implements ClientRequestFilter, ClientResponseFilter {
+
+  private static final String OPENCENSUS_CONTEXT = "opencensus.context";
+  private static final Setter<ClientRequestContext> SETTER = new Setter<ClientRequestContext>() {
+    @Override
+    public void put(ClientRequestContext carrier, String key, String value) {
+      carrier.getHeaders().putSingle(key, value);
+    }
+  };
+
+  private final HttpClientHandler<ClientRequestContext, ClientResponseContext, ClientRequestContext> handler;
+
+  public JaxrsClientFilter() {
+    handler = new HttpClientHandler<ClientRequestContext, ClientResponseContext, ClientRequestContext>(
+        Tracing.getTracer(),
+        new JaxrsClientExtractor(),
+        Tracing.getPropagationComponent().getTraceContextFormat(),
+        SETTER
+    );
+  }
+
+  @Override
+  public void filter(ClientRequestContext requestContext) throws IOException {
+    // get hold of parent span
+    HttpRequestContext context = handler.handleStart(null, requestContext, requestContext);
+    requestContext.setProperty(OPENCENSUS_CONTEXT, context);
+
+  }
+
+  @Override
+  public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext)
+      throws IOException {
+    HttpRequestContext context = (HttpRequestContext) requestContext
+        .getProperty(OPENCENSUS_CONTEXT);
+    handler.handleEnd(context, requestContext, responseContext, null);
+  }
+}

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilter.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilter.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opencensus.contrib.http.jaxrs;
 
 import io.opencensus.contrib.http.HttpClientHandler;
@@ -21,22 +37,25 @@ import javax.ws.rs.ext.Provider;
 public class JaxrsClientFilter implements ClientRequestFilter, ClientResponseFilter {
 
   private static final String OPENCENSUS_CONTEXT = "opencensus.context";
-  private static final Setter<ClientRequestContext> SETTER = new Setter<ClientRequestContext>() {
-    @Override
-    public void put(ClientRequestContext carrier, String key, String value) {
-      carrier.getHeaders().putSingle(key, value);
-    }
-  };
+  private static final Setter<ClientRequestContext> SETTER =
+      new Setter<ClientRequestContext>() {
+        @Override
+        public void put(ClientRequestContext carrier, String key, String value) {
+          carrier.getHeaders().putSingle(key, value);
+        }
+      };
 
-  private final HttpClientHandler<ClientRequestContext, ClientResponseContext, ClientRequestContext> handler;
+  private final HttpClientHandler<ClientRequestContext, ClientResponseContext, ClientRequestContext>
+      handler;
 
+  /** Constructs new client filter with default configuration. */
   public JaxrsClientFilter() {
-    handler = new HttpClientHandler<>(
-        Tracing.getTracer(),
-        new JaxrsClientExtractor(),
-        Tracing.getPropagationComponent().getTraceContextFormat(),
-        SETTER
-    );
+    handler =
+        new HttpClientHandler<>(
+            Tracing.getTracer(),
+            new JaxrsClientExtractor(),
+            Tracing.getPropagationComponent().getTraceContextFormat(),
+            SETTER);
   }
 
   @Override
@@ -48,8 +67,8 @@ public class JaxrsClientFilter implements ClientRequestFilter, ClientResponseFil
   @Override
   public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext)
       throws IOException {
-    HttpRequestContext context = (HttpRequestContext) requestContext
-        .getProperty(OPENCENSUS_CONTEXT);
+    HttpRequestContext context =
+        (HttpRequestContext) requestContext.getProperty(OPENCENSUS_CONTEXT);
     handler.handleEnd(context, requestContext, responseContext, null);
   }
 }

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilter.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilter.java
@@ -41,10 +41,8 @@ public class JaxrsClientFilter implements ClientRequestFilter, ClientResponseFil
 
   @Override
   public void filter(ClientRequestContext requestContext) throws IOException {
-    // get hold of parent span
     HttpRequestContext context = handler.handleStart(null, requestContext, requestContext);
     requestContext.setProperty(OPENCENSUS_CONTEXT, context);
-
   }
 
   @Override

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractor.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractor.java
@@ -72,6 +72,8 @@ public class JaxrsContainerExtractor
     return response != null ? response.getStatus() : 0;
   }
 
+  @Nullable
+  @SuppressWarnings("dereference.of.nullable") // The annotations are checked
   private static String resolveRoute(ResourceInfo info) {
     StringBuilder path = new StringBuilder();
 

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractor.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractor.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.http.jaxrs;
+
+import io.opencensus.contrib.http.HttpExtractor;
+import java.util.List;
+import javax.annotation.Nullable;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+
+/**
+ * Extracts information from JAX-RS container request and response.
+ *
+ * @since 0.19
+ */
+public class JaxrsContainerExtractor extends
+    HttpExtractor<ContainerRequestContext, ContainerResponseContext> {
+
+  @Nullable
+  @Override
+  public String getRoute(ContainerRequestContext request) {
+    List<String> uris = request.getUriInfo().getMatchedURIs();
+    return uris.isEmpty() ? null : uris.get(0);
+  }
+
+  @Nullable
+  @Override
+  public String getUrl(ContainerRequestContext request) {
+    return request.getUriInfo().getRequestUri().toString();
+  }
+
+  @Nullable
+  @Override
+  public String getHost(ContainerRequestContext request) {
+    return request.getHeaderString("host");
+  }
+
+  @Nullable
+  @Override
+  public String getMethod(ContainerRequestContext request) {
+    return request.getMethod();
+  }
+
+  @Nullable
+  @Override
+  public String getPath(ContainerRequestContext request) {
+    return request.getUriInfo().getPath();
+  }
+
+  @Nullable
+  @Override
+  public String getUserAgent(ContainerRequestContext request) {
+    return request.getHeaderString("user-agent");
+  }
+
+  @Override
+  public int getStatusCode(@Nullable ContainerResponseContext response) {
+    return response != null ? response.getStatus() : 0;
+  }
+}

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractor.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractor.java
@@ -27,8 +27,8 @@ import javax.ws.rs.container.ContainerResponseContext;
  *
  * @since 0.19
  */
-public class JaxrsContainerExtractor extends
-    HttpExtractor<ContainerRequestContext, ContainerResponseContext> {
+public class JaxrsContainerExtractor
+    extends HttpExtractor<ContainerRequestContext, ContainerResponseContext> {
 
   @Nullable
   @Override

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilter.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilter.java
@@ -60,8 +60,7 @@ public class JaxrsContainerFilter implements ContainerRequestFilter, ContainerRe
           ExtendedContainerRequest, ContainerResponseContext, ContainerRequestContext>
       handler;
 
-  @Context
-  private ResourceInfo info;
+  @Context private ResourceInfo info;
 
   /**
    * Default constructor construct new instance with {@link JaxrsContainerExtractor}, {@link

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilter.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilter.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.http.jaxrs;
+
+import io.opencensus.contrib.http.HttpExtractor;
+import io.opencensus.contrib.http.HttpRequestContext;
+import io.opencensus.contrib.http.HttpServerHandler;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.propagation.TextFormat;
+import io.opencensus.trace.propagation.TextFormat.Getter;
+import java.io.IOException;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerRequestFilter;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ContainerResponseFilter;
+import javax.ws.rs.ext.Provider;
+
+/**
+ * JAX-RS request and response filter to provide instrumentation of JAX-RS based endpoint with
+ * OpenCensus.
+ *
+ * @since 0.19
+ */
+@Provider
+public class JaxrsContainerFilter implements ContainerRequestFilter, ContainerResponseFilter {
+
+  private static final String CONTEXT_PROPERTY = "opencensus.context";
+  private static final Getter<ContainerRequestContext> GETTER = new Getter<ContainerRequestContext>() {
+    @Override
+    public String get(ContainerRequestContext request, String key) {
+      return request.getHeaderString(key);
+    }
+  };
+
+  private final HttpServerHandler<ContainerRequestContext, ContainerResponseContext, ContainerRequestContext> handler;
+
+  /**
+   * Default constructor construct new instance with {@link JaxrsContainerExtractor}, {@link
+   * Tracing#getPropagationComponent()#getTraceContextFormat()} and as public endpoint.
+   *
+   * @see #JaxrsContainerFilter(HttpExtractor, TextFormat, Boolean)
+   */
+  public JaxrsContainerFilter() {
+    this(new JaxrsContainerExtractor(), Tracing.getPropagationComponent().getTraceContextFormat(),
+        true);
+  }
+
+  /**
+   * Construct instance with custom configuration.
+   *
+   * @param extractor the {@code HttpExtractor} used to extract information from the
+   * request/response.
+   * @param propagationFormat the {@code TextFormat} used in HTTP propagation.
+   * @param publicEndpoint set to true for publicly accessible HTTP(S) server. If true then incoming
+   * tracecontext will be added as a link instead of as a parent.
+   */
+  public JaxrsContainerFilter(
+      HttpExtractor<ContainerRequestContext, ContainerResponseContext> extractor,
+      TextFormat propagationFormat, Boolean publicEndpoint) {
+    this.handler = new HttpServerHandler<ContainerRequestContext, ContainerResponseContext, ContainerRequestContext>(
+        Tracing.getTracer(),
+        extractor,
+        propagationFormat,
+        GETTER,
+        publicEndpoint);
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext) throws IOException {
+    HttpRequestContext context = handler.handleStart(requestContext, requestContext);
+    requestContext.setProperty(CONTEXT_PROPERTY, context);
+    if (requestContext.getLength() > 0) {
+      handler.handleMessageReceived(context, requestContext.getLength());
+    }
+  }
+
+  @Override
+  public void filter(ContainerRequestContext requestContext,
+      ContainerResponseContext responseContext) throws IOException {
+    if (requestContext.getProperty(CONTEXT_PROPERTY) == null) {
+      // JAX-RS response filters are always invoked - we only want to record something if
+      // request came through this filter
+      return;
+    }
+    HttpRequestContext context = (HttpRequestContext) requestContext.getProperty(CONTEXT_PROPERTY);
+    if (responseContext.getLength() > 0) {
+      handler.handleMessageSent(context, responseContext.getLength());
+    }
+    handler.handleEnd(context, requestContext, responseContext, null);
+  }
+}

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilter.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilter.java
@@ -60,7 +60,9 @@ public class JaxrsContainerFilter implements ContainerRequestFilter, ContainerRe
           ExtendedContainerRequest, ContainerResponseContext, ContainerRequestContext>
       handler;
 
-  @Context private ResourceInfo info;
+  @SuppressWarnings("initialization.fields.uninitialized") // Will be injected by JAX-RS
+  @Context
+  private ResourceInfo info;
 
   /**
    * Default constructor construct new instance with {@link JaxrsContainerExtractor}, {@link

--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/Metrics.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/Metrics.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.http.jaxrs;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.ws.rs.NameBinding;
+
+/**
+ * Annotation to mark JAX-RS endpoint or method for metrics collection.
+ *
+ * @since 0.19
+ */
+@NameBinding
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Metrics {}

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientExtractorTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientExtractorTest.java
@@ -1,0 +1,37 @@
+package io.opencensus.contrib.http.jaxrs;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import org.junit.Test;
+
+public class JaxrsClientExtractorTest {
+
+  @Test
+  public void testExtraction() {
+    URI uri = URI.create("https://myhost/resource");
+
+    ClientRequestContext requestContext = mock(ClientRequestContext.class);
+    when(requestContext.getUri()).thenReturn(uri);
+    when(requestContext.getMethod()).thenReturn("GET");
+    when(requestContext.getHeaderString("user-agent")).thenReturn("java/1.8");
+
+    ClientResponseContext responseContext = mock(ClientResponseContext.class);
+    when(responseContext.getStatus()).thenReturn(200);
+
+    JaxrsClientExtractor extractor = new JaxrsClientExtractor();
+    assertEquals("myhost", extractor.getHost(requestContext));
+    assertEquals("GET", extractor.getMethod(requestContext));
+    assertEquals("/resource", extractor.getPath(requestContext));
+    assertNull(extractor.getRoute(requestContext));
+    assertEquals("https://myhost/resource", extractor.getUrl(requestContext));
+    assertEquals("java/1.8", extractor.getUserAgent(requestContext));
+    assertEquals(200, extractor.getStatusCode(responseContext));
+  }
+
+}

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientExtractorTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientExtractorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opencensus.contrib.http.jaxrs;
 
 import static org.junit.Assert.assertEquals;
@@ -33,5 +49,4 @@ public class JaxrsClientExtractorTest {
     assertEquals("java/1.8", extractor.getUserAgent(requestContext));
     assertEquals(200, extractor.getStatusCode(responseContext));
   }
-
 }

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilterTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opencensus.contrib.http.jaxrs;
 
 import static org.mockito.Mockito.mock;
@@ -56,8 +72,8 @@ public class JaxrsClientFilterTest {
 
   static HttpRequestContext createHttpRequestContext(Span span, TagContext tagContext)
       throws Exception {
-    Constructor<HttpRequestContext> constructor = HttpRequestContext.class
-        .getDeclaredConstructor(Span.class, TagContext.class);
+    Constructor<HttpRequestContext> constructor =
+        HttpRequestContext.class.getDeclaredConstructor(Span.class, TagContext.class);
     constructor.setAccessible(true);
     return constructor.newInstance(span, tagContext);
   }
@@ -69,36 +85,27 @@ public class JaxrsClientFilterTest {
     }
 
     @Override
-    public void putAttribute(String key, AttributeValue value) {
-    }
+    public void putAttribute(String key, AttributeValue value) {}
 
     @Override
-    public void putAttributes(Map<String, AttributeValue> attributes) {
-    }
+    public void putAttributes(Map<String, AttributeValue> attributes) {}
 
     @Override
-    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {
-    }
+    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
 
     @Override
-    public void addAnnotation(Annotation annotation) {
-    }
+    public void addAnnotation(Annotation annotation) {}
 
     @Override
-    public void addMessageEvent(MessageEvent messageEvent) {
-    }
+    public void addMessageEvent(MessageEvent messageEvent) {}
 
     @Override
-    public void addLink(Link link) {
-    }
+    public void addLink(Link link) {}
 
     @Override
-    public void setStatus(Status status) {
-    }
+    public void setStatus(Status status) {}
 
     @Override
-    public void end(EndSpanOptions options) {
-    }
+    public void end(EndSpanOptions options) {}
   }
-
 }

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilterTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilterTest.java
@@ -1,0 +1,94 @@
+package io.opencensus.contrib.http.jaxrs;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opencensus.contrib.http.HttpRequestContext;
+import io.opencensus.tags.TagContext;
+import io.opencensus.trace.Annotation;
+import io.opencensus.trace.AttributeValue;
+import io.opencensus.trace.EndSpanOptions;
+import io.opencensus.trace.Link;
+import io.opencensus.trace.MessageEvent;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanContext;
+import io.opencensus.trace.Status;
+import java.lang.reflect.Constructor;
+import java.net.URI;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.Map;
+import javax.ws.rs.client.ClientRequestContext;
+import javax.ws.rs.client.ClientResponseContext;
+import org.junit.Test;
+
+public class JaxrsClientFilterTest {
+
+  JaxrsClientFilter filter = new JaxrsClientFilter();
+
+  @Test
+  public void testRequestFilter() throws Exception {
+    URI uri = URI.create("https://mydomain/myresource");
+    ClientRequestContext requestContext = mock(ClientRequestContext.class);
+    when(requestContext.getUri()).thenReturn(uri);
+    filter.filter(requestContext);
+    verify(requestContext).getUri();
+  }
+
+  @Test
+  public void testResponseFilter() throws Exception{
+    Span span = new FakeSpan(SpanContext.INVALID, null);
+    TagContext tagContext = mock(TagContext.class);
+
+    HttpRequestContext context = createHttpRequestContext(span, tagContext);
+
+    ClientRequestContext requestContext = mock(ClientRequestContext.class);
+    when(requestContext.getProperty("opencensus.context")).thenReturn(context);
+
+    ClientResponseContext responseContext = mock(ClientResponseContext.class);
+
+    filter.filter(requestContext, responseContext);
+
+    verify(requestContext).getProperty("opencensus.context");
+    verify(responseContext, times(2)).getStatus();
+  }
+
+  static HttpRequestContext createHttpRequestContext(Span span, TagContext tagContext) throws Exception {
+    Constructor<HttpRequestContext> constructor = HttpRequestContext.class.getDeclaredConstructor(Span.class, TagContext.class);
+    constructor.setAccessible(true);
+    return constructor.newInstance(span, tagContext);
+  }
+
+  static class FakeSpan extends Span {
+    public FakeSpan(SpanContext context, EnumSet<Options> options) {
+      super(context, options);
+    }
+
+    @Override
+    public void putAttribute(String key, AttributeValue value) {}
+
+    @Override
+    public void putAttributes(Map<String, AttributeValue> attributes) {}
+
+    @Override
+    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
+
+    @Override
+    public void addAnnotation(Annotation annotation) {}
+
+    @Override
+    public void addMessageEvent(MessageEvent messageEvent) {}
+
+    @Override
+    public void addLink(Link link) {}
+
+    @Override
+    public void setStatus(Status status) {}
+
+    @Override
+    public void end(EndSpanOptions options) {}
+  }
+
+}

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilterTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsClientFilterTest.java
@@ -17,7 +17,6 @@ import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.Status;
 import java.lang.reflect.Constructor;
 import java.net.URI;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.Map;
 import javax.ws.rs.client.ClientRequestContext;
@@ -38,7 +37,7 @@ public class JaxrsClientFilterTest {
   }
 
   @Test
-  public void testResponseFilter() throws Exception{
+  public void testResponseFilter() throws Exception {
     Span span = new FakeSpan(SpanContext.INVALID, null);
     TagContext tagContext = mock(TagContext.class);
 
@@ -55,40 +54,51 @@ public class JaxrsClientFilterTest {
     verify(responseContext, times(2)).getStatus();
   }
 
-  static HttpRequestContext createHttpRequestContext(Span span, TagContext tagContext) throws Exception {
-    Constructor<HttpRequestContext> constructor = HttpRequestContext.class.getDeclaredConstructor(Span.class, TagContext.class);
+  static HttpRequestContext createHttpRequestContext(Span span, TagContext tagContext)
+      throws Exception {
+    Constructor<HttpRequestContext> constructor = HttpRequestContext.class
+        .getDeclaredConstructor(Span.class, TagContext.class);
     constructor.setAccessible(true);
     return constructor.newInstance(span, tagContext);
   }
 
   static class FakeSpan extends Span {
+
     public FakeSpan(SpanContext context, EnumSet<Options> options) {
       super(context, options);
     }
 
     @Override
-    public void putAttribute(String key, AttributeValue value) {}
+    public void putAttribute(String key, AttributeValue value) {
+    }
 
     @Override
-    public void putAttributes(Map<String, AttributeValue> attributes) {}
+    public void putAttributes(Map<String, AttributeValue> attributes) {
+    }
 
     @Override
-    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {}
+    public void addAnnotation(String description, Map<String, AttributeValue> attributes) {
+    }
 
     @Override
-    public void addAnnotation(Annotation annotation) {}
+    public void addAnnotation(Annotation annotation) {
+    }
 
     @Override
-    public void addMessageEvent(MessageEvent messageEvent) {}
+    public void addMessageEvent(MessageEvent messageEvent) {
+    }
 
     @Override
-    public void addLink(Link link) {}
+    public void addLink(Link link) {
+    }
 
     @Override
-    public void setStatus(Status status) {}
+    public void setStatus(Status status) {
+    }
 
     @Override
-    public void end(EndSpanOptions options) {}
+    public void end(EndSpanOptions options) {
+    }
   }
 
 }

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractorTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractorTest.java
@@ -1,0 +1,41 @@
+package io.opencensus.contrib.http.jaxrs;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.Collections;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.UriInfo;
+import org.junit.Test;
+
+public class JaxrsContainerExtractorTest {
+  @Test
+  public void testExtraction() {
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getPath()).thenReturn("mypath");
+    when(uriInfo.getMatchedURIs()).thenReturn(Collections.singletonList("/resource/{route}"));
+    when(uriInfo.getRequestUri()).thenReturn(URI.create("https://myhost/resource/1"));
+
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getHeaderString("host")).thenReturn("myhost");
+    when(requestContext.getMethod()).thenReturn("GET");
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    when(requestContext.getHeaderString("user-agent")).thenReturn("java/1.8");
+
+    ContainerResponseContext responseContext = mock(ContainerResponseContext.class);
+    when(responseContext.getStatus()).thenReturn(200);
+
+    JaxrsContainerExtractor extractor = new JaxrsContainerExtractor();
+    assertEquals("myhost", extractor.getHost(requestContext));
+    assertEquals("GET", extractor.getMethod(requestContext));
+    assertEquals("mypath", extractor.getPath(requestContext));
+    assertEquals("/resource/{route}", extractor.getRoute(requestContext));
+    assertEquals("https://myhost/resource/1", extractor.getUrl(requestContext));
+    assertEquals("java/1.8", extractor.getUserAgent(requestContext));
+    assertEquals(200, extractor.getStatusCode(responseContext));
+  }
+
+}

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractorTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractorTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opencensus.contrib.http.jaxrs;
 
 import static org.junit.Assert.assertEquals;
@@ -37,5 +53,4 @@ public class JaxrsContainerExtractorTest {
     assertEquals("java/1.8", extractor.getUserAgent(requestContext));
     assertEquals(200, extractor.getStatusCode(responseContext));
   }
-
 }

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractorTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractorTest.java
@@ -62,4 +62,3 @@ public class JaxrsContainerExtractorTest {
   }
 
 }
-}

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractorTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerExtractorTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.contrib.http.jaxrs;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -24,10 +25,12 @@ import java.net.URI;
 import java.util.Collections;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.UriInfo;
 import org.junit.Test;
 
 public class JaxrsContainerExtractorTest {
+
   @Test
   public void testExtraction() {
     UriInfo uriInfo = mock(UriInfo.class);
@@ -41,16 +44,22 @@ public class JaxrsContainerExtractorTest {
     when(requestContext.getUriInfo()).thenReturn(uriInfo);
     when(requestContext.getHeaderString("user-agent")).thenReturn("java/1.8");
 
+    ResourceInfo info = mock(ResourceInfo.class);
+
+    ExtendedContainerRequest extendedRequest = new ExtendedContainerRequest(requestContext, info);
+
     ContainerResponseContext responseContext = mock(ContainerResponseContext.class);
     when(responseContext.getStatus()).thenReturn(200);
 
     JaxrsContainerExtractor extractor = new JaxrsContainerExtractor();
-    assertEquals("myhost", extractor.getHost(requestContext));
-    assertEquals("GET", extractor.getMethod(requestContext));
-    assertEquals("mypath", extractor.getPath(requestContext));
-    assertEquals("/resource/{route}", extractor.getRoute(requestContext));
-    assertEquals("https://myhost/resource/1", extractor.getUrl(requestContext));
-    assertEquals("java/1.8", extractor.getUserAgent(requestContext));
+    assertEquals("myhost", extractor.getHost(extendedRequest));
+    assertEquals("GET", extractor.getMethod(extendedRequest));
+    assertEquals("mypath", extractor.getPath(extendedRequest));
+    assertNull(extractor.getRoute(extendedRequest));
+    assertEquals("https://myhost/resource/1", extractor.getUrl(extendedRequest));
+    assertEquals("java/1.8", extractor.getUserAgent(extendedRequest));
     assertEquals(200, extractor.getStatusCode(responseContext));
   }
+
+}
 }

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilterTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilterTest.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package io.opencensus.contrib.http.jaxrs;
 
 import static org.mockito.Matchers.any;
@@ -50,5 +66,4 @@ public class JaxrsContainerFilterTest {
     verify(requestContext).getProperty("opencensus.context");
     verify(responseContext, times(2)).getStatus();
   }
-
 }

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilterTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilterTest.java
@@ -31,12 +31,20 @@ import io.opencensus.trace.SpanContext;
 import java.util.Collections;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.container.ResourceInfo;
 import javax.ws.rs.core.UriInfo;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+@RunWith(MockitoJUnitRunner.class)
 public class JaxrsContainerFilterTest {
 
-  JaxrsContainerFilter filter = new JaxrsContainerFilter();
+  @Mock ResourceInfo info;
+
+  @InjectMocks JaxrsContainerFilter filter = new JaxrsContainerFilter();
 
   @Test
   public void testRequestFilter() throws Exception {

--- a/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilterTest.java
+++ b/contrib/http_jaxrs/src/test/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilterTest.java
@@ -1,0 +1,54 @@
+package io.opencensus.contrib.http.jaxrs;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opencensus.contrib.http.HttpRequestContext;
+import io.opencensus.contrib.http.jaxrs.JaxrsClientFilterTest.FakeSpan;
+import io.opencensus.tags.TagContext;
+import io.opencensus.trace.Span;
+import io.opencensus.trace.SpanContext;
+import java.util.Collections;
+import javax.ws.rs.container.ContainerRequestContext;
+import javax.ws.rs.container.ContainerResponseContext;
+import javax.ws.rs.core.UriInfo;
+import org.junit.Test;
+
+public class JaxrsContainerFilterTest {
+
+  JaxrsContainerFilter filter = new JaxrsContainerFilter();
+
+  @Test
+  public void testRequestFilter() throws Exception {
+    UriInfo uriInfo = mock(UriInfo.class);
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+    filter.filter(requestContext);
+    verify(requestContext).setProperty(eq("opencensus.context"), any());
+  }
+
+  @Test
+  public void testResponseFilter() throws Exception {
+    Span span = new FakeSpan(SpanContext.INVALID, null);
+    TagContext tagContext = mock(TagContext.class);
+
+    HttpRequestContext context = JaxrsClientFilterTest.createHttpRequestContext(span, tagContext);
+
+    UriInfo uriInfo = mock(UriInfo.class);
+    when(uriInfo.getMatchedURIs()).thenReturn(Collections.singletonList("/resource/{route}"));
+
+    ContainerRequestContext requestContext = mock(ContainerRequestContext.class);
+    when(requestContext.getProperty("opencensus.context")).thenReturn(context);
+    when(requestContext.getUriInfo()).thenReturn(uriInfo);
+
+    ContainerResponseContext responseContext = mock(ContainerResponseContext.class);
+    filter.filter(requestContext, responseContext);
+    verify(requestContext).getProperty("opencensus.context");
+    verify(responseContext, times(2)).getStatus();
+  }
+
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -84,11 +84,13 @@ if (JavaVersion.current().isJava8Compatible()) {
     include ":opencensus-benchmarks"
     include ":opencensus-contrib-zpages"
     include ":opencensus-contrib-dropwizard5"
+    include ":opencensus-contrib-http-jaxrs"
 
     project(':opencensus-all').projectDir = "$rootDir/all" as File
     project(':opencensus-benchmarks').projectDir = "$rootDir/benchmarks" as File
     project(':opencensus-contrib-zpages').projectDir = "$rootDir/contrib/zpages" as File
     project(':opencensus-contrib-dropwizard5').projectDir = "$rootDir/contrib/dropwizard5" as File
+    project(':opencensus-contrib-http-jaxrs').projectDir = "$rootDir/contrib/http_jaxrs" as File
     project(':opencensus-exporter-trace-datadog').projectDir =
         "$rootDir/exporters/trace/datadog" as File
 }


### PR DESCRIPTION
Adding module to provide a JAX-RS container and client filter utilizing the existing http utilities to provide instrumentation for REST services developed using any JAX-RS stack (e.g., RESTeasy or Jersey).