### PR TITLE
Extract "b3 single" header format

### DIFF
--- a/api/src/main/java/io/opencensus/trace/propagation/B3InjectionFormat.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/B3InjectionFormat.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.trace.propagation;
+
+/**
+ * Controls how trace context is propagated. Multiple formats may be specified when configuring B3
+ * propagation. An enumeration is used (as opposed to a boolean) to allow for future formats.
+ *
+ * @since 0.25
+ */
+public enum B3InjectionFormat {
+
+  /**
+   * Trace context is encoded with multiple "X-B3-*" fields (default). More information available at
+   * https://github.com/openzipkin/b3-propagation#multiple-headers.
+   */
+  MULTI,
+
+  /**
+   * Trace context is encoded with a single "b3" field. More information available at
+   * https://github.com/openzipkin/b3-propagation#single-header.
+   */
+  SINGLE;
+}

--- a/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
@@ -50,6 +50,19 @@ public abstract class PropagationComponent {
   public abstract TextFormat getB3Format();
 
   /**
+   * Returns the B3 {@link TextFormat} with the provided implementations. See <a href=
+   * "https://github.com/openzipkin/b3-propagation">b3-propagation</a> for more information. If no
+   * implementation is provided then no-op implementation will be used. Extraction is equivalent to
+   * {@link #getB3Format()}, however when injecting fields, the compact B3 single format is used
+   * instead.
+   *
+   * @since 0.25.0
+   * @return the B3 {@code TextFormat} implementation.
+   */
+  @ExperimentalApi
+  public abstract TextFormat getB3SingleFormat();
+
+  /**
    * Returns the TraceContext {@link TextFormat} with the provided implementations. See <a
    * href="https://github.com/w3c/distributed-tracing">w3c/distributed-tracing</a> for more
    * information. If no implementation is provided then no-op implementation will be used.
@@ -78,6 +91,11 @@ public abstract class PropagationComponent {
 
     @Override
     public TextFormat getB3Format() {
+      return TextFormat.getNoopTextFormat();
+    }
+
+    @Override
+    public TextFormat getB3SingleFormat() {
       return TextFormat.getNoopTextFormat();
     }
 

--- a/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
@@ -47,20 +47,22 @@ public abstract class PropagationComponent {
    * @return the B3 {@code TextFormat} implementation.
    */
   @ExperimentalApi
-  public abstract TextFormat getB3Format();
+  public TextFormat getB3Format() {
+    return getB3Format(B3InjectionFormat.MULTI);
+  }
 
   /**
    * Returns the B3 {@link TextFormat} with the provided implementations. See <a
    * href="https://github.com/openzipkin/b3-propagation">b3-propagation</a> for more information. If
    * no implementation is provided then no-op implementation will be used.
    *
+   * @param formats the injection formats to use. At least one must be specified.
    * @since 0.25.0
-   * @param singleOutput true if and only if the compact "b3 single" should be used when emitting
-   *     trace data, otherwise the multiple header format will be used
    * @return the B3 {@code TextFormat} implementation.
+   * @see B3InjectionFormat
    */
   @ExperimentalApi
-  public abstract TextFormat getB3Format(boolean singleOutput);
+  public abstract TextFormat getB3Format(B3InjectionFormat... formats);
 
   /**
    * Returns the TraceContext {@link TextFormat} with the provided implementations. See <a
@@ -90,12 +92,7 @@ public abstract class PropagationComponent {
     }
 
     @Override
-    public TextFormat getB3Format() {
-      return TextFormat.getNoopTextFormat();
-    }
-
-    @Override
-    public TextFormat getB3Format(final boolean singleOutput) {
+    public TextFormat getB3Format(final B3InjectionFormat... formats) {
       return TextFormat.getNoopTextFormat();
     }
 

--- a/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
+++ b/api/src/main/java/io/opencensus/trace/propagation/PropagationComponent.java
@@ -50,17 +50,17 @@ public abstract class PropagationComponent {
   public abstract TextFormat getB3Format();
 
   /**
-   * Returns the B3 {@link TextFormat} with the provided implementations. See <a href=
-   * "https://github.com/openzipkin/b3-propagation">b3-propagation</a> for more information. If no
-   * implementation is provided then no-op implementation will be used. Extraction is equivalent to
-   * {@link #getB3Format()}, however when injecting fields, the compact B3 single format is used
-   * instead.
+   * Returns the B3 {@link TextFormat} with the provided implementations. See <a
+   * href="https://github.com/openzipkin/b3-propagation">b3-propagation</a> for more information. If
+   * no implementation is provided then no-op implementation will be used.
    *
    * @since 0.25.0
+   * @param singleOutput true if and only if the compact "b3 single" should be used when emitting
+   *     trace data, otherwise the multiple header format will be used
    * @return the B3 {@code TextFormat} implementation.
    */
   @ExperimentalApi
-  public abstract TextFormat getB3SingleFormat();
+  public abstract TextFormat getB3Format(boolean singleOutput);
 
   /**
    * Returns the TraceContext {@link TextFormat} with the provided implementations. See <a
@@ -95,7 +95,7 @@ public abstract class PropagationComponent {
     }
 
     @Override
-    public TextFormat getB3SingleFormat() {
+    public TextFormat getB3Format(final boolean singleOutput) {
       return TextFormat.getNoopTextFormat();
     }
 

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/OpenCensusProperties.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/OpenCensusProperties.java
@@ -63,15 +63,37 @@ public class OpenCensusProperties {
       TRACE_PROPAGATION_TRACE_CONTEXT,
 
       /**
-       * Specifies B3 format for span context propagation.
+       * Specifies B3 format for span context propagation. For more granular configuration of the B3
+       * format, see {@link B3Properties}.
        *
        * @since 0.23
+       * @see B3Properties
        */
       TRACE_PROPAGATION_B3,
     }
 
