### PR TITLE
Use Zipkin quickstart script in download instructions

### DIFF
--- a/exporters/trace/zipkin/README.md
+++ b/exporters/trace/zipkin/README.md
@@ -18,7 +18,7 @@ applications instrumented with Census. The easiest way to start a zipkin
 server is to paste the below:
 
 ```bash
-wget -O zipkin.jar 'https://search.maven.org/remote_content?g=io.zipkin.java&a=zipkin-server&v=LATEST&c=exec'
+curl -sSL https://zipkin.io/quickstart.sh | bash -s
 java -jar zipkin.jar
 ```
 


### PR DESCRIPTION
The group id of the Zipkin Server maven artifact has changed in recent versions, so the previous instructions would not download the latest version of the server. The quickstart script provided by Zipkin is the recommended way to download the Zipkin Server jar and will download the latest version.