### PR TITLE
Exporter/OcAgent: Support TLS credentials.

### DIFF
--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -186,6 +186,7 @@ General guidelines on imports:
       <subpackage name="ocagent">
         <allow pkg="com.google.protobuf"/>
         <allow pkg="io.grpc"/>
+        <allow pkg="io.netty.handler.ssl"/>
         <allow pkg="io.opencensus.contrib.opencensus.proto.util"/>
         <allow pkg="io.opencensus.contrib.resource.util"/>
         <allow pkg="io.opencensus.exporter.metrics.ocagent"/>
@@ -231,6 +232,7 @@ General guidelines on imports:
       <subpackage name="ocagent">
         <allow pkg="com.google.protobuf"/>
         <allow pkg="io.grpc"/>
+        <allow pkg="io.netty.handler.ssl"/>
         <allow pkg="io.opencensus.contrib.resource.util"/>
         <allow pkg="io.opencensus.contrib.opencensus.proto.util"/>
         <allow pkg="io.opencensus.exporter.trace.ocagent"/>

--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporter.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporter.java
@@ -20,6 +20,7 @@ import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkState;
 
+import io.netty.handler.ssl.SslContext;
 import io.opencensus.common.Duration;
 import io.opencensus.metrics.Metrics;
 import io.opencensus.metrics.export.MetricProducerManager;
