### PR TITLE
CI: Temporarily disable example bazel build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,9 @@ matrix:
     env: TASK=BUILD_EXAMPLES_MAVEN
     os: linux
 
-  - jdk: oraclejdk8
-    env: TASK=BUILD_EXAMPLES_BAZEL
-    os: linux
+#  - jdk: oraclejdk8
+#    env: TASK=BUILD_EXAMPLES_BAZEL
+#    os: linux
 
   # Work around https://github.com/travis-ci/travis-ci/issues/2317
   - env: TASK=BUILD


### PR DESCRIPTION
Avoid blocking other PRs while fixing bazel (https://github.com/census-instrumentation/opencensus-java/pull/1697).