### PR TITLE
Stats: Map deprecated RPC tags when record against new tags.

### DIFF
--- a/impl_core/src/main/java/io/opencensus/implcore/stats/RecordUtils.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/RecordUtils.java
@@ -68,8 +68,8 @@ final class RecordUtils {
   @VisibleForTesting static final TagKey RPC_METHOD = TagKey.create("method");
   @VisibleForTesting static final TagKey GRPC_CLIENT_STATUS = TagKey.create("grpc_client_status");
   @VisibleForTesting static final TagKey GRPC_CLIENT_METHOD = TagKey.create("grpc_client_method");
-  private static final TagKey GRPC_SERVER_STATUS = TagKey.create("grpc_server_status");
-  private static final TagKey GRPC_SERVER_METHOD = TagKey.create("grpc_server_method");
+  @VisibleForTesting static final TagKey GRPC_SERVER_STATUS = TagKey.create("grpc_server_status");
+  @VisibleForTesting static final TagKey GRPC_SERVER_METHOD = TagKey.create("grpc_server_method");
   private static final Map<TagKey, TagKey[]> RPC_TAG_MAPPINGS =
       ImmutableMap.<TagKey, TagKey[]>builder()
           .put(RPC_STATUS, new TagKey[] {GRPC_CLIENT_STATUS, GRPC_SERVER_STATUS})

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/RecordUtils.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/RecordUtils.java
@@ -98,8 +98,9 @@ final class RecordUtils {
       TagKey tagKey = columns.get(i);
       if (!tags.containsKey(tagKey)) {
         @javax.annotation.Nullable TagValue tagValue = UNKNOWN_TAG_VALUE;
-        if (RPC_TAG_MAPPINGS.containsKey(tagKey)) {
-          tagValue = getTagValueForDeprecatedRpcTag(tags, tagKey);
+        TagKey[] newKeys = RPC_TAG_MAPPINGS.get(tagKey);
+        if (newKeys != null) {
+          tagValue = getTagValueForDeprecatedRpcTag(tags, newKeys);
         }
         tagValues.add(tagValue);
       } else {
@@ -112,14 +113,11 @@ final class RecordUtils {
   // TODO(songy23): remove the mapping once we completely remove the deprecated RPC constants.
   @javax.annotation.Nullable
   private static TagValue getTagValueForDeprecatedRpcTag(
-      Map<? extends TagKey, TagValueWithMetadata> tags, TagKey oldKey) {
-    TagKey[] newKeys = RPC_TAG_MAPPINGS.get(oldKey);
-    if (newKeys == null) { // fix checker framework
-      return UNKNOWN_TAG_VALUE;
-    }
+      Map<? extends TagKey, TagValueWithMetadata> tags, TagKey[] newKeys) {
     for (TagKey newKey : newKeys) {
-      if (tags.containsKey(newKey)) {
-        return tags.get(newKey).getTagValue();
+      TagValueWithMetadata valueWithMetadata = tags.get(newKey);
+      if (valueWithMetadata != null) {
+        return valueWithMetadata.getTagValue();
       }
     }
     return UNKNOWN_TAG_VALUE;

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/RecordUtilsTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/RecordUtilsTest.java
@@ -135,6 +135,19 @@ public class RecordUtilsTest {
   }
 
   @Test
+  public void testGetTagValues_WithNewTags() {
+    List<TagKey> columns = Arrays.asList(RecordUtils.GRPC_CLIENT_METHOD, RecordUtils.GRPC_SERVER_METHOD);
+    Map<TagKey, TagValueWithMetadata> tags =
+        ImmutableMap.of(
+            RecordUtils.GRPC_SERVER_METHOD, METHOD_V_WITH_MD,
+            RecordUtils.GRPC_CLIENT_METHOD, METHOD_V_2_WITH_MD);
+
+    assertThat(RecordUtils.getTagValues(tags, columns))
+        .containsExactly(METHOD_V_2, METHOD_V)
+        .inOrder();
+  }
+
+  @Test
   public void createMutableAggregation() {
     BucketBoundaries bucketBoundaries = BucketBoundaries.create(Arrays.asList(-1.0, 0.0, 1.0));
 

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/RecordUtilsTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/RecordUtilsTest.java
@@ -62,13 +62,19 @@ public class RecordUtilsTest {
   private static final TagKey METHOD = TagKey.create("method");
   private static final TagValue CALLER_V = TagValue.create("some caller");
   private static final TagValue METHOD_V = TagValue.create("some method");
+  private static final TagValue METHOD_V_2 = TagValue.create("some other method");
   private static final TagValue STATUS_V = TagValue.create("ok");
+  private static final TagValue STATUS_V_2 = TagValue.create("error");
   private static final TagValueWithMetadata CALLER_V_WITH_MD =
       TagValueWithMetadata.create(CALLER_V, METADATA_UNLIMITED_PROPAGATION);
   private static final TagValueWithMetadata METHOD_V_WITH_MD =
       TagValueWithMetadata.create(METHOD_V, METADATA_UNLIMITED_PROPAGATION);
+  private static final TagValueWithMetadata METHOD_V_2_WITH_MD =
+      TagValueWithMetadata.create(METHOD_V_2, METADATA_UNLIMITED_PROPAGATION);
   private static final TagValueWithMetadata STATUS_V_WITH_MD =
       TagValueWithMetadata.create(STATUS_V, METADATA_UNLIMITED_PROPAGATION);
+  private static final TagValueWithMetadata STATUS_V_2_WITH_MD =
+      TagValueWithMetadata.create(STATUS_V_2, METADATA_UNLIMITED_PROPAGATION);
 
   @Test
   public void testConstants() {
@@ -96,6 +102,35 @@ public class RecordUtilsTest {
 
     assertThat(RecordUtils.getTagValues(tags, columns))
         .containsExactly(STATUS_V, METHOD_V)
+        .inOrder();
+  }
+
+  @Test
+  public void testGetTagValues_MapDeprecatedRpcTag_WithServerTag() {
+    List<TagKey> columns = Arrays.asList(RecordUtils.RPC_STATUS, RecordUtils.RPC_METHOD);
+    Map<TagKey, TagValueWithMetadata> tags =
+        ImmutableMap.of(
+            RecordUtils.GRPC_SERVER_METHOD, METHOD_V_WITH_MD,
+            RecordUtils.GRPC_SERVER_STATUS, STATUS_V_WITH_MD);
+
+    assertThat(RecordUtils.getTagValues(tags, columns))
+        .containsExactly(STATUS_V, METHOD_V)
+        .inOrder();
+  }
+
+  @Test
+  public void testGetTagValues_MapDeprecatedRpcTag_PreferClientTag() {
+    List<TagKey> columns = Arrays.asList(RecordUtils.RPC_STATUS, RecordUtils.RPC_METHOD);
+    Map<TagKey, TagValueWithMetadata> tags =
+        ImmutableMap.of(
+            RecordUtils.GRPC_SERVER_METHOD, METHOD_V_WITH_MD,
+            RecordUtils.GRPC_SERVER_STATUS, STATUS_V_WITH_MD,
+            RecordUtils.GRPC_CLIENT_METHOD, METHOD_V_2_WITH_MD,
+            RecordUtils.GRPC_CLIENT_STATUS, STATUS_V_2_WITH_MD);
+
+    // When both client and server new tags are present, client values take precedence.
+    assertThat(RecordUtils.getTagValues(tags, columns))
+        .containsExactly(STATUS_V_2, METHOD_V_2)
         .inOrder();
   }
 

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/RecordUtilsTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/RecordUtilsTest.java
@@ -63,6 +63,7 @@ public class RecordUtilsTest {
   private static final TagValue CALLER_V = TagValue.create("some caller");
   private static final TagValue METHOD_V = TagValue.create("some method");
   private static final TagValue METHOD_V_2 = TagValue.create("some other method");
+  private static final TagValue METHOD_V_3 = TagValue.create("the third method");
   private static final TagValue STATUS_V = TagValue.create("ok");
   private static final TagValue STATUS_V_2 = TagValue.create("error");
   private static final TagValueWithMetadata CALLER_V_WITH_MD =
@@ -71,6 +72,8 @@ public class RecordUtilsTest {
       TagValueWithMetadata.create(METHOD_V, METADATA_UNLIMITED_PROPAGATION);
   private static final TagValueWithMetadata METHOD_V_2_WITH_MD =
       TagValueWithMetadata.create(METHOD_V_2, METADATA_UNLIMITED_PROPAGATION);
+  private static final TagValueWithMetadata METHOD_V_3_WITH_MD =
+      TagValueWithMetadata.create(METHOD_V_3, METADATA_UNLIMITED_PROPAGATION);
   private static final TagValueWithMetadata STATUS_V_WITH_MD =
       TagValueWithMetadata.create(STATUS_V, METADATA_UNLIMITED_PROPAGATION);
   private static final TagValueWithMetadata STATUS_V_2_WITH_MD =
@@ -135,8 +138,22 @@ public class RecordUtilsTest {
   }
 
   @Test
+  public void testGetTagValues_WithOldMethodTag() {
+    List<TagKey> columns = Arrays.asList(RecordUtils.RPC_METHOD);
+    Map<TagKey, TagValueWithMetadata> tags =
+        ImmutableMap.of(
+            RecordUtils.GRPC_SERVER_METHOD, METHOD_V_WITH_MD,
+            RecordUtils.GRPC_CLIENT_METHOD, METHOD_V_2_WITH_MD,
+            RecordUtils.RPC_METHOD, METHOD_V_3_WITH_MD);
+
+    // When the old "method" tag is set, it always takes precedence.
+    assertThat(RecordUtils.getTagValues(tags, columns)).containsExactly(METHOD_V_3).inOrder();
+  }
+
+  @Test
   public void testGetTagValues_WithNewTags() {
-    List<TagKey> columns = Arrays.asList(RecordUtils.GRPC_CLIENT_METHOD, RecordUtils.GRPC_SERVER_METHOD);
+    List<TagKey> columns =
+        Arrays.asList(RecordUtils.GRPC_CLIENT_METHOD, RecordUtils.GRPC_SERVER_METHOD);
     Map<TagKey, TagValueWithMetadata> tags =
         ImmutableMap.of(
             RecordUtils.GRPC_SERVER_METHOD, METHOD_V_WITH_MD,

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/RecordUtilsTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/RecordUtilsTest.java
@@ -62,10 +62,13 @@ public class RecordUtilsTest {
   private static final TagKey METHOD = TagKey.create("method");
   private static final TagValue CALLER_V = TagValue.create("some caller");
   private static final TagValue METHOD_V = TagValue.create("some method");
+  private static final TagValue STATUS_V = TagValue.create("ok");
   private static final TagValueWithMetadata CALLER_V_WITH_MD =
       TagValueWithMetadata.create(CALLER_V, METADATA_UNLIMITED_PROPAGATION);
   private static final TagValueWithMetadata METHOD_V_WITH_MD =
       TagValueWithMetadata.create(METHOD_V, METADATA_UNLIMITED_PROPAGATION);
+  private static final TagValueWithMetadata STATUS_V_WITH_MD =
+      TagValueWithMetadata.create(STATUS_V, METADATA_UNLIMITED_PROPAGATION);
 
   @Test
   public void testConstants() {
@@ -80,6 +83,19 @@ public class RecordUtilsTest {
 
     assertThat(RecordUtils.getTagValues(tags, columns))
         .containsExactly(CALLER_V, METHOD_V, RecordUtils.UNKNOWN_TAG_VALUE)
+        .inOrder();
+  }
+
+  @Test
+  public void testGetTagValues_MapDeprecatedRpcTag() {
+    List<TagKey> columns = Arrays.asList(RecordUtils.RPC_STATUS, RecordUtils.RPC_METHOD);
+    Map<TagKey, TagValueWithMetadata> tags =
+        ImmutableMap.of(
+            RecordUtils.GRPC_CLIENT_METHOD, METHOD_V_WITH_MD,
+            RecordUtils.GRPC_CLIENT_STATUS, STATUS_V_WITH_MD);
+
+    assertThat(RecordUtils.getTagValues(tags, columns))
+        .containsExactly(STATUS_V, METHOD_V)
         .inOrder();
   }
 

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
@@ -296,6 +296,30 @@ public final class StatsRecorderImplTest {
   }
 
   @Test
+  public void record_MapDeprecatedRpcConstants() {
+    View view =
+        View.create(
+            VIEW_NAME,
+            "description",
+            MEASURE_DOUBLE,
+            Sum.create(),
+            Arrays.asList(RecordUtils.RPC_METHOD));
+
+    viewManager.registerView(view);
+    MeasureMap statsRecord = statsRecorder.newMeasureMap().put(MEASURE_DOUBLE, 1.0);
+    statsRecord.record(new SimpleTagContext(Tag.create(RecordUtils.GRPC_CLIENT_METHOD, VALUE)));
+    ViewData viewData = viewManager.getView(VIEW_NAME);
+
+    // There should be two entries.
+    StatsTestUtil.assertAggregationMapEquals(
+        viewData.getAggregationMap(),
+        ImmutableMap.of(
+            Arrays.asList(VALUE),
+            StatsTestUtil.createAggregationData(Sum.create(), MEASURE_DOUBLE, 1.0)),
+        1e-6);
+  }
+
+  @Test
   @SuppressWarnings("deprecation")
   public void record_StatsDisabled() {
     View view =


### PR DESCRIPTION
gRPC may migrate to use the new RPC tags (e.g "grpc_client_method") in https://github.com/grpc/grpc-java/pull/5601 and stop recording against the deprecated tags (e.g "method"). However probably there're users who still use the deprecated RPC constants. To avoid breaking their metrics, we need to do some mappings when recording stats against the new tags.

Note the deprecated RPC measures are already mapped to the new ones in https://github.com/census-instrumentation/opencensus-java/pull/1738.

Updates https://github.com/census-instrumentation/opencensus-java/issues/1764.