### PR TITLE
Change Stackdriver trace to use Resource.

### DIFF
--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -175,6 +175,7 @@ General guidelines on imports:
   <subpackage name="exporter">
     <allow pkg="com.google.common"/>
     <allow pkg="io.opencensus.common"/>
+    <allow pkg="io.opencensus.resource"/>
     <subpackage name="metrics">
       <subpackage name="ocagent">
         <allow pkg="com.google.protobuf"/>
@@ -184,7 +185,6 @@ General guidelines on imports:
         <allow pkg="io.opencensus.exporter.metrics.ocagent"/>
         <allow pkg="io.opencensus.metrics"/>
         <allow pkg="io.opencensus.proto"/>
-        <allow pkg="io.opencensus.resource"/>
       </subpackage>
       <subpackage name="util">
         <allow pkg="io.opencensus.exporter.metrics.util"/>
@@ -210,7 +210,6 @@ General guidelines on imports:
         <allow pkg="io.opencensus.exporter.stats.stackdriver"/>
         <allow pkg="io.opencensus.trace"/>
         <allow pkg="io.opencensus.contrib.monitoredresource.util"/>
-        <allow pkg="io.opencensus.resource"/>
       </subpackage>
     </subpackage>
     <subpackage name="trace">


### PR DESCRIPTION
This PR also changes a bit the name of the resources that we export to stackdriver traces, by simplifying the name: `"g.co/r/" + resourceKey` where the `resourceKey` is the key that we used in our resource definitions.

For AWS:
g.co/r/aws.com/ec2/account_id
g.co/r/aws.com/ec2/instance_id
g.co/r/aws.com/ec2/region

For GCE:
g.co/r/cloud.google.com/gce/project_id
g.co/r/cloud.google.com/gce/instance_id
g.co/r/cloud.google.com/gce/zone

For k8s:
g.co/r/k8s.io/cluster/name
g.co/r/k8s.io/namespace/name
g.co/r/k8s.io/pod/name
g.co/r/k8s.io/container/name