+    /**
+     * B3 properties. This only applies if {@link Trace#getPropagation() propagation} is set to
+     * {@link Propagation#TRACE_PROPAGATION_B3}. Otherwise, these parameters are ignored.
+     *
+     * @since 0.25
+     * @see Propagation#TRACE_PROPAGATION_B3
+     */
+    public static final class B3Properties {
+      private boolean singleOutput = false;
+
+      public boolean isSingleOutput() {
+        return singleOutput;
+      }
+
+      public void setSingleOutput(final boolean singleOutput) {
+        this.singleOutput = singleOutput;
+      }
+    }
+
     private Propagation propagation = TRACE_PROPAGATION_TRACE_CONTEXT;
     private boolean publicEndpoint = false;
+    private B3Properties b3 = new B3Properties();
 
     public Propagation getPropagation() {
       return propagation;
@@ -87,6 +109,14 @@ public class OpenCensusProperties {
 
     public void setPublicEndpoint(boolean publicEndpoint) {
       this.publicEndpoint = publicEndpoint;
+    }
+
+    public B3Properties getB3() {
+      return b3;
+    }
+
+    public void setB3(final B3Properties b3) {
+      this.b3 = b3;
     }
   }
 }

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/OpenCensusProperties.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/OpenCensusProperties.java
@@ -19,7 +19,6 @@ package io.opencensus.contrib.spring.autoconfig;
 import static io.opencensus.contrib.spring.autoconfig.OpenCensusProperties.Trace.Propagation.TRACE_PROPAGATION_TRACE_CONTEXT;
 
 import io.opencensus.trace.propagation.B3InjectionFormat;
-import java.util.Arrays;
 import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
@@ -88,12 +87,16 @@ public class OpenCensusProperties {
           new B3InjectionFormat[] {B3InjectionFormat.MULTI};
 
       public B3InjectionFormat[] getInjectionFormats() {
-        return Arrays.copyOf(injectionFormats, injectionFormats.length);
+        final B3InjectionFormat[] retval = new B3InjectionFormat[injectionFormats.length];
+        System.arraycopy(injectionFormats, 0, retval, 0, injectionFormats.length);
+        return retval;
       }
 
       public void setInjectionFormats(final B3InjectionFormat[] injectionFormats) {
         Objects.requireNonNull(injectionFormats, "injectionFormats cannot be null");
-        this.injectionFormats = Arrays.copyOf(injectionFormats, injectionFormats.length);
+        final B3InjectionFormat[] copy = new B3InjectionFormat[injectionFormats.length];
+        System.arraycopy(injectionFormats, 0, copy, 0, injectionFormats.length);
+        this.injectionFormats = copy;
       }
     }
 

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/OpenCensusProperties.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/OpenCensusProperties.java
@@ -18,6 +18,9 @@ package io.opencensus.contrib.spring.autoconfig;
 
 import static io.opencensus.contrib.spring.autoconfig.OpenCensusProperties.Trace.Propagation.TRACE_PROPAGATION_TRACE_CONTEXT;
 
