### PR TITLE
 Deprecated measures use instance of new measures when 1to1 mapping. …

### DIFF
--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -113,126 +113,6 @@ public final class RpcMeasureConstants {
   // RPC client Measures.
 
   /**
-   * {@link Measure} for gRPC client error counts.
-   *
-   * @since 0.8
-   * @deprecated because error counts can be computed on your metrics backend by totalling the
-   *     different per-status values.
-   */
-  @Deprecated
-  public static final MeasureLong RPC_CLIENT_ERROR_COUNT =
-      Measure.MeasureLong.create("grpc.io/client/error_count", "RPC Errors", COUNT);
-
-  /**
-   * {@link Measure} for gRPC client request bytes.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC}.
-   */
-  @Deprecated
-  public static final MeasureDouble RPC_CLIENT_REQUEST_BYTES =
-      Measure.MeasureDouble.create("grpc.io/client/request_bytes", "Request bytes", BYTE);
-
-  /**
-   * {@link Measure} for gRPC client response bytes.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC}.
-   */
-  @Deprecated
-  public static final MeasureDouble RPC_CLIENT_RESPONSE_BYTES =
-      Measure.MeasureDouble.create("grpc.io/client/response_bytes", "Response bytes", BYTE);
-
-  /**
-   * {@link Measure} for gRPC client roundtrip latency in milliseconds.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_ROUNDTRIP_LATENCY}.
-   */
-  @Deprecated
-  public static final MeasureDouble RPC_CLIENT_ROUNDTRIP_LATENCY =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/roundtrip_latency", "RPC roundtrip latency msec", MILLISECOND);
-
-  /**
-   * {@link Measure} for gRPC client server elapsed time in milliseconds.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_SERVER_LATENCY}.
-   */
-  @Deprecated
-  public static final MeasureDouble RPC_CLIENT_SERVER_ELAPSED_TIME =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/server_elapsed_time", "Server elapsed time in msecs", MILLISECOND);
-
-  /**
-   * {@link Measure} for gRPC client uncompressed request bytes.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC}.
-   */
-  @Deprecated
-  public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/uncompressed_request_bytes", "Uncompressed Request bytes", BYTE);
-
-  /**
-   * {@link Measure} for gRPC client uncompressed response bytes.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC}.
-   */
-  @Deprecated
-  public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES =
-      Measure.MeasureDouble.create(
-          "grpc.io/client/uncompressed_response_bytes", "Uncompressed Response bytes", BYTE);
-
-  /**
-   * {@link Measure} for number of started client RPCs.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_STARTED_RPCS}.
-   */
-  @Deprecated
-  public static final MeasureLong RPC_CLIENT_STARTED_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/client/started_count", "Number of client RPCs (streams) started", COUNT);
-
-  /**
-   * {@link Measure} for number of finished client RPCs.
-   *
-   * @since 0.8
-   * @deprecated since finished count can be inferred with a {@code Count} aggregation on {@link
-   *     #GRPC_CLIENT_SERVER_LATENCY}.
-   */
-  @Deprecated
-  public static final MeasureLong RPC_CLIENT_FINISHED_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/client/finished_count", "Number of client RPCs (streams) finished", COUNT);
-
-  /**
-   * {@link Measure} for client RPC request message counts.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_MESSAGES_PER_RPC}.
-   */
-  @Deprecated
-  public static final MeasureLong RPC_CLIENT_REQUEST_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/client/request_count", "Number of client RPC request messages", COUNT);
-
-  /**
-   * {@link Measure} for client RPC response message counts.
-   *
-   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC}.
-   * @since 0.8
-   */
-  @Deprecated
-  public static final MeasureLong RPC_CLIENT_RESPONSE_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/client/response_count", "Number of client RPC response messages", COUNT);
-
-  /**
    * {@link Measure} for total bytes sent across all request messages per RPC.
    *
    * @since 0.13
@@ -347,127 +227,114 @@ public final class RpcMeasureConstants {
       Measure.MeasureLong.create(
           "grpc.io/client/started_rpcs", "Number of started client RPCs.", COUNT);
 
-  // RPC server Measures.
-
   /**
-   * {@link Measure} for gRPC server error counts.
+   * {@link Measure} for gRPC client error counts.
    *
    * @since 0.8
    * @deprecated because error counts can be computed on your metrics backend by totalling the
    *     different per-status values.
    */
   @Deprecated
-  public static final MeasureLong RPC_SERVER_ERROR_COUNT =
-      Measure.MeasureLong.create("grpc.io/server/error_count", "RPC Errors", COUNT);
+  public static final MeasureLong RPC_CLIENT_ERROR_COUNT =
+      Measure.MeasureLong.create("grpc.io/client/error_count", "RPC Errors", COUNT);
 
   /**
-   * {@link Measure} for gRPC server request bytes.
+   * {@link Measure} for gRPC client request bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_SERVER_REQUEST_BYTES =
-      Measure.MeasureDouble.create("grpc.io/server/request_bytes", "Request bytes", BYTE);
+  public static final MeasureDouble RPC_CLIENT_REQUEST_BYTES = GRPC_CLIENT_SENT_BYTES_PER_RPC;
 
   /**
-   * {@link Measure} for gRPC server response bytes.
+   * {@link Measure} for gRPC client response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_SERVER_RESPONSE_BYTES =
-      Measure.MeasureDouble.create("grpc.io/server/response_bytes", "Response bytes", BYTE);
+  public static final MeasureDouble RPC_CLIENT_RESPONSE_BYTES = GRPC_CLIENT_RECEIVED_BYTES_PER_RPC;
 
   /**
-   * {@link Measure} for gRPC server elapsed time in milliseconds.
+   * {@link Measure} for gRPC client roundtrip latency in milliseconds.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_ROUNDTRIP_LATENCY}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_SERVER_SERVER_ELAPSED_TIME =
+  public static final MeasureDouble RPC_CLIENT_ROUNDTRIP_LATENCY = GRPC_CLIENT_ROUNDTRIP_LATENCY;
+
+  /**
+   * {@link Measure} for gRPC client server elapsed time in milliseconds.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_SERVER_LATENCY}.
+   */
+  @Deprecated
+  public static final MeasureDouble RPC_CLIENT_SERVER_ELAPSED_TIME = GRPC_CLIENT_SERVER_LATENCY;
+
+  /**
+   * {@link Measure} for gRPC client uncompressed request bytes.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_BYTES_PER_RPC}.
+   */
+  @Deprecated
+  public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_REQUEST_BYTES =
       Measure.MeasureDouble.create(
-          "grpc.io/server/server_elapsed_time", "Server elapsed time in msecs", MILLISECOND);
+          "grpc.io/client/uncompressed_request_bytes", "Uncompressed Request bytes", BYTE);
 
   /**
-   * {@link Measure} for gRPC server latency in milliseconds.
+   * {@link Measure} for gRPC client uncompressed response bytes.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_BYTES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureDouble RPC_SERVER_SERVER_LATENCY =
+  public static final MeasureDouble RPC_CLIENT_UNCOMPRESSED_RESPONSE_BYTES =
       Measure.MeasureDouble.create(
-          "grpc.io/server/server_latency", "Latency in msecs", MILLISECOND);
+          "grpc.io/client/uncompressed_response_bytes", "Uncompressed Response bytes", BYTE);
 
   /**
-   * {@link Measure} for gRPC server uncompressed request bytes.
+   * {@link Measure} for number of started client RPCs.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_STARTED_RPCS}.
    */
