### PR TITLE
Exporter/Stackdriver: Allow to override the opencensus_task label.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Unreleased
 - Add HTTP text format serializer to Tag propagation component.
 - Support constant labels in Gauge APIs.
+- Add an option to allow users to override the default "opencensus_task" metric label in Stackdriver Stats Exporter.
 
 ## 0.20.0 - 2019-03-28
 - Add OpenCensus Java OC-Agent Trace Exporter.

--- a/exporters/stats/stackdriver/README.md
+++ b/exporters/stats/stackdriver/README.md
@@ -156,7 +156,7 @@ Stackdriver exporter adds a new `Metric` label for each custom `Metric` to ensur
 of the `Timeseries`. The format of the label is: `{LANGUAGE}-{PID}@{HOSTNAME}`, if `{PID}` is not
 available a random number will be used.
 
-You have the option to override the "opencensus_task" metric label with custom constant labels with
+You have the option to override the "opencensus_task" metric label with custom constant labels using
 `StackdriverStatsConfiguration.Builder.setConstantLabels()`. If you do so, make sure that the 
 monitored resource together with these labels is unique to the current process. This is to ensure 
 that there is only a single writer to each time series in Stackdriver.

--- a/exporters/stats/stackdriver/README.md
+++ b/exporters/stats/stackdriver/README.md
@@ -156,6 +156,15 @@ Stackdriver exporter adds a new `Metric` label for each custom `Metric` to ensur
 of the `Timeseries`. The format of the label is: `{LANGUAGE}-{PID}@{HOSTNAME}`, if `{PID}` is not
 available a random number will be used.
 
+You have the option to override the "opencensus_task" metric label with custom constant labels with
+`StackdriverStatsConfiguration.Builder.setConstantLabels()`. If you do so, make sure that the 
+monitored resource together with these labels is unique to the current process. This is to ensure 
+that there is only a single writer to each time series in Stackdriver.
+
+You can also set `StackdriverStatsConfiguration.Builder.setConstantLabels()` to an empty map to 
+avoid getting the default "opencensus_task" label. You should only do this if you know that the 
+monitored resource uniquely identifies this process.
+
 ### Why did I get an error "java.lang.NoSuchMethodError: com.google.common...", like "java.lang.NoSuchMethodError:com.google.common.base.Throwables.throwIfInstanceOf"?
 This is probably because there is a version conflict on Guava in the dependency tree.
 

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
@@ -23,6 +23,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.monitoring.v3.CreateMetricDescriptorRequest;
 import com.google.monitoring.v3.ProjectName;
 import io.opencensus.exporter.metrics.util.MetricExporter;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
 import io.opencensus.metrics.export.Metric;
 import io.opencensus.metrics.export.MetricDescriptor.Type;
 import io.opencensus.trace.Span;
@@ -51,18 +53,21 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
   private final String displayNamePrefix;
   private final Map<String, io.opencensus.metrics.export.MetricDescriptor>
       registeredMetricDescriptors = new LinkedHashMap<>();
+  private final Map<LabelKey, LabelValue> constantLabels;
   private final MetricExporter nextExporter;
 
   CreateMetricDescriptorExporter(
       String projectId,
       MetricServiceClient metricServiceClient,
       @javax.annotation.Nullable String metricNamePrefix,
+      Map<LabelKey, LabelValue> constantLabels,
       MetricExporter nextExporter) {
     this.projectId = projectId;
     projectName = ProjectName.newBuilder().setProject(projectId).build();
     this.metricServiceClient = metricServiceClient;
     this.domain = StackdriverExportUtils.getDomain(metricNamePrefix);
     this.displayNamePrefix = StackdriverExportUtils.getDisplayNamePrefix(metricNamePrefix);
+    this.constantLabels = constantLabels;
     this.nextExporter = nextExporter;
   }
 
@@ -95,7 +100,7 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
     span.addAnnotation("Create Stackdriver Metric.");
     MetricDescriptor stackDriverMetricDescriptor =
         StackdriverExportUtils.createMetricDescriptor(
-            metricDescriptor, projectId, domain, displayNamePrefix);
+            metricDescriptor, projectId, domain, displayNamePrefix, constantLabels);
 
     CreateMetricDescriptorRequest request =
         CreateMetricDescriptorRequest.newBuilder()

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateTimeSeriesExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateTimeSeriesExporter.java
@@ -26,6 +26,8 @@ import com.google.monitoring.v3.CreateTimeSeriesRequest;
 import com.google.monitoring.v3.ProjectName;
 import com.google.monitoring.v3.TimeSeries;
 import io.opencensus.exporter.metrics.util.MetricExporter;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
 import io.opencensus.metrics.export.Metric;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.Status;
