### PR TITLE
Exporter/Datadog, Elasticsearch: Add deadline option.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Monitoring client to make RPCs.
 with default value 10 seconds.
 - Use `ZipkinExporterConfiguration` for creating `ZipkinTraceExporter`. Provide a `Deadline` option
 with default value 10 seconds.
+- Provide a `Deadline` option to Datadog and Elasticsearch exporter. Default value is 10 seconds.
 
 ## 0.21.0 - 2019-04-30
 - Add HTTP text format serializer to Tag propagation component.

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceConfiguration.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceConfiguration.java
@@ -17,6 +17,9 @@
 package io.opencensus.exporter.trace.datadog;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import io.opencensus.common.Duration;
 import javax.annotation.concurrent.Immutable;
 
 /**
@@ -27,6 +30,9 @@ import javax.annotation.concurrent.Immutable;
 @AutoValue
 @Immutable
 public abstract class DatadogTraceConfiguration {
+
+  @VisibleForTesting static final Duration DEFAULT_DEADLINE = Duration.create(10, 0);
+  @VisibleForTesting static final Duration ZERO = Duration.fromMillis(0);
 
   DatadogTraceConfiguration() {}
 
@@ -55,13 +61,23 @@ public abstract class DatadogTraceConfiguration {
   public abstract String getType();
 
   /**
+   * Returns the deadline for exporting to Datadog.
+   *
+   * <p>Default value is 10 seconds.
+   *
+   * @return the export deadline.
+   * @since 0.22
+   */
+  public abstract Duration getDeadline();
+
+  /**
    * Return a new {@link Builder}.
    *
    * @return a {@code Builder}
    * @since 0.19
    */
   public static Builder builder() {
-    return new AutoValue_DatadogTraceConfiguration.Builder();
+    return new AutoValue_DatadogTraceConfiguration.Builder().setDeadline(DEFAULT_DEADLINE);
   }
 
   /**
@@ -101,6 +117,28 @@ public abstract class DatadogTraceConfiguration {
      */
     public abstract Builder setType(String type);
 
-    public abstract DatadogTraceConfiguration build();
+    /**
+     * Sets the deadline for exporting to Datadog.
+     *
+     * @param deadline the export deadline.
+     * @return this
+     * @since 0.22
+     */
+    public abstract Builder setDeadline(Duration deadline);
+
+    abstract Duration getDeadline();
+
+    abstract DatadogTraceConfiguration autoBuild();
+
+    /**
+     * Builds a {@link DatadogTraceConfiguration}.
+     *
+     * @return a {@code DatadogTraceConfiguration}.
+     * @since 0.22
+     */
+    public DatadogTraceConfiguration build() {
+      Preconditions.checkArgument(getDeadline().compareTo(ZERO) > 0, "Deadline must be positive.");
+      return autoBuild();
+    }
   }
 }

