### PR TITLE
Exporter/OcAgent: Add a note about netty-tcnative-boringssl dependency.

### DIFF
--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -37,6 +37,7 @@ def opencensusVersion = "0.22.0" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.19.0" // CURRENT_GRPC_VERSION
 def prometheusVersion = "0.6.0"
 def jettyVersion = "9.4.17.v20190418"
+def tcnativeVersion = "2.0.20.Final"
 
 tasks.withType(JavaCompile) {
     sourceCompatibility = '1.8'
@@ -69,7 +70,7 @@ dependencies {
             "org.slf4j:slf4j-log4j12:1.7.25"
 
     runtime "io.opencensus:opencensus-impl:${opencensusVersion}",
-            "io.netty:netty-tcnative-boringssl-static:2.0.8.Final"
+            "io.netty:netty-tcnative-boringssl-static:${tcnativeVersion}"
 }
 
 googleJavaFormat {

--- a/exporters/metrics/ocagent/README.md
+++ b/exporters/metrics/ocagent/README.md
@@ -26,6 +26,12 @@ For Maven add to your `pom.xml`:
     <version>0.22.0</version>
     <scope>runtime</scope>
   </dependency>
+  <dependency>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-tcnative-boringssl-static</artifactId>
+    <version>2.0.20.Final</version>
+    <scope>runtime</scope>
+  </dependency>
 </dependencies>
 ```
 
@@ -34,6 +40,7 @@ For Gradle add to your dependencies:
 compile 'io.opencensus:opencensus-api:0.22.0'
 compile 'io.opencensus:opencensus-exporter-metrics-ocagent:0.22.0'
 runtime 'io.opencensus:opencensus-impl:0.22.0'
+runtime 'io.netty:netty-tcnative-boringssl-static:2.0.20.Final'
 ```
 
 ### Register the exporter

--- a/exporters/metrics/ocagent/README.md
+++ b/exporters/metrics/ocagent/README.md
@@ -55,3 +55,11 @@ public class MyMainClass {
   }
 }
 ```
+
+## FAQ
+
+### Why is `netty-tcnative-boringssl-static` needed? Which version should I use?
+
+It's because this artifact depends on `grpc-netty` which requires a runtime dependency on `netty-tcnative-boringssl-static`
+for it to work. For more details and a table of known working version combinations, see
+https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty.

--- a/exporters/trace/ocagent/README.md
+++ b/exporters/trace/ocagent/README.md
@@ -53,3 +53,11 @@ public class MyMainClass {
   }
 }
 ```
+
+## FAQ
+
+### Why is `netty-tcnative-boringssl-static` needed? Which version should I use?
+
+It's because this artifact depends on `grpc-netty` which requires a runtime dependency on `netty-tcnative-boringssl-static`
+for it to work. For more details and a table of known working version combinations, see
+https://github.com/grpc/grpc-java/blob/master/SECURITY.md#netty.

--- a/exporters/trace/ocagent/README.md
+++ b/exporters/trace/ocagent/README.md
@@ -26,6 +26,12 @@ For Maven add to your `pom.xml`:
     <version>0.22.0</version>
     <scope>runtime</scope>
   </dependency>
+  <dependency>
+    <groupId>io.netty</groupId>
+    <artifactId>netty-tcnative-boringssl-static</artifactId>
+    <version>2.0.20.Final</version>
+    <scope>runtime</scope>
+  </dependency>
 </dependencies>
 ```
 
@@ -34,6 +40,7 @@ For Gradle add to your dependencies:
 compile 'io.opencensus:opencensus-api:0.22.0'
 compile 'io.opencensus:opencensus-exporter-trace-ocagent:0.22.0'
 runtime 'io.opencensus:opencensus-impl:0.22.0'
+runtime 'io.netty:netty-tcnative-boringssl-static:2.0.20.Final'
 ```
 
 ### Register the exporter


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1897.