### PR TITLE
Exporter/Jaeger: Set span status as tags.

### DIFF
--- a/exporters/trace/jaeger/src/main/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandler.java
+++ b/exporters/trace/jaeger/src/main/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandler.java
@@ -72,7 +72,6 @@ final class JaegerExporterHandler extends TimeLimitedHandler {
   private static final String MESSAGE_EVENT_UNCOMPRESSED_SIZE = "uncompressed_size";
   @VisibleForTesting static final String STATUS_CODE = "status.code";
   @VisibleForTesting static final String STATUS_MESSAGE = "status.message";
-  @VisibleForTesting static final String STATUS_ERROR = "error";
 
   private static final Function<? super String, Tag> stringAttributeConverter =
       new Function<String, Tag>() {
@@ -350,10 +349,6 @@ final class JaegerExporterHandler extends TimeLimitedHandler {
     }
     Tag statusTag = new Tag(STATUS_CODE, TagType.LONG).setVLong(status.getCanonicalCode().value());
     tags.add(statusTag);
-    if (!status.isOk()) {
-      // Ensure that if Status.Code is not OK, that we set the "error" tag on the Jaeger span.
-      tags.add(new Tag(STATUS_ERROR, TagType.BOOL).setVBool(true));
-    }
     if (status.getDescription() != null) {
       tags.add(new Tag(STATUS_MESSAGE, TagType.STRING).setVStr(status.getDescription()));
     }

--- a/exporters/trace/jaeger/src/main/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandler.java
+++ b/exporters/trace/jaeger/src/main/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandler.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import static java.util.concurrent.TimeUnit.NANOSECONDS;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Lists;
 import com.google.common.primitives.Ints;
 import com.google.common.primitives.Longs;
@@ -58,7 +59,7 @@ import javax.annotation.concurrent.NotThreadSafe;
 @NotThreadSafe
 final class JaegerExporterHandler extends TimeLimitedHandler {
   private static final String EXPORT_SPAN_NAME = "ExportJaegerTraces";
-  private static final String SPAN_KIND = "span.kind";
+  @VisibleForTesting static final String SPAN_KIND = "span.kind";
   private static final Tag SERVER_KIND_TAG = new Tag(SPAN_KIND, TagType.STRING).setVStr("server");
   private static final Tag CLIENT_KIND_TAG = new Tag(SPAN_KIND, TagType.STRING).setVStr("client");
   private static final String DESCRIPTION = "message";
@@ -69,9 +70,9 @@ final class JaegerExporterHandler extends TimeLimitedHandler {
   private static final String MESSAGE_EVENT_ID = "id";
   private static final String MESSAGE_EVENT_COMPRESSED_SIZE = "compressed_size";
   private static final String MESSAGE_EVENT_UNCOMPRESSED_SIZE = "uncompressed_size";
-  private static final String STATUS_CODE = "status.code";
-  private static final String STATUS_MESSAGE = "status.message";
-  private static final String STATUS_ERROR = "error";
+  @VisibleForTesting static final String STATUS_CODE = "status.code";
+  @VisibleForTesting static final String STATUS_MESSAGE = "status.message";
+  @VisibleForTesting static final String STATUS_ERROR = "error";
 
   private static final Function<? super String, Tag> stringAttributeConverter =
       new Function<String, Tag>() {

--- a/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
+++ b/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
@@ -173,11 +173,15 @@ public class JaegerExporterHandlerIntegrationTest {
     assertThat(span.get("duration").getAsLong()).isAtMost(durationInMicros);
 
     JsonArray tags = span.get("tags").getAsJsonArray();
-    assertThat(tags.size()).isEqualTo(1);
+    assertThat(tags.size()).isEqualTo(2);
     JsonObject tag = tags.get(0).getAsJsonObject();
     assertThat(tag.get("key").getAsString()).isEqualTo("foo");
     assertThat(tag.get("type").getAsString()).isEqualTo("string");
     assertThat(tag.get("value").getAsString()).isEqualTo("bar");
+    JsonObject statusTag = tags.get(1).getAsJsonObject();
+    assertThat(statusTag.get("key").getAsString()).isEqualTo("status.code");
+    assertThat(statusTag.get("type").getAsString()).isEqualTo("int64");
+    assertThat(statusTag.get("value").getAsLong()).isEqualTo(0);
 
     JsonArray logs = span.get("logs").getAsJsonArray();
     assertThat(logs.size()).isEqualTo(2);

--- a/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
+++ b/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerIntegrationTest.java
@@ -179,7 +179,7 @@ public class JaegerExporterHandlerIntegrationTest {
     assertThat(tag.get("type").getAsString()).isEqualTo("string");
     assertThat(tag.get("value").getAsString()).isEqualTo("bar");
     JsonObject statusTag = tags.get(1).getAsJsonObject();
-    assertThat(statusTag.get("key").getAsString()).isEqualTo("status.code");
+    assertThat(statusTag.get("key").getAsString()).isEqualTo(JaegerExporterHandler.STATUS_CODE);
     assertThat(statusTag.get("type").getAsString()).isEqualTo("int64");
     assertThat(statusTag.get("value").getAsLong()).isEqualTo(0);
 

--- a/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerTest.java
+++ b/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerTest.java
@@ -173,13 +173,12 @@ public class JaegerExporterHandlerTest {
     assertThat(spans.size()).isEqualTo(1);
     Span span = spans.get(0);
 
-    assertThat(span.tags.size()).isEqualTo(4);
+    assertThat(span.tags.size()).isEqualTo(3);
     assertThat(span.tags)
         .containsExactly(
             new Tag(JaegerExporterHandler.SPAN_KIND, TagType.STRING).setVStr("server"),
             new Tag(JaegerExporterHandler.STATUS_CODE, TagType.LONG).setVLong(4),
-            new Tag(JaegerExporterHandler.STATUS_MESSAGE, TagType.STRING).setVStr(statusMessage),
-            new Tag(JaegerExporterHandler.STATUS_ERROR, TagType.BOOL).setVBool(true));
+            new Tag(JaegerExporterHandler.STATUS_MESSAGE, TagType.STRING).setVStr(statusMessage));
   }
 
   private static SpanContext sampleSpanContext() {

--- a/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerTest.java
+++ b/exporters/trace/jaeger/src/test/java/io/opencensus/exporter/trace/jaeger/JaegerExporterHandlerTest.java
@@ -110,10 +110,10 @@ public class JaegerExporterHandlerTest {
         .containsExactly(
             new Tag("BOOL", TagType.BOOL).setVBool(false),
             new Tag("LONG", TagType.LONG).setVLong(Long.MAX_VALUE),
-            new Tag("span.kind", TagType.STRING).setVStr("server"),
+            new Tag(JaegerExporterHandler.SPAN_KIND, TagType.STRING).setVStr("server"),
             new Tag("STRING", TagType.STRING)
                 .setVStr("Judge of a man by his questions rather than by his answers. -- Voltaire"),
-            new Tag("status.code", TagType.LONG).setVLong(0));
+            new Tag(JaegerExporterHandler.STATUS_CODE, TagType.LONG).setVLong(0));
 
     assertThat(span.logs.size()).isEqualTo(2);
     Log log = span.logs.get(0);
@@ -176,10 +176,10 @@ public class JaegerExporterHandlerTest {
     assertThat(span.tags.size()).isEqualTo(4);
     assertThat(span.tags)
         .containsExactly(
-            new Tag("span.kind", TagType.STRING).setVStr("server"),
-            new Tag("status.code", TagType.LONG).setVLong(4),
-            new Tag("status.message", TagType.STRING).setVStr(statusMessage),
-            new Tag("error", TagType.BOOL).setVBool(true));
+            new Tag(JaegerExporterHandler.SPAN_KIND, TagType.STRING).setVStr("server"),
+            new Tag(JaegerExporterHandler.STATUS_CODE, TagType.LONG).setVLong(4),
+            new Tag(JaegerExporterHandler.STATUS_MESSAGE, TagType.STRING).setVStr(statusMessage),
+            new Tag(JaegerExporterHandler.STATUS_ERROR, TagType.BOOL).setVBool(true));
   }
 
   private static SpanContext sampleSpanContext() {


### PR DESCRIPTION
Fixes #1927.

Tags conversion matches Go Jaeger exporter: 
https://github.com/census-ecosystem/opencensus-go-exporter-jaeger/blob/e8b55949d948652e47aae4378212f933ecee856b/jaeger.go#L210-L219