--- a/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceExporter.java
+++ b/exporters/trace/datadog/src/main/java/io/opencensus/exporter/trace/datadog/DatadogTraceExporter.java
@@ -32,10 +32,10 @@ import javax.annotation.concurrent.GuardedBy;
  * <pre>{@code
  * public static void main(String[] args) {
  *   DatadogTraceConfiguration config = DatadogTraceConfiguration.builder()
- * .setAgentEndpoint("http://localhost:8126/v0.3/traces")
- * .setService("myService")
- * .setType("web")
- * .build();
+ *     .setAgentEndpoint("http://localhost:8126/v0.3/traces")
+ *     .setService("myService")
+ *     .setType("web")
+ *     .build();
  * DatadogTraceExporter.createAndRegister(config);
  *   ... // Do work.
  * }
@@ -72,7 +72,7 @@ public final class DatadogTraceExporter {
       String type = configuration.getType();
 
       final DatadogExporterHandler exporterHandler =
-          new DatadogExporterHandler(agentEndpoint, service, type);
+          new DatadogExporterHandler(agentEndpoint, service, type, configuration.getDeadline());
       handler = exporterHandler;
       Tracing.getExportComponent()
           .getSpanExporter()

--- a/exporters/trace/datadog/src/test/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandlerTest.java
+++ b/exporters/trace/datadog/src/test/java/io/opencensus/exporter/trace/datadog/DatadogExporterHandlerTest.java
@@ -17,6 +17,7 @@
 package io.opencensus.exporter.trace.datadog;
 
 import static com.google.common.truth.Truth.assertThat;
+import static io.opencensus.exporter.trace.datadog.DatadogTraceConfiguration.DEFAULT_DEADLINE;
 
 import com.google.common.collect.ImmutableMap;
 import io.opencensus.common.Timestamp;
@@ -56,7 +57,8 @@ public class DatadogExporterHandlerTest {
 
   @Before
   public void setup() throws Exception {
-    this.handler = new DatadogExporterHandler("http://localhost", "service", "web");
+    this.handler =
+        new DatadogExporterHandler("http://localhost", "service", "web", DEFAULT_DEADLINE);
   }
 
   @Test

--- a/exporters/trace/elasticsearch/src/main/java/io/opencensus/exporter/trace/elasticsearch/ElasticsearchTraceConfiguration.java
+++ b/exporters/trace/elasticsearch/src/main/java/io/opencensus/exporter/trace/elasticsearch/ElasticsearchTraceConfiguration.java
@@ -17,8 +17,10 @@
 package io.opencensus.exporter.trace.elasticsearch;
 
 import com.google.auto.value.AutoValue;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
+import io.opencensus.common.Duration;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.Immutable;
 
@@ -31,6 +33,9 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public abstract class ElasticsearchTraceConfiguration {
 
+  @VisibleForTesting static final Duration DEFAULT_DEADLINE = Duration.create(10, 0);
+  @VisibleForTesting static final Duration ZERO = Duration.fromMillis(0);
+
   /**
    * Returns a new {@link Builder}.
    *
@@ -38,7 +43,7 @@ public abstract class ElasticsearchTraceConfiguration {
    * @since 0.20.0
    */
   public static Builder builder() {
-    return new AutoValue_ElasticsearchTraceConfiguration.Builder();
+    return new AutoValue_ElasticsearchTraceConfiguration.Builder().setDeadline(DEFAULT_DEADLINE);
   }
 
   /**
@@ -90,6 +95,16 @@ public abstract class ElasticsearchTraceConfiguration {
    * @since 0.20.0
    */
   public abstract String getElasticsearchType();
+
+  /**
+   * Returns the deadline for exporting to Elasticsearch.
+   *
+   * <p>Default value is 10 seconds.
+   *
+   * @return the export deadline.
+   * @since 0.22
+   */
+  public abstract Duration getDeadline();
 
   /**
    * Builds a {@link ElasticsearchTraceConfiguration}.
@@ -158,6 +173,15 @@ public abstract class ElasticsearchTraceConfiguration {
     public abstract Builder setElasticsearchType(String elasticsearchType);
 
     /**
+     * Sets the deadline for exporting to Elasticsearch.
+     *
+     * @param deadline the export deadline.
+     * @return this
+     * @since 0.22
+     */
+    public abstract Builder setDeadline(Duration deadline);
+
+    /**
      * Builder for {@link ElasticsearchTraceConfiguration}.
      *
      * @return a {@code ElasticsearchTraceConfiguration}.
@@ -174,6 +198,9 @@ public abstract class ElasticsearchTraceConfiguration {
       Preconditions.checkArgument(
           !Strings.isNullOrEmpty(elasticsearchTraceConfiguration.getElasticsearchIndex()),
           "Invalid Elasticsearch type.");
+      Preconditions.checkArgument(
+          elasticsearchTraceConfiguration.getDeadline().compareTo(ZERO) > 0,
+          "Deadline must be positive.");
       return elasticsearchTraceConfiguration;
     }
   }

--- a/exporters/trace/elasticsearch/src/main/java/io/opencensus/exporter/trace/elasticsearch/ElasticsearchTraceHandler.java
+++ b/exporters/trace/elasticsearch/src/main/java/io/opencensus/exporter/trace/elasticsearch/ElasticsearchTraceHandler.java
@@ -17,6 +17,9 @@
 package io.opencensus.exporter.trace.elasticsearch;
 
 import com.google.common.io.BaseEncoding;
+import com.google.common.util.concurrent.SimpleTimeLimiter;
+import com.google.common.util.concurrent.TimeLimiter;
+import io.opencensus.common.Duration;
 import io.opencensus.common.Scope;
 import io.opencensus.trace.Sampler;
 import io.opencensus.trace.Status;
@@ -34,12 +37,17 @@ import java.net.URL;
 import java.nio.charset.Charset;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 final class ElasticsearchTraceHandler extends SpanExporter.Handler {
 
   private final ElasticsearchTraceConfiguration elasticsearchTraceConfiguration;
   private final String appName;
   private final URL indexUrl;
+  private final Duration deadline;
   private static final String CONTENT_TYPE = "application/json";
   private static final String REQUEST_METHOD = "POST";
   private static final int CONNECTION_TIMEOUT_MILLISECONDS = 6000;
@@ -56,6 +64,7 @@ final class ElasticsearchTraceHandler extends SpanExporter.Handler {
     sb.append(elasticsearchTraceConfiguration.getElasticsearchType()).append("/");
     indexUrl = new URL(sb.toString());
     appName = elasticsearchTraceConfiguration.getAppName();
+    deadline = elasticsearchTraceConfiguration.getDeadline();
   }
 
   /**
@@ -64,7 +73,7 @@ final class ElasticsearchTraceHandler extends SpanExporter.Handler {
    * @param spanDataList Collection of {@code SpanData} to be exported.
    */
   @Override
-  public void export(Collection<SpanData> spanDataList) {
+  public void export(final Collection<SpanData> spanDataList) {
     Scope scope =
         tracer
             .spanBuilder("ExportElasticsearchTraces")
@@ -72,67 +81,85 @@ final class ElasticsearchTraceHandler extends SpanExporter.Handler {
             .setRecordEvents(true)
             .startScopedSpan();
     try {
-      List<String> jsonList = JsonConversionUtils.convertToJson(appName, spanDataList);
-      if (jsonList.isEmpty()) {
-        return;
-      }
-      for (String json : jsonList) {
-
-        OutputStream outputStream = null;
-        InputStream inputStream = null;
-
-        try {
-          HttpURLConnection connection = (HttpURLConnection) indexUrl.openConnection();
-          if (elasticsearchTraceConfiguration.getUserName() != null) {
-            String parameters =
-                BaseEncoding.base64()
-                    .encode(
-                        (elasticsearchTraceConfiguration.getUserName()
-                                + ":"
-                                + elasticsearchTraceConfiguration.getPassword())
-                            .getBytes("UTF-8"));
-            connection.setRequestProperty("Authorization", "Basic " + parameters);
-          }
-          connection.setRequestMethod(REQUEST_METHOD);
-          connection.setDoOutput(true);
-          connection.setConnectTimeout(CONNECTION_TIMEOUT_MILLISECONDS);
-          connection.setRequestProperty("Content-Type", CONTENT_TYPE);
-          outputStream = connection.getOutputStream();
-          outputStream.write(json.getBytes(Charset.defaultCharset()));
-          outputStream.flush();
-          inputStream = connection.getInputStream();
-          if (connection.getResponseCode() != 200) {
-            tracer
-                .getCurrentSpan()
-                .setStatus(
-                    Status.UNKNOWN.withDescription("Response " + connection.getResponseCode()));
-          }
-        } catch (IOException e) {
-          tracer
-              .getCurrentSpan()
-              .setStatus(
-                  Status.UNKNOWN.withDescription(
-                      e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage()));
-          // dropping span batch
-        } finally {
-          if (inputStream != null) {
-            try {
-              inputStream.close();
-            } catch (IOException e) {
-              // ignore
+      TimeLimiter timeLimiter = SimpleTimeLimiter.create(Executors.newSingleThreadExecutor());
+      timeLimiter.callWithTimeout(
+          new Callable<Void>() {
+            @Override
+            public Void call() {
+              doExport(spanDataList);
+              return null;
             }
-          }
-          if (outputStream != null) {
-            try {
-              outputStream.close();
-            } catch (IOException e) {
-              // ignore
-            }
-          }
-        }
-      }
+          },
+          deadline.toMillis(),
+          TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      handleException(e);
     } finally {
       scope.close();
     }
+  }
+
+  private void doExport(Collection<SpanData> spanDataList) {
+    List<String> jsonList = JsonConversionUtils.convertToJson(appName, spanDataList);
+    if (jsonList.isEmpty()) {
+      return;
+    }
+    for (String json : jsonList) {
+
+      OutputStream outputStream = null;
+      InputStream inputStream = null;
+
+      try {
+        HttpURLConnection connection = (HttpURLConnection) indexUrl.openConnection();
+        if (elasticsearchTraceConfiguration.getUserName() != null) {
+          String parameters =
+              BaseEncoding.base64()
+                  .encode(
+                      (elasticsearchTraceConfiguration.getUserName()
+                              + ":"
+                              + elasticsearchTraceConfiguration.getPassword())
+                          .getBytes("UTF-8"));
+          connection.setRequestProperty("Authorization", "Basic " + parameters);
+        }
+        connection.setRequestMethod(REQUEST_METHOD);
+        connection.setDoOutput(true);
+        connection.setConnectTimeout(CONNECTION_TIMEOUT_MILLISECONDS);
+        connection.setRequestProperty("Content-Type", CONTENT_TYPE);
+        outputStream = connection.getOutputStream();
+        outputStream.write(json.getBytes(Charset.defaultCharset()));
+        outputStream.flush();
+        inputStream = connection.getInputStream();
+        if (connection.getResponseCode() != 200) {
+          handleException(new Exception("Response " + connection.getResponseCode()));
+        }
+      } catch (IOException e) {
+        handleException(e);
+        // dropping span batch
+      } finally {
+        if (inputStream != null) {
+          try {
+            inputStream.close();
+          } catch (IOException e) {
+            // ignore
+          }
+        }
+        if (outputStream != null) {
+          try {
+            outputStream.close();
+          } catch (IOException e) {
+            // ignore
+          }
+        }
+      }
+    }
+  }
+
+  private static void handleException(Exception e) {
+    Status status = e instanceof TimeoutException ? Status.DEADLINE_EXCEEDED : Status.UNKNOWN;
+    tracer
+        .getCurrentSpan()
+        .setStatus(
+            status.withDescription(
+                e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage()));
   }
 }


### PR DESCRIPTION
Another two of https://github.com/census-instrumentation/opencensus-java/issues/1880.

I'm consider adding a common `SpanExportWithDeadline` interface to reduce the duplicated codes, similar to https://github.com/census-instrumentation/opencensus-java/tree/master/exporters/metrics/util. WDYT?