+import io.opencensus.trace.propagation.B3InjectionFormat;
+import java.util.Arrays;
+import java.util.Objects;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 /**
@@ -64,7 +67,7 @@ public class OpenCensusProperties {
 
       /**
        * Specifies B3 format for span context propagation. For more granular configuration of the B3
-       * format, see {@link B3Properties}.
+       * format, see {@link B3Properties} and https://github.com/openzipkin/b3-propagation.
        *
        * @since 0.23
        * @see B3Properties
@@ -80,14 +83,17 @@ public class OpenCensusProperties {
      * @see Propagation#TRACE_PROPAGATION_B3
      */
     public static final class B3Properties {
-      private boolean singleOutput = false;
 
-      public boolean isSingleOutput() {
-        return singleOutput;
+      private B3InjectionFormat[] injectionFormats =
+          new B3InjectionFormat[] {B3InjectionFormat.MULTI};
+
+      public B3InjectionFormat[] getInjectionFormats() {
+        return Arrays.copyOf(injectionFormats, injectionFormats.length);
       }
 
-      public void setSingleOutput(final boolean singleOutput) {
-        this.singleOutput = singleOutput;
+      public void setInjectionFormats(final B3InjectionFormat[] injectionFormats) {
+        Objects.requireNonNull(injectionFormats, "injectionFormats cannot be null");
+        this.injectionFormats = Arrays.copyOf(injectionFormats, injectionFormats.length);
       }
     }
 

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/OpenCensusProperties.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/OpenCensusProperties.java
@@ -86,12 +86,22 @@ public class OpenCensusProperties {
       private B3InjectionFormat[] injectionFormats =
           new B3InjectionFormat[] {B3InjectionFormat.MULTI};
 
+      /**
+       * Retrieve the propagation formats.
+       *
+       * @return the propagation formats that will be sent downstream
+       */
       public B3InjectionFormat[] getInjectionFormats() {
         final B3InjectionFormat[] retval = new B3InjectionFormat[injectionFormats.length];
         System.arraycopy(injectionFormats, 0, retval, 0, injectionFormats.length);
         return retval;
       }
 
+      /**
+       * Specify the propagation formats.
+       *
+       * @param injectionFormats the propagation formats to send downstream
+       */
       public void setInjectionFormats(final B3InjectionFormat[] injectionFormats) {
         Objects.requireNonNull(injectionFormats, "injectionFormats cannot be null");
         final B3InjectionFormat[] copy = new B3InjectionFormat[injectionFormats.length];

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/TraceWebAsyncClientAutoConfiguration.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/TraceWebAsyncClientAutoConfiguration.java
@@ -22,6 +22,7 @@ import io.opencensus.contrib.spring.autoconfig.OpenCensusProperties.Trace;
 import io.opencensus.contrib.spring.autoconfig.OpenCensusProperties.Trace.Propagation;
 import io.opencensus.contrib.spring.instrument.web.client.TracingAsyncClientHttpRequestInterceptor;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.propagation.B3InjectionFormat;
 import io.opencensus.trace.propagation.TextFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -63,8 +64,8 @@ public class TraceWebAsyncClientAutoConfiguration {
     @Value("${opencensus.spring.trace.propagation:TRACE_PROPAGATION_TRACE_CONTEXT}")
     private Trace.Propagation propagation;
 
-    @Value("${opencensus.spring.trace.b3.singleOutput:false}")
-    private boolean b3SingleFormat;
+    @Value("${opencensus.spring.trace.b3.injectionFormats:MULTI}")
+    private B3InjectionFormat[] b3InjectionFormats;
 
     @Autowired(required = false)
     HttpExtractor<HttpRequest, ClientHttpResponse> extractor;
@@ -74,7 +75,7 @@ public class TraceWebAsyncClientAutoConfiguration {
       TextFormat propagator;
 
       if (propagation != null && propagation == Propagation.TRACE_PROPAGATION_B3) {
-        propagator = Tracing.getPropagationComponent().getB3Format(b3SingleFormat);
+        propagator = Tracing.getPropagationComponent().getB3Format(b3InjectionFormats);
       } else {
         propagator = Tracing.getPropagationComponent().getTraceContextFormat();
       }

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/TraceWebAsyncClientAutoConfiguration.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/autoconfig/TraceWebAsyncClientAutoConfiguration.java
@@ -63,6 +63,9 @@ public class TraceWebAsyncClientAutoConfiguration {
     @Value("${opencensus.spring.trace.propagation:TRACE_PROPAGATION_TRACE_CONTEXT}")
     private Trace.Propagation propagation;
 
+    @Value("${opencensus.spring.trace.b3.singleOutput:false}")
+    private boolean b3SingleFormat;
+
     @Autowired(required = false)
     HttpExtractor<HttpRequest, ClientHttpResponse> extractor;
 
@@ -71,7 +74,7 @@ public class TraceWebAsyncClientAutoConfiguration {
       TextFormat propagator;
 
       if (propagation != null && propagation == Propagation.TRACE_PROPAGATION_B3) {
-        propagator = Tracing.getPropagationComponent().getB3Format();
+        propagator = Tracing.getPropagationComponent().getB3Format(b3SingleFormat);
       } else {
         propagator = Tracing.getPropagationComponent().getTraceContextFormat();
       }

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/instrument/web/HttpServletFilter.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/instrument/web/HttpServletFilter.java
@@ -39,6 +39,9 @@ public class HttpServletFilter extends OcHttpServletFilter implements Filter {
   @Value("${opencensus.spring.trace.propagation:TRACE_PROPAGATION_TRACE_CONTEXT}")
   private Trace.Propagation propagation;
 
+  @Value("${opencensus.spring.trace.b3.singleOutput:false}")
+  private boolean b3SingleOutput;
+
   @Value("${opencensus.spring.trace.publicEndpoint:false}")
   private Boolean publicEndpoint;
 
@@ -46,7 +49,8 @@ public class HttpServletFilter extends OcHttpServletFilter implements Filter {
   public void init(FilterConfig filterConfig) throws ServletException {
     ServletContext context = filterConfig.getServletContext();
     if (propagation != null && propagation == Propagation.TRACE_PROPAGATION_B3) {
-      context.setAttribute(OC_TRACE_PROPAGATOR, Tracing.getPropagationComponent().getB3Format());
+      context.setAttribute(
+          OC_TRACE_PROPAGATOR, Tracing.getPropagationComponent().getB3Format(b3SingleOutput));
     }
     if (publicEndpoint) {
       context.setInitParameter(OC_PUBLIC_ENDPOINT, publicEndpoint.toString());

--- a/contrib/spring/src/main/java/io/opencensus/contrib/spring/instrument/web/HttpServletFilter.java
+++ b/contrib/spring/src/main/java/io/opencensus/contrib/spring/instrument/web/HttpServletFilter.java
@@ -22,6 +22,7 @@ import io.opencensus.contrib.spring.autoconfig.OpenCensusAutoConfiguration;
 import io.opencensus.contrib.spring.autoconfig.OpenCensusProperties.Trace;
 import io.opencensus.contrib.spring.autoconfig.OpenCensusProperties.Trace.Propagation;
 import io.opencensus.trace.Tracing;
+import io.opencensus.trace.propagation.B3InjectionFormat;
 import javax.servlet.Filter;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletContext;
@@ -39,8 +40,8 @@ public class HttpServletFilter extends OcHttpServletFilter implements Filter {
   @Value("${opencensus.spring.trace.propagation:TRACE_PROPAGATION_TRACE_CONTEXT}")
   private Trace.Propagation propagation;
 
-  @Value("${opencensus.spring.trace.b3.singleOutput:false}")
-  private boolean b3SingleOutput;
+  @Value("${opencensus.spring.trace.b3.injectionFormats:MULTI}")
+  private B3InjectionFormat[] b3InjectionFormats;
 
   @Value("${opencensus.spring.trace.publicEndpoint:false}")
   private Boolean publicEndpoint;
@@ -50,7 +51,7 @@ public class HttpServletFilter extends OcHttpServletFilter implements Filter {
     ServletContext context = filterConfig.getServletContext();
     if (propagation != null && propagation == Propagation.TRACE_PROPAGATION_B3) {
       context.setAttribute(
-          OC_TRACE_PROPAGATOR, Tracing.getPropagationComponent().getB3Format(b3SingleOutput));
+          OC_TRACE_PROPAGATOR, Tracing.getPropagationComponent().getB3Format(b3InjectionFormats));
     }
     if (publicEndpoint) {
       context.setInitParameter(OC_PUBLIC_ENDPOINT, publicEndpoint.toString());

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/PropagationComponentImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/PropagationComponentImpl.java
@@ -23,7 +23,8 @@ import io.opencensus.trace.propagation.TextFormat;
 /** Implementation of the {@link PropagationComponent}. */
 public class PropagationComponentImpl extends PropagationComponent {
   private final BinaryFormat binaryFormat = new BinaryFormatImpl();
-  private final TextFormat b3Format = new B3Format();
+  private final TextFormat b3Format = new B3Format(/* singleOutput= */ false);
+  private final TextFormat b3SingleFormat = new B3Format(/* singleOutput= */ true);
   private final TextFormat traceContextFormat = new TraceContextFormat();
 
   @Override
@@ -34,6 +35,11 @@ public class PropagationComponentImpl extends PropagationComponent {
   @Override
   public TextFormat getB3Format() {
     return b3Format;
+  }
+
+  @Override
+  public TextFormat getB3SingleFormat() {
+    return b3SingleFormat;
   }
 
   @Override

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/PropagationComponentImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/PropagationComponentImpl.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.implcore.trace.propagation;
 
+import io.opencensus.trace.propagation.B3InjectionFormat;
 import io.opencensus.trace.propagation.BinaryFormat;
 import io.opencensus.trace.propagation.PropagationComponent;
 import io.opencensus.trace.propagation.TextFormat;
@@ -23,8 +24,6 @@ import io.opencensus.trace.propagation.TextFormat;
 /** Implementation of the {@link PropagationComponent}. */
 public class PropagationComponentImpl extends PropagationComponent {
   private final BinaryFormat binaryFormat = new BinaryFormatImpl();
-  private final TextFormat b3Format = new B3Format(/* singleOutput= */ false);
-  private final TextFormat b3SingleFormat = new B3Format(/* singleOutput= */ true);
   private final TextFormat traceContextFormat = new TraceContextFormat();
 
   @Override
@@ -33,13 +32,8 @@ public class PropagationComponentImpl extends PropagationComponent {
   }
 
   @Override
-  public TextFormat getB3Format() {
-    return b3Format;
-  }
-
-  @Override
-  public TextFormat getB3Format(final boolean singleOutput) {
-    return singleOutput ? b3SingleFormat : b3Format;
+  public TextFormat getB3Format(final B3InjectionFormat... formats) {
+    return new B3Format(formats);
   }
 
   @Override

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/PropagationComponentImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/propagation/PropagationComponentImpl.java
@@ -38,8 +38,8 @@ public class PropagationComponentImpl extends PropagationComponent {
   }
 
   @Override
-  public TextFormat getB3SingleFormat() {
-    return b3SingleFormat;
+  public TextFormat getB3Format(final boolean singleOutput) {
+    return singleOutput ? b3SingleFormat : b3Format;
   }
 
   @Override


### PR DESCRIPTION
This is an alternative implementation of #1400 that modifies the existing `B3Format` class to read and prioritise the single `b3` header or `tracestate` header with "b3=" prefix over the multi-header format. It only affects extraction, no changes are made to injection.

Addresses: #1400