### PR TITLE
 update jetty client and server example to use updated api.

### DIFF
--- a/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
+++ b/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
@@ -72,7 +72,7 @@ public class HelloWorldClient {
     initStatsExporter();
 
     // Create http client that will trace requests. By default trace context is propagated using
-    // using w3c TraceContext propagator.
+    // w3c TraceContext propagator.
     // To use B3 propagation use following
     //    OcJettyHttpClient httpClient =
     //        new OcJettyHttpClient(

--- a/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
+++ b/examples/src/main/java/io/opencensus/examples/http/jetty/client/HelloWorldClient.java
@@ -35,9 +35,7 @@ import org.eclipse.jetty.client.util.StringContentProvider;
 import org.eclipse.jetty.http.HttpMethod;
 import org.eclipse.jetty.util.ssl.SslContextFactory;
 
-/**
- * Sample application that shows how to instrument jetty client.
- */
+/** Sample application that shows how to instrument jetty client. */
 public class HelloWorldClient {
 
   private static final Logger logger = Logger.getLogger(HelloWorldClient.class.getName());
@@ -84,23 +82,26 @@ public class HelloWorldClient {
     //            Tracing.getPropagationComponent().getB3Format());
     OcJettyHttpClient httpClient =
         new OcJettyHttpClient(
-            new HttpClientTransportOverHTTP(),
-            new SslContextFactory(),
-            null,
-            null);
+            new HttpClientTransportOverHTTP(), new SslContextFactory(), null, null);
 
     httpClient.start();
 
     do {
       HttpRequest request =
-          (HttpRequest) httpClient.newRequest("http://localhost:8080/helloworld/request")
-              .method(HttpMethod.GET);
+          (HttpRequest)
+              httpClient
+                  .newRequest("http://localhost:8080/helloworld/request")
+                  .method(HttpMethod.GET);
       HttpRequest asyncRequest =
-          (HttpRequest) httpClient.newRequest("http://localhost:8080/helloworld/request/async")
-              .method(HttpMethod.GET);
+          (HttpRequest)
+              httpClient
+                  .newRequest("http://localhost:8080/helloworld/request/async")
+                  .method(HttpMethod.GET);
       HttpRequest postRequest =
-          (HttpRequest) httpClient.newRequest("http://localhost:8080/helloworld/request")
-              .method(HttpMethod.POST);
+          (HttpRequest)
+              httpClient
+                  .newRequest("http://localhost:8080/helloworld/request")
+                  .method(HttpMethod.POST);
       postRequest.content(new StringContentProvider("{\"hello\": \"world\"}"), "application/json");
 
       if (request == null) {

--- a/examples/src/main/java/io/opencensus/examples/http/jetty/server/HelloWorldServer.java
+++ b/examples/src/main/java/io/opencensus/examples/http/jetty/server/HelloWorldServer.java
@@ -46,9 +46,7 @@ import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 
-/**
- * Sample application that shows how to instrument jetty server.
- */
+/** Sample application that shows how to instrument jetty server. */
 public class HelloWorldServer extends AbstractHandler {
 
   private static final Logger logger = Logger.getLogger(HelloWorldServer.class.getName());
@@ -199,7 +197,7 @@ public class HelloWorldServer extends AbstractHandler {
     //    OC_TRACE_PROPAGATOR, Tracing.getPropagationComponent().getB3Format());
 
     // By default publicEndpoint parameter is set to false and incoming trace context is added as
-    // a parent link.
+    // a parent.
     // If the endpoint for http request is public then uncomment following line to set the
     // publicEndpoint parameter to true. When set to true incoming trace context is added as a
     // parent link instead of as a parent.

--- a/examples/src/main/java/io/opencensus/examples/http/jetty/server/HelloWorldServer.java
+++ b/examples/src/main/java/io/opencensus/examples/http/jetty/server/HelloWorldServer.java
@@ -44,13 +44,17 @@ import org.eclipse.jetty.server.Request;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.server.handler.AbstractHandler;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
+import org.eclipse.jetty.servlet.ServletHolder;
 
-/** Sample application that shows how to instrument jetty server. */
+/**
+ * Sample application that shows how to instrument jetty server.
+ */
 public class HelloWorldServer extends AbstractHandler {
+
   private static final Logger logger = Logger.getLogger(HelloWorldServer.class.getName());
 
   public static class HelloServlet extends HttpServlet {
+
     private static String body = "<h1>Hello World Servlet Get</h1>";
 
     private static final long serialVersionUID = 1L;
@@ -179,18 +183,35 @@ public class HelloWorldServer extends AbstractHandler {
   public static void main(String[] args) throws Exception {
     initTracing();
     initStatsExporter();
-    ServletContextHandler context = new ServletContextHandler(ServletContextHandler.SESSIONS);
-    context.setContextPath("/");
 
     Server server = new Server(8080);
-    ServletHandler handler = new ServletHandler();
-    server.setHandler(handler);
+    ServletContextHandler contextHandler =
+        new ServletContextHandler(ServletContextHandler.SESSIONS);
+    contextHandler.setContextPath("/helloworld");
+    ServletHolder sh = new ServletHolder(new HelloServlet());
+    contextHandler.addServlet(sh, "/request/*");
 
-    handler.addFilterWithMapping(
-        OcHttpServletFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
-    handler.addServletWithMapping(HelloServlet.class, "/*");
+    // Enable tracing by adding OcHttpServleFilter for all path
+    contextHandler.addFilter(OcHttpServletFilter.class, "/*", EnumSet.of(DispatcherType.REQUEST));
 
-    server.start();
-    server.join();
+    // Uncomment following line to use B3Format for trace context propagation.
+    // contextHandler.setAttribute(
+    //    OC_TRACE_PROPAGATOR, Tracing.getPropagationComponent().getB3Format());
+
+    // By default publicEndpoint parameter is set to false and incoming trace context is added as
+    // a parent link.
+    // If the endpoint for http request is public then uncomment following line to set the
+    // publicEndpoint parameter to true. When set to true incoming trace context is added as a
+    // parent link instead of as a parent.
+    //
+    // contextHandler.setInitParameter(OC_PUBLIC_ENDPOINT, "true");
+
+    server.setHandler(contextHandler);
+    try {
+      server.start();
+      server.join();
+    } catch (Exception e) {
+      logger.error("Failed to start application", e);
+    }
   }
 }


### PR DESCRIPTION
- use client api that supports ssl context.
- use default value for publicEndpoint on server.
- Add comment on how to use B3 format on both sides, client and server.