### PR TITLE
Start dropping spans when the span exporter thread holds more than 10K spans references.

### DIFF
--- a/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporterIntegrationTest.java
+++ b/exporters/metrics/ocagent/src/test/java/io/opencensus/exporter/metrics/ocagent/OcAgentMetricsExporterIntegrationTest.java
@@ -261,7 +261,7 @@ public class OcAgentMetricsExporterIntegrationTest {
     for (Metric metricProto : metricProtos) {
       actualMetrics.add(metricProto.getMetricDescriptor().getName());
     }
-    assertThat(actualMetrics).containsExactlyElementsIn(expectedMetrics);
+    assertThat(actualMetrics).containsAllIn(expectedMetrics);
   }
 
   private static void registerAllViews() {

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/export/SpanExporterImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/export/SpanExporterImpl.java
@@ -123,41 +123,41 @@ public final class SpanExporterImpl extends SpanExporter {
     this.workerThread.start();
     this.worker = worker;
     droppedSpans.createTimeSeries(
-        Collections.<LabelValue>emptyList(),
-        this.worker,
-        new ToLongFunction</*@Nullable*/ Worker>() {
-          @Override
-          public long applyAsLong(/*@Nullable*/ Worker worker) {
-            if (worker == null) {
-              return 0;
-            }
-            return worker.getDroppedSpans();
-          }
-        });
+        Collections.<LabelValue>emptyList(), this.worker, new ReportDroppedSpans());
     referencedSpans.createTimeSeries(
-        Collections.<LabelValue>emptyList(),
-        this.worker,
-        new ToLongFunction</*@Nullable*/ Worker>() {
-          @Override
-          public long applyAsLong(/*@Nullable*/ Worker worker) {
-            if (worker == null) {
-              return 0;
-            }
-            return worker.getReferencedSpans();
-          }
-        });
+        Collections.<LabelValue>emptyList(), this.worker, new ReportReferencedSpans());
     pushedSpans.createTimeSeries(
-        Collections.<LabelValue>emptyList(),
-        this.worker,
-        new ToLongFunction</*@Nullable*/ Worker>() {
-          @Override
-          public long applyAsLong(/*@Nullable*/ Worker worker) {
-            if (worker == null) {
-              return 0;
-            }
-            return worker.getPushedSpans();
-          }
-        });
+        Collections.<LabelValue>emptyList(), this.worker, new ReportPushedSpans());
+  }
+
+  private static class ReportDroppedSpans implements ToLongFunction</*@Nullable*/ Worker> {
+    @Override
+    public long applyAsLong(/*@Nullable*/ Worker worker) {
+      if (worker == null) {
+        return 0;
+      }
+      return worker.getDroppedSpans();
+    }
+  }
+
+  private static class ReportReferencedSpans implements ToLongFunction</*@Nullable*/ Worker> {
+    @Override
+    public long applyAsLong(/*@Nullable*/ Worker worker) {
+      if (worker == null) {
+        return 0;
+      }
+      return worker.getReferencedSpans();
+    }
+  }
+
+  private static class ReportPushedSpans implements ToLongFunction</*@Nullable*/ Worker> {
+    @Override
+    public long applyAsLong(/*@Nullable*/ Worker worker) {
+      if (worker == null) {
+        return 0;
+      }
+      return worker.getPushedSpans();
+    }
   }
 
   @VisibleForTesting

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/export/SpanExporterImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/export/SpanExporterImplTest.java
@@ -181,7 +181,7 @@ public class SpanExporterImplTest {
   @Test
   public void exportMoreSpansThanTheMaximumLimit() {
     final int bufferSize = 4;
-    final int maxReferencedSpans = bufferSize * 10;
+    final int maxReferencedSpans = bufferSize * 4;
     SpanExporterImpl spanExporter = SpanExporterImpl.create(bufferSize, Duration.create(1, 0));
     StartEndHandler startEndHandler =
         new StartEndHandlerImpl(


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1767