### PR TITLE
feat: Allow users to specify a metric display name prefix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 ## Unreleased
-
+- feat: Allow users to specify a metric display name prefix, separately from the metric name prefix
 
 ## 0.26.0 - 2020-03-19
 - feat: Allow users to register the same Meter multiple times without exception (#2017)

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
@@ -61,13 +61,16 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
       String projectId,
       MetricServiceClient metricServiceClient,
       @javax.annotation.Nullable String metricNamePrefix,
+      @javax.annotation.Nullable String displayNamePrefix,
       Map<LabelKey, LabelValue> constantLabels,
       MetricExporter nextExporter) {
     this.projectId = projectId;
     projectName = ProjectName.newBuilder().setProject(projectId).build();
     this.metricServiceClient = metricServiceClient;
     this.domain = StackdriverExportUtils.getDomain(metricNamePrefix);
-    this.displayNamePrefix = StackdriverExportUtils.getDisplayNamePrefix(metricNamePrefix);
+    this.displayNamePrefix =
+        StackdriverExportUtils.getDisplayNamePrefix(
+            displayNamePrefix == null ? metricNamePrefix : displayNamePrefix);
     this.constantLabels = constantLabels;
     this.nextExporter = nextExporter;
   }

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfiguration.java
@@ -95,6 +95,15 @@ public abstract class StackdriverStatsConfiguration {
   public abstract String getMetricNamePrefix();
 
   /**
+   * Returns the display name prefix for Stackdriver metrics.
+   *
+   * @return the metric display name prefix.
+   * @since 0.27
+   */
+  @Nullable
+  public abstract String getDisplayNamePrefix();
+
+  /**
    * Returns the constant labels that will be applied to every Stackdriver metric.
    *
    * @return the constant labels.
@@ -197,6 +206,15 @@ public abstract class StackdriverStatsConfiguration {
      * @since 0.16
      */
     public abstract Builder setMetricNamePrefix(String prefix);
+
+    /**
+     * Sets the the display name prefix for Stackdriver metrics.
+     *
+     * @param prefix the metric display name prefix.
+     * @return this.
+     * @since 0.27
+     */
+    public abstract Builder setDisplayNamePrefix(String prefix);
 
     /**
      * Sets the constant labels that will be applied to every Stackdriver metric. This default

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsExporter.java
@@ -94,6 +94,7 @@ public final class StackdriverStatsExporter {
       Duration exportInterval,
       MonitoredResource monitoredResource,
       @Nullable String metricNamePrefix,
+      @Nullable String displayNamePrefix,
       Map<LabelKey, LabelValue> constantLabels) {
     IntervalMetricReader.Options.Builder intervalMetricReaderOptionsBuilder =
         IntervalMetricReader.Options.builder();
@@ -104,6 +105,7 @@ public final class StackdriverStatsExporter {
                 projectId,
                 metricServiceClient,
                 metricNamePrefix,
+                displayNamePrefix,
                 constantLabels,
                 new CreateTimeSeriesExporter(
                     projectId,
@@ -145,6 +147,7 @@ public final class StackdriverStatsExporter {
         exportInterval,
         DEFAULT_RESOURCE,
         null,
+        null,
         DEFAULT_CONSTANT_LABELS,
         DEFAULT_DEADLINE,
         null);
@@ -182,6 +185,7 @@ public final class StackdriverStatsExporter {
         projectId,
         exportInterval,
         DEFAULT_RESOURCE,
+        null,
         null,
         DEFAULT_CONSTANT_LABELS,
         DEFAULT_DEADLINE,
@@ -224,6 +228,7 @@ public final class StackdriverStatsExporter {
         configuration.getExportInterval(),
         configuration.getMonitoredResource(),
         configuration.getMetricNamePrefix(),
+        configuration.getDisplayNamePrefix(),
         configuration.getConstantLabels(),
         configuration.getDeadline(),
         configuration.getMetricServiceStub());
@@ -291,6 +296,7 @@ public final class StackdriverStatsExporter {
         exportInterval,
         DEFAULT_RESOURCE,
         null,
+        null,
         DEFAULT_CONSTANT_LABELS,
         DEFAULT_DEADLINE,
         null);
@@ -327,6 +333,7 @@ public final class StackdriverStatsExporter {
         projectId,
         exportInterval,
         monitoredResource,
+        null,
         null,
         DEFAULT_CONSTANT_LABELS,
         DEFAULT_DEADLINE,
@@ -365,6 +372,7 @@ public final class StackdriverStatsExporter {
         exportInterval,
         monitoredResource,
         null,
+        null,
         DEFAULT_CONSTANT_LABELS,
         DEFAULT_DEADLINE,
         null);
@@ -377,6 +385,7 @@ public final class StackdriverStatsExporter {
       Duration exportInterval,
       MonitoredResource monitoredResource,
       @Nullable String metricNamePrefix,
+      @Nullable String displayNamePrefix,
       Map<LabelKey, LabelValue> constantLabels,
       Duration deadline,
       @Nullable MetricServiceStub stub)
@@ -394,6 +403,7 @@ public final class StackdriverStatsExporter {
               exportInterval,
               monitoredResource,
               metricNamePrefix,
+              displayNamePrefix,
               constantLabels);
     }
   }

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporterTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporterTest.java
@@ -139,6 +139,7 @@ public class CreateMetricDescriptorExporterTest {
             PROJECT_ID,
             new FakeMetricServiceClient(mockStub),
             null,
+            null,
             DEFAULT_CONSTANT_LABELS,
             fakeMetricExporter);
     exporter.export(Arrays.asList(METRIC, METRIC_2));
@@ -185,6 +186,7 @@ public class CreateMetricDescriptorExporterTest {
             PROJECT_ID,
             new FakeMetricServiceClient(mockStub),
             null,
+            null,
             DEFAULT_CONSTANT_LABELS,
             fakeMetricExporter);
     exporter.export(Arrays.asList(METRIC_5));
@@ -215,6 +217,7 @@ public class CreateMetricDescriptorExporterTest {
             PROJECT_ID,
             new FakeMetricServiceClient(mockStub),
             null,
+            null,
             DEFAULT_CONSTANT_LABELS,
             fakeMetricExporter);
     exporter.export(Collections.<Metric>emptyList());
@@ -231,6 +234,7 @@ public class CreateMetricDescriptorExporterTest {
             PROJECT_ID,
             new FakeMetricServiceClient(mockStub),
             null,
+            null,
             DEFAULT_CONSTANT_LABELS,
             fakeMetricExporter);
 
@@ -246,6 +250,7 @@ public class CreateMetricDescriptorExporterTest {
         new CreateMetricDescriptorExporter(
             PROJECT_ID,
             new FakeMetricServiceClient(mockStub),
+            null,
             null,
             DEFAULT_CONSTANT_LABELS,
             fakeMetricExporter);
@@ -266,6 +271,7 @@ public class CreateMetricDescriptorExporterTest {
             PROJECT_ID,
             new FakeMetricServiceClient(mockStub),
             null,
+            null,
             DEFAULT_CONSTANT_LABELS,
             fakeMetricExporter);
     exporter.export(Collections.singletonList(METRIC));
@@ -284,6 +290,7 @@ public class CreateMetricDescriptorExporterTest {
         new CreateMetricDescriptorExporter(
             PROJECT_ID,
             new FakeMetricServiceClient(mockStub),
+            null,
             null,
             DEFAULT_CONSTANT_LABELS,
             fakeMetricExporter);

--- a/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
+++ b/exporters/stats/stackdriver/src/test/java/io/opencensus/exporter/stats/stackdriver/StackdriverStatsConfigurationTest.java
@@ -56,6 +56,7 @@ public class StackdriverStatsConfigurationTest {
           .putLabels("instance-id", "instance")
           .build();
   private static final String CUSTOM_PREFIX = "myorg";
+  private static final String CUSTOM_DISPLAY_PREFIX = "display-prefix";
 
   @Mock private final MetricServiceStub mockStub = Mockito.mock(MetricServiceStub.class);
 
@@ -75,6 +76,7 @@ public class StackdriverStatsConfigurationTest {
             .setExportInterval(DURATION)
             .setMonitoredResource(RESOURCE)
             .setMetricNamePrefix(CUSTOM_PREFIX)
+            .setDisplayNamePrefix(CUSTOM_DISPLAY_PREFIX)
             .setConstantLabels(Collections.<LabelKey, LabelValue>emptyMap())
             .setDeadline(DURATION)
             .setMetricServiceStub(mockStub)
@@ -84,6 +86,7 @@ public class StackdriverStatsConfigurationTest {
     assertThat(configuration.getExportInterval()).isEqualTo(DURATION);
     assertThat(configuration.getMonitoredResource()).isEqualTo(RESOURCE);
     assertThat(configuration.getMetricNamePrefix()).isEqualTo(CUSTOM_PREFIX);
+    assertThat(configuration.getDisplayNamePrefix()).isEqualTo(CUSTOM_DISPLAY_PREFIX);
     assertThat(configuration.getConstantLabels()).isEmpty();
     assertThat(configuration.getDeadline()).isEqualTo(DURATION);
     assertThat(configuration.getMetricServiceStub()).isEqualTo(mockStub);
@@ -193,6 +196,16 @@ public class StackdriverStatsConfigurationTest {
         StackdriverStatsConfiguration.builder()
             .setProjectId(PROJECT_ID)
             .setMetricNamePrefix(null)
+            .build();
+    assertThat(configuration.getMetricNamePrefix()).isNull();
+  }
+
+  @Test
+  public void allowNullDisplayPrefix() {
+    StackdriverStatsConfiguration configuration =
+        StackdriverStatsConfiguration.builder()
+            .setProjectId(PROJECT_ID)
+            .setDisplayNamePrefix(null)
             .build();
     assertThat(configuration.getMetricNamePrefix()).isNull();
   }


### PR DESCRIPTION
Allow users to specify a metric display name prefix, separately from the metric name prefix