### PR TITLE
Prevent blocking on queue overflow (#1809)

### DIFF
--- a/buildscripts/import-control.xml
+++ b/buildscripts/import-control.xml
@@ -270,6 +270,7 @@ General guidelines on imports:
     <allow pkg="io.opencensus.trace"/>
   </subpackage>
   <subpackage name="impl">
+    <allow pkg="com.google.common"/>
     <allow pkg="com.lmax.disruptor"/>
     <allow pkg="io.opencensus.common"/>
     <allow pkg="io.opencensus.impl"/>

--- a/impl/src/test/java/io/opencensus/impl/internal/DisruptorEventQueueTest.java
+++ b/impl/src/test/java/io/opencensus/impl/internal/DisruptorEventQueueTest.java
@@ -79,6 +79,7 @@ public class DisruptorEventQueueTest {
   private static class IncrementEvent implements EventQueue.Entry {
 
     private final Counter counter;
+    private volatile boolean isRejected = false;
 
     IncrementEvent(Counter counter) {
       this.counter = counter;
@@ -87,6 +88,11 @@ public class DisruptorEventQueueTest {
     @Override
     public void process() {
       counter.increment();
+    }
+
+    @Override
+    public void rejected() {
+      isRejected = true;
     }
   }
 
@@ -147,6 +153,7 @@ public class DisruptorEventQueueTest {
     // Queue event into filled queue to test overflow behavior
     IncrementEvent ie = new IncrementEvent(counter);
     DisruptorEventQueue.getInstance().enqueue(ie);
+    assertThat(ie.isRejected).isTrue();
     assertThat(DisruptorEventQueue.overflowCount.get()).isEqualTo(overflowCountBefore + 1);
 
     // Cleanup events

--- a/impl/src/test/java/io/opencensus/impl/internal/DisruptorEventQueueTest.java
+++ b/impl/src/test/java/io/opencensus/impl/internal/DisruptorEventQueueTest.java
@@ -19,6 +19,9 @@ package io.opencensus.impl.internal;
 import static com.google.common.truth.Truth.assertThat;
 
 import io.opencensus.implcore.internal.EventQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.annotation.Nullable;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,39 +29,55 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link DisruptorEventQueue}. */
 @RunWith(JUnit4.class)
 public class DisruptorEventQueueTest {
+
   // Simple class to use that keeps an incrementing counter. Will fail with an assertion if
   // increment is used from multiple threads, or if the stored value is different from that expected
   // by the caller.
   private static class Counter {
-    private int count;
+
+    @Nullable private final CountDownLatch latch;
+    private final AtomicInteger count = new AtomicInteger();
     private volatile long id; // stores thread ID used in first increment operation.
 
     public Counter() {
-      count = 0;
+      this(null);
+    }
+
+    public Counter(@Nullable CountDownLatch latch) {
+      this.latch = latch;
       id = -1;
     }
 
     // Increments counter by 1. Will fail in assertion if multiple different threads are used
     // (the EventQueue backend should be single-threaded).
     public void increment() {
+      if (latch != null) {
+        try {
+          latch.await();
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+
       long tid = Thread.currentThread().getId();
       if (id == -1) {
-        assertThat(count).isEqualTo(0);
+        assertThat(count.get()).isEqualTo(0);
         id = tid;
       } else {
         assertThat(id).isEqualTo(tid);
       }
-      count++;
+      count.incrementAndGet();
     }
 
     // Check the current value of the counter. Assert if it is not the expected value.
     public void check(int value) {
-      assertThat(count).isEqualTo(value);
+      assertThat(count.get()).isEqualTo(value);
     }
   }
 
   // EventQueueEntry for incrementing a Counter.
   private static class IncrementEvent implements EventQueue.Entry {
+
     private final Counter counter;
 
     IncrementEvent(Counter counter) {
@@ -88,10 +107,20 @@ public class DisruptorEventQueueTest {
   @Test
   public void incrementTenK() {
     final int tenK = 10000;
+    final int sleepEach = 1000;
     Counter counter = new Counter();
     for (int i = 0; i < tenK; i++) {
       IncrementEvent ie = new IncrementEvent(counter);
       DisruptorEventQueue.getInstance().enqueue(ie);
+
+      // Sleep to prevent queue overflow
+      if (i % sleepEach == 0) {
+        try {
+          Thread.sleep(10);
+        } catch (InterruptedException ex) {
+          Thread.currentThread().interrupt();
+        }
+      }
     }
     // Sleep briefly, to allow background operations to complete.
     try {
@@ -100,5 +129,33 @@ public class DisruptorEventQueueTest {
       Thread.currentThread().interrupt();
     }
     counter.check(tenK);
+  }
+
+  @Test(timeout = 30 * 1000)
+  public void shouldNotBlockWhenOverflow() {
+    long overflowCountBefore = DisruptorEventQueue.overflowCount.get();
+
+    // Queue blocking events to fill queue
+    CountDownLatch latch = new CountDownLatch(1);
+    Counter counter = new Counter(latch);
+    for (int i = 0; i < DisruptorEventQueue.DISRUPTOR_BUFFER_SIZE; i++) {
+      IncrementEvent ie = new IncrementEvent(counter);
+      DisruptorEventQueue.getInstance().enqueue(ie);
+    }
+    counter.check(0);
+
+    // Queue event into filled queue to test overflow behavior
+    IncrementEvent ie = new IncrementEvent(counter);
+    DisruptorEventQueue.getInstance().enqueue(ie);
+    assertThat(DisruptorEventQueue.overflowCount.get()).isEqualTo(overflowCountBefore + 1);
+
+    // Cleanup events
+    latch.countDown();
+    try {
+      Thread.sleep(500);
+    } catch (InterruptedException ex) {
+      Thread.currentThread().interrupt();
+    }
+    counter.check(DisruptorEventQueue.DISRUPTOR_BUFFER_SIZE);
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/internal/EventQueue.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/EventQueue.java
@@ -32,5 +32,11 @@ public interface EventQueue {
      * associated {@link EventQueue}.
      */
     void process();
+
+    /**
+     * Cleanup resources associated with this entry to prevent leak. This method is called when this
+     * event is rejected. Note that this method might be called in foreground (application) thread.
+     */
+    void rejected();
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -100,5 +100,8 @@ final class StatsManager {
       // Add Timestamp to value after it went through the DisruptorQueue.
       statsManager.measureToViewMap.record(tags, stats, statsManager.clock.now());
     }
+
+    @Override
+    public void rejected() {}
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/StartEndHandlerImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/StartEndHandlerImpl.java
@@ -113,7 +113,11 @@ public final class StartEndHandlerImpl implements StartEndHandler {
       if (span.getContext().getTraceOptions().isSampled()) {
         spanExporter.addSpan(span);
       }
+
+      // Note that corresponding SpanStartEvent / onStart(span) might not have called if queue was
+      // full.
       inProcessRunningSpanStore.onEnd(span);
+
       if (sampledSpanStore != null) {
         sampledSpanStore.considerForSampling(span);
       }

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessRunningSpanStore.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessRunningSpanStore.java
@@ -59,12 +59,14 @@ public final class InProcessRunningSpanStore extends RunningSpanStore {
    * Removes the {@code Span} from the running spans list when the {@code Span} ends.
    *
    * @param span the {@code Span} that ended.
+   * @return If span was not found, returns false.
    */
-  public void onEnd(RecordEventsSpanImpl span) {
+  public boolean onEnd(RecordEventsSpanImpl span) {
     InProcessRunningSpanStoreImpl impl = this.impl;
     if (impl != null) {
-      impl.onEnd(span);
+      return impl.onEnd(span);
     }
+    return false;
   }
 
   /**
@@ -120,9 +122,9 @@ public final class InProcessRunningSpanStore extends RunningSpanStore {
       runningSpans.addElement(span);
     }
 
-    private void onEnd(RecordEventsSpanImpl span) {
+    private boolean onEnd(RecordEventsSpanImpl span) {
       // TODO: Count and display when try to remove span that was not present.
-      runningSpans.removeElement(span);
+      return runningSpans.removeElement(span);
     }
 
     private Summary getSummary() {

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessSampledSpanStoreImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/InProcessSampledSpanStoreImpl.java
@@ -318,6 +318,9 @@ public final class InProcessSampledSpanStoreImpl extends SampledSpanStoreImpl {
     public void process() {
       sampledSpanStore.internaltRegisterSpanNamesForCollection(spanNames);
     }
+
+    @Override
+    public void rejected() {}
   }
 
   @Override
@@ -346,6 +349,9 @@ public final class InProcessSampledSpanStoreImpl extends SampledSpanStoreImpl {
     public void process() {
       sampledSpanStore.internalUnregisterSpanNamesForCollection(spanNames);
     }
+
+    @Override
+    public void rejected() {}
   }
 
   @Override


### PR DESCRIPTION
https://github.com/census-instrumentation/opencensus-java/issues/1809

I implemented queue overflow handling to prevent blocking foreground (application) thread.

It drops event and show `WARN` log when queue get full.