### PR TITLE
Exporter/OcAgent: Update all since tags.

### DIFF
--- a/exporters/metrics/ocagent/README.md
+++ b/exporters/metrics/ocagent/README.md
@@ -13,17 +13,17 @@ For Maven add to your `pom.xml`:
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-api</artifactId>
-    <version>0.19.0</version>
+    <version>0.20.0</version>
   </dependency>
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-exporter-metrics-ocagent</artifactId>
-    <version>0.19.0</version>
+    <version>0.20.0</version>
   </dependency>
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-impl</artifactId>
-    <version>0.19.0</version>
+    <version>0.20.0</version>
     <scope>runtime</scope>
   </dependency>
 </dependencies>
@@ -31,9 +31,9 @@ For Maven add to your `pom.xml`:
 
 For Gradle add to your dependencies:
 ```groovy
-compile 'io.opencensus:opencensus-api:0.19.0'
-compile 'io.opencensus:opencensus-exporter-metrics-ocagent:0.19.0'
-runtime 'io.opencensus:opencensus-impl:0.19.0'
+compile 'io.opencensus:opencensus-api:0.20.0'
+compile 'io.opencensus:opencensus-exporter-metrics-ocagent:0.20.0'
+runtime 'io.opencensus:opencensus-impl:0.20.0'
 ```
 
 ### Register the exporter