@@ -34,6 +36,7 @@ import io.opencensus.trace.Tracing;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -45,16 +48,19 @@ final class CreateTimeSeriesExporter extends MetricExporter {
   private final MetricServiceClient metricServiceClient;
   private final MonitoredResource monitoredResource;
   private final String domain;
+  private final Map<LabelKey, LabelValue> constantLabels;
 
   CreateTimeSeriesExporter(
       String projectId,
       MetricServiceClient metricServiceClient,
       MonitoredResource monitoredResource,
-      @javax.annotation.Nullable String metricNamePrefix) {
+      @javax.annotation.Nullable String metricNamePrefix,
+      Map<LabelKey, LabelValue> constantLabels) {
     projectName = ProjectName.newBuilder().setProject(projectId).build();
     this.metricServiceClient = metricServiceClient;
     this.monitoredResource = monitoredResource;
     this.domain = StackdriverExportUtils.getDomain(metricNamePrefix);
+    this.constantLabels = constantLabels;
   }
 
   @Override
@@ -63,7 +69,7 @@ final class CreateTimeSeriesExporter extends MetricExporter {
     for (Metric metric : metrics) {
       timeSeriesList.addAll(
           StackdriverExportUtils.createTimeSeriesList(
-              metric, monitoredResource, domain, projectName.getProject()));
+              metric, monitoredResource, domain, projectName.getProject(), constantLabels));
     }
 
     Span span = tracer.getCurrentSpan();

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -338,7 +338,10 @@ final class StackdriverExportUtils {
       stringTagMap.put(labelKeys.get(i).getKey(), value);
     }
     for (Map.Entry<LabelKey, LabelValue> constantLabel : constantLabels.entrySet()) {
-      stringTagMap.put(constantLabel.getKey().getKey(), constantLabel.getValue().getValue());
+      String constantLabelKey = constantLabel.getKey().getKey();
+      String constantLabelValue = constantLabel.getValue().getValue();
+      constantLabelValue = constantLabelValue == null ? "" : constantLabelValue;
+      stringTagMap.put(constantLabelKey, constantLabelValue);
     }
     builder.putAllLabels(stringTagMap);
     return builder.build();

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
@@ -16,10 +16,15 @@
 
 package io.opencensus.exporter.stats.stackdriver;
 