-  @Deprecated
-  public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/uncompressed_request_bytes", "Uncompressed Request bytes", BYTE);
+  @Deprecated public static final MeasureLong RPC_CLIENT_STARTED_COUNT = GRPC_CLIENT_STARTED_RPCS;
 
   /**
-   * {@link Measure} for gRPC server uncompressed response bytes.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC}.
-   */
-  @Deprecated
-  public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES =
-      Measure.MeasureDouble.create(
-          "grpc.io/server/uncompressed_response_bytes", "Uncompressed Response bytes", BYTE);
-
-  /**
-   * {@link Measure} for number of started server RPCs.
-   *
-   * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_STARTED_RPCS}.
-   */
-  @Deprecated
-  public static final MeasureLong RPC_SERVER_STARTED_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/server/started_count", "Number of server RPCs (streams) started", COUNT);
-
-  /**
-   * {@link Measure} for number of finished server RPCs.
+   * {@link Measure} for number of finished client RPCs.
    *
    * @since 0.8
    * @deprecated since finished count can be inferred with a {@code Count} aggregation on {@link
-   *     #GRPC_SERVER_SERVER_LATENCY}.
+   *     #GRPC_CLIENT_SERVER_LATENCY}.
    */
   @Deprecated
-  public static final MeasureLong RPC_SERVER_FINISHED_COUNT =
+  public static final MeasureLong RPC_CLIENT_FINISHED_COUNT =
       Measure.MeasureLong.create(
-          "grpc.io/server/finished_count", "Number of server RPCs (streams) finished", COUNT);
+          "grpc.io/client/finished_count", "Number of client RPCs (streams) finished", COUNT);
 
   /**
-   * {@link Measure} for server RPC request message counts.
+   * {@link Measure} for client RPC request message counts.
    *
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC}.
+   * @deprecated in favor of {@link #GRPC_CLIENT_SENT_MESSAGES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureLong RPC_SERVER_REQUEST_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/server/request_count", "Number of server RPC request messages", COUNT);
+  public static final MeasureLong RPC_CLIENT_REQUEST_COUNT = GRPC_CLIENT_SENT_MESSAGES_PER_RPC;
 
   /**
-   * {@link Measure} for server RPC response message counts.
+   * {@link Measure} for client RPC response message counts.
    *
+   * @deprecated in favor of {@link #GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC}.
    * @since 0.8
-   * @deprecated in favor of {@link #GRPC_SERVER_SENT_MESSAGES_PER_RPC}.
    */
   @Deprecated
