### PR TITLE
Changed publicEndpoint to be an init parameter, default to false

### DIFF
--- a/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
+++ b/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
@@ -145,13 +145,9 @@ public class OcHttpServletFilter implements Filter {
       extractor = new OcHttpServletExtractor();
     }
 
-    obj = context.getAttribute(OC_PUBLIC_ENDPOINT);
+    String publicEndVal = context.getInitParameter(OC_PUBLIC_ENDPOINT);
     if (obj != null) {
-      if (obj instanceof Boolean) {
-        publicEndpoint = (Boolean) obj;
-      } else {
-        throw new ServletException(EXCEPTION_MESSAGE + OC_PUBLIC_ENDPOINT);
-      }
+        publicEndpoint = Boolean.parseBoolean(publicEndVal);
     } else {
       publicEndpoint = false;
     }

--- a/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
+++ b/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
@@ -146,7 +146,7 @@ public class OcHttpServletFilter implements Filter {
     }
 
     String publicEndVal = context.getInitParameter(OC_PUBLIC_ENDPOINT);
-    if (obj != null) {
+    if (publicEndVal != null) {
         publicEndpoint = Boolean.parseBoolean(publicEndVal);
     } else {
       publicEndpoint = false;


### PR DESCRIPTION
For HTTP integration with Jetty, changed publicEndpoint to be an init parameter to be easier to configure via web.xml web application file and changed default to false to addresses

https://github.com/census-instrumentation/opencensus-java/issues/1780