### PR TITLE
Example: Don't export to Stackdriver too frequent.

### DIFF
--- a/examples/src/main/java/io/opencensus/examples/grpc/helloworld/HelloWorldClient.java
+++ b/examples/src/main/java/io/opencensus/examples/grpc/helloworld/HelloWorldClient.java
@@ -126,7 +126,7 @@ public class HelloWorldClient {
       StackdriverStatsExporter.createAndRegister(
           StackdriverStatsConfiguration.builder()
               .setProjectId(cloudProjectId)
-              .setExportInterval(Duration.create(15, 0))
+              .setExportInterval(Duration.create(60, 0))
               .build());
     }
 

--- a/examples/src/main/java/io/opencensus/examples/grpc/helloworld/HelloWorldServer.java
+++ b/examples/src/main/java/io/opencensus/examples/grpc/helloworld/HelloWorldServer.java
@@ -138,7 +138,7 @@ public class HelloWorldServer {
       StackdriverStatsExporter.createAndRegister(
           StackdriverStatsConfiguration.builder()
               .setProjectId(cloudProjectId)
-              .setExportInterval(Duration.create(15, 0))
+              .setExportInterval(Duration.create(60, 0))
               .build());
     }
 


### PR DESCRIPTION
The recommended export interval from Stackdriver Monitoring is >= 60s now. If exporting too fast we may get error like "one or more timeseries cannot be written...".