### PR TITLE
Restrict access to context key, add helper methods to interact with Context.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Add Cumulative (`DoubleCumulative`, `LongCumulative`, `DerivedDoubleCumulative`, `DerivedLongCumulative`) APIs.
 - Add convenience APIs `TagContextBuilder.putLocal()` that adds non-propagating tags,
 and `TagContextBuilder.putPropagating()` that adds unlimited propagating tags.
+- Deprecate context keys for tags and spans. Provide helper methods for interacting with context.
 
 ## 0.20.0 - 2019-03-28
 - Add OpenCensus Java OC-Agent Trace Exporter.

--- a/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
@@ -43,7 +43,7 @@ public final class ContextUtils {
    *
    * @since 0.8
    * @deprecated from API since 0.21. Use {@link #withValue(Context, TagContext)} and {@link
-   * #getValue(Context)} instead.
+   *     #getValue(Context)} instead.
    */
   // TODO(songy23): make this private once gRPC migrates to use the alternative APIs.
   @Deprecated

--- a/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
@@ -17,6 +17,7 @@
 package io.opencensus.tags.unsafe;
 
 import io.grpc.Context;
+import io.opencensus.internal.Utils;
 import io.opencensus.tags.Tag;
 import io.opencensus.tags.TagContext;
 import java.util.Collections;
@@ -41,9 +42,36 @@ public final class ContextUtils {
    * {@link io.grpc.Context}.
    *
    * @since 0.8
+   * @deprecated from API since 0.21. Use {@link #withValue(Context, TagContext)} and {@link
+   * #getValue(Context)} instead.
    */
+  // TODO(songy23): make this private once gRPC migrates to use the alternative APIs.
+  @Deprecated
   public static final Context.Key<TagContext> TAG_CONTEXT_KEY =
       Context.keyWithDefault("opencensus-tag-context-key", EMPTY_TAG_CONTEXT);
+
+  /**
+   * Creates a new {@code Context} with the given value set.
+   *
+   * @param context the parent {@code Context}.
+   * @param tagContext the value to be set.
+   * @return a new context with the given value set.
+   * @since 0.21
+   */
+  public static Context withValue(Context context, TagContext tagContext) {
+    return Utils.checkNotNull(context, "context").withValue(TAG_CONTEXT_KEY, tagContext);
+  }
+
+  /**
+   * Returns the value from the specified {@code Context}.
+   *
+   * @param context the specified {@code Context}.
+   * @return the value from the specified {@code Context}.
+   * @since 0.21
+   */
+  public static TagContext getValue(Context context) {
+    return TAG_CONTEXT_KEY.get(context);
+  }
 
   @Immutable
   private static final class EmptyTagContext extends TagContext {

--- a/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
@@ -24,6 +24,10 @@ import java.util.Collections;
 import java.util.Iterator;
 import javax.annotation.concurrent.Immutable;
 
+/*>>>
+import org.checkerframework.checker.nullness.qual.Nullable;
+*/
+
 /**
  * Utility methods for accessing the {@link TagContext} contained in the {@link io.grpc.Context}.
  *
@@ -47,7 +51,7 @@ public final class ContextUtils {
    */
   // TODO(songy23): make this private once gRPC migrates to use the alternative APIs.
   @Deprecated
-  public static final Context.Key<TagContext> TAG_CONTEXT_KEY =
+  public static final Context.Key</*@Nullable*/ TagContext> TAG_CONTEXT_KEY =
       Context.keyWithDefault("opencensus-tag-context-key", EMPTY_TAG_CONTEXT);
 
   /**
@@ -70,7 +74,8 @@ public final class ContextUtils {
    * @since 0.21
    */
   public static TagContext getValue(Context context) {
-    return TAG_CONTEXT_KEY.get(context);
+    @javax.annotation.Nullable TagContext tags = TAG_CONTEXT_KEY.get(context);
+    return tags == null ? EMPTY_TAG_CONTEXT : tags;
   }
 
   @Immutable

--- a/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
@@ -62,7 +62,8 @@ public final class ContextUtils {
    * @return a new context with the given value set.
    * @since 0.21
    */
-  public static Context withValue(Context context, TagContext tagContext) {
+  public static Context withValue(
+      Context context, @javax.annotation.Nullable TagContext tagContext) {
     return Utils.checkNotNull(context, "context").withValue(TAG_CONTEXT_KEY, tagContext);
   }
 

--- a/api/src/main/java/io/opencensus/trace/CurrentSpanUtils.java
+++ b/api/src/main/java/io/opencensus/trace/CurrentSpanUtils.java
@@ -34,7 +34,7 @@ final class CurrentSpanUtils {
    */
   @Nullable
   static Span getCurrentSpan() {
-    return ContextUtils.CONTEXT_SPAN_KEY.get();
+    return ContextUtils.getValue(Context.current());
   }
 
   /**
@@ -90,7 +90,7 @@ final class CurrentSpanUtils {
     private ScopeInSpan(Span span, boolean endSpan) {
       this.span = span;
       this.endSpan = endSpan;
-      origContext = Context.current().withValue(ContextUtils.CONTEXT_SPAN_KEY, span).attach();
+      origContext = ContextUtils.withValue(Context.current(), span).attach();
     }
 
     @Override
@@ -116,8 +116,7 @@ final class CurrentSpanUtils {
 
     @Override
     public void run() {
-      Context origContext =
-          Context.current().withValue(ContextUtils.CONTEXT_SPAN_KEY, span).attach();
+      Context origContext = ContextUtils.withValue(Context.current(), span).attach();
       try {
         runnable.run();
       } catch (Throwable t) {
@@ -150,8 +149,7 @@ final class CurrentSpanUtils {
 
     @Override
     public V call() throws Exception {
-      Context origContext =
-          Context.current().withValue(ContextUtils.CONTEXT_SPAN_KEY, span).attach();
+      Context origContext = ContextUtils.withValue(Context.current(), span).attach();
       try {
         return callable.call();
       } catch (Exception e) {

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -18,6 +18,7 @@ package io.opencensus.trace.unsafe;
 
 import io.grpc.Context;
 import io.opencensus.internal.Utils;
+import io.opencensus.trace.BlankSpan;
 import io.opencensus.trace.Span;
 
 /*>>>
@@ -67,8 +68,9 @@ public final class ContextUtils {
    * @return the value from the specified {@code Context}.
    * @since 0.21
    */
-  @javax.annotation.Nullable
   public static Span getValue(Context context) {
-    return CONTEXT_SPAN_KEY.get(Utils.checkNotNull(context, "context"));
+    @javax.annotation.Nullable
+    Span span = CONTEXT_SPAN_KEY.get(Utils.checkNotNull(context, "context"));
+    return span == null ? BlankSpan.INSTANCE : span;
   }
 }

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -41,7 +41,7 @@ public final class ContextUtils {
    *
    * @since 0.5
    * @deprecated from API since 0.21. Use {@link #withValue(Context, Span)} and {@link
-   * #getValue(Context)} instead.
+   *     #getValue(Context)} instead.
    */
   // TODO(songy23): make this private once gRPC migrates to use the alternative APIs.
   @Deprecated

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -57,7 +57,7 @@ public final class ContextUtils {
    * @return a new context with the given value set.
    * @since 0.21
    */
-  public static Context withValue(Context context, Span span) {
+  public static Context withValue(Context context, @javax.annotation.Nullable Span span) {
     return Utils.checkNotNull(context, "context").withValue(CONTEXT_SPAN_KEY, span);
   }
 

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -17,6 +17,7 @@
 package io.opencensus.trace.unsafe;
 
 import io.grpc.Context;
+import io.opencensus.internal.Utils;
 import io.opencensus.trace.Span;
 
 /*>>>
@@ -39,7 +40,35 @@ public final class ContextUtils {
    * The {@link io.grpc.Context.Key} used to interact with {@link io.grpc.Context}.
    *
    * @since 0.5
+   * @deprecated from API since 0.21. Use {@link #withValue(Context, Span)} and {@link
+   * #getValue(Context)} instead.
    */
+  // TODO(songy23): make this private once gRPC migrates to use the alternative APIs.
+  @Deprecated
   public static final Context.Key</*@Nullable*/ Span> CONTEXT_SPAN_KEY =
-      Context.key("opencensus-trace-span-key");
+      Context.<Span>key("opencensus-trace-span-key");
+
+  /**
+   * Creates a new {@code Context} with the given value set.
+   *
+   * @param context the parent {@code Context}.
+   * @param span the value to be set.
+   * @return a new context with the given value set.
+   * @since 0.21
+   */
+  public static Context withValue(Context context, Span span) {
+    return Utils.checkNotNull(context, "context").withValue(CONTEXT_SPAN_KEY, span);
+  }
+
+  /**
+   * Returns the value from the specified {@code Context}.
+   *
+   * @param context the specified {@code Context}.
+   * @return the value from the specified {@code Context}.
+   * @since 0.21
+   */
+  @javax.annotation.Nullable
+  public static Span getValue(Context context) {
+    return CONTEXT_SPAN_KEY.get(Utils.checkNotNull(context, "context"));
+  }
 }

--- a/api/src/test/java/io/opencensus/trace/CurrentSpanUtilsTest.java
+++ b/api/src/test/java/io/opencensus/trace/CurrentSpanUtilsTest.java
@@ -68,12 +68,12 @@ public class CurrentSpanUtilsTest {
 
   @Test
   public void getCurrentSpan_WhenNoContext() {
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void getCurrentSpan() {
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Context origContext = ContextUtils.withValue(Context.current(), span).attach();
     // Make sure context is detached even if test fails.
     try {
@@ -81,38 +81,38 @@ public class CurrentSpanUtilsTest {
     } finally {
       Context.current().detach(origContext);
     }
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpan_CloseDetaches() {
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Scope ws = CurrentSpanUtils.withSpan(span, false);
     try {
       assertThat(CurrentSpanUtils.getCurrentSpan()).isSameAs(span);
     } finally {
       ws.close();
     }
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     verifyZeroInteractions(span);
   }
 
   @Test
   public void withSpan_CloseDetachesAndEndsSpan() {
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Scope ss = CurrentSpanUtils.withSpan(span, true);
     try {
       assertThat(CurrentSpanUtils.getCurrentSpan()).isSameAs(span);
     } finally {
       ss.close();
     }
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     verify(span).end(same(EndSpanOptions.DEFAULT));
   }
 
   @Test
   public void withSpanRunnable() {
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Runnable runnable =
         new Runnable() {
           @Override
@@ -123,12 +123,12 @@ public class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, false, runnable).run();
     verifyZeroInteractions(span);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanRunnable_EndSpan() {
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Runnable runnable =
         new Runnable() {
           @Override
@@ -139,13 +139,13 @@ public class CurrentSpanUtilsTest {
         };
     CurrentSpanUtils.withSpan(span, true, runnable).run();
     verify(span).end(EndSpanOptions.DEFAULT);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanRunnable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Runnable runnable =
         new Runnable() {
           @Override
@@ -158,13 +158,13 @@ public class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(Status.UNKNOWN.withDescription("MyError"));
     verify(span).end(EndSpanOptions.DEFAULT);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanRunnable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Runnable runnable =
         new Runnable() {
           @Override
@@ -177,13 +177,13 @@ public class CurrentSpanUtilsTest {
     executeRunnableAndExpectError(runnable, error);
     verify(span).setStatus(Status.UNKNOWN.withDescription("AssertionError"));
     verify(span).end(EndSpanOptions.DEFAULT);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable() throws Exception {
     final Object ret = new Object();
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -195,13 +195,13 @@ public class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, false, callable).call()).isEqualTo(ret);
     verifyZeroInteractions(span);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_EndSpan() throws Exception {
     final Object ret = new Object();
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -213,13 +213,13 @@ public class CurrentSpanUtilsTest {
         };
     assertThat(CurrentSpanUtils.withSpan(span, true, callable).call()).isEqualTo(ret);
     verify(span).end(EndSpanOptions.DEFAULT);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_WithException() {
     final Exception exception = new Exception("MyException");
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -232,13 +232,13 @@ public class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(Status.UNKNOWN.withDescription("MyException"));
     verify(span).end(EndSpanOptions.DEFAULT);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_WithExceptionNoMessage() {
     final Exception exception = new Exception();
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -251,13 +251,13 @@ public class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, exception);
     verify(span).setStatus(Status.UNKNOWN.withDescription("Exception"));
     verify(span).end(EndSpanOptions.DEFAULT);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_WithError() {
     final AssertionError error = new AssertionError("MyError");
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -270,13 +270,13 @@ public class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(Status.UNKNOWN.withDescription("MyError"));
     verify(span).end(EndSpanOptions.DEFAULT);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
   public void withSpanCallable_WithErrorNoMessage() {
     final AssertionError error = new AssertionError();
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
     Callable<Object> callable =
         new Callable<Object>() {
           @Override
@@ -289,6 +289,6 @@ public class CurrentSpanUtilsTest {
     executeCallableAndExpectError(callable, error);
     verify(span).setStatus(Status.UNKNOWN.withDescription("AssertionError"));
     verify(span).end(EndSpanOptions.DEFAULT);
-    assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
+    assertThat(CurrentSpanUtils.getCurrentSpan()).isEqualTo(BlankSpan.INSTANCE);
   }
 }

--- a/api/src/test/java/io/opencensus/trace/CurrentSpanUtilsTest.java
+++ b/api/src/test/java/io/opencensus/trace/CurrentSpanUtilsTest.java
@@ -74,7 +74,7 @@ public class CurrentSpanUtilsTest {
   @Test
   public void getCurrentSpan() {
     assertThat(CurrentSpanUtils.getCurrentSpan()).isNull();
-    Context origContext = Context.current().withValue(ContextUtils.CONTEXT_SPAN_KEY, span).attach();
+    Context origContext = ContextUtils.withValue(Context.current(), span).attach();
     // Make sure context is detached even if test fails.
     try {
       assertThat(CurrentSpanUtils.getCurrentSpan()).isSameAs(span);

--- a/api/src/test/java/io/opencensus/trace/unsafe/ContextUtilsTest.java
+++ b/api/src/test/java/io/opencensus/trace/unsafe/ContextUtilsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2017, OpenCensus Authors
+ * Copyright 2019, OpenCensus Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,44 +14,35 @@
  * limitations under the License.
  */
 
-package io.opencensus.tags.unsafe;
+package io.opencensus.trace.unsafe;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import com.google.common.collect.Lists;
 import io.grpc.Context;
-import io.opencensus.tags.InternalUtils;
-import io.opencensus.tags.Tag;
-import io.opencensus.tags.TagContext;
-import java.util.List;
+import io.opencensus.trace.BlankSpan;
+import io.opencensus.trace.Span;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link ContextUtils}. */
 @RunWith(JUnit4.class)
-public final class ContextUtilsTest {
+public class ContextUtilsTest {
 
   @Test
-  public void testGetCurrentTagContext_DefaultContext() {
-    TagContext tags = ContextUtils.getValue(Context.current());
-    assertThat(tags).isNotNull();
-    assertThat(asList(tags)).isEmpty();
+  public void testGetCurrentSpan_DefaultContext() {
+    Span span = ContextUtils.getValue(Context.current());
+    assertThat(span).isNull();
   }
 
   @Test
-  public void testGetCurrentTagContext_ContextSetToNull() {
-    Context orig = ContextUtils.withValue(Context.current(), null).attach();
+  public void testGetCurrentSpan_ContextSetToNonNull() {
+    Context orig = ContextUtils.withValue(Context.current(), BlankSpan.INSTANCE).attach();
     try {
-      TagContext tags = ContextUtils.getValue(Context.current());
-      assertThat(tags).isNotNull();
-      assertThat(asList(tags)).isEmpty();
+      Span span = ContextUtils.getValue(Context.current());
+      assertThat(span).isNotNull();
     } finally {
       Context.current().detach(orig);
     }
-  }
-
-  private static List<Tag> asList(TagContext tags) {
-    return Lists.newArrayList(InternalUtils.getTags(tags));
   }
 }

--- a/api/src/test/java/io/opencensus/trace/unsafe/ContextUtilsTest.java
+++ b/api/src/test/java/io/opencensus/trace/unsafe/ContextUtilsTest.java
@@ -32,15 +32,16 @@ public class ContextUtilsTest {
   @Test
   public void testGetCurrentSpan_DefaultContext() {
     Span span = ContextUtils.getValue(Context.current());
-    assertThat(span).isNull();
+    assertThat(span).isEqualTo(BlankSpan.INSTANCE);
   }
 
   @Test
-  public void testGetCurrentSpan_ContextSetToNonNull() {
-    Context orig = ContextUtils.withValue(Context.current(), BlankSpan.INSTANCE).attach();
+  public void testGetCurrentSpan_ContextSetToNull() {
+    Context orig = ContextUtils.withValue(Context.current(), null).attach();
     try {
       Span span = ContextUtils.getValue(Context.current());
-      assertThat(span).isNotNull();
+      // ContextUtils.getValue always returns non-null.
+      assertThat(span).isEqualTo(BlankSpan.INSTANCE);
     } finally {
       Context.current().detach(orig);
     }

--- a/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/ContextDataUtils.java
+++ b/contrib/log_correlation/log4j2/src/main/java/io/opencensus/contrib/logcorrelation/log4j2/ContextDataUtils.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.contrib.logcorrelation.log4j2;
 
+import io.grpc.Context;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.unsafe.ContextUtils;
@@ -80,7 +81,7 @@ final class ContextDataUtils {
   }
 
   private static SpanContext getCurrentSpanContext() {
-    Span span = ContextUtils.CONTEXT_SPAN_KEY.get();
+    Span span = ContextUtils.getValue(Context.current());
     return span == null ? SpanContext.INVALID : span.getContext();
   }
 }

--- a/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
+++ b/contrib/log_correlation/stackdriver/src/main/java/io/opencensus/contrib/logcorrelation/stackdriver/OpenCensusTraceLoggingEnhancer.java
@@ -19,6 +19,7 @@ package io.opencensus.contrib.logcorrelation.stackdriver;
 import com.google.cloud.ServiceOptions;
 import com.google.cloud.logging.LogEntry;
 import com.google.cloud.logging.LoggingEnhancer;
+import io.grpc.Context;
 import io.opencensus.trace.Span;
 import io.opencensus.trace.SpanContext;
 import io.opencensus.trace.TraceId;
@@ -98,7 +99,7 @@ public final class OpenCensusTraceLoggingEnhancer implements LoggingEnhancer {
   }
 
   private static SpanContext getCurrentSpanContext() {
-    Span span = ContextUtils.CONTEXT_SPAN_KEY.get();
+    Span span = ContextUtils.getValue(Context.current());
     return span == null ? SpanContext.INVALID : span.getContext();
   }
 

--- a/contrib/spring_sleuth_v1x/src/main/java/io/opencensus/contrib/spring/sleuth/v1x/OpenCensusSleuthSpanContextHolder.java
+++ b/contrib/spring_sleuth_v1x/src/main/java/io/opencensus/contrib/spring/sleuth/v1x/OpenCensusSleuthSpanContextHolder.java
@@ -143,8 +143,7 @@ final class OpenCensusSleuthSpanContextHolder {
       this.autoClose = autoClose;
       this.parent = CURRENT_SPAN.get();
       this.ocSpan = new OpenCensusSleuthSpan(span);
-      this.ocCurrentContext =
-          Context.current().withValue(ContextUtils.CONTEXT_SPAN_KEY, this.ocSpan);
+      this.ocCurrentContext = ContextUtils.withValue(Context.current(), this.ocSpan);
     }
   }
 

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureMapImpl.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.implcore.stats;
 
+import io.grpc.Context;
 import io.opencensus.metrics.data.AttachmentValue;
 import io.opencensus.stats.Measure.MeasureDouble;
 import io.opencensus.stats.Measure.MeasureLong;
@@ -68,7 +69,7 @@ final class MeasureMapImpl extends MeasureMap {
   @Override
   public void record() {
     // Use the context key directly, to avoid depending on the tags implementation.
-    record(ContextUtils.TAG_CONTEXT_KEY.get());
+    record(ContextUtils.getValue(Context.current()));
   }
 
   @Override

--- a/impl_core/src/main/java/io/opencensus/implcore/tags/CurrentTagMapUtils.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/tags/CurrentTagMapUtils.java
@@ -34,7 +34,7 @@ final class CurrentTagMapUtils {
    * @return the {@code TagContext} from the current context.
    */
   static TagContext getCurrentTagMap() {
-    return ContextUtils.TAG_CONTEXT_KEY.get();
+    return ContextUtils.getValue(Context.current());
   }
 
   /**
@@ -60,7 +60,7 @@ final class CurrentTagMapUtils {
      * @param tags the {@code TagContext} to be added to the current {@code Context}.
      */
     private WithTagMap(TagContext tags) {
-      orig = Context.current().withValue(ContextUtils.TAG_CONTEXT_KEY, tags).attach();
+      orig = ContextUtils.withValue(Context.current(), tags).attach();
     }
 
     @Override

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
@@ -119,10 +119,8 @@ public final class StatsRecorderImplTest {
             Arrays.asList(KEY),
             Cumulative.create());
     viewManager.registerView(view);
-    Context orig =
-        Context.current()
-            .withValue(ContextUtils.TAG_CONTEXT_KEY, new SimpleTagContext(Tag.create(KEY, VALUE)))
-            .attach();
+    TagContext tags = new SimpleTagContext(Tag.create(KEY, VALUE));
+    Context orig = ContextUtils.withValue(Context.current(), tags);
     try {
       statsRecorder.newMeasureMap().put(MEASURE_DOUBLE, 1.0).record();
     } finally {

--- a/impl_core/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/stats/StatsRecorderImplTest.java
@@ -120,7 +120,7 @@ public final class StatsRecorderImplTest {
             Cumulative.create());
     viewManager.registerView(view);
     TagContext tags = new SimpleTagContext(Tag.create(KEY, VALUE));
-    Context orig = ContextUtils.withValue(Context.current(), tags);
+    Context orig = ContextUtils.withValue(Context.current(), tags).attach();
     try {
       statsRecorder.newMeasureMap().put(MEASURE_DOUBLE, 1.0).record();
     } finally {

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/CurrentTagMapUtilsTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/CurrentTagMapUtilsTest.java
@@ -55,7 +55,7 @@ public class CurrentTagMapUtilsTest {
 
   @Test
   public void testGetCurrentTagMap_ContextSetToNull() {
-    Context orig = ContextUtils.withValue(Context.current(), null);
+    Context orig = ContextUtils.withValue(Context.current(), null).attach();
     try {
       TagContext tags = CurrentTagMapUtils.getCurrentTagMap();
       assertThat(tags).isNotNull();

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/CurrentTagMapUtilsTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/CurrentTagMapUtilsTest.java
@@ -55,7 +55,7 @@ public class CurrentTagMapUtilsTest {
 
   @Test
   public void testGetCurrentTagMap_ContextSetToNull() {
-    Context orig = Context.current().withValue(ContextUtils.TAG_CONTEXT_KEY, null).attach();
+    Context orig = ContextUtils.withValue(Context.current(), null);
     try {
       TagContext tags = CurrentTagMapUtils.getCurrentTagMap();
       assertThat(tags).isNotNull();

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/TaggerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/TaggerImplTest.java
@@ -143,7 +143,7 @@ public class TaggerImplTest {
   }
 
   private TagContextBuilder getResultOfCurrentBuilder(TagContext tagsToSet) {
-    Context orig = Context.current().withValue(ContextUtils.TAG_CONTEXT_KEY, tagsToSet).attach();
+    Context orig = ContextUtils.withValue(Context.current(), tagsToSet);
     try {
       return tagger.currentBuilder();
     } finally {
@@ -240,7 +240,7 @@ public class TaggerImplTest {
   }
 
   private TagContext getResultOfGetCurrentTagContext(TagContext tagsToSet) {
-    Context orig = Context.current().withValue(ContextUtils.TAG_CONTEXT_KEY, tagsToSet).attach();
+    Context orig = ContextUtils.withValue(Context.current(), tagsToSet);
     try {
       return tagger.getCurrentTagContext();
     } finally {
@@ -296,7 +296,7 @@ public class TaggerImplTest {
   private TagContext getResultOfWithTagContext(TagContext tagsToSet) {
     Scope scope = tagger.withTagContext(tagsToSet);
     try {
-      return ContextUtils.TAG_CONTEXT_KEY.get();
+      return ContextUtils.getValue(Context.current());
     } finally {
       scope.close();
     }

--- a/impl_core/src/test/java/io/opencensus/implcore/tags/TaggerImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/tags/TaggerImplTest.java
@@ -143,7 +143,7 @@ public class TaggerImplTest {
   }
 
   private TagContextBuilder getResultOfCurrentBuilder(TagContext tagsToSet) {
-    Context orig = ContextUtils.withValue(Context.current(), tagsToSet);
+    Context orig = ContextUtils.withValue(Context.current(), tagsToSet).attach();
     try {
       return tagger.currentBuilder();
     } finally {
@@ -240,7 +240,7 @@ public class TaggerImplTest {
   }
 
   private TagContext getResultOfGetCurrentTagContext(TagContext tagsToSet) {
-    Context orig = ContextUtils.withValue(Context.current(), tagsToSet);
+    Context orig = ContextUtils.withValue(Context.current(), tagsToSet).attach();
     try {
       return tagger.getCurrentTagContext();
     } finally {


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1863.

Similar to https://github.com/bogdandrutu/openconsensus/pull/211.

/cc @zhangkun83 