### PR TITLE
Context: Remove CONTEXT_SPAN_KEY and TAG_CONTEXT_KEY from API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 ## Unreleased
+- Remove `CONTEXT_SPAN_KEY` and `TAG_CONTEXT_KEY` from API. This will be a breaking change to those who
+depend on these two keys, but anyone except gRPC shouldn't use it directly anyway.
 
 ## 0.23.0 - 2019-06-12
 - Make `StackdriverStatsExporter.unregister()` a public API.

--- a/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/tags/unsafe/ContextUtils.java
@@ -44,14 +44,8 @@ public final class ContextUtils {
   /**
    * The {@link io.grpc.Context.Key} used to interact with the {@code TagContext} contained in the
    * {@link io.grpc.Context}.
-   *
-   * @since 0.8
-   * @deprecated from API since 0.21. Use {@link #withValue(Context, TagContext)} and {@link
-   *     #getValue(Context)} instead.
    */
-  // TODO(songy23): make this private once gRPC migrates to use the alternative APIs.
-  @Deprecated
-  public static final Context.Key</*@Nullable*/ TagContext> TAG_CONTEXT_KEY =
+  private static final Context.Key</*@Nullable*/ TagContext> TAG_CONTEXT_KEY =
       Context.keyWithDefault("opencensus-tag-context-key", EMPTY_TAG_CONTEXT);
 
   /**

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -37,16 +37,8 @@ public final class ContextUtils {
   // No instance of this class.
   private ContextUtils() {}
 
-  /**
-   * The {@link io.grpc.Context.Key} used to interact with {@link io.grpc.Context}.
-   *
-   * @since 0.5
-   * @deprecated from API since 0.21. Use {@link #withValue(Context, Span)} and {@link
-   *     #getValue(Context)} instead.
-   */
-  // TODO(songy23): make this private once gRPC migrates to use the alternative APIs.
-  @Deprecated
-  public static final Context.Key</*@Nullable*/ Span> CONTEXT_SPAN_KEY =
+  /** The {@link io.grpc.Context.Key} used to interact with {@link io.grpc.Context}. */
+  private static final Context.Key</*@Nullable*/ Span> CONTEXT_SPAN_KEY =
       Context.<Span>key("opencensus-trace-span-key");
 
   /**

--- a/build.gradle
+++ b/build.gradle
@@ -161,7 +161,7 @@ subprojects {
         findBugsAnnotationsVersion = '3.0.1'
         findBugsJsr305Version = '3.0.2'
         errorProneVersion = '2.3.2'
-        grpcVersion = '1.19.0'
+        grpcVersion = '1.21.0'
         guavaVersion = '26.0-android'
         googleAuthVersion = '0.13.0'
         googleCloudBetaVersion = '0.83.0-beta'

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -34,7 +34,7 @@ group = "io.opencensus"
 version = "0.24.0-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.23.0" // LATEST_OPENCENSUS_RELEASE_VERSION
-def grpcVersion = "1.19.0" // CURRENT_GRPC_VERSION
+def grpcVersion = "1.21.0" // CURRENT_GRPC_VERSION
 def prometheusVersion = "0.6.0"
 def jettyVersion = "9.4.17.v20190418"
 def tcnativeVersion = "2.0.20.Final"

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -13,7 +13,7 @@
     <!-- change to the version you want to use. -->
     <jetty.version>9.4.17.v20190418</jetty.version>
     <opencensus.version>0.23.0</opencensus.version><!-- LATEST_OPENCENSUS_RELEASE_VERSION -->
-    <grpc.version>1.19.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
+    <grpc.version>1.21.0</grpc.version><!-- CURRENT_GRPC_VERSION -->
   </properties>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Users are discouraged from accessing these keys directly, instead they should use the `getValue`/`withValue` APIs. gRPC is also migrated.