### PR TITLE
 Deprecated measures use instance of new measures when 1to1 mapping.

### DIFF
--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -302,8 +302,7 @@ public final class RpcMeasureConstants {
    * @since 0.8
    * @deprecated in favor of {@link #GRPC_CLIENT_STARTED_RPCS}.
    */
-  @Deprecated
-  public static final MeasureLong RPC_CLIENT_STARTED_COUNT = GRPC_CLIENT_STARTED_RPCS;
+  @Deprecated public static final MeasureLong RPC_CLIENT_STARTED_COUNT = GRPC_CLIENT_STARTED_RPCS;
 
   /**
    * {@link Measure} for number of finished client RPCs.
@@ -520,8 +519,7 @@ public final class RpcMeasureConstants {
    * @since 0.8
    * @deprecated in favor of {@link #GRPC_SERVER_STARTED_RPCS}.
    */
-  @Deprecated
-  public static final MeasureLong RPC_SERVER_STARTED_COUNT = GRPC_SERVER_STARTED_RPCS;
+  @Deprecated public static final MeasureLong RPC_SERVER_STARTED_COUNT = GRPC_SERVER_STARTED_RPCS;
 
   /**
    * {@link Measure} for number of finished server RPCs.

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -113,6 +113,121 @@ public final class RpcMeasureConstants {
   // RPC client Measures.
 
   /**
+   * {@link Measure} for total bytes sent across all request messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_SENT_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/sent_bytes_per_rpc",
+          "Total bytes sent across all request messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for total bytes received across all response messages per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_RECEIVED_BYTES_PER_RPC =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/received_bytes_per_rpc",
+          "Total bytes received across all response messages per RPC",
+          BYTE);
+
+  /**
+   * {@link Measure} for total bytes sent per method, recorded real-time as bytes are sent.
+   *
+   * @since 0.18
+   */
+  public static final MeasureDouble GRPC_CLIENT_SENT_BYTES_PER_METHOD =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/sent_bytes_per_method",
+          "Total bytes sent per method, recorded real-time as bytes are sent.",
+          BYTE);
+
+  /**
+   * {@link Measure} for total bytes received per method, recorded real-time as bytes are received.
+   *
+   * @since 0.18
+   */
+  public static final MeasureDouble GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/received_bytes_per_method",
+          "Total bytes received per method, recorded real-time as bytes are received.",
+          BYTE);
+
+  /**
+   * {@link Measure} for total client sent messages.
+   *
+   * @since 0.18
+   */
+  public static final MeasureLong GRPC_CLIENT_SENT_MESSAGES_PER_METHOD =
+      Measure.MeasureLong.create(
+          "grpc.io/client/sent_messages_per_method", "Total messages sent per method.", COUNT);
+
+  /**
+   * {@link Measure} for total client received messages.
+   *
+   * @since 0.18
+   */
+  public static final MeasureLong GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD =
+      Measure.MeasureLong.create(
+          "grpc.io/client/received_messages_per_method",
+          "Total messages received per method.",
+          COUNT);
+
+  /**
+   * {@link Measure} for gRPC client roundtrip latency in milliseconds.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_ROUNDTRIP_LATENCY =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/roundtrip_latency",
+          "Time between first byte of request sent to last byte of response received, "
+              + "or terminal error.",
+          MILLISECOND);
+
+  /**
+   * {@link Measure} for number of messages sent in the RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_CLIENT_SENT_MESSAGES_PER_RPC =
+      Measure.MeasureLong.create(
+          "grpc.io/client/sent_messages_per_rpc", "Number of messages sent in the RPC", COUNT);
+
+  /**
+   * {@link Measure} for number of response messages received per RPC.
+   *
+   * @since 0.13
+   */
+  public static final MeasureLong GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC =
+      Measure.MeasureLong.create(
+          "grpc.io/client/received_messages_per_rpc",
+          "Number of response messages received per RPC",
+          COUNT);
+
+  /**
+   * {@link Measure} for gRPC server latency in milliseconds.
+   *
+   * @since 0.13
+   */
+  public static final MeasureDouble GRPC_CLIENT_SERVER_LATENCY =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/server_latency", "Server latency in msecs", MILLISECOND);
+
+  /**
+   * {@link Measure} for total number of client RPCs ever opened, including those that have not
+   * completed.
+   *
+   * @since 0.14
+   */
+  public static final MeasureLong GRPC_CLIENT_STARTED_RPCS =
+      Measure.MeasureLong.create(
+          "grpc.io/client/started_rpcs", "Number of started client RPCs.", COUNT);
+
+  /**
    * {@link Measure} for gRPC client error counts.
    *
    * @since 0.8
@@ -232,26 +347,28 @@ public final class RpcMeasureConstants {
       Measure.MeasureLong.create(
           "grpc.io/client/response_count", "Number of client RPC response messages", COUNT);
 
+  // RPC server Measures.
+
   /**
-   * {@link Measure} for total bytes sent across all request messages per RPC.
+   * {@link Measure} for total bytes sent across all response messages per RPC.
    *
    * @since 0.13
    */
