### PR TITLE
Exporter/Stackdriver: Fail fast on invalid project ID.

### DIFF
--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
@@ -18,17 +18,22 @@ package io.opencensus.exporter.stats.stackdriver;
 
 import static com.google.common.truth.Truth.assertThat;
 import static io.opencensus.exporter.stats.stackdriver.StackdriverExportUtils.DEFAULT_CONSTANT_LABELS;
+import static io.opencensus.exporter.stats.stackdriver.StackdriverStatsConfiguration.DEFAULT_INTERVAL;
 
 import com.google.api.MonitoredResource;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.ServiceOptions;
 import io.opencensus.common.Duration;
 import io.opencensus.metrics.LabelKey;
 import io.opencensus.metrics.LabelValue;
 import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -46,6 +51,13 @@ public class StackdriverStatsConfigurationTest {
           .putLabels("instance-id", "instance")
           .build();
   private static final String CUSTOM_PREFIX = "myorg";
+
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
+  @Test
+  public void testConstants() {
+    assertThat(DEFAULT_INTERVAL).isEqualTo(Duration.create(60, 0));
+  }
 
   @Test
   public void testBuild() {
@@ -68,12 +80,96 @@ public class StackdriverStatsConfigurationTest {
 
   @Test
   public void testBuild_Default() {
-    StackdriverStatsConfiguration configuration = StackdriverStatsConfiguration.builder().build();
+    StackdriverStatsConfiguration configuration;
+    try {
+      configuration = StackdriverStatsConfiguration.builder().build();
+    } catch (Exception e) {
+      // Some test hosts may not have cloud project ID set up.
+      configuration = StackdriverStatsConfiguration.builder().setProjectId("test").build();
+    }
     assertThat(configuration.getCredentials()).isNull();
-    assertThat(configuration.getProjectId()).isNull();
-    assertThat(configuration.getExportInterval()).isNull();
-    assertThat(configuration.getMonitoredResource()).isNull();
+    assertThat(configuration.getProjectId()).isNotNull();
+    assertThat(configuration.getExportInterval()).isEqualTo(DEFAULT_INTERVAL);
+    assertThat(configuration.getMonitoredResource()).isNotNull();
     assertThat(configuration.getMetricNamePrefix()).isNull();
     assertThat(configuration.getConstantLabels()).isEqualTo(DEFAULT_CONSTANT_LABELS);
+  }
+
+  @Test
+  public void disallowNullProjectId() {
+    StackdriverStatsConfiguration.Builder builder = StackdriverStatsConfiguration.builder();
+    thrown.expect(NullPointerException.class);
+    builder.setProjectId(null);
+  }
+
+  @Test
+  public void disallowEmptyProjectId() {
+    StackdriverStatsConfiguration.Builder builder = StackdriverStatsConfiguration.builder();
+    builder.setProjectId("");
+    thrown.expect(IllegalArgumentException.class);
+    builder.build();
+  }
+
+  @Test
+  public void allowToUseDefaultProjectId() {
+    String defaultProjectId = ServiceOptions.getDefaultProjectId();
+    if (defaultProjectId != null) {
+      StackdriverStatsConfiguration configuration = StackdriverStatsConfiguration.builder().build();
+      assertThat(configuration.getProjectId()).isEqualTo(defaultProjectId);
+    }
+  }
+
+  @Test
+  public void disallowNullResource() {
+    StackdriverStatsConfiguration.Builder builder = StackdriverStatsConfiguration.builder();
+    thrown.expect(NullPointerException.class);
+    builder.setMonitoredResource(null);
+  }
+
+  @Test
+  public void disallowNullExportInterval() {
+    StackdriverStatsConfiguration.Builder builder = StackdriverStatsConfiguration.builder();
+    thrown.expect(NullPointerException.class);
+    builder.setExportInterval(null);
+  }
+
+  @Test
+  public void disallowNullConstantLabels() {
+    StackdriverStatsConfiguration.Builder builder = StackdriverStatsConfiguration.builder();
+    thrown.expect(NullPointerException.class);
+    builder.setConstantLabels(null);
+  }
+
+  @Test
+  public void disallowNullConstantLabelKey() {
+    StackdriverStatsConfiguration.Builder builder = StackdriverStatsConfiguration.builder();
+    Map<LabelKey, LabelValue> labels = Collections.singletonMap(null, LabelValue.create("val"));
+    builder.setConstantLabels(labels);
+    thrown.expect(NullPointerException.class);
+    builder.build();
+  }
+
+  @Test
+  public void disallowNullConstantLabelValue() {
+    StackdriverStatsConfiguration.Builder builder = StackdriverStatsConfiguration.builder();
+    Map<LabelKey, LabelValue> labels =
+        Collections.singletonMap(LabelKey.create("key", "desc"), null);
+    builder.setConstantLabels(labels);
+    thrown.expect(NullPointerException.class);
+    builder.build();
+  }
+
+  @Test
+  public void allowNullCredentials() {
+    StackdriverStatsConfiguration configuration =
+        StackdriverStatsConfiguration.builder().setCredentials(null).build();
+    assertThat(configuration.getCredentials()).isNull();
+  }
+
+  @Test
+  public void allowNullMetricPrefix() {
+    StackdriverStatsConfiguration configuration =
+        StackdriverStatsConfiguration.builder().setMetricNamePrefix(null).build();
+    assertThat(configuration.getMetricNamePrefix()).isNull();
   }
 }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -51,11 +51,6 @@ public class StackdriverStatsExporterTest {
   @Rule public final ExpectedException thrown = ExpectedException.none();
 
   @Test
-  public void testConstants() {
-    assertThat(StackdriverStatsExporter.DEFAULT_INTERVAL).isEqualTo(Duration.create(60, 0));
-  }
-
-  @Test
   public void createWithNullStackdriverStatsConfiguration() throws IOException {
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("configuration");

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceExporter.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceExporter.java
@@ -79,9 +79,6 @@ public final class StackdriverTraceExporter {
       Credentials credentials = configuration.getCredentials();
       String projectId = configuration.getProjectId();
 
-      // TODO(sebright): Handle null default project ID.
-      projectId = projectId != null ? projectId : castNonNull(ServiceOptions.getDefaultProjectId());
-
       StackdriverV2ExporterHandler handler;
       TraceServiceStub stub = configuration.getTraceServiceStub();
       if (stub == null) {
@@ -98,12 +95,6 @@ public final class StackdriverTraceExporter {
 
       registerInternal(handler);
     }
-  }
-
-  // TODO(sebright): Remove this method.
-  @SuppressWarnings("nullness")
-  private static <T> T castNonNull(@javax.annotation.Nullable T arg) {
-    return arg;
   }
 
   private static void registerInternal(Handler newHandler) {

--- a/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
+++ b/exporters/trace/stackdriver/src/main/java/io/opencensus/exporter/trace/stackdriver/StackdriverV2ExporterHandler.java
@@ -148,19 +148,14 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
   private StackdriverV2ExporterHandler(
       String projectId,
       TraceServiceClient traceServiceClient,
-      @javax.annotation.Nullable Map<String, io.opencensus.trace.AttributeValue> fixedAttributes) {
-    this.projectId = checkNotNull(projectId, "projectId");
+      Map<String, io.opencensus.trace.AttributeValue> fixedAttributes) {
+    this.projectId = projectId;
     this.traceServiceClient = traceServiceClient;
-    if (fixedAttributes == null) {
-      this.fixedAttributes = Collections.emptyMap();
-    } else {
-      this.fixedAttributes = new HashMap<>();
-      for (Map.Entry<String, io.opencensus.trace.AttributeValue> label :
-          fixedAttributes.entrySet()) {
-        AttributeValue value = toAttributeValueProto(label.getValue());
-        if (value != null) {
-          this.fixedAttributes.put(label.getKey(), value);
-        }
+    this.fixedAttributes = new HashMap<>();
+    for (Map.Entry<String, io.opencensus.trace.AttributeValue> label : fixedAttributes.entrySet()) {
+      AttributeValue value = toAttributeValueProto(label.getValue());
+      if (value != null) {
+        this.fixedAttributes.put(label.getKey(), value);
       }
     }
     projectName = ProjectName.of(this.projectId);
@@ -169,14 +164,14 @@ final class StackdriverV2ExporterHandler extends SpanExporter.Handler {
   static StackdriverV2ExporterHandler createWithStub(
       String projectId,
       TraceServiceClient traceServiceClient,
-      @javax.annotation.Nullable Map<String, io.opencensus.trace.AttributeValue> fixedAttributes) {
+      Map<String, io.opencensus.trace.AttributeValue> fixedAttributes) {
     return new StackdriverV2ExporterHandler(projectId, traceServiceClient, fixedAttributes);
   }
 
   static StackdriverV2ExporterHandler createWithCredentials(
       String projectId,
       Credentials credentials,
-      @javax.annotation.Nullable Map<String, io.opencensus.trace.AttributeValue> fixedAttributes)
+      Map<String, io.opencensus.trace.AttributeValue> fixedAttributes)
       throws IOException {
     TraceServiceSettings traceServiceSettings =
         TraceServiceSettings.newBuilder()

--- a/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfigurationTest.java
+++ b/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfigurationTest.java
@@ -21,8 +21,14 @@ import static com.google.common.truth.Truth.assertThat;
 import com.google.auth.Credentials;
 import com.google.auth.oauth2.AccessToken;
 import com.google.auth.oauth2.GoogleCredentials;
+import com.google.cloud.ServiceOptions;
+import io.opencensus.trace.AttributeValue;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Map;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
@@ -34,21 +40,85 @@ public class StackdriverTraceConfigurationTest {
       GoogleCredentials.newBuilder().setAccessToken(new AccessToken("fake", new Date(100))).build();
   private static final String PROJECT_ID = "project";
 
+  @Rule public final ExpectedException thrown = ExpectedException.none();
+
   @Test
   public void defaultConfiguration() {
-    StackdriverTraceConfiguration configuration = StackdriverTraceConfiguration.builder().build();
+    StackdriverTraceConfiguration configuration;
+    try {
+      configuration = StackdriverTraceConfiguration.builder().build();
+    } catch (Exception e) {
+      // Some test hosts may not have cloud project ID set up.
+      configuration = StackdriverTraceConfiguration.builder().setProjectId("test").build();
+    }
     assertThat(configuration.getCredentials()).isNull();
-    assertThat(configuration.getProjectId()).isNull();
+    assertThat(configuration.getProjectId()).isNotNull();
+    assertThat(configuration.getTraceServiceStub()).isNull();
+    assertThat(configuration.getFixedAttributes()).isEmpty();
   }
 
   @Test
   public void updateAll() {
+    Map<String, AttributeValue> attributes =
+        Collections.singletonMap("key", AttributeValue.stringAttributeValue("val"));
     StackdriverTraceConfiguration configuration =
         StackdriverTraceConfiguration.builder()
             .setCredentials(FAKE_CREDENTIALS)
             .setProjectId(PROJECT_ID)
+            .setFixedAttributes(attributes)
             .build();
     assertThat(configuration.getCredentials()).isEqualTo(FAKE_CREDENTIALS);
     assertThat(configuration.getProjectId()).isEqualTo(PROJECT_ID);
+    assertThat(configuration.getFixedAttributes()).isEqualTo(attributes);
+  }
+
+  @Test
+  public void disallowNullProjectId() {
+    StackdriverTraceConfiguration.Builder builder = StackdriverTraceConfiguration.builder();
+    thrown.expect(NullPointerException.class);
+    builder.setProjectId(null);
+  }
+
+  @Test
+  public void disallowEmptyProjectId() {
+    StackdriverTraceConfiguration.Builder builder = StackdriverTraceConfiguration.builder();
+    builder.setProjectId("");
+    thrown.expect(IllegalArgumentException.class);
+    builder.build();
+  }
+
+  @Test
+  public void allowToUseDefaultProjectId() {
+    String defaultProjectId = ServiceOptions.getDefaultProjectId();
+    if (defaultProjectId != null) {
+      StackdriverTraceConfiguration configuration = StackdriverTraceConfiguration.builder().build();
+      assertThat(configuration.getProjectId()).isEqualTo(defaultProjectId);
+    }
+  }
+
+  @Test
+  public void disallowNullFixedAttributes() {
+    StackdriverTraceConfiguration.Builder builder = StackdriverTraceConfiguration.builder();
+    thrown.expect(NullPointerException.class);
+    builder.setFixedAttributes(null);
+  }
+
+  @Test
+  public void disallowNullFixedAttributeKey() {
+    StackdriverTraceConfiguration.Builder builder = StackdriverTraceConfiguration.builder();
+    Map<String, AttributeValue> attributes =
+        Collections.singletonMap(null, AttributeValue.stringAttributeValue("val"));
+    builder.setFixedAttributes(attributes);
+    thrown.expect(NullPointerException.class);
+    builder.build();
+  }
+
+  @Test
+  public void disallowNullFixedAttributeValue() {
+    StackdriverTraceConfiguration.Builder builder = StackdriverTraceConfiguration.builder();
+    Map<String, AttributeValue> attributes = Collections.singletonMap("key", null);
+    builder.setFixedAttributes(attributes);
+    thrown.expect(NullPointerException.class);
+    builder.build();
   }
 }


### PR DESCRIPTION
Also require a few configurations to be non-null.

Related to https://github.com/census-instrumentation/opencensus-java/issues/1547. /cc @sebright 