-  public static final MeasureLong RPC_SERVER_RESPONSE_COUNT =
-      Measure.MeasureLong.create(
-          "grpc.io/server/response_count", "Number of server RPC response messages", COUNT);
+  public static final MeasureLong RPC_CLIENT_RESPONSE_COUNT = GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC;
+
+  // RPC server Measures.
 
   /**
    * {@link Measure} for total bytes sent across all response messages per RPC.
@@ -574,6 +441,115 @@ public final class RpcMeasureConstants {
   public static final MeasureLong GRPC_SERVER_STARTED_RPCS =
       Measure.MeasureLong.create(
           "grpc.io/server/started_rpcs", "Number of started server RPCs.", COUNT);
+
+  /**
+   * {@link Measure} for gRPC server error counts.
+   *
+   * @since 0.8
+   * @deprecated because error counts can be computed on your metrics backend by totalling the
+   *     different per-status values.
+   */
+  @Deprecated
+  public static final MeasureLong RPC_SERVER_ERROR_COUNT =
+      Measure.MeasureLong.create("grpc.io/server/error_count", "RPC Errors", COUNT);
+
+  /**
+   * {@link Measure} for gRPC server request bytes.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC}.
+   */
+  @Deprecated
+  public static final MeasureDouble RPC_SERVER_REQUEST_BYTES = GRPC_SERVER_RECEIVED_BYTES_PER_RPC;
+
+  /**
+   * {@link Measure} for gRPC server response bytes.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC}.
+   */
+  @Deprecated
+  public static final MeasureDouble RPC_SERVER_RESPONSE_BYTES = GRPC_SERVER_SENT_BYTES_PER_RPC;
+
+  /**
+   * {@link Measure} for gRPC server elapsed time in milliseconds.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY}.
+   */
+  @Deprecated
+  public static final MeasureDouble RPC_SERVER_SERVER_ELAPSED_TIME =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/server_elapsed_time", "Server elapsed time in msecs", MILLISECOND);
+
+  /**
+   * {@link Measure} for gRPC server latency in milliseconds.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SERVER_LATENCY}.
+   */
+  @Deprecated
+  public static final MeasureDouble RPC_SERVER_SERVER_LATENCY = GRPC_SERVER_SERVER_LATENCY;
+
+  /**
+   * {@link Measure} for gRPC server uncompressed request bytes.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_BYTES_PER_RPC}.
+   */
+  @Deprecated
+  public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_REQUEST_BYTES =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/uncompressed_request_bytes", "Uncompressed Request bytes", BYTE);
+
+  /**
+   * {@link Measure} for gRPC server uncompressed response bytes.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_BYTES_PER_RPC}.
+   */
+  @Deprecated
+  public static final MeasureDouble RPC_SERVER_UNCOMPRESSED_RESPONSE_BYTES =
+      Measure.MeasureDouble.create(
+          "grpc.io/server/uncompressed_response_bytes", "Uncompressed Response bytes", BYTE);
+
+  /**
+   * {@link Measure} for number of started server RPCs.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_STARTED_RPCS}.
+   */
+  @Deprecated public static final MeasureLong RPC_SERVER_STARTED_COUNT = GRPC_SERVER_STARTED_RPCS;
+
+  /**
+   * {@link Measure} for number of finished server RPCs.
+   *
+   * @since 0.8
+   * @deprecated since finished count can be inferred with a {@code Count} aggregation on {@link
+   *     #GRPC_SERVER_SERVER_LATENCY}.
+   */
+  @Deprecated
+  public static final MeasureLong RPC_SERVER_FINISHED_COUNT =
+      Measure.MeasureLong.create(
+          "grpc.io/server/finished_count", "Number of server RPCs (streams) finished", COUNT);
+
+  /**
+   * {@link Measure} for server RPC request message counts.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC}.
+   */
+  @Deprecated
+  public static final MeasureLong RPC_SERVER_REQUEST_COUNT = GRPC_SERVER_RECEIVED_MESSAGES_PER_RPC;
+
+  /**
+   * {@link Measure} for server RPC response message counts.
+   *
+   * @since 0.8
+   * @deprecated in favor of {@link #GRPC_SERVER_SENT_MESSAGES_PER_RPC}.
+   */
+  @Deprecated
+  public static final MeasureLong RPC_SERVER_RESPONSE_COUNT = GRPC_SERVER_SENT_MESSAGES_PER_RPC;
 
   private RpcMeasureConstants() {}
 }

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -127,7 +127,7 @@ public final class RpcViews {
           RpcViewConstants.RPC_SERVER_FINISHED_COUNT_HOUR_VIEW);
 
   @VisibleForTesting
