### PR TITLE
Remove finalize from RecordEventsSpanImpl

### DIFF
--- a/buildscripts/checkstyle.xml
+++ b/buildscripts/checkstyle.xml
@@ -173,7 +173,6 @@
             <message key="name.invalidPattern"
              value="Interface type name ''{0}'' must match pattern ''{1}''."/>
         </module>
-        <module name="NoFinalizer"/>
         <module name="GenericWhitespace">
             <message key="ws.followed"
              value="GenericWhitespace ''{0}'' is followed by whitespace."/>

--- a/impl_core/src/main/java/io/opencensus/implcore/trace/RecordEventsSpanImpl.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/trace/RecordEventsSpanImpl.java
@@ -586,15 +586,4 @@ public final class RecordEventsSpanImpl extends Span implements Element<RecordEv
         timestampConverter != null ? timestampConverter : TimestampConverter.now(clock);
     startNanoTime = clock.nowNanos();
   }
-
-  @SuppressWarnings("NoFinalizer")
-  @Override
-  protected void finalize() throws Throwable {
-    synchronized (this) {
-      if (!hasBeenEnded) {
-        logger.log(Level.SEVERE, "Span " + name + " is GC'ed without being ended.");
-      }
-    }
-    super.finalize();
-  }
 }


### PR DESCRIPTION
Fixes #2045

This will reduce GC pressure since the VM will not call
Finalizer.register() when creating Span objects.

Since this method is synchronized on a static lock
it can be a source of contention.

It also avoids contention on the same lock when running
runFinalizer() as part of GC