-  public static final MeasureDouble GRPC_CLIENT_SENT_BYTES_PER_RPC =
+  public static final MeasureDouble GRPC_SERVER_SENT_BYTES_PER_RPC =
       Measure.MeasureDouble.create(
-          "grpc.io/client/sent_bytes_per_rpc",
-          "Total bytes sent across all request messages per RPC",
+          "grpc.io/server/sent_bytes_per_rpc",
+          "Total bytes sent across all response messages per RPC",
           BYTE);
 
   /**
-   * {@link Measure} for total bytes received across all response messages per RPC.
+   * {@link Measure} for total bytes received across all messages per RPC.
    *
    * @since 0.13
    */
-  public static final MeasureDouble GRPC_CLIENT_RECEIVED_BYTES_PER_RPC =
+  public static final MeasureDouble GRPC_SERVER_RECEIVED_BYTES_PER_RPC =
       Measure.MeasureDouble.create(
-          "grpc.io/client/received_bytes_per_rpc",
-          "Total bytes received across all response messages per RPC",
+          "grpc.io/server/received_bytes_per_rpc",
+          "Total bytes received across all messages per RPC",
           BYTE);
 
   /**
@@ -259,9 +376,9 @@ public final class RpcMeasureConstants {
    *
    * @since 0.18
    */
-  public static final MeasureDouble GRPC_CLIENT_SENT_BYTES_PER_METHOD =
+  public static final MeasureDouble GRPC_SERVER_SENT_BYTES_PER_METHOD =
       Measure.MeasureDouble.create(
-          "grpc.io/client/sent_bytes_per_method",
+          "grpc.io/server/sent_bytes_per_method",
           "Total bytes sent per method, recorded real-time as bytes are sent.",
           BYTE);
 
@@ -270,62 +387,50 @@ public final class RpcMeasureConstants {
    *
    * @since 0.18
    */
-  public static final MeasureDouble GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD =
+  public static final MeasureDouble GRPC_SERVER_RECEIVED_BYTES_PER_METHOD =
       Measure.MeasureDouble.create(
-          "grpc.io/client/received_bytes_per_method",
+          "grpc.io/server/received_bytes_per_method",
           "Total bytes received per method, recorded real-time as bytes are received.",
           BYTE);
 
   /**
-   * {@link Measure} for total client sent messages.
+   * {@link Measure} for total server sent messages.
    *
    * @since 0.18
    */
-  public static final MeasureLong GRPC_CLIENT_SENT_MESSAGES_PER_METHOD =
+  public static final MeasureLong GRPC_SERVER_SENT_MESSAGES_PER_METHOD =
       Measure.MeasureLong.create(
-          "grpc.io/client/sent_messages_per_method", "Total messages sent per method.", COUNT);
+          "grpc.io/server/sent_messages_per_method", "Total messages sent per method.", COUNT);
 
   /**
-   * {@link Measure} for total client received messages.
+   * {@link Measure} for total server received messages.
    *
    * @since 0.18
    */
