### PR TITLE
Metrics: Add Cumulative APIs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - Support constant labels in Gauge APIs.
 - Add an option to allow users to override the default "opencensus_task" metric label in Stackdriver Stats Exporter.
 - Allow setting custom namespace in Prometheus exporter.
+- Add Cumulative (`DoubleCumulative`, `LongCumulative`, `DerivedDoubleCumulative`, `DerivedLongCumulative`) APIs.
 
 ## 0.20.0 - 2019-03-28
 - Add OpenCensus Java OC-Agent Trace Exporter.

--- a/api/src/main/java/io/opencensus/metrics/DerivedDoubleCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedDoubleCumulative.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import io.opencensus.common.ToDoubleFunction;
+import io.opencensus.internal.Utils;
+import java.lang.ref.WeakReference;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
+/**
+ * Derived Double Cumulative metric, to report cumulative measurement of a double value. Cumulative
+ * values can go up or stay the same, but can never go down. The cumulative values cannot be
+ * negative.
+ *
+ * <p>Example: Create a Cumulative with an object and a callback function.
+ *
+ * <pre>{@code
+ * class YourClass {
+ *
+ *   private static final MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+ *
+ *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
+ *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
+ *
+ *   DerivedDoubleCumulative cumulative = metricRegistry.addDerivedDoubleCumulative(
+ *       "processed_jobs", "Processed jobs in a queue", "1", labelKeys);
+ *
+ *   QueueManager queueManager = new QueueManager();
+ *   cumulative.createTimeSeries(labelValues, queueManager,
+ *         new ToDoubleFunction<QueueManager>() {
+ *           {@literal @}Override
+ *           public double applyAsDouble(QueueManager queue) {
+ *             return queue.size();
+ *           }
+ *         });
+ *
+ *   void doWork() {
+ *      // Your code here.
+ *   }
+ * }
+ *
+ * }</pre>
+ *
+ * @since 0.21
+ */
+@ThreadSafe
+public abstract class DerivedDoubleCumulative {
+  /**
+   * Creates a {@code TimeSeries}. The value of a single point in the TimeSeries is observed from a
+   * callback function. This function is invoked whenever metrics are collected, meaning the
+   * reported value is up-to-date. It keeps a {@link WeakReference} to the object and it is the
+   * user's responsibility to manage the lifetime of the object.
+   *
+   * @param labelValues the list of label values.
+   * @param obj the state object from which the function derives a measurement.
+   * @param function the function to be called.
+   * @param <T> the type of the object upon which the function derives a measurement.
+   * @throws NullPointerException if {@code labelValues} is null OR any element of {@code
+   *     labelValues} is null OR {@code function} is null.
+   * @throws IllegalArgumentException if different time series with the same labels already exists
+   *     OR if number of {@code labelValues}s are not equal to the label keys.
+   * @since 0.21
+   */
+  public abstract <T> void createTimeSeries(
+      List<LabelValue> labelValues,
+      /*@Nullable*/ T obj,
+      ToDoubleFunction</*@Nullable*/ T> function);
+
+  /**
+   * Removes the {@code TimeSeries} from the cumulative metric, if it is present.
+   *
+   * @param labelValues the list of label values.
+   * @throws NullPointerException if {@code labelValues} is null.
+   * @since 0.21
+   */
+  public abstract void removeTimeSeries(List<LabelValue> labelValues);
+
+  /**
+   * Removes all {@code TimeSeries} from the cumulative metric.
+   *
+   * @since 0.21
+   */
+  public abstract void clear();
+
+  /**
+   * Returns the no-op implementation of the {@code DerivedDoubleCumulative}.
+   *
+   * @return the no-op implementation of the {@code DerivedDoubleCumulative}.
+   * @since 0.21
+   */
+  static DerivedDoubleCumulative newNoopDerivedDoubleCumulative(
+      String name, String description, String unit, List<LabelKey> labelKeys) {
+    return NoopDerivedDoubleCumulative.create(name, description, unit, labelKeys);
+  }
+
+  /** No-op implementations of DerivedDoubleCumulative class. */
+  private static final class NoopDerivedDoubleCumulative extends DerivedDoubleCumulative {
+    private final int labelKeysSize;
+
+    static NoopDerivedDoubleCumulative create(
+        String name, String description, String unit, List<LabelKey> labelKeys) {
+      return new NoopDerivedDoubleCumulative(name, description, unit, labelKeys);
+    }
+
+    /** Creates a new {@code NoopDerivedDoubleCumulative}. */
+    NoopDerivedDoubleCumulative(
+        String name, String description, String unit, List<LabelKey> labelKeys) {
+      Utils.checkNotNull(name, "name");
+      Utils.checkNotNull(description, "description");
+      Utils.checkNotNull(unit, "unit");
+      Utils.checkListElementNotNull(Utils.checkNotNull(labelKeys, "labelKeys"), "labelKey");
+      labelKeysSize = labelKeys.size();
+    }
+
+    @Override
+    public <T> void createTimeSeries(
+        List<LabelValue> labelValues,
+        /*@Nullable*/ T obj,
+        ToDoubleFunction</*@Nullable*/ T> function) {
+      Utils.checkListElementNotNull(Utils.checkNotNull(labelValues, "labelValues"), "labelValue");
+      Utils.checkArgument(
+          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+      Utils.checkNotNull(function, "function");
+    }
+
+    @Override
+    public void removeTimeSeries(List<LabelValue> labelValues) {
+      Utils.checkNotNull(labelValues, "labelValues");
+    }
+
+    @Override
+    public void clear() {}
+  }
+}

--- a/api/src/main/java/io/opencensus/metrics/DerivedDoubleCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedDoubleCumulative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, OpenCensus Authors
+ * Copyright 2019, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/opencensus/metrics/DerivedDoubleCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedDoubleCumulative.java
@@ -28,8 +28,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Derived Double Cumulative metric, to report cumulative measurement of a double value. Cumulative
- * values can go up or stay the same, but can never go down. The cumulative values cannot be
- * negative.
+ * values can go up or stay the same, but can never go down. Cumulative values cannot be negative.
  *
  * <p>Example: Create a Cumulative with an object and a callback function.
  *

--- a/api/src/main/java/io/opencensus/metrics/DerivedLongCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedLongCumulative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, OpenCensus Authors
+ * Copyright 2019, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/opencensus/metrics/DerivedLongCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedLongCumulative.java
@@ -28,8 +28,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Derived Long Cumulative metric, to report cumulative measurement of an int64 value. Cumulative
- * values can go up or stay the same, but can never go down. The cumulative values cannot be
- * negative.
+ * values can go up or stay the same, but can never go down. Cumulative values cannot be negative.
  *
  * <p>Example: Create a Cumulative with an object and a callback function.
  *

--- a/api/src/main/java/io/opencensus/metrics/DerivedLongCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DerivedLongCumulative.java
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import io.opencensus.common.ToLongFunction;
+import io.opencensus.internal.Utils;
+import java.lang.ref.WeakReference;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
+/**
+ * Derived Long Cumulative metric, to report cumulative measurement of an int64 value. Cumulative
+ * values can go up or stay the same, but can never go down. The cumulative values cannot be
+ * negative.
+ *
+ * <p>Example: Create a Cumulative with an object and a callback function.
+ *
+ * <pre>{@code
+ * class YourClass {
+ *
+ *   private static final MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+ *
+ *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
+ *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
+ *
+ *   DerivedLongCumulative cumulative = metricRegistry.addDerivedLongCumulative(
+ *       "processed_jobs", "Total processed jobs in a queue", "1", labelKeys);
+ *
+ *   QueueManager queueManager = new QueueManager();
+ *   cumulative.createTimeSeries(labelValues, queueManager,
+ *         new ToLongFunction<QueueManager>() {
+ *           {@literal @}Override
+ *           public long applyAsLong(QueueManager queue) {
+ *             return queue.size();
+ *           }
+ *         });
+ *
+ *   void doWork() {
+ *      // Your code here.
+ *   }
+ * }
+ *
+ * }</pre>
+ *
+ * @since 0.21
+ */
+@ThreadSafe
+public abstract class DerivedLongCumulative {
+  /**
+   * Creates a {@code TimeSeries}. The value of a single point in the TimeSeries is observed from a
+   * callback function. This function is invoked whenever metrics are collected, meaning the
+   * reported value is up-to-date. It keeps a {@link WeakReference} to the object and it is the
+   * user's responsibility to manage the lifetime of the object.
+   *
+   * @param labelValues the list of label values.
+   * @param obj the state object from which the function derives a measurement.
+   * @param function the function to be called.
+   * @param <T> the type of the object upon which the function derives a measurement.
+   * @throws NullPointerException if {@code labelValues} is null OR any element of {@code
+   *     labelValues} is null OR {@code function} is null.
+   * @throws IllegalArgumentException if different time series with the same labels already exists
+   *     OR if number of {@code labelValues}s are not equal to the label keys.
+   * @since 0.21
+   */
+  public abstract <T> void createTimeSeries(
+      List<LabelValue> labelValues, /*@Nullable*/ T obj, ToLongFunction</*@Nullable*/ T> function);
+
+  /**
+   * Removes the {@code TimeSeries} from the cumulative metric, if it is present.
+   *
+   * @param labelValues the list of label values.
+   * @throws NullPointerException if {@code labelValues} is null.
+   * @since 0.21
+   */
+  public abstract void removeTimeSeries(List<LabelValue> labelValues);
+
+  /**
+   * Removes all {@code TimeSeries} from the cumulative metric.
+   *
+   * @since 0.21
+   */
+  public abstract void clear();
+
+  /**
+   * Returns the no-op implementation of the {@code DerivedLongCumulative}.
+   *
+   * @return the no-op implementation of the {@code DerivedLongCumulative}.
+   * @since 0.21
+   */
+  static DerivedLongCumulative newNoopDerivedLongCumulative(
+      String name, String description, String unit, List<LabelKey> labelKeys) {
+    return NoopDerivedLongCumulative.create(name, description, unit, labelKeys);
+  }
+
+  /** No-op implementations of DerivedLongCumulative class. */
+  private static final class NoopDerivedLongCumulative extends DerivedLongCumulative {
+    private final int labelKeysSize;
+
+    static NoopDerivedLongCumulative create(
+        String name, String description, String unit, List<LabelKey> labelKeys) {
+      return new NoopDerivedLongCumulative(name, description, unit, labelKeys);
+    }
+
+    /** Creates a new {@code NoopDerivedLongCumulative}. */
+    NoopDerivedLongCumulative(
+        String name, String description, String unit, List<LabelKey> labelKeys) {
+      Utils.checkNotNull(name, "name");
+      Utils.checkNotNull(description, "description");
+      Utils.checkNotNull(unit, "unit");
+      Utils.checkListElementNotNull(Utils.checkNotNull(labelKeys, "labelKeys"), "labelKey");
+      labelKeysSize = labelKeys.size();
+    }
+
+    @Override
+    public <T> void createTimeSeries(
+        List<LabelValue> labelValues,
+        /*@Nullable*/ T obj,
+        ToLongFunction</*@Nullable*/ T> function) {
+      Utils.checkListElementNotNull(Utils.checkNotNull(labelValues, "labelValues"), "labelValue");
+      Utils.checkArgument(
+          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+      Utils.checkNotNull(function, "function");
+    }
+
+    @Override
+    public void removeTimeSeries(List<LabelValue> labelValues) {
+      Utils.checkNotNull(labelValues, "labelValues");
+    }
+
+    @Override
+    public void clear() {}
+  }
+}

--- a/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
@@ -141,12 +141,12 @@ public abstract class DoubleCumulative {
   public abstract static class DoublePoint {
 
     /**
-     * Adds the given value to the current value. The values can be negative.
+     * Adds the given value to the current value. The values cannot be negative.
      *
-     * @param amt the value to add
+     * @param delta the value to add
      * @since 0.21
      */
-    public abstract void add(double amt);
+    public abstract void add(double delta);
 
     /**
      * Sets the given value.
@@ -203,7 +203,7 @@ public abstract class DoubleCumulative {
       private NoopDoublePoint() {}
 
       @Override
-      public void add(double amt) {}
+      public void add(double delta) {}
 
       @Override
       public void set(double val) {}

--- a/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, OpenCensus Authors
+ * Copyright 2019, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
@@ -1,0 +1,213 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import io.opencensus.internal.Utils;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Double Cumulative metric, to report instantaneous measurement of a double value. Cumulative
+ * values can go up or stay the same, but can never go down. The cumulative values cannot be
+ * negative.
+ *
+ * <p>Example 1: Create a Cumulative with default labels.
+ *
+ * <pre>{@code
+ * class YourClass {
+ *
+ *   private static final MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+ *
+ *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
+ *
+ *   DoubleCumulative cumulative = metricRegistry.addDoubleCumulative("processed_jobs",
+ *                       "Processed jobs", "1", labelKeys);
+ *
+ *   // It is recommended to keep a reference of a point for manual operations.
+ *   DoublePoint defaultPoint = cumulative.getDefaultTimeSeries();
+ *
+ *   void doWork() {
+ *      // Your code here.
+ *      defaultPoint.add(10);
+ *   }
+ *
+ * }
+ * }</pre>
+ *
+ * <p>Example 2: You can also use labels(keys and values) to track different types of metric.
+ *
+ * <pre>{@code
+ * class YourClass {
+ *
+ *   private static final MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+ *
+ *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
+ *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
+ *
+ *   DoubleCumulative cumulative = metricRegistry.addDoubleCumulative("processed_jobs",
+ *                       "Processed jobs", "1", labelKeys);
+ *
+ *   // It is recommended to keep a reference of a point for manual operations.
+ *   DoublePoint inboundPoint = cumulative.getOrCreateTimeSeries(labelValues);
+ *
+ *   void doSomeWork() {
+ *      // Your code here.
+ *      inboundPoint.set(15);
+ *   }
+ *
+ * }
+ * }</pre>
+ *
+ * @since 0.21
+ */
+@ThreadSafe
+public abstract class DoubleCumulative {
+
+  /**
+   * Creates a {@code TimeSeries} and returns a {@code DoublePoint} if the specified {@code
+   * labelValues} is not already associated with this cumulative, else returns an existing {@code
+   * DoublePoint}.
+   *
+   * <p>It is recommended to keep a reference to the DoublePoint instead of always calling this
+   * method for manual operations.
+   *
+   * @param labelValues the list of label values. The number of label values must be the same to
+   *     that of the label keys passed to {@link MetricRegistry#addDoubleCumulative}.
+   * @return a {@code DoublePoint} the value of single cumulative.
+   * @throws NullPointerException if {@code labelValues} is null OR any element of {@code
+   *     labelValues} is null.
+   * @throws IllegalArgumentException if number of {@code labelValues}s are not equal to the label
+   *     keys.
+   * @since 0.21
+   */
+  public abstract DoublePoint getOrCreateTimeSeries(List<LabelValue> labelValues);
+
+  /**
+   * Returns a {@code DoublePoint} for a cumulative with all labels not set, or default labels.
+   *
+   * @return a {@code DoublePoint} for a cumulative with all labels not set, or default labels.
+   * @since 0.21
+   */
+  public abstract DoublePoint getDefaultTimeSeries();
+
+  /**
+   * Removes the {@code TimeSeries} from the cumulative metric, if it is present. i.e. references to
+   * previous {@code DoublePoint} objects are invalid (not part of the metric).
+   *
+   * @param labelValues the list of label values.
+   * @throws NullPointerException if {@code labelValues} is null or any element of {@code
+   *     labelValues} is null.
+   * @since 0.21
+   */
+  public abstract void removeTimeSeries(List<LabelValue> labelValues);
+
+  /**
+   * Removes all {@code TimeSeries} from the cumulative metric. i.e. references to all previous
+   * {@code DoublePoint} objects are invalid (not part of the metric).
+   *
+   * @since 0.21
+   */
+  public abstract void clear();
+
+  /**
+   * Returns the no-op implementation of the {@code DoubleCumulative}.
+   *
+   * @return the no-op implementation of the {@code DoubleCumulative}.
+   * @since 0.21
+   */
+  static DoubleCumulative newNoopDoubleCumulative(
+      String name, String description, String unit, List<LabelKey> labelKeys) {
+    return NoopDoubleCumulative.create(name, description, unit, labelKeys);
+  }
+
+  /**
+   * The value of a single point in the Cumulative.TimeSeries.
+   *
+   * @since 0.21
+   */
+  public abstract static class DoublePoint {
+
+    /**
+     * Adds the given value to the current value. The values can be negative.
+     *
+     * @param amt the value to add
+     * @since 0.21
+     */
+    public abstract void add(double amt);
+
+    /**
+     * Sets the given value.
+     *
+     * @param val the new value.
+     * @since 0.21
+     */
+    public abstract void set(double val);
+  }
+
+  /** No-op implementations of DoubleCumulative class. */
+  private static final class NoopDoubleCumulative extends DoubleCumulative {
+    private final int labelKeysSize;
+
+    static NoopDoubleCumulative create(
+        String name, String description, String unit, List<LabelKey> labelKeys) {
+      return new NoopDoubleCumulative(name, description, unit, labelKeys);
+    }
+
+    /** Creates a new {@code NoopDoublePoint}. */
+    NoopDoubleCumulative(String name, String description, String unit, List<LabelKey> labelKeys) {
+      Utils.checkNotNull(name, "name");
+      Utils.checkNotNull(description, "description");
+      Utils.checkNotNull(unit, "unit");
+      Utils.checkListElementNotNull(Utils.checkNotNull(labelKeys, "labelKeys"), "labelKey");
+      labelKeysSize = labelKeys.size();
+    }
+
+    @Override
+    public NoopDoublePoint getOrCreateTimeSeries(List<LabelValue> labelValues) {
+      Utils.checkListElementNotNull(Utils.checkNotNull(labelValues, "labelValues"), "labelValue");
+      Utils.checkArgument(
+          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+      return NoopDoublePoint.INSTANCE;
+    }
+
+    @Override
+    public NoopDoublePoint getDefaultTimeSeries() {
+      return NoopDoublePoint.INSTANCE;
+    }
+
+    @Override
+    public void removeTimeSeries(List<LabelValue> labelValues) {
+      Utils.checkNotNull(labelValues, "labelValues");
+    }
+
+    @Override
+    public void clear() {}
+
+    /** No-op implementations of DoublePoint class. */
+    private static final class NoopDoublePoint extends DoublePoint {
+      private static final NoopDoublePoint INSTANCE = new NoopDoublePoint();
+
+      private NoopDoublePoint() {}
+
+      @Override
+      public void add(double amt) {}
+
+      @Override
+      public void set(double val) {}
+    }
+  }
+}

--- a/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
@@ -22,8 +22,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Double Cumulative metric, to report instantaneous measurement of a double value. Cumulative
- * values can go up or stay the same, but can never go down. The cumulative values cannot be
- * negative.
+ * values can go up or stay the same, but can never go down. Cumulative values cannot be negative.
  *
  * <p>Example 1: Create a Cumulative with default labels.
  *

--- a/api/src/main/java/io/opencensus/metrics/LongCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/LongCumulative.java
@@ -140,12 +140,12 @@ public abstract class LongCumulative {
   public abstract static class LongPoint {
 
     /**
-     * Adds the given value to the current value. The values can be negative.
+     * Adds the given value to the current value. The values cannot be negative.
      *
-     * @param amt the value to add
+     * @param delta the value to add
      * @since 0.21
      */
-    public abstract void add(long amt);
+    public abstract void add(long delta);
 
     /**
      * Sets the given value.
@@ -198,7 +198,7 @@ public abstract class LongCumulative {
       private NoopLongPoint() {}
 
       @Override
-      public void add(long amt) {}
+      public void add(long delta) {}
 
       @Override
       public void set(long val) {}

--- a/api/src/main/java/io/opencensus/metrics/LongCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/LongCumulative.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import io.opencensus.internal.Utils;
+import java.util.List;
+import javax.annotation.concurrent.ThreadSafe;
+
+/**
+ * Long Cumulative metric, to report instantaneous measurement of an int64 value. Cumulative values
+ * can go up or stay the same, but can never go down. The cumulative values cannot be negative.
+ *
+ * <p>Example 1: Create a Cumulative with default labels.
+ *
+ * <pre>{@code
+ * class YourClass {
+ *
+ *   private static final MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+ *
+ *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
+ *
+ *   LongCumulative cumulative = metricRegistry.addLongCumulative(
+ *     "processed_jobs", "Processed jobs", "1", labelKeys);
+ *
+ *   // It is recommended to keep a reference of a point for manual operations.
+ *   LongPoint defaultPoint = cumulative.getDefaultTimeSeries();
+ *
+ *   void doWork() {
+ *      // Your code here.
+ *      defaultPoint.add(10);
+ *   }
+ *
+ * }
+ * }</pre>
+ *
+ * <p>Example 2: You can also use labels(keys and values) to track different types of metric.
+ *
+ * <pre>{@code
+ * class YourClass {
+ *
+ *   private static final MetricRegistry metricRegistry = Metrics.getMetricRegistry();
+ *
+ *   List<LabelKey> labelKeys = Arrays.asList(LabelKey.create("Name", "desc"));
+ *   List<LabelValue> labelValues = Arrays.asList(LabelValue.create("Inbound"));
+ *
+ *   LongCumulative cumulative = metricRegistry.addLongCumulative(
+ *     "processed_jobs", "Processed jobs", "1", labelKeys);
+ *
+ *   // It is recommended to keep a reference of a point for manual operations.
+ *   LongPoint inboundPoint = cumulative.getOrCreateTimeSeries(labelValues);
+ *
+ *   void doSomeWork() {
+ *      // Your code here.
+ *      inboundPoint.set(15);
+ *   }
+ *
+ * }
+ * }</pre>
+ *
+ * @since 0.21
+ */
+@ThreadSafe
+public abstract class LongCumulative {
+
+  /**
+   * Creates a {@code TimeSeries} and returns a {@code LongPoint} if the specified {@code
+   * labelValues} is not already associated with this cumulative, else returns an existing {@code
+   * LongPoint}.
+   *
+   * <p>It is recommended to keep a reference to the LongPoint instead of always calling this method
+   * for manual operations.
+   *
+   * @param labelValues the list of label values. The number of label values must be the same to
+   *     that of the label keys passed to {@link MetricRegistry#addLongCumulative}.
+   * @return a {@code LongPoint} the value of single cumulative.
+   * @throws NullPointerException if {@code labelValues} is null OR any element of {@code
+   *     labelValues} is null.
+   * @throws IllegalArgumentException if number of {@code labelValues}s are not equal to the label
+   *     keys passed to {@link MetricRegistry#addLongCumulative}.
+   * @since 0.21
+   */
+  public abstract LongPoint getOrCreateTimeSeries(List<LabelValue> labelValues);
+
+  /**
+   * Returns a {@code LongPoint} for a cumulative with all labels not set, or default labels.
+   *
+   * @return a {@code LongPoint} for a cumulative with all labels not set, or default labels.
+   * @since 0.21
+   */
+  public abstract LongPoint getDefaultTimeSeries();
+
+  /**
+   * Removes the {@code TimeSeries} from the cumulative metric, if it is present. i.e. references to
+   * previous {@code LongPoint} objects are invalid (not part of the metric).
+   *
+   * @param labelValues the list of label values.
+   * @throws NullPointerException if {@code labelValues} is null.
+   * @since 0.21
+   */
+  public abstract void removeTimeSeries(List<LabelValue> labelValues);
+
+  /**
+   * Removes all {@code TimeSeries} from the cumulative metric. i.e. references to all previous
+   * {@code LongPoint} objects are invalid (not part of the metric).
+   *
+   * @since 0.21
+   */
+  public abstract void clear();
+
+  /**
+   * Returns the no-op implementation of the {@code LongCumulative}.
+   *
+   * @return the no-op implementation of the {@code LongCumulative}.
+   * @since 0.21
+   */
+  static LongCumulative newNoopLongCumulative(
+      String name, String description, String unit, List<LabelKey> labelKeys) {
+    return NoopLongCumulative.create(name, description, unit, labelKeys);
+  }
+
+  /**
+   * The value of a single point in the Cumulative.TimeSeries.
+   *
+   * @since 0.21
+   */
+  public abstract static class LongPoint {
+
+    /**
+     * Adds the given value to the current value. The values can be negative.
+     *
+     * @param amt the value to add
+     * @since 0.21
+     */
+    public abstract void add(long amt);
+
+    /**
+     * Sets the given value.
+     *
+     * @param val the new value.
+     * @since 0.21
+     */
+    public abstract void set(long val);
+  }
+
+  /** No-op implementations of LongCumulative class. */
+  private static final class NoopLongCumulative extends LongCumulative {
+    private final int labelKeysSize;
+
+    static NoopLongCumulative create(
+        String name, String description, String unit, List<LabelKey> labelKeys) {
+      return new NoopLongCumulative(name, description, unit, labelKeys);
+    }
+
+    /** Creates a new {@code NoopLongPoint}. */
+    NoopLongCumulative(String name, String description, String unit, List<LabelKey> labelKeys) {
+      labelKeysSize = labelKeys.size();
+    }
+
+    @Override
+    public NoopLongPoint getOrCreateTimeSeries(List<LabelValue> labelValues) {
+      Utils.checkListElementNotNull(Utils.checkNotNull(labelValues, "labelValues"), "labelValue");
+      Utils.checkArgument(
+          labelKeysSize == labelValues.size(), "Label Keys and Label Values don't have same size.");
+      return NoopLongPoint.INSTANCE;
+    }
+
+    @Override
+    public NoopLongPoint getDefaultTimeSeries() {
+      return NoopLongPoint.INSTANCE;
+    }
+
+    @Override
+    public void removeTimeSeries(List<LabelValue> labelValues) {
+      Utils.checkNotNull(labelValues, "labelValues");
+    }
+
+    @Override
+    public void clear() {}
+
+    /** No-op implementations of LongPoint class. */
+    private static final class NoopLongPoint extends LongPoint {
+      private static final NoopLongPoint INSTANCE = new NoopLongPoint();
+
+      private NoopLongPoint() {}
+
+      @Override
+      public void add(long amt) {}
+
+      @Override
+      public void set(long val) {}
+    }
+  }
+}

--- a/api/src/main/java/io/opencensus/metrics/LongCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/LongCumulative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018, OpenCensus Authors
+ * Copyright 2019, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/api/src/main/java/io/opencensus/metrics/LongCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/LongCumulative.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Long Cumulative metric, to report instantaneous measurement of an int64 value. Cumulative values
- * can go up or stay the same, but can never go down. The cumulative values cannot be negative.
+ * can go up or stay the same, but can never go down. Cumulative values cannot be negative.
  *
  * <p>Example 1: Create a Cumulative with default labels.
  *

--- a/api/src/main/java/io/opencensus/metrics/MetricRegistry.java
+++ b/api/src/main/java/io/opencensus/metrics/MetricRegistry.java
@@ -159,6 +159,64 @@ public abstract class MetricRegistry {
   @ExperimentalApi
   public abstract DerivedDoubleGauge addDerivedDoubleGauge(String name, MetricOptions options);
 
+  /**
+   * Builds a new long cumulative to be added to the registry. This is more convenient form when you
+   * want to manually increase values as per your service requirements.
+   *
+   * @param name the name of the metric.
+   * @param options the options for the metric.
+   * @return a {@code LongCumulative}.
+   * @throws NullPointerException if {@code name} is null.
+   * @throws IllegalArgumentException if different metric with the same name already registered.
+   * @since 0.20
+   */
+  @ExperimentalApi
+  public abstract LongCumulative addLongCumulative(String name, MetricOptions options);
+
+  /**
+   * Builds a new double cumulative to be added to the registry. This is more convenient form when
+   * you want to manually increase values as per your service requirements.
+   *
+   * @param name the name of the metric.
+   * @param options the options for the metric.
+   * @return a {@code DoubleCumulative}.
+   * @throws NullPointerException if {@code name} is null.
+   * @throws IllegalArgumentException if different metric with the same name already registered.
+   * @since 0.20
+   */
+  @ExperimentalApi
+  public abstract DoubleCumulative addDoubleCumulative(String name, MetricOptions options);
+
+  /**
+   * Builds a new derived long cumulative to be added to the registry. This is more convenient form
+   * when you want to define a cumulative by executing a {@link ToLongFunction} on an object.
+   *
+   * @param name the name of the metric.
+   * @param options the options for the metric.
+   * @return a {@code DerivedLongCumulative}.
+   * @throws NullPointerException if {@code name} is null.
+   * @throws IllegalArgumentException if different metric with the same name already registered.
+   * @since 0.17
+   */
+  @ExperimentalApi
+  public abstract DerivedLongCumulative addDerivedLongCumulative(
+      String name, MetricOptions options);
+
+  /**
+   * Builds a new derived double cumulative to be added to the registry. This is more convenient
+   * form when you want to define a cumulative by executing a {@link ToDoubleFunction} on an object.
+   *
+   * @param name the name of the metric.
+   * @param options the options for the metric.
+   * @return a {@code DerivedDoubleCumulative}.
+   * @throws NullPointerException if {@code name} is null.
+   * @throws IllegalArgumentException if different metric with the same name already registered.
+   * @since 0.17
+   */
+  @ExperimentalApi
+  public abstract DerivedDoubleCumulative addDerivedDoubleCumulative(
+      String name, MetricOptions options);
+
   static MetricRegistry newNoopMetricRegistry() {
     return new NoopMetricRegistry();
   }
@@ -195,6 +253,42 @@ public abstract class MetricRegistry {
     @Override
     public DerivedDoubleGauge addDerivedDoubleGauge(String name, MetricOptions options) {
       return DerivedDoubleGauge.newNoopDerivedDoubleGauge(
+          Utils.checkNotNull(name, "name"),
+          options.getDescription(),
+          options.getUnit(),
+          options.getLabelKeys());
+    }
+
+    @Override
+    public LongCumulative addLongCumulative(String name, MetricOptions options) {
+      return LongCumulative.newNoopLongCumulative(
+          Utils.checkNotNull(name, "name"),
+          options.getDescription(),
+          options.getUnit(),
+          options.getLabelKeys());
+    }
+
+    @Override
+    public DoubleCumulative addDoubleCumulative(String name, MetricOptions options) {
+      return DoubleCumulative.newNoopDoubleCumulative(
+          Utils.checkNotNull(name, "name"),
+          options.getDescription(),
+          options.getUnit(),
+          options.getLabelKeys());
+    }
+
+    @Override
+    public DerivedLongCumulative addDerivedLongCumulative(String name, MetricOptions options) {
+      return DerivedLongCumulative.newNoopDerivedLongCumulative(
+          Utils.checkNotNull(name, "name"),
+          options.getDescription(),
+          options.getUnit(),
+          options.getLabelKeys());
+    }
+
+    @Override
+    public DerivedDoubleCumulative addDerivedDoubleCumulative(String name, MetricOptions options) {
+      return DerivedDoubleCumulative.newNoopDerivedDoubleCumulative(
           Utils.checkNotNull(name, "name"),
           options.getDescription(),
           options.getUnit(),

--- a/api/src/main/java/io/opencensus/metrics/MetricRegistry.java
+++ b/api/src/main/java/io/opencensus/metrics/MetricRegistry.java
@@ -50,8 +50,8 @@ public abstract class MetricRegistry {
   }
 
   /**
-   * Builds a new long gauge to be added to the registry. This is more convenient form when you want
-   * to manually increase and decrease values as per your service requirements.
+   * Builds a new long gauge to be added to the registry. This is a more convenient form when you
+   * want to manually increase and decrease values as per your service requirements.
    *
    * @param name the name of the metric.
    * @param options the options for the metric.
@@ -82,7 +82,7 @@ public abstract class MetricRegistry {
   }
 
   /**
-   * Builds a new double gauge to be added to the registry. This is more convenient form when you
+   * Builds a new double gauge to be added to the registry. This is a more convenient form when you
    * want to manually increase and decrease values as per your service requirements.
    *
    * @param name the name of the metric.
@@ -114,8 +114,8 @@ public abstract class MetricRegistry {
   }
 
   /**
-   * Builds a new derived long gauge to be added to the registry. This is more convenient form when
-   * you want to define a gauge by executing a {@link ToLongFunction} on an object.
+   * Builds a new derived long gauge to be added to the registry. This is a more convenient form
+   * when you want to define a gauge by executing a {@link ToLongFunction} on an object.
    *
    * @param name the name of the metric.
    * @param options the options for the metric.
@@ -146,7 +146,7 @@ public abstract class MetricRegistry {
   }
 
   /**
-   * Builds a new derived double gauge to be added to the registry. This is more convenient form
+   * Builds a new derived double gauge to be added to the registry. This is a more convenient form
    * when you want to define a gauge by executing a {@link ToDoubleFunction} on an object.
    *
    * @param name the name of the metric.
@@ -160,8 +160,8 @@ public abstract class MetricRegistry {
   public abstract DerivedDoubleGauge addDerivedDoubleGauge(String name, MetricOptions options);
 
   /**
-   * Builds a new long cumulative to be added to the registry. This is more convenient form when you
-   * want to manually increase values as per your service requirements.
+   * Builds a new long cumulative to be added to the registry. This is a more convenient form when
+   * you want to manually increase values as per your service requirements.
    *
    * @param name the name of the metric.
    * @param options the options for the metric.
@@ -174,7 +174,7 @@ public abstract class MetricRegistry {
   public abstract LongCumulative addLongCumulative(String name, MetricOptions options);
 
   /**
-   * Builds a new double cumulative to be added to the registry. This is more convenient form when
+   * Builds a new double cumulative to be added to the registry. This is a more convenient form when
    * you want to manually increase values as per your service requirements.
    *
    * @param name the name of the metric.
@@ -188,8 +188,8 @@ public abstract class MetricRegistry {
   public abstract DoubleCumulative addDoubleCumulative(String name, MetricOptions options);
 
   /**
-   * Builds a new derived long cumulative to be added to the registry. This is more convenient form
-   * when you want to define a cumulative by executing a {@link ToLongFunction} on an object.
+   * Builds a new derived long cumulative to be added to the registry. This is a more convenient
+   * form when you want to define a cumulative by executing a {@link ToLongFunction} on an object.
    *
    * @param name the name of the metric.
    * @param options the options for the metric.
@@ -203,7 +203,7 @@ public abstract class MetricRegistry {
       String name, MetricOptions options);
 
   /**
-   * Builds a new derived double cumulative to be added to the registry. This is more convenient
+   * Builds a new derived double cumulative to be added to the registry. This is a more convenient
    * form when you want to define a cumulative by executing a {@link ToDoubleFunction} on an object.
    *
    * @param name the name of the metric.

--- a/api/src/main/java/io/opencensus/metrics/MetricRegistry.java
+++ b/api/src/main/java/io/opencensus/metrics/MetricRegistry.java
@@ -168,7 +168,7 @@ public abstract class MetricRegistry {
    * @return a {@code LongCumulative}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
-   * @since 0.20
+   * @since 0.21
    */
   @ExperimentalApi
   public abstract LongCumulative addLongCumulative(String name, MetricOptions options);
@@ -182,7 +182,7 @@ public abstract class MetricRegistry {
    * @return a {@code DoubleCumulative}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
-   * @since 0.20
+   * @since 0.21
    */
   @ExperimentalApi
   public abstract DoubleCumulative addDoubleCumulative(String name, MetricOptions options);
@@ -196,7 +196,7 @@ public abstract class MetricRegistry {
    * @return a {@code DerivedLongCumulative}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
-   * @since 0.17
+   * @since 0.21
    */
   @ExperimentalApi
   public abstract DerivedLongCumulative addDerivedLongCumulative(
@@ -211,7 +211,7 @@ public abstract class MetricRegistry {
    * @return a {@code DerivedDoubleCumulative}.
    * @throws NullPointerException if {@code name} is null.
    * @throws IllegalArgumentException if different metric with the same name already registered.
-   * @since 0.17
+   * @since 0.21
    */
   @ExperimentalApi
   public abstract DerivedDoubleCumulative addDerivedDoubleCumulative(

--- a/api/src/test/java/io/opencensus/metrics/DerivedDoubleCumulativeTest.java
+++ b/api/src/test/java/io/opencensus/metrics/DerivedDoubleCumulativeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import io.opencensus.common.ToDoubleFunction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DerivedDoubleCumulative}. */
+@RunWith(JUnit4.class)
+public class DerivedDoubleCumulativeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final DerivedDoubleCumulative derivedDoubleCumulative =
+      DerivedDoubleCumulative.newNoopDerivedDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+  private static final ToDoubleFunction<Object> doubleFunction =
+      new ToDoubleFunction<Object>() {
+        @Override
+        public double applyAsDouble(Object value) {
+          return 5.0;
+        }
+      };
+
+  @Test
+  public void noopCreateTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleCumulative.createTimeSeries(null, null, doubleFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    derivedDoubleCumulative.createTimeSeries(labelValues, null, doubleFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithInvalidLabelSize() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    derivedDoubleCumulative.createTimeSeries(EMPTY_LABEL_VALUES, null, doubleFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithNullFunction() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("function");
+    derivedDoubleCumulative.createTimeSeries(LABEL_VALUES, null, null);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedDoubleCumulative.removeTimeSeries(null);
+  }
+}

--- a/api/src/test/java/io/opencensus/metrics/DerivedLongCumulativeTest.java
+++ b/api/src/test/java/io/opencensus/metrics/DerivedLongCumulativeTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import io.opencensus.common.ToLongFunction;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DerivedLongCumulative}. */
+@RunWith(JUnit4.class)
+public class DerivedLongCumulativeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  private final DerivedLongCumulative derivedLongCumulative =
+      DerivedLongCumulative.newNoopDerivedLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+  private static final ToLongFunction<Object> longFunction =
+      new ToLongFunction<Object>() {
+        @Override
+        public long applyAsLong(Object value) {
+          return 5;
+        }
+      };
+
+  @Test
+  public void noopCreateTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedLongCumulative.createTimeSeries(null, null, longFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    derivedLongCumulative.createTimeSeries(labelValues, null, longFunction);
+  }
+
+  @Test
+  public void noopCreateTimeSeries_WithInvalidLabelSize() {
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    derivedLongCumulative.createTimeSeries(EMPTY_LABEL_VALUES, null, longFunction);
+  }
+
+  @Test
+  public void createTimeSeries_WithNullFunction() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("function");
+    derivedLongCumulative.createTimeSeries(LABEL_VALUES, null, null);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    derivedLongCumulative.removeTimeSeries(null);
+  }
+}

--- a/api/src/test/java/io/opencensus/metrics/DoubleCumulativeTest.java
+++ b/api/src/test/java/io/opencensus/metrics/DoubleCumulativeTest.java
@@ -54,7 +54,8 @@ public class DoubleCumulativeTest {
   @Test
   public void noopGetOrCreateTimeSeries_WithNullElement() {
     List<LabelValue> labelValues = Collections.singletonList(null);
-    DoubleCumulative doubleCumulative = DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    DoubleCumulative doubleCumulative =
+        DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValue");
     doubleCumulative.getOrCreateTimeSeries(labelValues);
@@ -62,7 +63,8 @@ public class DoubleCumulativeTest {
 
   @Test
   public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
-    DoubleCumulative doubleCumulative = DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    DoubleCumulative doubleCumulative =
+        DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Label Keys and Label Values don't have same size.");
     doubleCumulative.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
@@ -70,7 +72,8 @@ public class DoubleCumulativeTest {
 
   @Test
   public void noopRemoveTimeSeries_WithNullLabelValues() {
-    DoubleCumulative doubleCumulative = DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    DoubleCumulative doubleCumulative =
+        DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
     doubleCumulative.removeTimeSeries(null);
@@ -78,8 +81,10 @@ public class DoubleCumulativeTest {
 
   @Test
   public void noopSameAs() {
-    DoubleCumulative doubleCumulative = DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
-    assertThat(doubleCumulative.getDefaultTimeSeries()).isSameAs(doubleCumulative.getDefaultTimeSeries());
+    DoubleCumulative doubleCumulative =
+        DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    assertThat(doubleCumulative.getDefaultTimeSeries())
+        .isSameAs(doubleCumulative.getDefaultTimeSeries());
     assertThat(doubleCumulative.getDefaultTimeSeries())
         .isSameAs(doubleCumulative.getOrCreateTimeSeries(LABEL_VALUES));
   }

--- a/api/src/test/java/io/opencensus/metrics/DoubleCumulativeTest.java
+++ b/api/src/test/java/io/opencensus/metrics/DoubleCumulativeTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link DoubleCumulative}. */
+@RunWith(JUnit4.class)
+public class DoubleCumulativeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelKey> EMPTY_LABEL_KEYS = new ArrayList<LabelKey>();
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
+    DoubleCumulative doubleCumulative =
+        DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, EMPTY_LABEL_KEYS);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    doubleCumulative.getOrCreateTimeSeries(null);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    DoubleCumulative doubleCumulative = DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    doubleCumulative.getOrCreateTimeSeries(labelValues);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
+    DoubleCumulative doubleCumulative = DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    doubleCumulative.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    DoubleCumulative doubleCumulative = DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    doubleCumulative.removeTimeSeries(null);
+  }
+
+  @Test
+  public void noopSameAs() {
+    DoubleCumulative doubleCumulative = DoubleCumulative.newNoopDoubleCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    assertThat(doubleCumulative.getDefaultTimeSeries()).isSameAs(doubleCumulative.getDefaultTimeSeries());
+    assertThat(doubleCumulative.getDefaultTimeSeries())
+        .isSameAs(doubleCumulative.getOrCreateTimeSeries(LABEL_VALUES));
+  }
+}

--- a/api/src/test/java/io/opencensus/metrics/LongCumulativeTest.java
+++ b/api/src/test/java/io/opencensus/metrics/LongCumulativeTest.java
@@ -44,7 +44,8 @@ public class LongCumulativeTest {
 
   @Test
   public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
-    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, EMPTY_LABEL_KEYS);
+    LongCumulative longCumulative =
+        LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, EMPTY_LABEL_KEYS);
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
     longCumulative.getOrCreateTimeSeries(null);
@@ -53,7 +54,8 @@ public class LongCumulativeTest {
   @Test
   public void noopGetOrCreateTimeSeries_WithNullElement() {
     List<LabelValue> labelValues = Collections.singletonList(null);
-    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    LongCumulative longCumulative =
+        LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValue");
     longCumulative.getOrCreateTimeSeries(labelValues);
@@ -61,7 +63,8 @@ public class LongCumulativeTest {
 
   @Test
   public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
-    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    LongCumulative longCumulative =
+        LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
     thrown.expect(IllegalArgumentException.class);
     thrown.expectMessage("Label Keys and Label Values don't have same size.");
     longCumulative.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
@@ -69,7 +72,8 @@ public class LongCumulativeTest {
 
   @Test
   public void noopRemoveTimeSeries_WithNullLabelValues() {
-    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    LongCumulative longCumulative =
+        LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
     thrown.expect(NullPointerException.class);
     thrown.expectMessage("labelValues");
     longCumulative.removeTimeSeries(null);
@@ -77,8 +81,10 @@ public class LongCumulativeTest {
 
   @Test
   public void noopSameAs() {
-    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
-    assertThat(longCumulative.getDefaultTimeSeries()).isSameAs(longCumulative.getDefaultTimeSeries());
+    LongCumulative longCumulative =
+        LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    assertThat(longCumulative.getDefaultTimeSeries())
+        .isSameAs(longCumulative.getDefaultTimeSeries());
     assertThat(longCumulative.getDefaultTimeSeries())
         .isSameAs(longCumulative.getOrCreateTimeSeries(LABEL_VALUES));
   }

--- a/api/src/test/java/io/opencensus/metrics/LongCumulativeTest.java
+++ b/api/src/test/java/io/opencensus/metrics/LongCumulativeTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.metrics;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Unit tests for {@link LongCumulative}. */
+@RunWith(JUnit4.class)
+public class LongCumulativeTest {
+  @Rule public ExpectedException thrown = ExpectedException.none();
+
+  private static final String NAME = "name";
+  private static final String DESCRIPTION = "description";
+  private static final String UNIT = "1";
+  private static final List<LabelKey> LABEL_KEY =
+      Collections.singletonList(LabelKey.create("key", "key description"));
+  private static final List<LabelValue> LABEL_VALUES =
+      Collections.singletonList(LabelValue.create("value"));
+  private static final List<LabelKey> EMPTY_LABEL_KEYS = new ArrayList<LabelKey>();
+  private static final List<LabelValue> EMPTY_LABEL_VALUES = new ArrayList<LabelValue>();
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullLabelValues() {
+    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, EMPTY_LABEL_KEYS);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    longCumulative.getOrCreateTimeSeries(null);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithNullElement() {
+    List<LabelValue> labelValues = Collections.singletonList(null);
+    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValue");
+    longCumulative.getOrCreateTimeSeries(labelValues);
+  }
+
+  @Test
+  public void noopGetOrCreateTimeSeries_WithInvalidLabelSize() {
+    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    thrown.expect(IllegalArgumentException.class);
+    thrown.expectMessage("Label Keys and Label Values don't have same size.");
+    longCumulative.getOrCreateTimeSeries(EMPTY_LABEL_VALUES);
+  }
+
+  @Test
+  public void noopRemoveTimeSeries_WithNullLabelValues() {
+    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("labelValues");
+    longCumulative.removeTimeSeries(null);
+  }
+
+  @Test
+  public void noopSameAs() {
+    LongCumulative longCumulative = LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEY);
+    assertThat(longCumulative.getDefaultTimeSeries()).isSameAs(longCumulative.getDefaultTimeSeries());
+    assertThat(longCumulative.getDefaultTimeSeries())
+        .isSameAs(longCumulative.getOrCreateTimeSeries(LABEL_VALUES));
+  }
+}

--- a/api/src/test/java/io/opencensus/metrics/MetricRegistryTest.java
+++ b/api/src/test/java/io/opencensus/metrics/MetricRegistryTest.java
@@ -125,12 +125,14 @@ public class MetricRegistryTest {
         .isSameAs(doubleGauge.getOrCreateTimeSeries(LABEL_VALUES));
 
     LongCumulative longCumulative = metricRegistry.addLongCumulative(NAME, METRIC_OPTIONS);
-    assertThat(longCumulative.getDefaultTimeSeries()).isSameAs(longCumulative.getDefaultTimeSeries());
+    assertThat(longCumulative.getDefaultTimeSeries())
+        .isSameAs(longCumulative.getDefaultTimeSeries());
     assertThat(longCumulative.getDefaultTimeSeries())
         .isSameAs(longCumulative.getOrCreateTimeSeries(LABEL_VALUES));
 
     DoubleCumulative doubleCumulative = metricRegistry.addDoubleCumulative(NAME_2, METRIC_OPTIONS);
-    assertThat(doubleCumulative.getDefaultTimeSeries()).isSameAs(doubleCumulative.getDefaultTimeSeries());
+    assertThat(doubleCumulative.getDefaultTimeSeries())
+        .isSameAs(doubleCumulative.getDefaultTimeSeries());
     assertThat(doubleCumulative.getDefaultTimeSeries())
         .isSameAs(doubleCumulative.getOrCreateTimeSeries(LABEL_VALUES));
   }
@@ -152,17 +154,21 @@ public class MetricRegistryTest {
                 .getClass());
 
     assertThat(metricRegistry.addLongCumulative(NAME, METRIC_OPTIONS))
-        .isInstanceOf(LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEYS).getClass());
+        .isInstanceOf(
+            LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEYS).getClass());
     assertThat(metricRegistry.addDoubleCumulative(NAME_2, METRIC_OPTIONS))
         .isInstanceOf(
-            DoubleCumulative.newNoopDoubleCumulative(NAME_2, DESCRIPTION, UNIT, LABEL_KEYS).getClass());
+            DoubleCumulative.newNoopDoubleCumulative(NAME_2, DESCRIPTION, UNIT, LABEL_KEYS)
+                .getClass());
     assertThat(metricRegistry.addDerivedLongCumulative(NAME_3, METRIC_OPTIONS))
         .isInstanceOf(
-            DerivedLongCumulative.newNoopDerivedLongCumulative(NAME_3, DESCRIPTION, UNIT, LABEL_KEYS)
+            DerivedLongCumulative.newNoopDerivedLongCumulative(
+                    NAME_3, DESCRIPTION, UNIT, LABEL_KEYS)
                 .getClass());
     assertThat(metricRegistry.addDerivedDoubleCumulative(NAME_4, METRIC_OPTIONS))
         .isInstanceOf(
-            DerivedDoubleCumulative.newNoopDerivedDoubleCumulative(NAME_4, DESCRIPTION, UNIT, LABEL_KEYS)
+            DerivedDoubleCumulative.newNoopDerivedDoubleCumulative(
+                    NAME_4, DESCRIPTION, UNIT, LABEL_KEYS)
                 .getClass());
   }
 }

--- a/api/src/test/java/io/opencensus/metrics/MetricRegistryTest.java
+++ b/api/src/test/java/io/opencensus/metrics/MetricRegistryTest.java
@@ -85,6 +85,34 @@ public class MetricRegistryTest {
   }
 
   @Test
+  public void noopAddLongCumulative_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addLongCumulative(null, METRIC_OPTIONS);
+  }
+
+  @Test
+  public void noopAddDoubleCumulative_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addDoubleCumulative(null, METRIC_OPTIONS);
+  }
+
+  @Test
+  public void noopAddDerivedLongCumulative_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addDerivedLongCumulative(null, METRIC_OPTIONS);
+  }
+
+  @Test
+  public void noopAddDerivedDoubleCumulative_NullName() {
+    thrown.expect(NullPointerException.class);
+    thrown.expectMessage("name");
+    metricRegistry.addDerivedDoubleCumulative(null, METRIC_OPTIONS);
+  }
+
+  @Test
   public void noopSameAs() {
     LongGauge longGauge = metricRegistry.addLongGauge(NAME, METRIC_OPTIONS);
     assertThat(longGauge.getDefaultTimeSeries()).isSameAs(longGauge.getDefaultTimeSeries());
@@ -95,6 +123,16 @@ public class MetricRegistryTest {
     assertThat(doubleGauge.getDefaultTimeSeries()).isSameAs(doubleGauge.getDefaultTimeSeries());
     assertThat(doubleGauge.getDefaultTimeSeries())
         .isSameAs(doubleGauge.getOrCreateTimeSeries(LABEL_VALUES));
+
+    LongCumulative longCumulative = metricRegistry.addLongCumulative(NAME, METRIC_OPTIONS);
+    assertThat(longCumulative.getDefaultTimeSeries()).isSameAs(longCumulative.getDefaultTimeSeries());
+    assertThat(longCumulative.getDefaultTimeSeries())
+        .isSameAs(longCumulative.getOrCreateTimeSeries(LABEL_VALUES));
+
+    DoubleCumulative doubleCumulative = metricRegistry.addDoubleCumulative(NAME_2, METRIC_OPTIONS);
+    assertThat(doubleCumulative.getDefaultTimeSeries()).isSameAs(doubleCumulative.getDefaultTimeSeries());
+    assertThat(doubleCumulative.getDefaultTimeSeries())
+        .isSameAs(doubleCumulative.getOrCreateTimeSeries(LABEL_VALUES));
   }
 
   @Test
@@ -111,6 +149,20 @@ public class MetricRegistryTest {
     assertThat(metricRegistry.addDerivedDoubleGauge(NAME_4, METRIC_OPTIONS))
         .isInstanceOf(
             DerivedDoubleGauge.newNoopDerivedDoubleGauge(NAME_4, DESCRIPTION, UNIT, LABEL_KEYS)
+                .getClass());
+
+    assertThat(metricRegistry.addLongCumulative(NAME, METRIC_OPTIONS))
+        .isInstanceOf(LongCumulative.newNoopLongCumulative(NAME, DESCRIPTION, UNIT, LABEL_KEYS).getClass());
+    assertThat(metricRegistry.addDoubleCumulative(NAME_2, METRIC_OPTIONS))
+        .isInstanceOf(
+            DoubleCumulative.newNoopDoubleCumulative(NAME_2, DESCRIPTION, UNIT, LABEL_KEYS).getClass());
+    assertThat(metricRegistry.addDerivedLongCumulative(NAME_3, METRIC_OPTIONS))
+        .isInstanceOf(
+            DerivedLongCumulative.newNoopDerivedLongCumulative(NAME_3, DESCRIPTION, UNIT, LABEL_KEYS)
+                .getClass());
+    assertThat(metricRegistry.addDerivedDoubleCumulative(NAME_4, METRIC_OPTIONS))
+        .isInstanceOf(
+            DerivedDoubleCumulative.newNoopDerivedDoubleCumulative(NAME_4, DESCRIPTION, UNIT, LABEL_KEYS)
                 .getClass());
   }
 }

--- a/impl_core/src/main/java/io/opencensus/implcore/metrics/MetricRegistryImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/metrics/MetricRegistryImpl.java
@@ -19,9 +19,13 @@ package io.opencensus.implcore.metrics;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import io.opencensus.common.Clock;
+import io.opencensus.metrics.DerivedDoubleCumulative;
 import io.opencensus.metrics.DerivedDoubleGauge;
+import io.opencensus.metrics.DerivedLongCumulative;
 import io.opencensus.metrics.DerivedLongGauge;
+import io.opencensus.metrics.DoubleCumulative;
 import io.opencensus.metrics.DoubleGauge;
+import io.opencensus.metrics.LongCumulative;
 import io.opencensus.metrics.LongGauge;
 import io.opencensus.metrics.MetricOptions;
 import io.opencensus.metrics.MetricRegistry;
@@ -94,6 +98,26 @@ public final class MetricRegistryImpl extends MetricRegistry {
             options.getConstantLabels());
     registeredMeters.registerMeter(name, derivedDoubleGauge);
     return derivedDoubleGauge;
+  }
+
+  @Override
+  public LongCumulative addLongCumulative(String name, MetricOptions options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DoubleCumulative addDoubleCumulative(String name, MetricOptions options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DerivedLongCumulative addDerivedLongCumulative(String name, MetricOptions options) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DerivedDoubleCumulative addDerivedDoubleCumulative(String name, MetricOptions options) {
+    throw new UnsupportedOperationException();
   }
 
   private static final class RegisteredMeters {


### PR DESCRIPTION
Updates https://github.com/census-instrumentation/opencensus-java/issues/1815.

Although the Spec PR (https://github.com/census-instrumentation/opencensus-specs/pull/254) hasn't been submitted, Cumulative APIs have already been added to Go and Node. This PR adds the Cumulative APIs in Java similar to Go (https://github.com/census-instrumentation/opencensus-go/pull/1090).

Most are a copy-and-paste from Gauge APIs since they are very similar.