### PR TITLE
Allow setting span start/end times explicitly

### DIFF
--- a/api/src/main/java/io/opencensus/trace/Span.java
+++ b/api/src/main/java/io/opencensus/trace/Span.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.trace;
 
+import io.opencensus.common.Timestamp;
 import io.opencensus.internal.Utils;
 import io.opencensus.trace.internal.BaseMessageEventUtils;
 import java.util.Collections;
@@ -222,6 +223,18 @@ public abstract class Span {
   }
 
   /**
+   * Explicitly sets the start time of the span.
+   *
+   * <p>If this method is not called then the start time of the span is set equal to the clock time
+   * at the time when the span is created. The default implementation does nothing. Implementations
+   * that keep track of start time are expected to override this method.
+   *
+   * @param startTimestamp the {@link Timestamp} to set.
+   * @since 0.23
+   */
+  public void setStartTime(Timestamp startTimestamp) {}
+
+  /**
    * Marks the end of {@code Span} execution with the given options.
    *
    * <p>Only the timing of the first end call for a given {@code Span} will be recorded, and
@@ -242,6 +255,22 @@ public abstract class Span {
    */
   public final void end() {
     end(EndSpanOptions.DEFAULT);
+  }
+
+  /**
+   * Marks the end of {@code Span} execution with the given options and end time.
+   *
+   * <p>Only the timing of the first end call for a given {@code Span} will be recorded, and
+   * implementations are free to ignore all further calls. The default implementation ignores
+   * endTimestamp parameter and calls {@link end} method. Implementations that keep track of end
+   * time are expected to override this method.
+   *
+   * @param options the options to be used for the end of the {@code Span}.
+   * @param endTimestamp the {@link Timestamp} to set end time of the span to.
+   * @since 0.23
+   */
+  public void end(EndSpanOptions options, Timestamp endTimestamp) {
+    end(options);
   }
 
   /**

--- a/impl_core/src/main/java/io/opencensus/implcore/internal/TimestampConverter.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/internal/TimestampConverter.java
@@ -22,7 +22,7 @@ import javax.annotation.concurrent.Immutable;
 
 /**
  * This class provides a mechanism for converting {@link System#nanoTime() nanoTime} values to
- * {@link Timestamp}.
+ * {@link Timestamp} and back.
  */
 @Immutable
 public final class TimestampConverter {
@@ -42,6 +42,16 @@ public final class TimestampConverter {
    */
   public Timestamp convertNanoTime(long nanoTime) {
     return timestamp.addNanos(nanoTime - this.nanoTime);
+  }
+
+  /**
+   * Converts a {@link Timestamp} value to {@link System#nanoTime() nanoTime}.
+   *
+   * @param timestamp value to convert.
+   * @return the nanoTime representation of the time.
+   */
+  public long convertTimestamp(Timestamp timestamp) {
+    return timestamp.subtractTimestamp(this.timestamp).getNanos() + this.nanoTime;
   }
 
   private TimestampConverter(Timestamp timestamp, long nanoTime) {

--- a/impl_core/src/test/java/io/opencensus/implcore/internal/TimestampConverterTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/internal/TimestampConverterTest.java
@@ -48,4 +48,13 @@ public class TimestampConverterTest {
     assertThat(timeConverter.convertNanoTime(1000)).isEqualTo(Timestamp.create(1234, 5444));
     assertThat(timeConverter.convertNanoTime(999995556)).isEqualTo(Timestamp.create(1235, 0));
   }
+
+  @Test
+  public void convertTimestamp() {
+    when(mockClock.now()).thenReturn(timestamp);
+    when(mockClock.nowNanos()).thenReturn(1234L);
+    TimestampConverter timeConverter = TimestampConverter.now(mockClock);
+    assertThat(timeConverter.convertTimestamp(timestamp)).isEqualTo(1234L);
+    assertThat(timeConverter.convertTimestamp(Timestamp.create(1234, 10678))).isEqualTo(6234L);
+  }
 }

--- a/impl_core/src/test/java/io/opencensus/implcore/trace/RecordEventsSpanImplTest.java
+++ b/impl_core/src/test/java/io/opencensus/implcore/trace/RecordEventsSpanImplTest.java
@@ -591,4 +591,28 @@ public class RecordEventsSpanImplTest {
             testClock);
     assertThat(span.getKind()).isEqualTo(Kind.SERVER);
   }
+
+  @Test
+  public void startEndTimes() {
+    RecordEventsSpanImpl span =
+        RecordEventsSpanImpl.startSpan(
+            spanContext,
+            SPAN_NAME,
+            Kind.SERVER,
+            parentSpanId,
+            false,
+            TraceParams.DEFAULT,
+            startEndHandler,
+            timestampConverter,
+            testClock);
+
+    Timestamp start = Timestamp.create(1234, 5678);
+    Timestamp end = Timestamp.create(4567, 7890);
+
+    span.setStartTime(start);
+    span.end(EndSpanOptions.DEFAULT, end);
+
+    assertThat(span.getStartNanoTime()).isEqualTo(timestampConverter.convertTimestamp(start));
+    assertThat(span.getEndNanoTime()).isEqualTo(timestampConverter.convertTimestamp(end));
+  }
 }


### PR DESCRIPTION
We have a use case where the start/end times of traces is coming from an external system.
We need to be able to explicitly set the times instead of the times automatically
retrieved from the local clock.

The change to the Span API is the following:

1. Add `void setStartTime(Timestamp startTimestamp)` to Span.
2. Add `void end(EndSpanOptions options, Timestamp endTimestamp)` to Span.