+import static io.opencensus.exporter.stats.stackdriver.StackdriverExportUtils.DEFAULT_CONSTANT_LABELS;
+
 import com.google.api.MonitoredResource;
 import com.google.auth.Credentials;
 import com.google.auto.value.AutoValue;
 import io.opencensus.common.Duration;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -80,13 +85,22 @@ public abstract class StackdriverStatsConfiguration {
   public abstract String getMetricNamePrefix();
 
   /**
+   * Returns the constant labels that will be applied to every Stackdriver metric.
+   *
+   * @return the constant labels.
+   * @since 0.21
+   */
+  public abstract Map<LabelKey, LabelValue> getConstantLabels();
+
+  /**
    * Returns a new {@link Builder}.
    *
    * @return a {@code Builder}.
    * @since 0.11
    */
   public static Builder builder() {
-    return new AutoValue_StackdriverStatsConfiguration.Builder();
+    return new AutoValue_StackdriverStatsConfiguration.Builder()
+        .setConstantLabels(DEFAULT_CONSTANT_LABELS);
   }
 
   /**
@@ -147,6 +161,26 @@ public abstract class StackdriverStatsConfiguration {
      * @since 0.16
      */
     public abstract Builder setMetricNamePrefix(String prefix);
+
+    /**
+     * Sets the constant labels that will be applied to every Stackdriver metric. This default
+     * ensures that the set of labels together with the default resource (global) are unique to this
+     * process, as required by stackdriver.
+     *
+     * <p>If not set, the exporter will use the "opencensus_task" label.
+     *
+     * <p>If you set constant labels, make sure that the monitored resource together with these
+     * labels is unique to the current process. This is to ensure that there is only a single writer
+     * to each time series in Stackdriver.
+     *
+     * <p>Set constant labels to empty to avoid getting the default "opencensus_task" label. You
+     * should only do this if you know that the monitored resource uniquely identifies this process.
+     *
+     * @param constantLabels constant labels that will be applied to every Stackdriver metric.
+     * @return this
+     * @since 0.21
+     */
+    public abstract Builder setConstantLabels(Map<LabelKey, LabelValue> constantLabels);
 
     /**
      * Builds a new {@link StackdriverStatsConfiguration} with current settings.

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporterTest.java
@@ -18,6 +18,7 @@ package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.opencensus.exporter.stats.stackdriver.StackdriverExportUtils.CUSTOM_OPENCENSUS_DOMAIN;
+import static io.opencensus.exporter.stats.stackdriver.StackdriverExportUtils.DEFAULT_CONSTANT_LABELS;
 import static io.opencensus.exporter.stats.stackdriver.StackdriverExportUtils.DEFAULT_DISPLAY_NAME_PREFIX;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
@@ -123,14 +124,22 @@ public class CreateMetricDescriptorExporterTest {
     FakeMetricExporter fakeMetricExporter = new FakeMetricExporter();
     CreateMetricDescriptorExporter exporter =
         new CreateMetricDescriptorExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), null, fakeMetricExporter);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            null,
+            DEFAULT_CONSTANT_LABELS,
+            fakeMetricExporter);
     exporter.export(Arrays.asList(METRIC, METRIC_2));
 
     verify(mockStub, times(2)).createMetricDescriptorCallable();
 
     MetricDescriptor descriptor =
         StackdriverExportUtils.createMetricDescriptor(
-            METRIC_DESCRIPTOR, PROJECT_ID, CUSTOM_OPENCENSUS_DOMAIN, DEFAULT_DISPLAY_NAME_PREFIX);
+            METRIC_DESCRIPTOR,
+            PROJECT_ID,
+            CUSTOM_OPENCENSUS_DOMAIN,
+            DEFAULT_DISPLAY_NAME_PREFIX,
+            DEFAULT_CONSTANT_LABELS);
     verify(mockCreateMetricDescriptorCallable, times(1))
         .call(
             eq(
@@ -141,7 +150,11 @@ public class CreateMetricDescriptorExporterTest {
 
     MetricDescriptor descriptor2 =
         StackdriverExportUtils.createMetricDescriptor(
-            METRIC_DESCRIPTOR_2, PROJECT_ID, CUSTOM_OPENCENSUS_DOMAIN, DEFAULT_DISPLAY_NAME_PREFIX);
+            METRIC_DESCRIPTOR_2,
+            PROJECT_ID,
+            CUSTOM_OPENCENSUS_DOMAIN,
+            DEFAULT_DISPLAY_NAME_PREFIX,
+            DEFAULT_CONSTANT_LABELS);
     verify(mockCreateMetricDescriptorCallable, times(1))
         .call(
             eq(
@@ -157,7 +170,11 @@ public class CreateMetricDescriptorExporterTest {
     FakeMetricExporter fakeMetricExporter = new FakeMetricExporter();
     CreateMetricDescriptorExporter exporter =
         new CreateMetricDescriptorExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), null, fakeMetricExporter);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            null,
+            DEFAULT_CONSTANT_LABELS,
+            fakeMetricExporter);
     exporter.export(Collections.<Metric>emptyList());
     verify(mockStub, times(0)).createMetricDescriptorCallable();
     assertThat(fakeMetricExporter.getLastExported()).isEmpty();
@@ -169,7 +186,11 @@ public class CreateMetricDescriptorExporterTest {
     doThrow(new IllegalArgumentException()).when(mockStub).createMetricDescriptorCallable();
     CreateMetricDescriptorExporter exporter =
         new CreateMetricDescriptorExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), null, fakeMetricExporter);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            null,
+            DEFAULT_CONSTANT_LABELS,
+            fakeMetricExporter);
 
     exporter.export(Collections.singletonList(METRIC));
     verify(mockStub, times(1)).createMetricDescriptorCallable();
@@ -181,7 +202,11 @@ public class CreateMetricDescriptorExporterTest {
     FakeMetricExporter fakeMetricExporter = new FakeMetricExporter();
     CreateMetricDescriptorExporter exporter =
         new CreateMetricDescriptorExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), null, fakeMetricExporter);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            null,
+            DEFAULT_CONSTANT_LABELS,
+            fakeMetricExporter);
     exporter.export(Collections.singletonList(METRIC));
     verify(mockStub, times(1)).createMetricDescriptorCallable();
     assertThat(fakeMetricExporter.getLastExported()).containsExactly(METRIC);
@@ -196,7 +221,11 @@ public class CreateMetricDescriptorExporterTest {
     FakeMetricExporter fakeMetricExporter = new FakeMetricExporter();
     CreateMetricDescriptorExporter exporter =
         new CreateMetricDescriptorExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), null, fakeMetricExporter);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            null,
+            DEFAULT_CONSTANT_LABELS,
+            fakeMetricExporter);
     exporter.export(Collections.singletonList(METRIC));
     verify(mockStub, times(1)).createMetricDescriptorCallable();
     assertThat(fakeMetricExporter.getLastExported()).containsExactly(METRIC);
@@ -211,7 +240,11 @@ public class CreateMetricDescriptorExporterTest {
     FakeMetricExporter fakeMetricExporter = new FakeMetricExporter();
     CreateMetricDescriptorExporter exporter =
         new CreateMetricDescriptorExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), null, fakeMetricExporter);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            null,
+            DEFAULT_CONSTANT_LABELS,
+            fakeMetricExporter);
     exporter.export(Collections.singletonList(METRIC_4));
 
     // Should not create MetricDescriptor for built-in metrics, but TimeSeries should be uploaded.

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/CreateTimeSeriesExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/CreateTimeSeriesExporterTest.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.exporter.stats.stackdriver;
 
+import static io.opencensus.exporter.stats.stackdriver.StackdriverExportUtils.DEFAULT_CONSTANT_LABELS;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doReturn;
@@ -100,13 +101,21 @@ public class CreateTimeSeriesExporterTest {
   public void export() {
     CreateTimeSeriesExporter exporter =
         new CreateTimeSeriesExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), DEFAULT_RESOURCE, null);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            DEFAULT_RESOURCE,
+            null,
+            DEFAULT_CONSTANT_LABELS);
     exporter.export(Collections.singletonList(METRIC));
     verify(mockStub, times(1)).createTimeSeriesCallable();
 
     List<TimeSeries> timeSeries =
         StackdriverExportUtils.createTimeSeriesList(
-            METRIC, DEFAULT_RESOURCE, StackdriverExportUtils.CUSTOM_OPENCENSUS_DOMAIN, PROJECT_ID);
+            METRIC,
+            DEFAULT_RESOURCE,
+            StackdriverExportUtils.CUSTOM_OPENCENSUS_DOMAIN,
+            PROJECT_ID,
+            DEFAULT_CONSTANT_LABELS);
 
     verify(mockCreateTimeSeriesCallable, times(1))
         .call(
@@ -121,7 +130,11 @@ public class CreateTimeSeriesExporterTest {
   public void splitInMultipleBatches() {
     CreateTimeSeriesExporter exporter =
         new CreateTimeSeriesExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), DEFAULT_RESOURCE, null);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            DEFAULT_RESOURCE,
+            null,
+            DEFAULT_CONSTANT_LABELS);
     final int numExportedTimeSeries = 4 * StackdriverExportUtils.MAX_BATCH_EXPORT_SIZE;
     ArrayList<Metric> exportedMetrics = new ArrayList<>(numExportedTimeSeries);
     for (int i = 0; i < numExportedTimeSeries; i++) {
@@ -135,7 +148,11 @@ public class CreateTimeSeriesExporterTest {
   public void doNotExportForEmptyMetrics() {
     CreateTimeSeriesExporter exporter =
         new CreateTimeSeriesExporter(
-            PROJECT_ID, new FakeMetricServiceClient(mockStub), DEFAULT_RESOURCE, null);
+            PROJECT_ID,
+            new FakeMetricServiceClient(mockStub),
+            DEFAULT_RESOURCE,
+            null,
+            DEFAULT_CONSTANT_LABELS);
     exporter.export(Collections.<Metric>emptyList());
     verify(mockStub, times(0)).createTimeSeriesCallable();
   }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
@@ -17,12 +17,16 @@
 package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.exporter.stats.stackdriver.StackdriverExportUtils.DEFAULT_CONSTANT_LABELS;
 
 import com.google.api.MonitoredResource;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
 import io.opencensus.common.Duration;
+import io.opencensus.metrics.LabelKey;
+import io.opencensus.metrics.LabelValue;
+import java.util.Collections;
 import java.util.Date;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -52,12 +56,14 @@ public class StackdriverStatsConfigurationTest {
             .setExportInterval(DURATION)
             .setMonitoredResource(RESOURCE)
             .setMetricNamePrefix(CUSTOM_PREFIX)
+            .setConstantLabels(Collections.<LabelKey, LabelValue>emptyMap())
             .build();
     assertThat(configuration.getCredentials()).isEqualTo(FAKE_CREDENTIALS);
     assertThat(configuration.getProjectId()).isEqualTo(PROJECT_ID);
     assertThat(configuration.getExportInterval()).isEqualTo(DURATION);
     assertThat(configuration.getMonitoredResource()).isEqualTo(RESOURCE);
     assertThat(configuration.getMetricNamePrefix()).isEqualTo(CUSTOM_PREFIX);
+    assertThat(configuration.getConstantLabels()).isEmpty();
   }
 
   @Test
@@ -68,5 +74,6 @@ public class StackdriverStatsConfigurationTest {
     assertThat(configuration.getExportInterval()).isNull();
     assertThat(configuration.getMonitoredResource()).isNull();
     assertThat(configuration.getMetricNamePrefix()).isNull();
+    assertThat(configuration.getConstantLabels()).isEqualTo(DEFAULT_CONSTANT_LABELS);
   }
 }


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1844.

Equivalent to https://github.com/census-instrumentation/opencensus-python/pull/622 in Python and https://github.com/census-ecosystem/opencensus-go-exporter-stackdriver/pull/20 in Go.