### PR TITLE
Mark ContextUtils as public (but deprecated) 

### DIFF
--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextHandleUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextHandleUtils.java
@@ -79,7 +79,7 @@ public class ContextHandleUtils {
   }
 
   /**
-   * Attempts to pull the {@see io.grpc.Context} out of an OpenCensus {@code ContextHandle}.
+   * Attempts to pull the {@link io.grpc.Context} out of an OpenCensus {@code ContextHandle}.
    *
    * @return The context, or null if not a GRPC backed context handle.
    */

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextHandleUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextHandleUtils.java
@@ -83,6 +83,7 @@ public class ContextHandleUtils {
    *
    * @return The context, or null if not a GRPC backed context handle.
    */
+  @Nullable
   public static Context tryExtractGrpcContext(ContextHandle handle) {
     if (handle instanceof ContextHandleImpl) {
       return ((ContextHandleImpl) handle).getContext();

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextHandleUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextHandleUtils.java
@@ -16,6 +16,7 @@
 
 package io.opencensus.trace.unsafe;
 
+import io.grpc.Context;
 import io.opencensus.internal.Provider;
 import io.opencensus.trace.ContextHandle;
 import io.opencensus.trace.ContextManager;
@@ -75,5 +76,18 @@ public class ContextHandleUtils {
    */
   public static Span getValue(ContextHandle context) {
     return CONTEXT_MANAGER.getValue(context);
+  }
+
+  /**
+   * Attempts to pull the {@see io.grpc.Context} out of an OpenCensus {@code ContextHandle}.
+   *
+   * @return The context, or null if not a GRPC backed context handle.
+   */
+  public static Context tryExtractGrpcContext(ContextHandle handle) {
+    if (handle instanceof ContextHandleImpl) {
+      return ((ContextHandleImpl) handle).getContext();
+    }
+    // TODO: see if we can do something for the OpenTelemetry shim.
+    return null;
   }
 }

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextManagerImpl.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextManagerImpl.java
@@ -31,11 +31,13 @@ public class ContextManagerImpl implements ContextManager {
   }
 
   @Override
+  @SuppressWarnings({"deprecation"})
   public ContextHandle withValue(ContextHandle contextHandle, @Nullable Span span) {
     return wrapContext(ContextUtils.withValue(unwrapContext(contextHandle), span));
   }
 
   @Override
+  @SuppressWarnings({"deprecation"})
   public Span getValue(ContextHandle contextHandle) {
     return ContextUtils.getValue(unwrapContext(contextHandle));
   }

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -26,9 +26,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
 /**
+ * Utilities for grabbing manipulating current context and grabbing current span.
+ * 
  * @deprecated Please use {@link io.opencensus.trace.unsafe.ContextHandleUtils}
- *     <p>Util methods/functionality to interact with the {@link io.grpc.Context}.
- *     <p>Users must interact with the current Context via the public APIs in {@link
+ *     Util methods/functionality to interact with the {@link io.grpc.Context}.
+ *     Users must interact with the current Context via the public APIs in {@link
  *     io.opencensus.trace.Tracer} and avoid usages of the {@link #CONTEXT_SPAN_KEY} directly.
  * @since 0.5
  */

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -27,14 +27,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * @deprecated Please use {@link io.opencensus.trace.unsafe.ContextHandleUtils}
- * 
- * Util methods/functionality to interact with the {@link io.grpc.Context}.
- *
- * <p>Users must interact with the current Context via the public APIs in {@link
- * io.opencensus.trace.Tracer} and avoid usages of the {@link #CONTEXT_SPAN_KEY} directly.
- *
+ *     <p>Util methods/functionality to interact with the {@link io.grpc.Context}.
+ *     <p>Users must interact with the current Context via the public APIs in {@link
+ *     io.opencensus.trace.Tracer} and avoid usages of the {@link #CONTEXT_SPAN_KEY} directly.
  * @since 0.5
  */
+@Deprecated()
 public final class ContextUtils {
   // No instance of this class.
   private ContextUtils() {}

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -27,11 +27,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Utilities for grabbing manipulating current context and grabbing current span.
- * 
- * @deprecated Please use {@link io.opencensus.trace.unsafe.ContextHandleUtils}
- *     Util methods/functionality to interact with the {@link io.grpc.Context}.
- *     Users must interact with the current Context via the public APIs in {@link
- *     io.opencensus.trace.Tracer} and avoid usages of the {@link #CONTEXT_SPAN_KEY} directly.
+ *
+ * @deprecated Please use {@link io.opencensus.trace.unsafe.ContextHandleUtils} Util
+ *     methods/functionality to interact with the {@link io.grpc.Context}. Users must interact with
+ *     the current Context via the public APIs in {@link io.opencensus.trace.Tracer} and avoid
+ *     usages of the {@link #CONTEXT_SPAN_KEY} directly.
  * @since 0.5
  */
 @Deprecated()

--- a/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
+++ b/api/src/main/java/io/opencensus/trace/unsafe/ContextUtils.java
@@ -26,6 +26,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 */
 
 /**
+ * @deprecated Please use {@link io.opencensus.trace.unsafe.ContextHandleUtils}
+ * 
  * Util methods/functionality to interact with the {@link io.grpc.Context}.
  *
  * <p>Users must interact with the current Context via the public APIs in {@link
@@ -33,7 +35,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * @since 0.5
  */
-final class ContextUtils {
+public final class ContextUtils {
   // No instance of this class.
   private ContextUtils() {}
 

--- a/api/src/test/java/io/opencensus/trace/unsafe/ContextUtilsTest.java
+++ b/api/src/test/java/io/opencensus/trace/unsafe/ContextUtilsTest.java
@@ -47,4 +47,10 @@ public class ContextUtilsTest {
       ContextHandleUtils.currentContext().detach(orig);
     }
   }
+
+  @Test
+  public void testTryExtractGrpcContext_WillNotThrow() {
+    assertThat(ContextHandleUtils.tryExtractGrpcContext(ContextHandleUtils.currentContext()))
+        .isNotNull();
+  }
 }


### PR DESCRIPTION
Fixes #2069  - bincompat issues with 0.18.0->0.18.1  