### PR TITLE
Set kind on the outgoing HTTP spans in HttpClientHandler

### DIFF
--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpClientHandler.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpClientHandler.java
@@ -33,6 +33,7 @@ import io.opencensus.tags.TagValue;
 import io.opencensus.tags.Tagger;
 import io.opencensus.tags.Tags;
 import io.opencensus.trace.Span;
+import io.opencensus.trace.Span.Kind;
 import io.opencensus.trace.Span.Options;
 import io.opencensus.trace.SpanBuilder;
 import io.opencensus.trace.SpanContext;
@@ -112,7 +113,9 @@ public class HttpClientHandler<
       parent = tracer.getCurrentSpan();
     }
     String spanName = getSpanName(request, extractor);
-    SpanBuilder builder = tracer.spanBuilderWithExplicitParent(spanName, parent);
+    SpanBuilder builder = tracer.spanBuilderWithExplicitParent(spanName, parent)
+        .setSpanKind(Kind.CLIENT);
+    
     Span span = builder.startSpan();
 
     if (span.getOptions().contains(Options.RECORD_EVENTS)) {


### PR DESCRIPTION
[Http spec](https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/HTTP.md) suggests setting Span kind to Client on outgoing calls. 

`Outgoing requests should be a span kind of CLIENT and incoming requests should be a span kind of SERVER.`
Also HTTP instrumentation tests validate it. https://github.com/census-instrumentation/opencensus-specs/blob/master/trace/http-out-test-cases.json

It allows backends that have special logic for incoming/outgoing calls properly identify them.  Presence or absence of the remote/local parent is not really reliable for this purpose. 