### PR TITLE
Allow to specify options on spans created by HttpServerHandler.handleStart.

### DIFF
--- a/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilter.java
+++ b/contrib/http_jaxrs/src/main/java/io/opencensus/contrib/http/jaxrs/JaxrsContainerFilter.java
@@ -100,7 +100,7 @@ public class JaxrsContainerFilter implements ContainerRequestFilter, ContainerRe
   @SuppressWarnings("MustBeClosedChecker") // Close will happen in response filter method
   public void filter(ContainerRequestContext requestContext) throws IOException {
     ExtendedContainerRequest extendedRequest = new ExtendedContainerRequest(requestContext, info);
-    HttpRequestContext context = handler.handleStart(requestContext, extendedRequest);
+    HttpRequestContext context = handler.handleStart(requestContext, extendedRequest, null);
     requestContext.setProperty(CONTEXT_PROPERTY, context);
     if (requestContext.getLength() > 0) {
       handler.handleMessageReceived(context, requestContext.getLength());

--- a/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
+++ b/contrib/http_servlet/src/main/java/io/opencensus/contrib/http/servlet/OcHttpServletFilter.java
@@ -162,7 +162,7 @@ public class OcHttpServletFilter implements Filter {
       HttpServletRequest httpReq = (HttpServletRequest) request;
       HttpServletResponse httpResp = (HttpServletResponse) response;
 
-      HttpRequestContext context = handler.handleStart(httpReq, httpReq);
+      HttpRequestContext context = handler.handleStart(httpReq, httpReq, null);
       OcHttpServletListener listener = new OcHttpServletListener(handler, context);
       httpReq.setAttribute(OcHttpServletUtil.OPENCENSUS_SERVLET_LISTENER, listener);
 

--- a/contrib/http_servlet/src/test/java/io/opencensus/contrib/http/servlet/OcHttpServletListenerTest.java
+++ b/contrib/http_servlet/src/test/java/io/opencensus/contrib/http/servlet/OcHttpServletListenerTest.java
@@ -119,11 +119,11 @@ public class OcHttpServletListenerTest {
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
-    context = handler.handleStart(request, response);
+    context = handler.handleStart(request, response, null);
 
     listener = new OcHttpServletListener(mockHandler, context);
 
-    when(mockHandler.handleStart(mockRequest, mockRequest)).thenReturn(context);
+    when(mockHandler.handleStart(mockRequest, mockRequest, null)).thenReturn(context);
     when(mockAsyncEvent.getThrowable()).thenReturn(mockThrowable);
     when(mockAsyncEvent.getSuppliedResponse()).thenReturn(mockResponse);
     when(mockAsyncEvent.getSuppliedRequest()).thenReturn(mockRequest);

--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpServerHandler.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/HttpServerHandler.java
@@ -111,11 +111,12 @@ public class HttpServerHandler<
    *
    * @param carrier the entity that holds the HTTP information.
    * @param request the request entity.
+   * @param startOptions the options to use for the created span.
    * @return the {@link HttpRequestContext} that contains stats and trace data associated with the
    *     request.
    * @since 0.19
    */
-  public HttpRequestContext handleStart(C carrier, Q request) {
+  public HttpRequestContext handleStart(C carrier, Q request, @Nullable StartOptions startOptions) {
     checkNotNull(carrier, "carrier");
     checkNotNull(request, "request");
     SpanBuilder spanBuilder = null;
@@ -132,6 +133,10 @@ public class HttpServerHandler<
       spanBuilder = tracer.spanBuilder(spanName);
     } else {
       spanBuilder = tracer.spanBuilderWithRemoteParent(spanName, spanContext);
+    }
+
+    if (startOptions != null && startOptions.sampler != null) {
+      spanBuilder = spanBuilder.setSampler(startOptions.sampler);
     }
 
     Span span = spanBuilder.setSpanKind(Kind.SERVER).startSpan();
@@ -153,7 +158,7 @@ public class HttpServerHandler<
    * events for the span and record measurements associated with the request.
    *
    * @param context the {@link HttpRequestContext} used with {@link
-   *     HttpServerHandler#handleStart(Object, Object)}
+   *     HttpServerHandler#handleStart(Object, Object, StartOptions)}
    * @param request the HTTP request entity.
    * @param response the HTTP response entity. {@code null} means invalid response.
    * @param error the error occurs when processing the response.

--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/StartOptions.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/StartOptions.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018, OpenCensus Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.opencensus.contrib.http;
+
+import io.opencensus.common.ExperimentalApi;
+import io.opencensus.trace.Sampler;
+import javax.annotation.Nullable;
+
+/**
+ * A class that represents options applied to spans created by {@link
+ * HttpServerHandler#handleStart}.
+ *
+ * @since 0.27
+ */
+@ExperimentalApi
+public class StartOptions {
+
+  @Nullable final Sampler sampler;
+
+  protected StartOptions(@Nullable Sampler sampler) {
+    this.sampler = sampler;
+  }
+
+  /**
+   * Returns a {@link StartOptions.Builder} to construct a new {@link StartOptions} instance.
+   *
+   * @return a new {@link StartOptions.Builder}.
+   * @since 0.27
+   */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /**
+   * A class that is used to construct {@link StartOptions} instances.
+   *
+   * @since 0.27
+   */
+  public static class Builder {
+    @Nullable private Sampler sampler;
+
+    /**
+     * Sets the {@link Sampler} to use for the created span. If not set, the implementation will
+     * provide a default.
+     *
+     * @param sampler the {@code Sampler} to use when determining sampling for a {@code Span}.
+     * @return this.
+     * @since 0.27
+     */
+    public Builder setSampler(Sampler sampler) {
+      this.sampler = sampler;
+      return this;
+    }
+
+    /**
+     * Cosntructs a new {@link StartOptions} isntance.
+     *
+     * @return the newly created {@code Span}.
+     * @since 0.27
+     */
+    public StartOptions build() {
+      return new StartOptions(sampler);
+    }
+  }
+}


### PR DESCRIPTION
Allows to specify options on spans created by HttpServerHandler.handleStart method.

In particular, to set a span-specific io.opencensus.trace.Sampler but can be extended with other options (if any) in the future.