### PR TITLE
Stats: Don't put stats event onto the queue if no measures are registered.

### DIFF
--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MeasureToViewMap.java
@@ -175,6 +175,15 @@ final class MeasureToViewMap {
     return metrics;
   }
 
+  synchronized boolean isAnyMeasureRegistered(MeasureMapInternal measurementValues) {
+    for (Iterator<Measurement> iterator = measurementValues.iterator(); iterator.hasNext(); ) {
+      if (registeredMeasures.containsKey(iterator.next().getMeasure().getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   // Clear stats for all the current MutableViewData
   synchronized void clearStats() {
     for (Entry<String, Collection<MutableViewData>> entry : mutableMap.asMap().entrySet()) {

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/StatsManager.java
@@ -66,7 +66,8 @@ final class StatsManager {
   void record(TagContext tags, MeasureMapInternal measurementValues) {
     // TODO(songya): consider exposing No-op MeasureMap and use it when stats state is DISABLED, so
     // that we don't need to create actual MeasureMapImpl.
-    if (state.getInternal() == State.ENABLED) {
+    if (state.getInternal() == State.ENABLED
+        && measureToViewMap.isAnyMeasureRegistered(measurementValues)) {
       queue.enqueue(new StatsEvent(this, tags, measurementValues));
     }
   }


### PR DESCRIPTION
Small improvement on #1809.

This matches Go: https://github.com/census-instrumentation/opencensus-go/blob/0ac3701b0da6461885aa3ae14c555221d967c2c8/stats/record.go#L99-L108.