### PR TITLE
Exporter/Stackdriver: Fix AWS EC2 resource label and Stackdriver built-in metrics.

### DIFF
--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -702,7 +702,8 @@ public class StackdriverExportUtilsTest {
     Map<String, String> expectedResourceLabels = new HashMap<String, String>();
     expectedResourceLabels.put("project_id", "proj1");
     expectedResourceLabels.put("instance_id", "instance1");
-    expectedResourceLabels.put("region", "region1");
+    expectedResourceLabels.put(
+        "region", StackdriverExportUtils.AWS_REGION_VALUE_PREFIX + "region1");
     expectedResourceLabels.put("aws_account", "account1");
 
     Resource resource = Resource.create(AwsEc2InstanceResource.TYPE, resourceLabels);


### PR DESCRIPTION
- Do not create MetricDescriptor for Stackdriver built-in metrics.
- Add 'aws:' prefix for aws_ec2_instance's region field.