### PR TITLE
remove [final] from io.opencensus.contrib.http.AbstractHttpHandler.getSpanName

### DIFF
--- a/contrib/http_util/src/main/java/io/opencensus/contrib/http/AbstractHttpHandler.java
+++ b/contrib/http_util/src/main/java/io/opencensus/contrib/http/AbstractHttpHandler.java
@@ -111,7 +111,7 @@ abstract class AbstractHttpHandler<Q, P> {
     span.end();
   }
 
-  final String getSpanName(Q request, HttpExtractor<Q, P> extractor) {
+  String getSpanName(Q request, HttpExtractor<Q, P> extractor) {
     // default span name
     String path = extractor.getPath(request);
     if (path == null) {


### PR DESCRIPTION
I would like to customize names of spans originally created by HttpClientHandler.
e.g) Since HttpClientHandler generates `Recv. /foo/bar.html`, I want to change it to `Recv [GET] http://hostname/foo/bar.html` to recognize at a glance which service generates the span.

One of the easiest way to implement that is creating class which inherit HttpClientHandler and overriding getSpanName method.
The method currently forces names of spans to start with `/` and to display only path not url.

Therefore, please remove `final` from `io.opencensus.contrib.http.AbstractHttpHandler.getSpanName`.