-  public static final MeasureLong GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD =
+  public static final MeasureLong GRPC_SERVER_RECEIVED_MESSAGES_PER_METHOD =
       Measure.MeasureLong.create(
-          "grpc.io/client/received_messages_per_method",
+          "grpc.io/server/received_messages_per_method",
           "Total messages received per method.",
           COUNT);
 
   /**
-   * {@link Measure} for gRPC client roundtrip latency in milliseconds.
+   * {@link Measure} for number of messages sent in each RPC.
    *
    * @since 0.13
    */
-  public static final MeasureDouble GRPC_CLIENT_ROUNDTRIP_LATENCY =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/roundtrip_latency",
-          "Time between first byte of request sent to last byte of response received, "
-              + "or terminal error.",
-          MILLISECOND);
+  public static final MeasureLong GRPC_SERVER_SENT_MESSAGES_PER_RPC =
+      Measure.MeasureLong.create(
+          "grpc.io/server/sent_messages_per_rpc", "Number of messages sent in each RPC", COUNT);
 
   /**
-   * {@link Measure} for number of messages sent in the RPC.
+   * {@link Measure} for number of messages received in each RPC.
    *
    * @since 0.13
    */
-  public static final MeasureLong GRPC_CLIENT_SENT_MESSAGES_PER_RPC =
+  public static final MeasureLong GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC =
       Measure.MeasureLong.create(
-          "grpc.io/client/sent_messages_per_rpc", "Number of messages sent in the RPC", COUNT);
-
-  /**
-   * {@link Measure} for number of response messages received per RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureLong GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC =
-      Measure.MeasureLong.create(
-          "grpc.io/client/received_messages_per_rpc",
-          "Number of response messages received per RPC",
+          "grpc.io/server/received_messages_per_rpc",
+          "Number of messages received in each RPC",
           COUNT);
 
   /**
@@ -333,22 +438,23 @@ public final class RpcMeasureConstants {
    *
    * @since 0.13
    */
-  public static final MeasureDouble GRPC_CLIENT_SERVER_LATENCY =
+  public static final MeasureDouble GRPC_SERVER_SERVER_LATENCY =
       Measure.MeasureDouble.create(
-          "grpc.io/client/server_latency", "Server latency in msecs", MILLISECOND);
+          "grpc.io/server/server_latency",
+          "Time between first byte of request received to last byte of response sent, "
+              + "or terminal error.",
+          MILLISECOND);
 
   /**
-   * {@link Measure} for total number of client RPCs ever opened, including those that have not
+   * {@link Measure} for total number of server RPCs ever opened, including those that have not
    * completed.
    *
    * @since 0.14
    */
