### PR TITLE
Examples: Update gRPC version.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -34,7 +34,7 @@ group = "io.opencensus"
 version = "0.20.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.19.2" // LATEST_OPENCENSUS_RELEASE_VERSION
-def grpcVersion = "1.18.0" // CURRENT_GRPC_VERSION
+def grpcVersion = "1.19.0" // CURRENT_GRPC_VERSION
 def prometheusVersion = "0.6.0"
 def jettyVersion = "9.4.12.v20180830"
 


### PR DESCRIPTION
When running the examples with gRPC 1.18.0, I got:
```bash
io.grpc.internal.ManagedChannelImpl$1 uncaughtException
SEVERE: [Channel<49>: (localhost:55678)] Uncaught exception in the SynchronizationContext. Panic!
java.lang.NoSuchMethodError: io.grpc.internal.ClientTransportFactory$ClientTransportOptions.getProxyParameters()Lio/grpc/internal/ProxyParameters;
	at io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder$NettyTransportFactory.newClientTransport(NettyChannelBuilder.java:547)
...
```

Upgrading to 1.19.0 fixed this.