### PR TITLE
Remove package qualification from Immutable annotations.

### DIFF
--- a/api/src/main/java/io/opencensus/stats/AggregationData.java
+++ b/api/src/main/java/io/opencensus/stats/AggregationData.java
@@ -257,7 +257,7 @@ public abstract class AggregationData {
    *
    * @since 0.8
    */
-  @javax.annotation.concurrent.Immutable
+  @Immutable
   @AutoValue
   public abstract static class DistributionData extends AggregationData {
 
@@ -452,7 +452,7 @@ public abstract class AggregationData {
      *
      * @since 0.16
      */
-    @javax.annotation.concurrent.Immutable
+    @Immutable
     @AutoValue
     public abstract static class Exemplar {
 


### PR DESCRIPTION
Upgrading to Checker Framework 2.7.0 in #1792 seemed to fix issue #1782, so this
commit removes the unnecessary package qualification.

Fixes #1782.