### PR TITLE
Fix jetty https

### DIFF
--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -99,6 +99,7 @@ General guidelines on imports:
       <allow pkg="io.opencensus.contrib.http.util"/>
       <allow pkg="io.opencensus.trace"/>
       <allow pkg="org.eclipse.jetty.client"/>
+      <allow pkg="org.eclipse.jetty.util.ssl"/>
     </subpackage>
     <subpackage name="http.servlet">
       <allow pkg="io.opencensus.contrib.http"/>

--- a/contrib/http_jetty_client/src/main/java/io/opencensus/contrib/http/jetty/client/OcJettyHttpClient.java
+++ b/contrib/http_jetty_client/src/main/java/io/opencensus/contrib/http/jetty/client/OcJettyHttpClient.java
@@ -27,8 +27,10 @@ import io.opencensus.trace.propagation.TextFormat.Setter;
 import java.net.URI;
 import javax.annotation.Nullable;
 import org.eclipse.jetty.client.HttpClient;
+import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.api.Request;
 import org.eclipse.jetty.client.api.Response;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 /**
  * This class is a wrapper to {@link HttpClient}. It enables tracing for all {@link Request} created
@@ -56,8 +58,10 @@ public final class OcJettyHttpClient extends HttpClient {
   }
 
   /**
-   * Create a new {@code OcJettyHttpClient} with given extractor and propagator.
+   * Create a new {@code OcJettyHttpClient} with support for HTTPS, extractor and propagator.
    *
+   * @param transport {@link HttpClientTransport} The transport implementation.
+   * @param sslContextFactory {@link SslContextFactory} Used to configure SSL connectors.
    * @param extractor {@link HttpExtractor} to extract request and response specific attributes. If
    *     it is null then default extractor is used.
    * @param propagator {@link TextFormat} to propagate trace context to remote peer. If it is null
@@ -65,8 +69,11 @@ public final class OcJettyHttpClient extends HttpClient {
    * @since 0.20
    */
   public OcJettyHttpClient(
-      @Nullable HttpExtractor<Request, Response> extractor, @Nullable TextFormat propagator) {
-    super();
+      HttpClientTransport transport,
+      SslContextFactory sslContextFactory,
+      @Nullable HttpExtractor<Request, Response> extractor,
+      @Nullable TextFormat propagator) {
+    super(transport, sslContextFactory);
     handler = buildHandler(extractor, propagator);
   }
 

--- a/contrib/http_jetty_client/src/test/java/io/opencensus/contrib/http/jetty/client/OcJettyHttpClientTest.java
+++ b/contrib/http_jetty_client/src/test/java/io/opencensus/contrib/http/jetty/client/OcJettyHttpClientTest.java
@@ -48,20 +48,24 @@ public class OcJettyHttpClientTest {
   public void testOcJettyHttpClientNonDefault() {
     OcJettyHttpClient defaultClient =
         new OcJettyHttpClient(
-            new OcJettyHttpClientExtractor(), Tracing.getPropagationComponent().getB3Format());
+            null,
+            null,
+            new OcJettyHttpClientExtractor(),
+            Tracing.getPropagationComponent().getB3Format());
     assertThat(defaultClient.handler).isNotNull();
   }
 
   @Test
   public void testOcJettyHttpClientNullExtractor() {
     OcJettyHttpClient defaultClient =
-        new OcJettyHttpClient(null, Tracing.getPropagationComponent().getB3Format());
+        new OcJettyHttpClient(null, null, null, Tracing.getPropagationComponent().getB3Format());
     assertThat(defaultClient.handler).isNotNull();
   }
 
   @Test
   public void testOcJettyHttpClientNullPropagator() {
-    OcJettyHttpClient defaultClient = new OcJettyHttpClient(new OcJettyHttpClientExtractor(), null);
+    OcJettyHttpClient defaultClient =
+        new OcJettyHttpClient(null, null, new OcJettyHttpClientExtractor(), null);
     assertThat(defaultClient.handler).isNotNull();
   }
 

--- a/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
+++ b/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
@@ -68,10 +68,6 @@ public class HelloWorldClient {
     initTracing();
     initStatsExporter();
 
-    // For HTTPS URLs, uncomment the lines below using the SslContextFactory
-    // HttpClientTransport transport = new HttpClientTransportOverHTTP();
-    // SslContextFactory sslCf = new SslContextFactory();
-    // OcJettyHttpClient httpClient = new OcJettyHttpClient(transport, sslCf, null, null);
     OcJettyHttpClient httpClient = new OcJettyHttpClient();
 
     httpClient.start();

--- a/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
+++ b/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
@@ -29,12 +29,9 @@ import java.io.IOException;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
-import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.HttpRequest;
-import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
-import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 /** Sample application that shows how to instrument jetty client. */
 public class HelloWorldClient {
@@ -71,9 +68,11 @@ public class HelloWorldClient {
     initTracing();
     initStatsExporter();
 
-    HttpClientTransport transport = new HttpClientTransportOverHTTP();
-    SslContextFactory sslCf = new SslContextFactory();
-    OcJettyHttpClient httpClient = new OcJettyHttpClient(transport, sslCf, null, null);
+    // For HTTPS URLs, uncomment the lines below using the SslContextFactory
+    // HttpClientTransport transport = new HttpClientTransportOverHTTP();
+    // SslContextFactory sslCf = new SslContextFactory();
+    // OcJettyHttpClient httpClient = new OcJettyHttpClient(transport, sslCf, null, null);
+    OcJettyHttpClient httpClient = new OcJettyHttpClient();
 
     httpClient.start();
 

--- a/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
+++ b/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
@@ -29,9 +29,12 @@ import java.io.IOException;
 import org.apache.log4j.BasicConfigurator;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
+import org.eclipse.jetty.client.HttpClientTransport;
 import org.eclipse.jetty.client.HttpRequest;
+import org.eclipse.jetty.client.http.HttpClientTransportOverHTTP;
 import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
+import org.eclipse.jetty.util.ssl.SslContextFactory;
 
 /** Sample application that shows how to instrument jetty client. */
 public class HelloWorldClient {
@@ -68,7 +71,9 @@ public class HelloWorldClient {
     initTracing();
     initStatsExporter();
 
-    OcJettyHttpClient httpClient = new OcJettyHttpClient();
+    HttpClientTransport transport = new HttpClientTransportOverHTTP();
+    SslContextFactory sslCf = new SslContextFactory();
+    OcJettyHttpClient httpClient = new OcJettyHttpClient(transport, sslCf, null, null);
 
     httpClient.start();
 


### PR DESCRIPTION
Added options to OcJettyHttpClient constructor address issues/1756 [OcJettyHttpClient doesn't work with HTTPS](https://github.com/census-instrumentation/opencensus-java/issues/1756)

