### PR TITLE
Exporter/Stats/Stackdriver: Support Exemplar.

### DIFF
--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -221,6 +221,7 @@ General guidelines on imports:
       <subpackage name="stackdriver">
         <allow pkg="com.google"/>
         <allow pkg="io.opencensus.exporter.stats.stackdriver"/>
+        <allow pkg="io.opencensus.metrics.data"/>
         <allow pkg="io.opencensus.trace"/>
         <allow pkg="io.opencensus.contrib.exemplar.util"/>
         <allow pkg="io.opencensus.contrib.resource.util"/>

--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -222,6 +222,7 @@ General guidelines on imports:
         <allow pkg="com.google"/>
         <allow pkg="io.opencensus.exporter.stats.stackdriver"/>
         <allow pkg="io.opencensus.trace"/>
+        <allow pkg="io.opencensus.contrib.exemplar.util"/>
         <allow pkg="io.opencensus.contrib.resource.util"/>
       </subpackage>
     </subpackage>

--- a/exporters/stats/stackdriver/build.gradle
+++ b/exporters/stats/stackdriver/build.gradle
@@ -9,6 +9,7 @@ dependencies {
     compileOnly libraries.auto_value
 
     compile project(':opencensus-api'),
+            project(':opencensus-contrib-exemplar-util'),
             project(':opencensus-contrib-resource-util'),
             project(':opencensus-exporter-metrics-util'),
             libraries.google_auth,

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateTimeSeriesExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateTimeSeriesExporter.java
@@ -62,7 +62,8 @@ final class CreateTimeSeriesExporter extends MetricExporter {
     List<TimeSeries> timeSeriesList = new ArrayList<>(metrics.size());
     for (Metric metric : metrics) {
       timeSeriesList.addAll(
-          StackdriverExportUtils.createTimeSeriesList(metric, monitoredResource, domain));
+          StackdriverExportUtils.createTimeSeriesList(
+              metric, monitoredResource, domain, projectName.getProject()));
     }
 
     Span span = tracer.getCurrentSpan();

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -67,7 +67,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import javax.annotation.Nullable;
 
 /*>>>
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -444,7 +443,7 @@ final class StackdriverExportUtils {
   }
 
   @VisibleForTesting
-  static void setCachedProjectIdForExemplar(@Nullable String projectId) {
+  static void setCachedProjectIdForExemplar(@javax.annotation.Nullable String projectId) {
     cachedProjectIdForExemplar = projectId;
   }
 

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -383,8 +383,10 @@ final class StackdriverExportUtils {
     builder.addBucketCounts(0L);
     for (Bucket bucket : buckets) {
       builder.addBucketCounts(bucket.getCount());
-      if (bucket.getExemplar() != null) {
-        builder.addExemplars(toProtoExemplar(bucket.getExemplar()));
+      @javax.annotation.Nullable
+      io.opencensus.metrics.export.Distribution.Exemplar exemplar = bucket.getExemplar();
+      if (exemplar != null) {
+        builder.addExemplars(toProtoExemplar(exemplar));
       }
     }
   }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/CreateTimeSeriesExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/CreateTimeSeriesExporterTest.java
@@ -106,7 +106,7 @@ public class CreateTimeSeriesExporterTest {
 
     List<TimeSeries> timeSeries =
         StackdriverExportUtils.createTimeSeriesList(
-            METRIC, DEFAULT_RESOURCE, StackdriverExportUtils.CUSTOM_OPENCENSUS_DOMAIN);
+            METRIC, DEFAULT_RESOURCE, StackdriverExportUtils.CUSTOM_OPENCENSUS_DOMAIN, PROJECT_ID);
 
     verify(mockCreateTimeSeriesCallable, times(1))
         .call(


### PR DESCRIPTION
~~Depending on https://github.com/census-instrumentation/opencensus-java/pull/1770.~~

Stackdriver Monitoring has added support for `Exemplar` in the latest client libraries. Modify our Stackdriver Stats exporter to support it. 

~~Note that for now Stackdriver Monitoring backend only accepts string attachments. If we were to send other attachments (e.g `type.googleapis.com/google.devtools.cloudtrace.v1.Trace`), Stackdriver would return an error response saying that type is not supported.~~