### PR TITLE
Fix time skew exceptions crashing disruptor thread

### DIFF
--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -132,6 +132,7 @@ abstract class MutableViewData {
     @javax.annotation.Nullable
     @Override
     Metric toMetric(Timestamp now, State state) {
+      handleTimeRewinds(now);
       if (state == State.DISABLED) {
         return null;
       }
@@ -166,6 +167,7 @@ abstract class MutableViewData {
 
     @Override
     ViewData toViewData(Timestamp now, State state) {
+      handleTimeRewinds(now);
       if (state == State.ENABLED) {
         return ViewData.create(
             super.view,
@@ -177,6 +179,18 @@ abstract class MutableViewData {
             super.view,
             Collections.<List</*@Nullable*/ TagValue>, AggregationData>emptyMap(),
             ViewData.AggregationWindowData.CumulativeData.create(ZERO_TIMESTAMP, ZERO_TIMESTAMP));
+      }
+    }
+
+    /**
+     * This method attemps to migrate this view into a reasonable state in the event of time going
+     * backwards.
+     */
+    private void handleTimeRewinds(Timestamp now) {
+      if (now.compareTo(start) < 0) {
+        // Time went backwards, physics is broken, forget what we know.
+        tagValueAggregationMap.clear();
+        start = now;
       }
     }
 
@@ -311,6 +325,7 @@ abstract class MutableViewData {
         // - Drop events in the future, keep others within a duration.
         // - Drop all events on skew
         // - Guess at time-skew and "fix" events
+        // - Reset our "start" time to now if necessary.
         buckets.clear();
         shiftBucketList(N + 1, now);
         return;

--- a/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
+++ b/impl_core/src/main/java/io/opencensus/implcore/stats/MutableViewData.java
@@ -189,7 +189,7 @@ abstract class MutableViewData {
     private void handleTimeRewinds(Timestamp now) {
       if (now.compareTo(start) < 0) {
         // Time went backwards, physics is broken, forget what we know.
-        tagValueAggregationMap.clear();
+        clearStats();
         start = now;
       }
     }


### PR DESCRIPTION
For now, we fix all known issues with time skew in Metric Views.

- In the event of a detected time skew, we just throw away all our data.  We really don't know if it's safe to push anything we have, and we cannot safely do any aggregation / report correct timestamps.
- We add (the first?) tests for `MutableViewData` to ensure it does not throw when time rewinds, but instead drops recorded data points and resets itself.

Fixes #2068 (deemed to not have a workaround)