### PR TITLE
http_server_status tag should hold http status code

### DIFF
--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpClientHandler.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpClientHandler.java
@@ -25,7 +25,6 @@ import static io.opencensus.contrib.http.util.HttpMeasureConstants.HTTP_CLIENT_S
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import io.opencensus.common.ExperimentalApi;
-import io.opencensus.contrib.http.util.HttpTraceUtil;
 import io.opencensus.stats.Stats;
 import io.opencensus.stats.StatsRecorder;
 import io.opencensus.tags.TagContext;
@@ -158,15 +157,14 @@ public class HttpClientHandler<
     double requestLatency = NANOSECONDS.toMillis(System.nanoTime() - context.requestStartTime);
 
     String methodStr = request == null ? "" : extractor.getMethod(request);
+    int status = extractor.getStatusCode(response);
     TagContext startCtx =
         tagger
             .toBuilder(context.tagContext)
             .put(HTTP_CLIENT_METHOD, TagValue.create(methodStr == null ? "" : methodStr))
             .put(
                 HTTP_CLIENT_STATUS,
-                TagValue.create(
-                    HttpTraceUtil.parseResponseStatus(extractor.getStatusCode(response), error)
-                        .toString()))
+                TagValue.create(status == 0 ? "error" : Integer.toString(status)))
             .build();
 
     statsRecorder

--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpServerHandler.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpServerHandler.java
@@ -172,16 +172,14 @@ public class HttpServerHandler<
 
     String methodStr = extractor.getMethod(request);
     String routeStr = extractor.getRoute(request);
+    int status = extractor.getStatusCode(response);
     TagContext startCtx =
         tagger
             .toBuilder(context.tagContext)
             .put(HTTP_SERVER_METHOD, TagValue.create(methodStr == null ? "" : methodStr))
             .put(HTTP_SERVER_ROUTE, TagValue.create(routeStr == null ? "" : routeStr))
-            .put(
-                HTTP_SERVER_STATUS,
-                TagValue.create(
-                    HttpTraceUtil.parseResponseStatus(extractor.getStatusCode(response), error)
-                        .toString()))
+            .put(HTTP_SERVER_STATUS,
+                TagValue.create(status == 0 ? "error" : Integer.toString(status)))
             .build();
 
     statsRecorder

--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpServerHandler.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpServerHandler.java
@@ -26,7 +26,6 @@ import static io.opencensus.contrib.http.util.HttpMeasureConstants.HTTP_SERVER_S
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 import io.opencensus.common.ExperimentalApi;
-import io.opencensus.contrib.http.util.HttpTraceUtil;
 import io.opencensus.stats.Stats;
 import io.opencensus.stats.StatsRecorder;
 import io.opencensus.tags.TagContext;
@@ -178,7 +177,8 @@ public class HttpServerHandler<
             .toBuilder(context.tagContext)
             .put(HTTP_SERVER_METHOD, TagValue.create(methodStr == null ? "" : methodStr))
             .put(HTTP_SERVER_ROUTE, TagValue.create(routeStr == null ? "" : routeStr))
-            .put(HTTP_SERVER_STATUS,
+            .put(
+                HTTP_SERVER_STATUS,
                 TagValue.create(status == 0 ? "error" : Integer.toString(status)))
             .build();
 


### PR DESCRIPTION
Changing `HttpServerHandler` to follow [HTTP Stats](https://github.com/census-instrumentation/opencensus-specs/blob/master/stats/HTTP.md) such that the `http_server_status` will contain the http status code - not the OpenCensus canonical status.

See issue #1654 