-  static final ImmutableSet<View> RPC_REAL_TIME_METRICS_VIEWS_SET =
+  static final ImmutableSet<View> GRPC_REAL_TIME_METRICS_VIEWS_SET =
       ImmutableSet.of(
           RpcViewConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD_VIEW,
           RpcViewConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_METHOD_VIEW,
@@ -142,17 +142,13 @@ public final class RpcViews {
   static final ImmutableSet<View> GRPC_CLIENT_BASIC_VIEWS_SET =
       ImmutableSet.of(
           RpcViewConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY_VIEW,
-          RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW,
-          RpcViewConstants.RPC_CLIENT_ROUNDTRIP_LATENCY_VIEW,
-          RpcViewConstants.RPC_CLIENT_STARTED_COUNT_CUMULATIVE_VIEW);
+          RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW);
 
   @VisibleForTesting
   static final ImmutableSet<View> GRPC_SERVER_BASIC_VIEWS_SET =
       ImmutableSet.of(
           RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW,
-          RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW,
-          RpcViewConstants.RPC_SERVER_SERVER_LATENCY_VIEW,
-          RpcViewConstants.RPC_SERVER_STARTED_COUNT_CUMULATIVE_VIEW);
+          RpcViewConstants.GRPC_SERVER_STARTED_RPC_VIEW);
 
   /**
    * Registers all standard gRPC views.
@@ -341,7 +337,7 @@ public final class RpcViews {
 
   @VisibleForTesting
   static void registerRealTimeMetricsViews(ViewManager viewManager) {
-    for (View view : RPC_REAL_TIME_METRICS_VIEWS_SET) {
+    for (View view : GRPC_REAL_TIME_METRICS_VIEWS_SET) {
       viewManager.registerView(view);
     }
   }

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
@@ -124,7 +124,7 @@ public class RpcViewsTest {
     FakeViewManager fakeViewManager = new FakeViewManager();
     RpcViews.registerRealTimeMetricsViews(fakeViewManager);
     assertThat(fakeViewManager.getRegisteredViews())
-        .containsExactlyElementsIn(RpcViews.RPC_REAL_TIME_METRICS_VIEWS_SET);
+        .containsExactlyElementsIn(RpcViews.GRPC_REAL_TIME_METRICS_VIEWS_SET);
   }
 
   // TODO(bdrutu): Test with reflection that all defined gRPC views are registered.


### PR DESCRIPTION
…(#1738)

* Move deprecated measures after non-deprecated once.

* Deprecated measures use instance of new measures when 1to1 mapping.

* Run java format.

* Remove installation of the old views in grpc basic view.

* Fix RpcViewTests.

(cherry picked from commit 5d85e9ed3214152d1f57088664545b8a7dec7622)