### PR TITLE
zPages: Enable RunningSpanStore only when /tracez is in use.

### DIFF
--- a/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/ZPageHandlers.java
+++ b/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/ZPageHandlers.java
@@ -78,11 +78,6 @@ public final class ZPageHandlers {
   private static final ZPageHandler statszZPageHandler =
       StatszZPageHandler.create(Stats.getViewManager());
 
-  static {
-    // Sets the maximum number of elements as Integer.MAX_VALUE.
-    Tracing.getExportComponent().getRunningSpanStore().setMaxNumberOfSpans(Integer.MAX_VALUE);
-  }
-
   private static final Object monitor = new Object();
 
   @GuardedBy("monitor")
@@ -103,6 +98,7 @@ public final class ZPageHandlers {
    * @since 0.6
    */
   public static ZPageHandler getTracezZPageHandler() {
+    enableRunningSpanStore();
     return tracezZPageHandler;
   }
 
@@ -148,6 +144,7 @@ public final class ZPageHandlers {
    * @since 0.6
    */
   public static void registerAllToHttpServer(HttpServer server) {
+    enableRunningSpanStore();
     server.createContext(tracezZPageHandler.getUrlPath(), new ZPageHttpHandler(tracezZPageHandler));
     server.createContext(
         traceConfigzZPageHandler.getUrlPath(), new ZPageHttpHandler(traceConfigzZPageHandler));
@@ -199,6 +196,11 @@ public final class ZPageHandlers {
       server.stop(STOP_DELAY);
       server = null;
     }
+  }
+
+  // Sets the maximum number of elements as Integer.MAX_VALUE to enable RunningSpanStore.
+  private static void enableRunningSpanStore() {
+    Tracing.getExportComponent().getRunningSpanStore().setMaxNumberOfSpans(Integer.MAX_VALUE);
   }
 
   private ZPageHandlers() {}

--- a/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/ZPageHandlers.java
+++ b/contrib/zpages/src/main/java/io/opencensus/contrib/zpages/ZPageHandlers.java
@@ -94,6 +94,9 @@ public final class ZPageHandlers {
    * <p>If no sampled spans based on latency and error codes are available for a given name, make
    * sure that the span name is registered to the {@code SampledSpanStore}.
    *
+   * <p>When this method is called, {@link io.opencensus.trace.export.RunningSpanStore} will be
+   * enabled automatically.
+   *
    * @return a {@code ZPageHandler} for tracing debug.
    * @since 0.6
    */


### PR DESCRIPTION
A follow-up of https://github.com/census-instrumentation/opencensus-java/issues/1813#issuecomment-489685886.

Enable RunningSpanStore only when /tracez is in use, instead of always enabling it statically.