--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporter.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporter.java
@@ -41,7 +41,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.19
+ * @since 0.20
  */
 @ThreadSafe
 public final class OcAgentMetricsExporter {
@@ -65,7 +65,7 @@ public final class OcAgentMetricsExporter {
    * to the OpenCensus library.
    *
    * @param configuration the {@code OcAgentMetricsExporterConfiguration}.
-   * @since 0.19
+   * @since 0.20
    */
   public static void createAndRegister(OcAgentMetricsExporterConfiguration configuration) {
     checkNotNull(configuration, "configuration");

--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporterConfiguration.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporterConfiguration.java
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Configurations for {@code OcAgentMetricsExporter}.
  *
- * @since 0.19
+ * @since 0.20
  */
 @AutoValue
 @Immutable
@@ -37,7 +37,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
    * Returns the end point of OC-Agent. The end point can be dns, ip:port, etc.
    *
    * @return the end point of OC-Agent.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract String getEndPoint();
@@ -46,7 +46,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
    * Returns whether to disable client transport security for the exporter's gRPC connection or not.
    *
    * @return whether to disable client transport security for the exporter's gRPC connection or not.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract Boolean getUseInsecure();
@@ -64,7 +64,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
    * Returns the service name to be used for the {@code OcAgentMetricsExporter}.
    *
    * @return the service name.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract String getServiceName();
@@ -73,7 +73,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
    * Returns the retry time interval when trying to connect to Agent.
    *
    * @return the retry time interval.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract Duration getRetryInterval();
@@ -82,7 +82,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
    * Returns the export interval between pushes to Agent.
    *
    * @return the export interval.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract Duration getExportInterval();
@@ -91,7 +91,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
    * Returns a new {@link Builder}.
    *
    * @return a {@code Builder}.
-   * @since 0.19
+   * @since 0.20
    */
   public static Builder builder() {
     return new AutoValue_OcAgentMetricsExporterConfiguration.Builder().setUseInsecure(true);
@@ -100,7 +100,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
   /**
    * Builder for {@link OcAgentMetricsExporterConfiguration}.
    *
-   * @since 0.19
+   * @since 0.20
    */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -112,7 +112,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
      *
      * @param endPoint the end point of OC-Agent.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setEndPoint(String endPoint);
 
@@ -122,7 +122,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
      * @param useInsecure whether disable client transport security for the exporter's gRPC
      *     connection.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setUseInsecure(Boolean useInsecure);
 
@@ -140,7 +140,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
      *
      * @param serviceName the service name.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setServiceName(String serviceName);
 
@@ -149,7 +149,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
      *
      * @param retryInterval the retry time interval.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setRetryInterval(Duration retryInterval);
 
@@ -158,7 +158,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
      *
      * @param exportInterval the export time interval.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setExportInterval(Duration exportInterval);
 
@@ -168,7 +168,7 @@ public abstract class OcAgentMetricsExporterConfiguration {
      * Builds a {@link OcAgentMetricsExporterConfiguration}.
      *
      * @return a {@code OcAgentMetricsExporterConfiguration}.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract OcAgentMetricsExporterConfiguration build();
   }

--- a/exporters/trace/ocagent/README.md
+++ b/exporters/trace/ocagent/README.md
@@ -13,17 +13,17 @@ For Maven add to your `pom.xml`:
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-api</artifactId>
-    <version>0.19.2</version>
+    <version>0.20.0</version>
   </dependency>
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-exporter-trace-ocagent</artifactId>
-    <version>0.19.2</version>
+    <version>0.20.0</version>
   </dependency>
   <dependency>
     <groupId>io.opencensus</groupId>
     <artifactId>opencensus-impl</artifactId>
-    <version>0.19.2</version>
+    <version>0.20.0</version>
     <scope>runtime</scope>
   </dependency>
 </dependencies>
@@ -31,9 +31,9 @@ For Maven add to your `pom.xml`:
 
 For Gradle add to your dependencies:
 ```groovy
-compile 'io.opencensus:opencensus-api:0.19.2'
-compile 'io.opencensus:opencensus-exporter-trace-ocagent:0.19.2'
-runtime 'io.opencensus:opencensus-impl:0.19.2'
+compile 'io.opencensus:opencensus-api:0.20.0'
+compile 'io.opencensus:opencensus-exporter-trace-ocagent:0.20.0'
+runtime 'io.opencensus:opencensus-impl:0.20.0'
 ```
 
 ### Register the exporter

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporter.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporter.java
@@ -38,7 +38,7 @@ import javax.annotation.concurrent.ThreadSafe;
  * }
  * }</pre>
  *
- * @since 0.19
+ * @since 0.20
  */
 @ThreadSafe
 public final class OcAgentTraceExporter {
@@ -56,7 +56,7 @@ public final class OcAgentTraceExporter {
    * Creates a {@code OcAgentTraceExporterHandler} with default configurations and registers it to
    * the OpenCensus library.
    *
-   * @since 0.19
+   * @since 0.20
    */
   public static void createAndRegister() {
     synchronized (monitor) {
@@ -71,7 +71,7 @@ public final class OcAgentTraceExporter {
    * the OpenCensus library.
    *
    * @param configuration the {@code OcAgentTraceExporterConfiguration}.
-   * @since 0.19
+   * @since 0.20
    */
   public static void createAndRegister(OcAgentTraceExporterConfiguration configuration) {
     synchronized (monitor) {
@@ -108,7 +108,7 @@ public final class OcAgentTraceExporter {
   /**
    * Unregisters the OC-Agent exporter from the OpenCensus library.
    *
-   * @since 0.19
+   * @since 0.20
    */
   public static void unregister() {
     unregister(Tracing.getExportComponent().getSpanExporter());

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfiguration.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfiguration.java
@@ -25,7 +25,7 @@ import javax.annotation.concurrent.Immutable;
 /**
  * Configurations for {@link OcAgentTraceExporter}.
  *
- * @since 0.19
+ * @since 0.20
  */
 @AutoValue
 @Immutable
@@ -37,7 +37,7 @@ public abstract class OcAgentTraceExporterConfiguration {
    * Returns the end point of OC-Agent. The end point can be dns, ip:port, etc.
    *
    * @return the end point of OC-Agent.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract String getEndPoint();
@@ -46,7 +46,7 @@ public abstract class OcAgentTraceExporterConfiguration {
    * Returns whether to disable client transport security for the exporter's gRPC connection or not.
    *
    * @return whether to disable client transport security for the exporter's gRPC connection or not.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract Boolean getUseInsecure();
@@ -64,7 +64,7 @@ public abstract class OcAgentTraceExporterConfiguration {
    * Returns the service name to be used for this {@link OcAgentTraceExporter}.
    *
    * @return the service name.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract String getServiceName();
@@ -73,7 +73,7 @@ public abstract class OcAgentTraceExporterConfiguration {
    * Returns the retry time interval when trying to connect to Agent.
    *
    * @return the retry time interval.
-   * @since 0.19
+   * @since 0.20
    */
   @Nullable
   public abstract Duration getRetryInterval();
@@ -82,7 +82,7 @@ public abstract class OcAgentTraceExporterConfiguration {
    * Returns whether the {@link OcAgentTraceExporter} should handle the config streams.
    *
    * @return whether the {@code OcAgentTraceExporter} should handle the config streams.
-   * @since 0.19
+   * @since 0.20
    */
   public abstract boolean getEnableConfig();
 
@@ -90,7 +90,7 @@ public abstract class OcAgentTraceExporterConfiguration {
    * Returns a new {@link Builder}.
    *
    * @return a {@code Builder}.
-   * @since 0.19
+   * @since 0.20
    */
   public static Builder builder() {
     return new AutoValue_OcAgentTraceExporterConfiguration.Builder()
@@ -101,7 +101,7 @@ public abstract class OcAgentTraceExporterConfiguration {
   /**
    * Builder for {@link OcAgentTraceExporterConfiguration}.
    *
-   * @since 0.19
+   * @since 0.20
    */
   @AutoValue.Builder
   public abstract static class Builder {
@@ -113,7 +113,7 @@ public abstract class OcAgentTraceExporterConfiguration {
      *
      * @param endPoint the end point of OC-Agent.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setEndPoint(String endPoint);
 
@@ -123,7 +123,7 @@ public abstract class OcAgentTraceExporterConfiguration {
      * @param useInsecure whether disable client transport security for the exporter's gRPC
      *     connection.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setUseInsecure(Boolean useInsecure);
 
@@ -141,7 +141,7 @@ public abstract class OcAgentTraceExporterConfiguration {
      *
      * @param serviceName the service name.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setServiceName(String serviceName);
 
@@ -150,7 +150,7 @@ public abstract class OcAgentTraceExporterConfiguration {
      *
      * @param retryInterval the retry time interval.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setRetryInterval(Duration retryInterval);
 
@@ -159,7 +159,7 @@ public abstract class OcAgentTraceExporterConfiguration {
      *
      * @param enableConfig whether {@code OcAgentTraceExporter} should handle the config streams.
      * @return this.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract Builder setEnableConfig(boolean enableConfig);
 
@@ -169,7 +169,7 @@ public abstract class OcAgentTraceExporterConfiguration {
      * Builds a {@link OcAgentTraceExporterConfiguration}.
      *
      * @return a {@code OcAgentTraceExporterConfiguration}.
-     * @since 0.19
+     * @since 0.20
      */
     public abstract OcAgentTraceExporterConfiguration build();
   }


### PR DESCRIPTION
OcAgent Exporters are not included in the last release. Update to 0.20.

Split from #1761.