### PR TITLE
Checker Framework: 2.6.0 -> 2.7.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -238,7 +238,7 @@ subprojects {
 
     dependencies {
         if (useCheckerFramework) {
-            ext.checkerFrameworkVersion = '2.6.0'
+            ext.checkerFrameworkVersion = '2.7.0'
 
             // 2.4.0 is the last version of the Checker Framework compiler that supports annotations
             // in comments, though it should continue to work with newer versions of the Checker Framework.

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/DerivedDoubleGaugeImpl.java
@@ -47,9 +47,8 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
   private final MetricDescriptor metricDescriptor;
   private final int labelKeysSize;
 
-  @SuppressWarnings("rawtypes")
-  private volatile Map<List<LabelValue>, PointWithFunction> registeredPoints =
-      Collections.<List<LabelValue>, PointWithFunction>emptyMap();
+  private volatile Map<List<LabelValue>, PointWithFunction<?>> registeredPoints =
+      Collections.<List<LabelValue>, PointWithFunction<?>>emptyMap();
 
   DerivedDoubleGaugeImpl(String name, String description, String unit, List<LabelKey> labelKeys) {
     labelKeysSize = labelKeys.size();
@@ -58,10 +57,9 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
   }
 
   @Override
-  @SuppressWarnings("rawtypes")
   public synchronized <T> void createTimeSeries(
       List<LabelValue> labelValues,
-      /*@Nullable*/ T obj,
+      @javax.annotation.Nullable T obj,
       ToDoubleFunction</*@Nullable*/ T> function) {
     Utils.checkListElementNotNull(checkNotNull(labelValues, "labelValues"), "labelValue");
     checkArgument(
@@ -71,28 +69,27 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
     List<LabelValue> labelValuesCopy =
         Collections.<LabelValue>unmodifiableList(new ArrayList<LabelValue>(labelValues));
 
-    PointWithFunction existingPoint = registeredPoints.get(labelValuesCopy);
+    PointWithFunction<?> existingPoint = registeredPoints.get(labelValuesCopy);
     if (existingPoint != null) {
       throw new IllegalArgumentException(
           "A different time series with the same labels already exists.");
     }
 
-    PointWithFunction newPoint = new PointWithFunction<T>(labelValuesCopy, obj, function);
+    PointWithFunction<T> newPoint = new PointWithFunction<T>(labelValuesCopy, obj, function);
     // Updating the map of time series happens under a lock to avoid multiple add operations
     // to happen in the same time.
-    Map<List<LabelValue>, PointWithFunction> registeredPointsCopy =
-        new LinkedHashMap<List<LabelValue>, PointWithFunction>(registeredPoints);
+    Map<List<LabelValue>, PointWithFunction<?>> registeredPointsCopy =
+        new LinkedHashMap<List<LabelValue>, PointWithFunction<?>>(registeredPoints);
     registeredPointsCopy.put(labelValuesCopy, newPoint);
     registeredPoints = Collections.unmodifiableMap(registeredPointsCopy);
   }
 
   @Override
-  @SuppressWarnings("rawtypes")
   public synchronized void removeTimeSeries(List<LabelValue> labelValues) {
     checkNotNull(labelValues, "labelValues");
 
-    Map<List<LabelValue>, PointWithFunction> registeredPointsCopy =
-        new LinkedHashMap<List<LabelValue>, PointWithFunction>(registeredPoints);
+    Map<List<LabelValue>, PointWithFunction<?>> registeredPointsCopy =
+        new LinkedHashMap<List<LabelValue>, PointWithFunction<?>>(registeredPoints);
     if (registeredPointsCopy.remove(labelValues) == null) {
       // The element not present, no need to update the current map of time series.
       return;
@@ -101,27 +98,25 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
   }
 
   @Override
-  @SuppressWarnings("rawtypes")
   public synchronized void clear() {
-    registeredPoints = Collections.<List<LabelValue>, PointWithFunction>emptyMap();
+    registeredPoints = Collections.<List<LabelValue>, PointWithFunction<?>>emptyMap();
   }
 
-  /*@Nullable*/
+  @javax.annotation.Nullable
   @Override
-  @SuppressWarnings("rawtypes")
   public Metric getMetric(Clock clock) {
-    Map<List<LabelValue>, PointWithFunction> currentRegisteredPoints = registeredPoints;
+    Map<List<LabelValue>, PointWithFunction<?>> currentRegisteredPoints = registeredPoints;
     if (currentRegisteredPoints.isEmpty()) {
       return null;
     }
 
     if (currentRegisteredPoints.size() == 1) {
-      PointWithFunction point = currentRegisteredPoints.values().iterator().next();
+      PointWithFunction<?> point = currentRegisteredPoints.values().iterator().next();
       return Metric.createWithOneTimeSeries(metricDescriptor, point.getTimeSeries(clock));
     }
 
     List<TimeSeries> timeSeriesList = new ArrayList<TimeSeries>(currentRegisteredPoints.size());
-    for (Map.Entry<List<LabelValue>, PointWithFunction> entry :
+    for (Map.Entry<List<LabelValue>, PointWithFunction<?>> entry :
         currentRegisteredPoints.entrySet()) {
       timeSeriesList.add(entry.getValue().getTimeSeries(clock));
     }
@@ -136,7 +131,7 @@ public final class DerivedDoubleGaugeImpl extends DerivedDoubleGauge implements 
 
     PointWithFunction(
         List<LabelValue> labelValues,
-        /*@Nullable*/ T obj,
+        @javax.annotation.Nullable T obj,
         ToDoubleFunction</*@Nullable*/ T> function) {
       defaultTimeSeries = TimeSeries.create(labelValues);
       ref = obj != null ? new WeakReference<T>(obj) : null;


### PR DESCRIPTION
This commit also fixes some new warnings by removing raw types and uncommenting
some Nullable annotations that didn't need to be commented.