@@ -71,6 +72,7 @@ public final class OcAgentMetricsExporter {
     createInternal(
         configuration.getEndPoint(),
         configuration.getUseInsecure(),
+        configuration.getSslContext(),
         configuration.getServiceName(),
         configuration.getExportInterval(),
         configuration.getRetryInterval());
@@ -79,6 +81,7 @@ public final class OcAgentMetricsExporter {
   private static void createInternal(
       @Nullable String endPoint,
       @Nullable Boolean useInsecure,
+      @Nullable SslContext sslContext,
       @Nullable String serviceName,
       @Nullable Duration exportInterval,
       @Nullable Duration retryInterval) {
@@ -88,6 +91,8 @@ public final class OcAgentMetricsExporter {
     if (useInsecure == null) {
       useInsecure = false;
     }
+    checkArgument(
+        useInsecure == (sslContext == null), "Either use insecure or provide a valid SslContext.");
     if (serviceName == null || serviceName.isEmpty()) {
       serviceName = DEFAULT_SERVICE_NAME;
     }
@@ -103,6 +108,7 @@ public final class OcAgentMetricsExporter {
           new OcAgentMetricsExporter(
               endPoint,
               useInsecure,
+              sslContext,
               serviceName,
               exportInterval,
               retryInterval,
@@ -114,6 +120,7 @@ public final class OcAgentMetricsExporter {
   private OcAgentMetricsExporter(
       String endPoint,
       Boolean useInsecure,
+      @Nullable SslContext sslContext,
       String serviceName,
       Duration exportInterval,
       Duration retryInterval,
@@ -124,6 +131,7 @@ public final class OcAgentMetricsExporter {
         new OcAgentMetricsExporterWorker(
             endPoint,
             useInsecure,
+            sslContext,
             exportInterval,
             retryInterval,
             serviceName,

--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporterConfiguration.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporterConfiguration.java
@@ -17,6 +17,7 @@
 package io.opencensus.exporter.metrics.ocagent;
 
 import com.google.auto.value.AutoValue;
+import io.netty.handler.ssl.SslContext;
 import io.opencensus.common.Duration;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -49,6 +50,15 @@ public abstract class OcAgentMetricsExporterConfiguration {
    */
   @Nullable
   public abstract Boolean getUseInsecure();
+
+  /**
+   * Returns the {@link SslContext} for secure TLS gRPC connection.
+   *
+   * @return the {@code SslContext}.
+   * @since 0.20
+   */
+  @Nullable
+  public abstract SslContext getSslContext();
 
   /**
    * Returns the service name to be used for the {@code OcAgentMetricsExporter}.
@@ -84,7 +94,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
    * @since 0.19
    */
   public static Builder builder() {
-    return new AutoValue_OcAgentMetricsExporterConfiguration.Builder();
+    return new AutoValue_OcAgentMetricsExporterConfiguration.Builder().setUseInsecure(true);
   }
 
   /**
@@ -115,6 +125,15 @@ public abstract class OcAgentMetricsExporterConfiguration {
      * @since 0.19
      */
     public abstract Builder setUseInsecure(Boolean useInsecure);
+
+    /**
+     * Sets the {@link SslContext} for secure TLS gRPC connection.
+     *
+     * @param sslContext the {@code SslContext}.
+     * @return this.
+     * @since 0.20
+     */
+    public abstract Builder setSslContext(SslContext sslContext);
 
     /**
      * Sets the service name to be used for the {@code OcAgentMetricsExporter}.

--- a/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporterConfigurationTest.java
+++ b/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporterConfigurationTest.java
@@ -18,7 +18,10 @@ package io.opencensus.exporter.metrics.ocagent;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.opencensus.common.Duration;
+import javax.net.ssl.SSLException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,26 +36,30 @@ public class OcAgentMetricsExporterConfigurationTest {
         OcAgentMetricsExporterConfiguration.builder().build();
     assertThat(configuration.getEndPoint()).isNull();
     assertThat(configuration.getServiceName()).isNull();
-    assertThat(configuration.getUseInsecure()).isNull();
+    assertThat(configuration.getUseInsecure()).isTrue();
+    assertThat(configuration.getSslContext()).isNull();
     assertThat(configuration.getRetryInterval()).isNull();
     assertThat(configuration.getExportInterval()).isNull();
   }
 
   @Test
-  public void setAndGet() {
+  public void setAndGet() throws SSLException {
     Duration oneMinute = Duration.create(60, 0);
     Duration fiveMinutes = Duration.create(300, 0);
+    SslContext sslContext = SslContextBuilder.forClient().build();
     OcAgentMetricsExporterConfiguration configuration =
         OcAgentMetricsExporterConfiguration.builder()
             .setEndPoint("192.168.0.1:50051")
             .setServiceName("service")
-            .setUseInsecure(true)
+            .setUseInsecure(false)
+            .setSslContext(sslContext)
             .setRetryInterval(fiveMinutes)
             .setExportInterval(oneMinute)
             .build();
     assertThat(configuration.getEndPoint()).isEqualTo("192.168.0.1:50051");
     assertThat(configuration.getServiceName()).isEqualTo("service");
-    assertThat(configuration.getUseInsecure()).isTrue();
+    assertThat(configuration.getUseInsecure()).isFalse();
+    assertThat(configuration.getSslContext()).isEqualTo(sslContext);
     assertThat(configuration.getRetryInterval()).isEqualTo(fiveMinutes);
     assertThat(configuration.getExportInterval()).isEqualTo(oneMinute);
   }

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporter.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporter.java
@@ -81,6 +81,7 @@ public final class OcAgentTraceExporter {
               configuration.getEndPoint(),
               configuration.getServiceName(),
               configuration.getUseInsecure(),
+              configuration.getSslContext(),
               configuration.getRetryInterval(),
               configuration.getEnableConfig());
       registerInternal(newHandler);

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfiguration.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfiguration.java
@@ -17,6 +17,7 @@
 package io.opencensus.exporter.trace.ocagent;
 
 import com.google.auto.value.AutoValue;
+import io.netty.handler.ssl.SslContext;
 import io.opencensus.common.Duration;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
@@ -51,6 +52,15 @@ public abstract class OcAgentTraceExporterConfiguration {
   public abstract Boolean getUseInsecure();
 
   /**
+   * Returns the {@link SslContext} for secure TLS gRPC connection.
+   *
+   * @return the {@code SslContext}.
+   * @since 0.20
+   */
+  @Nullable
+  public abstract SslContext getSslContext();
+
+  /**
    * Returns the service name to be used for this {@link OcAgentTraceExporter}.
    *
    * @return the service name.
@@ -83,7 +93,9 @@ public abstract class OcAgentTraceExporterConfiguration {
    * @since 0.19
    */
   public static Builder builder() {
-    return new AutoValue_OcAgentTraceExporterConfiguration.Builder().setEnableConfig(true);
+    return new AutoValue_OcAgentTraceExporterConfiguration.Builder()
+        .setEnableConfig(true)
+        .setUseInsecure(true);
   }
 
   /**
@@ -114,6 +126,15 @@ public abstract class OcAgentTraceExporterConfiguration {
      * @since 0.19
      */
     public abstract Builder setUseInsecure(Boolean useInsecure);
+
+    /**
+     * Sets the {@link SslContext} for secure TLS gRPC connection.
+     *
+     * @param sslContext the {@code SslContext}.
+     * @return this.
+     * @since 0.20
+     */
+    public abstract Builder setSslContext(SslContext sslContext);
 
     /**
      * Sets the service name to be used for this {@link OcAgentTraceExporter}.

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterHandler.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterHandler.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.exporter.trace.ocagent;
 
+import io.netty.handler.ssl.SslContext;
 import io.opencensus.common.Duration;
 import io.opencensus.trace.export.SpanData;
 import io.opencensus.trace.export.SpanExporter.Handler;
@@ -30,13 +31,14 @@ final class OcAgentTraceExporterHandler extends Handler {
   // private static final Duration DEFAULT_RETRY_INTERVAL = Duration.create(300, 0); // 5 minutes
 
   OcAgentTraceExporterHandler() {
-    this(null, null, null, null, /* enableConfig= */ true);
+    this(null, null, null, null, null, /* enableConfig= */ true);
   }
 
   OcAgentTraceExporterHandler(
       @Nullable String endPoint,
       @Nullable String serviceName,
       @Nullable Boolean useInsecure,
+      @Nullable SslContext sslContext,
       @Nullable Duration retryInterval,
       boolean enableConfig) {
     // if (endPoint == null) {

--- a/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfigurationTest.java
+++ b/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfigurationTest.java
@@ -18,7 +18,10 @@ package io.opencensus.exporter.trace.ocagent;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslContextBuilder;
 import io.opencensus.common.Duration;
+import javax.net.ssl.SSLException;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,25 +36,29 @@ public class OcAgentTraceExporterConfigurationTest {
         OcAgentTraceExporterConfiguration.builder().build();
     assertThat(configuration.getEndPoint()).isNull();
     assertThat(configuration.getServiceName()).isNull();
-    assertThat(configuration.getUseInsecure()).isNull();
+    assertThat(configuration.getUseInsecure()).isTrue();
+    assertThat(configuration.getSslContext()).isNull();
     assertThat(configuration.getRetryInterval()).isNull();
     assertThat(configuration.getEnableConfig()).isTrue();
   }
 
   @Test
-  public void setAndGet() {
+  public void setAndGet() throws SSLException {
     Duration oneMinute = Duration.create(60, 0);
+    SslContext sslContext = SslContextBuilder.forClient().build();
     OcAgentTraceExporterConfiguration configuration =
         OcAgentTraceExporterConfiguration.builder()
             .setEndPoint("192.168.0.1:50051")
             .setServiceName("service")
-            .setUseInsecure(true)
+            .setUseInsecure(false)
+            .setSslContext(sslContext)
             .setRetryInterval(oneMinute)
             .setEnableConfig(false)
             .build();
     assertThat(configuration.getEndPoint()).isEqualTo("192.168.0.1:50051");
     assertThat(configuration.getServiceName()).isEqualTo("service");
-    assertThat(configuration.getUseInsecure()).isTrue();
+    assertThat(configuration.getUseInsecure()).isFalse();
+    assertThat(configuration.getSslContext()).isEqualTo(sslContext);
     assertThat(configuration.getRetryInterval()).isEqualTo(oneMinute);
     assertThat(configuration.getEnableConfig()).isFalse();
   }


### PR DESCRIPTION
Also make `useInsecure` as the default option. Users need to either use
insecure connection or provide a TLS credential.

Counterpart in Go: https://github.com/census-ecosystem/opencensus-go-exporter-ocagent/pull/45.