### PR TITLE
CI: fix travis example bazel build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ before_install:
       echo "deb [arch=amd64] http://storage.googleapis.com/bazel-apt stable jdk1.8" | sudo tee /etc/apt/sources.list.d/bazel.list ;
       curl https://bazel.build/bazel-release.pub.gpg | sudo apt-key add - ;
       sudo apt-get update ;
-      sudo apt-get install bazel ;
+      sudo apt-get install bazel=0.21.0 ;
     fi
 
 # Skip Travis' default Gradle install step. See http://stackoverflow.com/a/26575080.

--- a/buildscripts/travis_script
+++ b/buildscripts/travis_script
@@ -62,7 +62,7 @@ case "$TASK" in
     ;;
   "BUILD_EXAMPLES_BAZEL")
     # TODO [:rghetia] figure out proper fix.
-    pushd examples && bazel clean && bazel build :all --incompatible_package_name_is_a_function=false && popd
+    pushd examples && bazel clean && bazel build :all && popd
     ;;
   *)
     echo "Unknown task $TASK"

--- a/buildscripts/travis_script
+++ b/buildscripts/travis_script
@@ -62,7 +62,7 @@ case "$TASK" in
     ;;
   "BUILD_EXAMPLES_BAZEL")
     # TODO [:rghetia] figure out proper fix.
-    pushd examples && bazel clean && bazel build :all && popd
+    pushd examples && bazel clean && bazel build :all --incompatible_package_name_is_a_function=false && popd
     ;;
   *)
     echo "Unknown task $TASK"


### PR DESCRIPTION
See https://travis-ci.org/census-instrumentation/opencensus-java/jobs/485548742#L564:
```bash
+bazel build :all --incompatible_package_name_is_a_function=false
ERROR: Unrecognized option: --incompatible_package_name_is_a_function=false
INFO: Invocation ID: aabc5a24-f3b6-4ce1-b2bd-89e42c84a2db
The command "buildscripts/travis_script" exited with 2.
```