### PR TITLE
Changed Public endpoint publicEndpoint from an attribute to init parameter

### DIFF
--- a/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
+++ b/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
@@ -147,7 +147,7 @@ public class OcHttpServletFilter implements Filter {
 
     String publicEndVal = context.getInitParameter(OC_PUBLIC_ENDPOINT);
     if (publicEndVal != null) {
-        publicEndpoint = Boolean.parseBoolean(publicEndVal);
+      publicEndpoint = Boolean.parseBoolean(publicEndVal);
     } else {
       publicEndpoint = false;
     }

--- a/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
+++ b/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
@@ -145,13 +145,9 @@ public class OcHttpServletFilter implements Filter {
       extractor = new OcHttpServletExtractor();
     }
 
-    obj = context.getAttribute(OC_PUBLIC_ENDPOINT);
-    if (obj != null) {
-      if (obj instanceof Boolean) {
-        publicEndpoint = (Boolean) obj;
-      } else {
-        throw new ServletException(EXCEPTION_MESSAGE + OC_PUBLIC_ENDPOINT);
-      }
+    String publicEndVal = context.getInitParameter(OC_PUBLIC_ENDPOINT);
+    if (publicEndVal != null) {
+        publicEndpoint = Boolean.parseBoolean(publicEndVal);
     } else {
       publicEndpoint = false;
     }

--- a/contrib/http_servlet/src/test/java/io/opencensus/contrib/http/servlet/OcHttpServletFilterTest.java
+++ b/contrib/http_servlet/src/test/java/io/opencensus/contrib/http/servlet/OcHttpServletFilterTest.java
@@ -93,17 +93,16 @@ public class OcHttpServletFilterTest {
     when(mockConfig.getServletContext()).thenReturn(mockServletContext);
     when(mockServletContext.getAttribute(OC_TRACE_PROPAGATOR)).thenReturn(null);
     when(mockServletContext.getAttribute(OC_EXTRACTOR)).thenReturn(null);
-    when(mockServletContext.getAttribute(OC_PUBLIC_ENDPOINT)).thenReturn(null);
+    when(mockServletContext.getInitParameter(OC_PUBLIC_ENDPOINT)).thenReturn("false");
 
     filter.init(mockConfig);
 
     verify(mockConfig).getServletContext();
-    verify(mockServletContext, times(3)).getAttribute(stringArgumentCaptor.capture());
+    verify(mockServletContext, times(2)).getAttribute(stringArgumentCaptor.capture());
 
     List<String> attributes = stringArgumentCaptor.getAllValues();
     assertThat(attributes.contains(OC_TRACE_PROPAGATOR)).isTrue();
     assertThat(attributes.contains(OC_EXTRACTOR)).isTrue();
-    assertThat(attributes.contains(OC_PUBLIC_ENDPOINT)).isTrue();
     assertThat(filter.handler).isNotEqualTo(oldHandler);
     assertThat(filter.handler).isNotNull();
   }
@@ -116,17 +115,16 @@ public class OcHttpServletFilterTest {
     when(mockConfig.getServletContext()).thenReturn(mockServletContext);
     when(mockServletContext.getAttribute(OC_TRACE_PROPAGATOR)).thenReturn(b3Propagator);
     when(mockServletContext.getAttribute(OC_EXTRACTOR)).thenReturn(customExtractor);
-    when(mockServletContext.getAttribute(OC_PUBLIC_ENDPOINT)).thenReturn(publicEndpoint);
+    when(mockServletContext.getInitParameter(OC_PUBLIC_ENDPOINT)).thenReturn("false");
 
     filter.init(mockConfig);
 
     verify(mockConfig).getServletContext();
-    verify(mockServletContext, times(3)).getAttribute(stringArgumentCaptor.capture());
+    verify(mockServletContext, times(2)).getAttribute(stringArgumentCaptor.capture());
 
     List<String> attributes = stringArgumentCaptor.getAllValues();
     assertThat(attributes.contains(OC_TRACE_PROPAGATOR)).isTrue();
     assertThat(attributes.contains(OC_EXTRACTOR)).isTrue();
-    assertThat(attributes.contains(OC_PUBLIC_ENDPOINT)).isTrue();
     assertThat(filter.handler).isNotEqualTo(oldHandler);
     assertThat(filter.handler).isNotNull();
   }
@@ -148,11 +146,6 @@ public class OcHttpServletFilterTest {
   @Test
   public void testInitInvalidPropagator() throws ServletException {
     testInitInvalidAttr(OC_TRACE_PROPAGATOR);
-  }
-
-  @Test
-  public void testInitInvalidPublicEndpoint() throws ServletException {
-    testInitInvalidAttr(OC_PUBLIC_ENDPOINT);
   }
 
   @Test

--- a/contrib/http_servlet/src/test/java/io/opencensus/contrib/http/servlet/OcHttpServletFilterTest.java
+++ b/contrib/http_servlet/src/test/java/io/opencensus/contrib/http/servlet/OcHttpServletFilterTest.java
@@ -92,12 +92,13 @@ public class OcHttpServletFilterTest {
     when(mockConfig.getServletContext()).thenReturn(mockServletContext);
     when(mockServletContext.getAttribute(OC_TRACE_PROPAGATOR)).thenReturn(null);
     when(mockServletContext.getAttribute(OC_EXTRACTOR)).thenReturn(null);
-    when(mockServletContext.getInitParameter(OC_PUBLIC_ENDPOINT)).thenReturn("false");
+    when(mockServletContext.getInitParameter(OC_PUBLIC_ENDPOINT)).thenReturn(null);
 
     filter.init(mockConfig);
 
     verify(mockConfig).getServletContext();
     verify(mockServletContext, times(2)).getAttribute(stringArgumentCaptor.capture());
+    verify(mockServletContext).getInitParameter(stringArgumentCaptor.capture());
 
     List<String> attributes = stringArgumentCaptor.getAllValues();
     assertThat(attributes.contains(OC_TRACE_PROPAGATOR)).isTrue();
@@ -120,6 +121,7 @@ public class OcHttpServletFilterTest {
 
     verify(mockConfig).getServletContext();
     verify(mockServletContext, times(2)).getAttribute(stringArgumentCaptor.capture());
+    verify(mockServletContext).getInitParameter(stringArgumentCaptor.capture());
 
     List<String> attributes = stringArgumentCaptor.getAllValues();
     assertThat(attributes.contains(OC_TRACE_PROPAGATOR)).isTrue();

--- a/contrib/http_servlet/src/test/java/io/opencensus/contrib/http/servlet/OcHttpServletFilterTest.java
+++ b/contrib/http_servlet/src/test/java/io/opencensus/contrib/http/servlet/OcHttpServletFilterTest.java
@@ -73,7 +73,6 @@ public class OcHttpServletFilterTest {
   @Mock ServletContext mockServletContext;
   TextFormat b3Propagator;
   HttpExtractor<HttpServletRequest, HttpServletResponse> customExtractor;
-  Boolean publicEndpoint = false;
   @Spy OcHttpServletFilter filter = new OcHttpServletFilter();
   @Captor ArgumentCaptor<String> stringArgumentCaptor;
   Object dummyAttr = new Object();


### PR DESCRIPTION
To enable application developers to set the value of publicEndpoint more easily, changed from a servlet context attribute to an init parameter.