### PR TITLE
Metrics: Remove Set from Cumulative.

### DIFF
--- a/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/DoubleCumulative.java
@@ -147,14 +147,6 @@ public abstract class DoubleCumulative {
      * @since 0.21
      */
     public abstract void add(double delta);
-
-    /**
-     * Sets the given value.
-     *
-     * @param val the new value.
-     * @since 0.21
-     */
-    public abstract void set(double val);
   }
 
   /** No-op implementations of DoubleCumulative class. */
@@ -204,9 +196,6 @@ public abstract class DoubleCumulative {
 
       @Override
       public void add(double delta) {}
-
-      @Override
-      public void set(double val) {}
     }
   }
 }

--- a/api/src/main/java/io/opencensus/metrics/LongCumulative.java
+++ b/api/src/main/java/io/opencensus/metrics/LongCumulative.java
@@ -146,14 +146,6 @@ public abstract class LongCumulative {
      * @since 0.21
      */
     public abstract void add(long delta);
-
-    /**
-     * Sets the given value.
-     *
-     * @param val the new value.
-     * @since 0.21
-     */
-    public abstract void set(long val);
   }
 
   /** No-op implementations of LongCumulative class. */
@@ -199,9 +191,6 @@ public abstract class LongCumulative {
 
       @Override
       public void add(long delta) {}
-
-      @Override
-      public void set(long val) {}
     }
   }
 }


### PR DESCRIPTION
Discussion is https://github.com/bogdandrutu/openconsensus/pull/168#discussion_r277065945. We cannot find a good use case for `Cumulative.Set`. Users should use DerivedCumulative instead.