### PR TITLE
Add github action PR build

### DIFF
--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -1,0 +1,25 @@
+name: Build Checker
+
+on: 
+  pull_request:
+      branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - id: setup-java
+        name: Setup Java 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 8
+      - uses: burrunan/gradle-cache-action@v1.10
+        with:
+          remote-build-cache-proxy-enabled: false
+          arguments: clean assemble -PcheckerFramework=true

--- a/.github/workflows/build-gradle-examples.yml
+++ b/.github/workflows/build-gradle-examples.yml
@@ -1,4 +1,4 @@
-name: Build Checker
+name: Build Gradle Examples
 
 on: 
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build Checker
+    name: Build Gradle Examples Ubuntu
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.3.4
@@ -22,4 +22,9 @@ jobs:
       - uses: burrunan/gradle-cache-action@v1.10
         with:
           remote-build-cache-proxy-enabled: false
-          arguments: clean assemble -PcheckerFramework=true
+      - name: Build Examples
+        working-directory: ./examples
+        run: ./gradlew clean assemble --stacktrace && ./gradlew check && ./gradlew verGJF 
+      - name: Build Spring Servlet example
+        working-directory: ./examples/spring/servlet
+        run: ./gradlew clean assemble --stacktrace && ./gradlew check && ./gradlew verGJF 

--- a/.github/workflows/build-maven-examples.yml
+++ b/.github/workflows/build-maven-examples.yml
@@ -1,0 +1,27 @@
+name: Build
+
+on: 
+  pull_request:
+      branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-18.04
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - id: setup-java
+        name: Setup Java 8
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: 8
+      - name: Build Examples
+        working-directory: ./examples
+        run: mvn --batch-mode --update-snapshots clean package appassembler:assemble -e
+      - name: Build Spring Servlet example
+        working-directory: ./examples/spring/servlet
+        run: mvn --batch-mode --update-snapshots clean package appassembler:assemble -e

--- a/.github/workflows/build-maven-examples.yml
+++ b/.github/workflows/build-maven-examples.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build Maven Examples
 
 on: 
   pull_request:
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: Build Maven Examples Ubuntu
     runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2.3.4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,26 +14,23 @@ jobs:
         os:
           - macos-latest
           - ubuntu-18.04
-        java-version:
+        java:
           - 8
           - 11
         include:
           - os: ubuntu-18.04
-            test-java-version: 8
+            java: 8
             coverage: true
     steps:
       - uses: actions/checkout@v2.3.4
         with:
           fetch-depth: 0
       - id: setup-java
-        name: Setup Java ${{ matrix.java-version }}
+        name: Setup Java ${{ matrix.java }}
         uses: actions/setup-java@v2
         with:
           distribution: adopt
-          java-version: ${{ matrix.java-version }}
-      - uses: burrunan/gradle-cache-action@v1.10
-        with:
-          remote-build-cache-proxy-enabled: false
-          arguments: clean assemble check --stacktrace
+          java-version: ${{ matrix.java }}
+      - run: gradle clean assemble check --stacktrace
       # TODO: Run jacocoTestReport
       # TODO: Run verGJF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,40 @@
+name: Build
+
+on: 
+  pull_request:
+      branches:
+      - master
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+          - macos-latest
+          - ubuntu-18.04
+        java-version:
+          - 8
+          - 9
+          - 10
+        include:
+          - os: ubuntu-18.04
+            test-java-version: 8
+            coverage: true
+    steps:
+      - uses: actions/checkout@v2.3.4
+        with:
+          fetch-depth: 0
+      - id: setup-java
+        name: Setup Java ${{ matrix.java-version }}
+        uses: actions/setup-java@v2
+        with:
+          distribution: adopt
+          java-version: ${{ matrix.java-version }}
+      - uses: burrunan/gradle-cache-action@v1.10
+        with:
+          remote-build-cache-proxy-enabled: false
+          arguments: clean assemble check --stacktrace
+      # TODO: Run jacocoTestReport
+      # TODO: Run verGJF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,7 @@ jobs:
           - ubuntu-18.04
         java-version:
           - 8
-          - 9
-          - 10
+          - 11
         include:
           - os: ubuntu-18.04
             test-java-version: 8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
           - ubuntu-18.04
         java:
           - 8
-          - 11
+          # TODO: Java 11 build doesn't work due to Java7 target.
         include:
           - os: ubuntu-18.04
             java: 8

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,6 +31,6 @@ jobs:
         with:
           distribution: adopt
           java-version: ${{ matrix.java }}
-      - run: gradle clean assemble check --stacktrace
+      - run: ./gradlew clean assemble check --stacktrace
       # TODO: Run jacocoTestReport
       # TODO: Run verGJF


### PR DESCRIPTION
- Migrate our existing travis CI workflow to github actions.
- ONLY runs Java8 build (no Java9/Java10 etc.)   Java 11 build is not working right now
- This is a precursor to getting some of the security fixes in.