### PR TITLE
Exporter/Stackdriver: Expose unregister API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 ## Unreleased
+- Make `StackdriverStatsExporter.unregister()` a public API.
 
 ## 0.22.1 - 2019-05-21
 - Increase the buffer size for the trace export batch to 2500 (previously it was 32).

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -420,9 +420,14 @@ public final class StackdriverStatsExporter {
     return MetricServiceClient.create(settingsBuilder.build());
   }
 
-  // Resets exporter to null. Used only for unit tests.
-  @VisibleForTesting
-  static void unsafeResetExporter() {
+  /**
+   * Unregisters the {@link StackdriverStatsExporter} and stops metrics exporting.
+   *
+   * <p>Unexported data will be flushed before the exporter is stopped.
+   *
+   * @since 0.23
+   */
+  public static void unregister() {
     synchronized (monitor) {
       if (instance != null) {
         instance.intervalMetricReader.stop();

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -47,6 +47,7 @@ import java.io.IOException;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
+import javax.annotation.concurrent.ThreadSafe;
 
 /**
  * Exporter to Stackdriver Monitoring Client API v3.
@@ -67,6 +68,7 @@ import javax.annotation.concurrent.GuardedBy;
  *
  * @since 0.9
  */
+@ThreadSafe
 public final class StackdriverStatsExporter {
 
   @VisibleForTesting static final Object monitor = new Object();

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporterTest.java
@@ -115,7 +115,20 @@ public class StackdriverStatsExporterTest {
       thrown.expectMessage("Stackdriver stats exporter is already created.");
       StackdriverStatsExporter.createAndRegister(CONFIGURATION);
     } finally {
-      StackdriverStatsExporter.unsafeResetExporter();
+      StackdriverStatsExporter.unregister();
+    }
+  }
+
+  @Test
+  public void unregister() throws IOException {
+    // unregister has no effect if exporter is not yet registered.
+    StackdriverStatsExporter.unregister();
+    try {
+      StackdriverStatsExporter.createAndRegister(CONFIGURATION);
+      StackdriverStatsExporter.unregister();
+      StackdriverStatsExporter.createAndRegister(CONFIGURATION);
+    } finally {
+      StackdriverStatsExporter.unregister();
     }
   }
 


### PR DESCRIPTION
Fixes https://github.com/census-instrumentation/opencensus-java/issues/1917.