-  public static final MeasureLong GRPC_CLIENT_STARTED_RPCS =
+  public static final MeasureLong GRPC_SERVER_STARTED_RPCS =
       Measure.MeasureLong.create(
-          "grpc.io/client/started_rpcs", "Number of started client RPCs.", COUNT);
-
-  // RPC server Measures.
-
+          "grpc.io/server/started_rpcs", "Number of started server RPCs.", COUNT);
+  
   /**
    * {@link Measure} for gRPC server error counts.
    *
@@ -469,111 +575,6 @@ public final class RpcMeasureConstants {
       Measure.MeasureLong.create(
           "grpc.io/server/response_count", "Number of server RPC response messages", COUNT);
 
-  /**
-   * {@link Measure} for total bytes sent across all response messages per RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureDouble GRPC_SERVER_SENT_BYTES_PER_RPC =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/sent_bytes_per_rpc",
-          "Total bytes sent across all response messages per RPC",
-          BYTE);
-
-  /**
-   * {@link Measure} for total bytes received across all messages per RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureDouble GRPC_SERVER_RECEIVED_BYTES_PER_RPC =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/received_bytes_per_rpc",
-          "Total bytes received across all messages per RPC",
-          BYTE);
-
-  /**
-   * {@link Measure} for total bytes sent per method, recorded real-time as bytes are sent.
-   *
-   * @since 0.18
-   */
-  public static final MeasureDouble GRPC_SERVER_SENT_BYTES_PER_METHOD =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/sent_bytes_per_method",
-          "Total bytes sent per method, recorded real-time as bytes are sent.",
-          BYTE);
-
-  /**
-   * {@link Measure} for total bytes received per method, recorded real-time as bytes are received.
-   *
-   * @since 0.18
-   */
-  public static final MeasureDouble GRPC_SERVER_RECEIVED_BYTES_PER_METHOD =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/received_bytes_per_method",
-          "Total bytes received per method, recorded real-time as bytes are received.",
-          BYTE);
-
-  /**
-   * {@link Measure} for total server sent messages.
-   *
-   * @since 0.18
-   */
-  public static final MeasureLong GRPC_SERVER_SENT_MESSAGES_PER_METHOD =
-      Measure.MeasureLong.create(
-          "grpc.io/server/sent_messages_per_method", "Total messages sent per method.", COUNT);
-
-  /**
-   * {@link Measure} for total server received messages.
-   *
-   * @since 0.18
-   */
-  public static final MeasureLong GRPC_SERVER_RECEIVED_MESSAGES_PER_METHOD =
-      Measure.MeasureLong.create(
-          "grpc.io/server/received_messages_per_method",
-          "Total messages received per method.",
-          COUNT);
-
-  /**
-   * {@link Measure} for number of messages sent in each RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureLong GRPC_SERVER_SENT_MESSAGES_PER_RPC =
-      Measure.MeasureLong.create(
-          "grpc.io/server/sent_messages_per_rpc", "Number of messages sent in each RPC", COUNT);
-
-  /**
-   * {@link Measure} for number of messages received in each RPC.
-   *
-   * @since 0.13
-   */
-  public static final MeasureLong GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC =
-      Measure.MeasureLong.create(
-          "grpc.io/server/received_messages_per_rpc",
-          "Number of messages received in each RPC",
-          COUNT);
-
-  /**
-   * {@link Measure} for gRPC server latency in milliseconds.
-   *
-   * @since 0.13
-   */
-  public static final MeasureDouble GRPC_SERVER_SERVER_LATENCY =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/server_latency",
-          "Time between first byte of request received to last byte of response sent, "
-              + "or terminal error.",
-          MILLISECOND);
-
-  /**
-   * {@link Measure} for total number of server RPCs ever opened, including those that have not
-   * completed.
-   *
-   * @since 0.14
-   */
-  public static final MeasureLong GRPC_SERVER_STARTED_RPCS =
-      Measure.MeasureLong.create(
-          "grpc.io/server/started_rpcs", "Number of started server RPCs.", COUNT);
 
   private RpcMeasureConstants() {}
 }

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -245,8 +245,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_CLIENT_REQUEST_BYTES =
-      Measure.MeasureDouble.create("grpc.io/client/request_bytes", "Request bytes", BYTE);
+  public static final MeasureDouble RPC_CLIENT_REQUEST_BYTES = GRPC_CLIENT_SENT_BYTES_PER_RPC;
 
   /**
    * {@link Measure} for gRPC client response bytes.
@@ -255,8 +254,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_CLIENT_RESPONSE_BYTES =
-      Measure.MeasureDouble.create("grpc.io/client/response_bytes", "Response bytes", BYTE);
+  public static final MeasureDouble RPC_CLIENT_RESPONSE_BYTES = GRPC_CLIENT_RECEIVED_BYTES_PER_RPC;
 
   /**
    * {@link Measure} for gRPC client roundtrip latency in milliseconds.
@@ -265,9 +263,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_CLIENT_ROUNDTRIP_LATENCY}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_CLIENT_ROUNDTRIP_LATENCY =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/roundtrip_latency", "RPC roundtrip latency msec", MILLISECOND);
+  public static final MeasureDouble RPC_CLIENT_ROUNDTRIP_LATENCY = GRPC_CLIENT_ROUNDTRIP_LATENCY;
 
   /**
    * {@link Measure} for gRPC client server elapsed time in milliseconds.
@@ -276,9 +272,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_CLIENT_SERVER_LATENCY}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_CLIENT_SERVER_ELAPSED_TIME =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/server_elapsed_time", "Server elapsed time in msecs", MILLISECOND);
+  public static final MeasureDouble RPC_CLIENT_SERVER_ELAPSED_TIME = GRPC_CLIENT_SERVER_LATENCY;
 
   /**
    * {@link Measure} for gRPC client uncompressed request bytes.
@@ -309,9 +303,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_CLIENT_STARTED_RPCS}.
    */
   @Deprecated
