### PR TITLE
Exporter/Stackdriver: Fix k8s_container resource.

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtils.java
@@ -683,7 +683,6 @@ final class StackdriverExportUtils {
     Map<String, String> resourceLabels = new LinkedHashMap<String, String>();
     resourceLabels.put("project_id", STACKDRIVER_PROJECT_ID_KEY);
     resourceLabels.put("location", CloudResource.ZONE_KEY);
-    resourceLabels.put("instance_id", HostResource.ID_KEY);
     resourceLabels.put("cluster_name", K8sResource.CLUSTER_NAME_KEY);
     resourceLabels.put("namespace_name", K8sResource.NAMESPACE_NAME_KEY);
     resourceLabels.put("pod_name", K8sResource.POD_NAME_KEY);

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverExportUtilsTest.java
@@ -844,7 +844,6 @@ public class StackdriverExportUtilsTest {
     Map<String, String> expectedResourceLabels = new HashMap<String, String>();
     expectedResourceLabels.put("project_id", "proj1");
     expectedResourceLabels.put("location", "zone1");
-    expectedResourceLabels.put("instance_id", "instance1");
     expectedResourceLabels.put("cluster_name", "cluster1");
     expectedResourceLabels.put("namespace_name", "namespace1");
     expectedResourceLabels.put("pod_name", "pod1");
@@ -856,7 +855,7 @@ public class StackdriverExportUtilsTest {
     assertThat(monitoredResourceBuilder.getType()).isNotNull();
     assertThat(monitoredResourceBuilder.getLabelsMap()).isNotEmpty();
     assertThat(monitoredResourceBuilder.getType()).isEqualTo("k8s_container");
-    assertThat(monitoredResourceBuilder.getLabelsMap().size()).isEqualTo(7);
+    assertThat(monitoredResourceBuilder.getLabelsMap().size()).isEqualTo(6);
     assertThat(monitoredResourceBuilder.getLabelsMap())
         .containsExactlyEntriesIn(expectedResourceLabels);
   }


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1888.

According to https://cloud.google.com/monitoring/api/resources#tag_k8s_container:
> k8s_container
Display name: Kubernetes Container
Description: A Kubernetes container instance.
Labels:
project_id: The identifier of the GCP project associated with this resource, such as "my-project".
location: The physical location of the cluster that contains the container.
cluster_name: The name of the cluster that the container is running in.
namespace_name: The name of the namespace that the container is running in.
pod_name: The name of the pod that the container is running in.
container_name: The name of the container.

`k8s_container` resource doesn't have an `instance_id` label.
