### PR TITLE
Updates for 0.28.3 release

### DIFF
--- a/api/src/main/java/io/opencensus/common/OpenCensusLibraryInformation.java
+++ b/api/src/main/java/io/opencensus/common/OpenCensusLibraryInformation.java
@@ -29,7 +29,7 @@ public final class OpenCensusLibraryInformation {
    *
    * @since 0.8
    */
-  public static final String VERSION = "0.28.3"; // CURRENT_OPENCENSUS_VERSION
+  public static final String VERSION = "0.28.4-SNAPSHOT"; // CURRENT_OPENCENSUS_VERSION
 
   private OpenCensusLibraryInformation() {}
 }

--- a/api/src/main/java/io/opencensus/common/OpenCensusLibraryInformation.java
+++ b/api/src/main/java/io/opencensus/common/OpenCensusLibraryInformation.java
@@ -29,7 +29,7 @@ public final class OpenCensusLibraryInformation {
    *
    * @since 0.8
    */
-  public static final String VERSION = "0.28.3-SNAPSHOT"; // CURRENT_OPENCENSUS_VERSION
+  public static final String VERSION = "0.28.3"; // CURRENT_OPENCENSUS_VERSION
 
   private OpenCensusLibraryInformation() {}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -339,6 +339,9 @@ subprojects {
 
     signing {
         required false
+        if (rootProject.hasProperty('signingUseGpgCmd')) {
+          useGpgCmd()
+        }
         sign configurations.archives
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     }
 
     group = "io.opencensus"
-    version = "0.28.3" // CURRENT_OPENCENSUS_VERSION
+    version = "0.28.4-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     }
 
     group = "io.opencensus"
-    version = "0.28.3-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
+    version = "0.28.3" // CURRENT_OPENCENSUS_VERSION
 
     sourceCompatibility = 1.7
     targetCompatibility = 1.7

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 group = "io.opencensus"
-version = "0.28.3" // CURRENT_OPENCENSUS_VERSION
+version = "0.28.4-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.27.1" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.32.2" // CURRENT_GRPC_VERSION

--- a/examples/build.gradle
+++ b/examples/build.gradle
@@ -31,7 +31,7 @@ repositories {
 }
 
 group = "io.opencensus"
-version = "0.28.3-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
+version = "0.28.3" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.27.1" // LATEST_OPENCENSUS_RELEASE_VERSION
 def grpcVersion = "1.32.2" // CURRENT_GRPC_VERSION

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.opencensus</groupId>
   <artifactId>opencensus-examples</artifactId>
   <packaging>jar</packaging>
-  <version>0.28.3-SNAPSHOT</version><!-- CURRENT_OPENCENSUS_VERSION -->
+  <version>0.28.3</version><!-- CURRENT_OPENCENSUS_VERSION -->
   <name>opencensus-examples</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,7 +5,7 @@
   <groupId>io.opencensus</groupId>
   <artifactId>opencensus-examples</artifactId>
   <packaging>jar</packaging>
-  <version>0.28.3</version><!-- CURRENT_OPENCENSUS_VERSION -->
+  <version>0.28.4-SNAPSHOT</version><!-- CURRENT_OPENCENSUS_VERSION -->
   <name>opencensus-examples</name>
   <url>http://maven.apache.org</url>
   <properties>

--- a/examples/spring/servlet/build.gradle
+++ b/examples/spring/servlet/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 group = "io.opencensus"
-version = "0.28.3" // CURRENT_OPENCENSUS_VERSION
+version = "0.28.4-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.26.0" // LATEST_OPENCENSUS_RELEASE_VERSION
 def prometheusVersion = "0.6.0"
@@ -85,7 +85,7 @@ apply plugin: 'io.spring.dependency-management'
 bootJar {
     mainClassName = 'com.baeldung.Application'
     baseName = 'opencensus-examples-spring-servlet'
-    version = "0.28.3" // CURRENT_OPENCENSUS_VERSION
+    version = "0.28.4-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
 }
 
 sourceCompatibility = 1.8

--- a/examples/spring/servlet/build.gradle
+++ b/examples/spring/servlet/build.gradle
@@ -30,7 +30,7 @@ repositories {
 }
 
 group = "io.opencensus"
-version = "0.28.3-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
+version = "0.28.3" // CURRENT_OPENCENSUS_VERSION
 
 def opencensusVersion = "0.26.0" // LATEST_OPENCENSUS_RELEASE_VERSION
 def prometheusVersion = "0.6.0"
@@ -85,7 +85,7 @@ apply plugin: 'io.spring.dependency-management'
 bootJar {
     mainClassName = 'com.baeldung.Application'
     baseName = 'opencensus-examples-spring-servlet'
-    version = "0.28.3-SNAPSHOT" // CURRENT_OPENCENSUS_VERSION
+    version = "0.28.3" // CURRENT_OPENCENSUS_VERSION
 }
 
 sourceCompatibility = 1.8

--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentNodeUtils.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentNodeUtils.java
@@ -39,7 +39,7 @@ final class OcAgentNodeUtils {
 
   // The current version of the OpenCensus OC-Agent Exporter.
   @VisibleForTesting
-  static final String OC_AGENT_EXPORTER_VERSION = "0.28.3-SNAPSHOT"; // CURRENT_OPENCENSUS_VERSION
+  static final String OC_AGENT_EXPORTER_VERSION = "0.28.3"; // CURRENT_OPENCENSUS_VERSION
 
   @Nullable
   private static final io.opencensus.resource.Resource AUTO_DETECTED_RESOURCE =

--- a/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentNodeUtils.java
+++ b/exporters/metrics/ocagent/src/main/java/io/opencensus/exporter/metrics/ocagent/OcAgentNodeUtils.java
@@ -39,7 +39,7 @@ final class OcAgentNodeUtils {
 
   // The current version of the OpenCensus OC-Agent Exporter.
   @VisibleForTesting
-  static final String OC_AGENT_EXPORTER_VERSION = "0.28.3"; // CURRENT_OPENCENSUS_VERSION
+  static final String OC_AGENT_EXPORTER_VERSION = "0.28.4-SNAPSHOT"; // CURRENT_OPENCENSUS_VERSION
 
   @Nullable
   private static final io.opencensus.resource.Resource AUTO_DETECTED_RESOURCE =

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentNodeUtils.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentNodeUtils.java
@@ -38,7 +38,7 @@ final class OcAgentNodeUtils {
 
   // The current version of the OpenCensus OC-Agent Exporter.
   @VisibleForTesting
-  static final String OC_AGENT_EXPORTER_VERSION = "0.28.3"; // CURRENT_OPENCENSUS_VERSION
+  static final String OC_AGENT_EXPORTER_VERSION = "0.28.4-SNAPSHOT"; // CURRENT_OPENCENSUS_VERSION
 
   @Nullable
   private static final io.opencensus.resource.Resource AUTO_DETECTED_RESOURCE =

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentNodeUtils.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentNodeUtils.java
@@ -38,7 +38,7 @@ final class OcAgentNodeUtils {
 
   // The current version of the OpenCensus OC-Agent Exporter.
   @VisibleForTesting
-  static final String OC_AGENT_EXPORTER_VERSION = "0.28.3-SNAPSHOT"; // CURRENT_OPENCENSUS_VERSION
+  static final String OC_AGENT_EXPORTER_VERSION = "0.28.3"; // CURRENT_OPENCENSUS_VERSION
 
   @Nullable
   private static final io.opencensus.resource.Resource AUTO_DETECTED_RESOURCE =


### PR DESCRIPTION
- Bump major version to 0.28.4
- Allow GPG agent for publishing (leaked into the release)
- Include the commit with the 0.28.3 tag.