### PR TITLE
Update static GCP metadata URL

### DIFF
--- a/contrib/resource_util/src/main/java/io/opencensus/contrib/resource/util/GcpMetadataConfig.java
+++ b/contrib/resource_util/src/main/java/io/opencensus/contrib/resource/util/GcpMetadataConfig.java
@@ -34,7 +34,7 @@ import java.nio.charset.Charset;
  */
 final class GcpMetadataConfig {
 
-  private static final String METADATA_URL = "http://metadata/computeMetadata/v1/";
+  private static final String METADATA_URL = "http://metadata.google.internal/computeMetadata/v1/";
 
   private GcpMetadataConfig() {}
 


### PR DESCRIPTION
When running Istio on Google Kubernetes Enginge (GKE), the Envoy sidecar
proxy will fail to route any requests made to the metadata server via
the `metadata` hostname (requests will 404). Requests made to the fully
qualified `metadata.google.internal` hostname can be routed.

Update the constant for the metadata host in `GcpMetadataConfig` to use
the FQDN.