### PR TITLE
Exporter/Stackdriver: Do create metric descriptor for custom metrics.

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
@@ -44,7 +44,7 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
   private static final Logger logger =
       Logger.getLogger(CreateMetricDescriptorExporter.class.getName());
   private static final ImmutableSet<String> SUPPORTED_EXTERNAL_DOMAINS =
-      ImmutableSet.<String>of("custom.googleapis.com/", "external.googleapis.com/");
+      ImmutableSet.<String>of("custom.googleapis.com", "external.googleapis.com");
 
   private final String projectId;
   private final ProjectName projectName;
@@ -92,7 +92,7 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
       }
     }
     registeredMetricDescriptors.put(metricName, metricDescriptor);
-    if (!isSupportedExternalMetric(metricName)) {
+    if (isBuiltInMetric(metricName)) {
       return true; // skip creating metric descriptor for stackdriver built-in metrics.
     }
 
@@ -153,12 +153,17 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
     nextExporter.export(registeredMetrics);
   }
 
-  private static boolean isSupportedExternalMetric(String metricName) {
-    for (String domain : SUPPORTED_EXTERNAL_DOMAINS) {
-      if (metricName.startsWith(domain)) {
-        return true;
-      }
+  private static boolean isBuiltInMetric(String metricName) {
+    int domainIndex = metricName.indexOf('/');
+    if (domainIndex < 0) {
+      return false;
     }
-    return false;
+    String metricDomain = metricName.substring(0, domainIndex);
+    if (!metricDomain.contains("googleapis.com")) {
+      return false; // domains like "my.org" are not Stackdriver built-in metrics.
+    }
+    // All googleapis.com domains except "custom.googleapis.com" or "external.googleapis.com"
+    // are built-in metrics.
+    return !SUPPORTED_EXTERNAL_DOMAINS.contains(metricDomain);
   }
 }

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
@@ -45,6 +45,7 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
       Logger.getLogger(CreateMetricDescriptorExporter.class.getName());
   private static final ImmutableSet<String> SUPPORTED_EXTERNAL_DOMAINS =
       ImmutableSet.<String>of("custom.googleapis.com", "external.googleapis.com");
+  private static final String GOOGLE_APIS_DOMAIN_SUFFIX = "googleapis.com";
 
   private final String projectId;
   private final ProjectName projectName;
@@ -159,7 +160,7 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
       return false;
     }
     String metricDomain = metricName.substring(0, domainIndex);
-    if (!metricDomain.contains("googleapis.com")) {
+    if (!metricDomain.endsWith(GOOGLE_APIS_DOMAIN_SUFFIX)) {
       return false; // domains like "my.org" are not Stackdriver built-in metrics.
     }
     // All googleapis.com domains except "custom.googleapis.com" or "external.googleapis.com"

--- a/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfigurationTest.java
+++ b/exporters/trace/stackdriver/src/test/java/io/opencensus/exporter/trace/stackdriver/StackdriverTraceConfigurationTest.java
@@ -98,14 +98,16 @@ public class StackdriverTraceConfigurationTest {
 
   @Test
   public void disallowNullFixedAttributes() {
-    StackdriverTraceConfiguration.Builder builder = StackdriverTraceConfiguration.builder();
+    StackdriverTraceConfiguration.Builder builder =
+        StackdriverTraceConfiguration.builder().setProjectId("test");
     thrown.expect(NullPointerException.class);
     builder.setFixedAttributes(null);
   }
 
   @Test
   public void disallowNullFixedAttributeKey() {
-    StackdriverTraceConfiguration.Builder builder = StackdriverTraceConfiguration.builder();
+    StackdriverTraceConfiguration.Builder builder =
+        StackdriverTraceConfiguration.builder().setProjectId("test");
     Map<String, AttributeValue> attributes =
         Collections.singletonMap(null, AttributeValue.stringAttributeValue("val"));
     builder.setFixedAttributes(attributes);
@@ -115,7 +117,8 @@ public class StackdriverTraceConfigurationTest {
 
   @Test
   public void disallowNullFixedAttributeValue() {
-    StackdriverTraceConfiguration.Builder builder = StackdriverTraceConfiguration.builder();
+    StackdriverTraceConfiguration.Builder builder =
+        StackdriverTraceConfiguration.builder().setProjectId("test");
     Map<String, AttributeValue> attributes = Collections.singletonMap("key", null);
     builder.setFixedAttributes(attributes);
     thrown.expect(NullPointerException.class);


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1841.

Previously metric names like "my.org/metric" are treated as Stackdriver built-in metrics by accident. This PR fixes this bug.