-  public static final MeasureLong RPC_CLIENT_STARTED_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/client/started_count", "Number of client RPCs (streams) started", COUNT);
+  public static final MeasureLong RPC_CLIENT_STARTED_COUNT = GRPC_CLIENT_STARTED_RPCS;
 
   /**
    * {@link Measure} for number of finished client RPCs.
@@ -332,9 +324,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_CLIENT_SENT_MESSAGES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureLong RPC_CLIENT_REQUEST_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/client/request_count", "Number of client RPC request messages", COUNT);
+  public static final MeasureLong RPC_CLIENT_REQUEST_COUNT = GRPC_CLIENT_SENT_MESSAGES_PER_RPC;
 
   /**
    * {@link Measure} for client RPC response message counts.
@@ -343,9 +333,7 @@ public final class RpcMeasureConstants {
    * @since 0.8
    */
   @Deprecated
-  public static final MeasureLong RPC_CLIENT_RESPONSE_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/client/response_count", "Number of client RPC response messages", COUNT);
+  public static final MeasureLong RPC_CLIENT_RESPONSE_COUNT = GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC;
 
   // RPC server Measures.
 
@@ -454,7 +442,7 @@ public final class RpcMeasureConstants {
   public static final MeasureLong GRPC_SERVER_STARTED_RPCS =
       Measure.MeasureLong.create(
           "grpc.io/server/started_rpcs", "Number of started server RPCs.", COUNT);
-  
+
   /**
    * {@link Measure} for gRPC server error counts.
    *
@@ -473,8 +461,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_SERVER_REQUEST_BYTES =
-      Measure.MeasureDouble.create("grpc.io/server/request_bytes", "Request bytes", BYTE);
+  public static final MeasureDouble RPC_SERVER_REQUEST_BYTES = GRPC_SERVER_RECEIVED_BYTES_PER_RPC;
 
   /**
    * {@link Measure} for gRPC server response bytes.
@@ -483,8 +470,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_SERVER_RESPONSE_BYTES =
-      Measure.MeasureDouble.create("grpc.io/server/response_bytes", "Response bytes", BYTE);
+  public static final MeasureDouble RPC_SERVER_RESPONSE_BYTES = GRPC_SERVER_SENT_BYTES_PER_RPC;
 
   /**
    * {@link Measure} for gRPC server elapsed time in milliseconds.
@@ -504,9 +490,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_SERVER_SERVER_LATENCY =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/server_latency", "Latency in msecs", MILLISECOND);
+  public static final MeasureDouble RPC_SERVER_SERVER_LATENCY = GRPC_SERVER_SERVER_LATENCY;
 
   /**
    * {@link Measure} for gRPC server uncompressed request bytes.
@@ -537,9 +521,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_SERVER_STARTED_RPCS}.
    */
   @Deprecated
-  public static final MeasureLong RPC_SERVER_STARTED_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/server/started_count", "Number of server RPCs (streams) started", COUNT);
+  public static final MeasureLong RPC_SERVER_STARTED_COUNT = GRPC_SERVER_STARTED_RPCS;
 
   /**
    * {@link Measure} for number of finished server RPCs.
@@ -560,9 +542,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureLong RPC_SERVER_REQUEST_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/server/request_count", "Number of server RPC request messages", COUNT);
+  public static final MeasureLong RPC_SERVER_REQUEST_COUNT = GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC;
 
   /**
    * {@link Measure} for server RPC response message counts.
@@ -571,10 +551,7 @@ public final class RpcMeasureConstants {
    * @deprecated in favor of {@link #GRPC_SERVER_SENT_MESSAGES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureLong RPC_SERVER_RESPONSE_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/server/response_count", "Number of server RPC response messages", COUNT);
-
+  public static final MeasureLong RPC_SERVER_RESPONSE_COUNT = GRPC_SERVER_SENT_MESSAGES_PER_RPC;
 
   private RpcMeasureConstants() {}
 }

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -127,7 +127,7 @@ public final class RpcViews {
           RpcViewConstants.RPC_SERVER_FINISHED_COUNT_HOUR_VIEW);
 
   @VisibleForTesting
-  static final ImmutableSet<View> RPC_REAL_TIME_METRICS_VIEWS_SET =
+  static final ImmutableSet<View> GRPC_REAL_TIME_METRICS_VIEWS_SET =
       ImmutableSet.of(
           RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD_VIEW,
           RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD_VIEW,
@@ -142,17 +142,13 @@ public final class RpcViews {
   static final ImmutableSet<View> GRPC_CLIENT_BASIC_VIEWS_SET =
       ImmutableSet.of(
           RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW,
-          RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW,
-          RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW,
-          RpcViewConstants.RPC_CLIENT_STARTED_COUNT_CUMULATIVE_VIEW);
+          RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW);
 
   @VisibleForTesting
   static final ImmutableSet<View> GRPC_SERVER_BASIC_VIEWS_SET =
       ImmutableSet.of(
           RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW,
-          RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW,
-          RpcViewConstants.RPC_SERVER_SERVER_LATENCY_VIEW,
-          RpcViewConstants.RPC_SERVER_STARTED_COUNT_CUMULATIVE_VIEW);
+          RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW);
 
   /**
    * Registers all standard gRPC views.
@@ -341,7 +337,7 @@ public final class RpcViews {
 
   @VisibleForTesting
   static void registerRealTimeMetricsViews(ViewManager viewManager) {
-    for (View view : RPC_REAL_TIME_METRICS_VIEWS_SET) {
+    for (View view : GRPC_REAL_TIME_METRICS_VIEWS_SET) {
       viewManager.registerView(view);
     }
   }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
@@ -124,7 +124,7 @@ public class RpcViewsTest {
     FakeViewManager fakeViewManager = new FakeViewManager();
     RpcViews.registerRealTimeMetricsViews(fakeViewManager);
     assertThat(fakeViewManager.getRegisteredViews())
-        .containsExactlyElementsIn(RpcViews.RPC_REAL_TIME_METRICS_VIEWS_SET);
+        .containsExactlyElementsIn(RpcViews.GRPC_REAL_TIME_METRICS_VIEWS_SET);
   }
 
   // TODO(bdrutu): Test with reflection that all defined gRPC views are registered.


### PR DESCRIPTION
Intentionally split this into 2 commits to make it easy to see the changes, first commit just moves the code of deprecated measures after the new measures, second commit actually does the main change.

This fixes an issue with registerAllGrpcBasicViews because we had 2 measures (rountrip_latency) with different descriptions and this will fail here https://github.com/census-instrumentation/opencensus-java/blob/master/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java#L115

This is a breaking change in regard to the measure name/description for the old measures, but nobody should depend on that.