### PR TITLE
implement gRPC client retry stats measures and views

### DIFF
--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -231,7 +231,7 @@ public final class RpcMeasureConstants {
    * {@link Measure} for total number of retry or hedging attempts excluding transparent retries
    * made during the client call.
    *
-   * @since 0.28
+   * @since 0.31.0
    */
   public static final MeasureLong GRPC_CLIENT_RETRIES_PER_CALL =
       Measure.MeasureLong.create(

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -228,6 +228,37 @@ public final class RpcMeasureConstants {
           "grpc.io/client/started_rpcs", "Number of started client RPCs.", COUNT);
 
   /**
+   * {@link Measure} for total number of retry or hedging attempts excluding transparent retries
+   * made during the client call.
+   *
+   * @since 0.28
+   */
+  public static final MeasureLong GRPC_CLIENT_RETRIES_PER_CALL =
+      Measure.MeasureLong.create(
+          "grpc.io/client/retries_per_call", "Number of retries per call.", COUNT);
+
+  /**
+   * {@link Measure} for total number of transparent retries made during the client call.
+   *
+   * @since 0.28
+   */
+  public static final MeasureLong GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL =
+      Measure.MeasureLong.create(
+          "grpc.io/client/transparent_retries_per_call",
+          "Number of transparent retries per call.",
+          COUNT);
+
+  /**
+   * {@link Measure} for total time of delay while there is no active attempt during the client
+   * call.
+   *
+   * @since 0.28
+   */
+  public static final MeasureLong GRPC_CLIENT_RETRY_DELAY_PER_CALL =
+      Measure.MeasureLong.create(
+          "grpc.io/client/retry_delay_per_call", "Retry delay per call.", MILLISECOND);
+
+  /**
    * {@link Measure} for gRPC client error counts.
    *
    * @since 0.8

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -515,7 +515,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/retries_per_call"),
           "Number of client retries per call",
           GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
-          COUNT,
+          AGGREGATION_WITH_COUNT_HISTOGRAM,
           Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
@@ -541,7 +541,7 @@ public final class RpcViewConstants {
                   View.Name.create("grpc.io/client/retry_delay_per_call"),
                   "Total time of delay while there is no active attempt during the client call",
                   GRPC_CLIENT_RETRY_DELAY_PER_CALL,
-                  COUNT,
+                  AGGREGATION_WITH_MILLIS_HISTOGRAM,
                   Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
@@ -567,7 +567,7 @@ public final class RpcViewConstants {
                   View.Name.create("grpc.io/client/transparent_retries_per_call"),
                   "Number of transparent client retries per call",
                   GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
-                  COUNT,
+                  AGGREGATION_WITH_COUNT_HISTOGRAM,
                   Arrays.asList(GRPC_CLIENT_METHOD));
 
   // Rpc server cumulative views.

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -136,7 +136,7 @@ public final class RpcViewConstants {
 
   @VisibleForTesting
   static final List<Double> RETRY_COUNT_PER_CALL_BUCKET_BOUNDARIES =
-      Collections.unmodifiableList(Arrays.asList(1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 100.0, 1000.0));
+      Collections.unmodifiableList(Arrays.asList(1.0, 2.0, 3.0, 4.0, 5.0));
 
   // Use Aggregation.Mean to record sum and count stats at the same time.
   @VisibleForTesting static final Aggregation MEAN = Aggregation.Mean.create();

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -522,7 +522,7 @@ public final class RpcViewConstants {
       View.create(
           View.Name.create("grpc.io/client/retries_per_call"),
           "Number of client retries per call",
-          GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+          GRPC_CLIENT_RETRIES_PER_CALL,
           AGGREGATION_WITH_COUNT_RETRY_HISTOGRAM,
           Arrays.asList(GRPC_CLIENT_METHOD));
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -28,6 +28,9 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RETRIES_PER_CALL;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STATUS;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_METHOD;
@@ -501,6 +504,71 @@ public final class RpcViewConstants {
           GRPC_CLIENT_STARTED_RPCS,
           COUNT,
           Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for client retries per call.
+   *
+   * @since 0.28
+   */
+  public static final View GRPC_CLIENT_RETRIES_PER_CALL_VIEW =
+      View.create(
+          View.Name.create("grpc.io/client/retries_per_call"),
+          "Number of client retries per call",
+          GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+          COUNT,
+          Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for total transparent client retries across calls.
+   *
+   * @since 0.28
+   */
+  public static final View GRPC_CLIENT_TRANSPARENT_RETRIES_VIEW =
+          View.create(
+                  View.Name.create("grpc.io/client/transparent_retries"),
+                  "Total number of transparent client retries across calls",
+                  GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+                  SUM,
+                  Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for total time of delay while there is no active attempt during the client call.
+   *
+   * @since 0.28
+   */
+  public static final View GRPC_CLIENT_RETRY_DELAY_PER_CALL_VIEW =
+          View.create(
+                  View.Name.create("grpc.io/client/retry_delay_per_call"),
+                  "Total time of delay while there is no active attempt during the client call",
+                  GRPC_CLIENT_RETRY_DELAY_PER_CALL,
+                  COUNT,
+                  Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for total retries across all calls, excluding transparent retries
+   *
+   * @since 0.28
+   */
+  public static final View GRPC_CLIENT_RETRIES_VIEW =
+          View.create(
+                  View.Name.create("grpc.io/client/retries"),
+                  "Total number of client retries across all calls",
+                  GRPC_CLIENT_RETRIES_PER_CALL,
+                  SUM,
+                  Arrays.asList(GRPC_CLIENT_METHOD));
+
+  /**
+   * {@link View} for transparent retries per call
+   *
+   * @since 0.28
+   */
+  public static final View GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL_VIEW =
+          View.create(
+                  View.Name.create("grpc.io/client/transparent_retries_per_call"),
+                  "Number of transparent client retries per call",
+                  GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+                  COUNT,
+                  Arrays.asList(GRPC_CLIENT_METHOD));
 
   // Rpc server cumulative views.
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -134,6 +134,10 @@ public final class RpcViewConstants {
               0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0,
               4096.0, 8192.0, 16384.0, 32768.0, 65536.0));
 
+  @VisibleForTesting
+  static final List<Double> RETRY_COUNT_PER_CALL_BUCKET_BOUNDARIES =
+      Collections.unmodifiableList(Arrays.asList(1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 100.0, 1000.0));
+
   // Use Aggregation.Mean to record sum and count stats at the same time.
   @VisibleForTesting static final Aggregation MEAN = Aggregation.Mean.create();
   @VisibleForTesting static final Aggregation COUNT = Count.create();
@@ -153,6 +157,10 @@ public final class RpcViewConstants {
   @VisibleForTesting
   static final Aggregation AGGREGATION_WITH_COUNT_HISTOGRAM =
       Distribution.create(BucketBoundaries.create(RPC_COUNT_BUCKET_BOUNDARIES));
+
+  @VisibleForTesting
+  static final Aggregation AGGREGATION_WITH_COUNT_RETRY_HISTOGRAM =
+      Distribution.create(BucketBoundaries.create(RETRY_COUNT_PER_CALL_BUCKET_BOUNDARIES));
 
   @VisibleForTesting static final Duration MINUTE = Duration.create(60, 0);
   @VisibleForTesting static final Duration HOUR = Duration.create(60 * 60, 0);
@@ -515,7 +523,7 @@ public final class RpcViewConstants {
           View.Name.create("grpc.io/client/retries_per_call"),
           "Number of client retries per call",
           GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
-          AGGREGATION_WITH_COUNT_HISTOGRAM,
+          AGGREGATION_WITH_COUNT_RETRY_HISTOGRAM,
           Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
@@ -524,12 +532,12 @@ public final class RpcViewConstants {
    * @since 0.28
    */
   public static final View GRPC_CLIENT_TRANSPARENT_RETRIES_VIEW =
-          View.create(
-                  View.Name.create("grpc.io/client/transparent_retries"),
-                  "Total number of transparent client retries across calls",
-                  GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
-                  SUM,
-                  Arrays.asList(GRPC_CLIENT_METHOD));
+      View.create(
+          View.Name.create("grpc.io/client/transparent_retries"),
+          "Total number of transparent client retries across calls",
+          GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+          SUM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
    * {@link View} for total time of delay while there is no active attempt during the client call.
@@ -537,12 +545,12 @@ public final class RpcViewConstants {
    * @since 0.28
    */
   public static final View GRPC_CLIENT_RETRY_DELAY_PER_CALL_VIEW =
-          View.create(
-                  View.Name.create("grpc.io/client/retry_delay_per_call"),
-                  "Total time of delay while there is no active attempt during the client call",
-                  GRPC_CLIENT_RETRY_DELAY_PER_CALL,
-                  AGGREGATION_WITH_MILLIS_HISTOGRAM,
-                  Arrays.asList(GRPC_CLIENT_METHOD));
+      View.create(
+          View.Name.create("grpc.io/client/retry_delay_per_call"),
+          "Total time of delay while there is no active attempt during the client call",
+          GRPC_CLIENT_RETRY_DELAY_PER_CALL,
+          AGGREGATION_WITH_MILLIS_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
    * {@link View} for total retries across all calls, excluding transparent retries.
@@ -550,12 +558,12 @@ public final class RpcViewConstants {
    * @since 0.28
    */
   public static final View GRPC_CLIENT_RETRIES_VIEW =
-          View.create(
-                  View.Name.create("grpc.io/client/retries"),
-                  "Total number of client retries across all calls",
-                  GRPC_CLIENT_RETRIES_PER_CALL,
-                  SUM,
-                  Arrays.asList(GRPC_CLIENT_METHOD));
+      View.create(
+          View.Name.create("grpc.io/client/retries"),
+          "Total number of client retries across all calls",
+          GRPC_CLIENT_RETRIES_PER_CALL,
+          SUM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
    * {@link View} for transparent retries per call.
@@ -563,12 +571,12 @@ public final class RpcViewConstants {
    * @since 0.28
    */
   public static final View GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL_VIEW =
-          View.create(
-                  View.Name.create("grpc.io/client/transparent_retries_per_call"),
-                  "Number of transparent client retries per call",
-                  GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
-                  AGGREGATION_WITH_COUNT_HISTOGRAM,
-                  Arrays.asList(GRPC_CLIENT_METHOD));
+      View.create(
+          View.Name.create("grpc.io/client/transparent_retries_per_call"),
+          "Number of transparent client retries per call",
+          GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL,
+          AGGREGATION_WITH_COUNT_RETRY_HISTOGRAM,
+          Arrays.asList(GRPC_CLIENT_METHOD));
 
   // Rpc server cumulative views.
 

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViewConstants.java
@@ -21,6 +21,8 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_BYTES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_RPC;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RETRIES_PER_CALL;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_BYTES_PER_RPC;
@@ -28,10 +30,8 @@ import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SENT_MESSAGES_PER_RPC;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS;
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RETRIES_PER_CALL;
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL;
-import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_STATUS;
+import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_METHOD;
 import static io.opencensus.contrib.grpc.metrics.RpcMeasureConstants.GRPC_SERVER_RECEIVED_BYTES_PER_RPC;
@@ -545,7 +545,7 @@ public final class RpcViewConstants {
                   Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
-   * {@link View} for total retries across all calls, excluding transparent retries
+   * {@link View} for total retries across all calls, excluding transparent retries.
    *
    * @since 0.28
    */
@@ -558,7 +558,7 @@ public final class RpcViewConstants {
                   Arrays.asList(GRPC_CLIENT_METHOD));
 
   /**
-   * {@link View} for transparent retries per call
+   * {@link View} for transparent retries per call.
    *
    * @since 0.28
    */

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -145,6 +145,15 @@ public final class RpcViews {
           RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW);
 
   @VisibleForTesting
+  static final ImmutableSet<View> GRPC_CLIENT_RETRY_VIEWS_SET =
+          ImmutableSet.of(
+                  RpcViewConstants.GRPC_CLIENT_RETRIES_PER_CALL_VIEW,
+                  RpcViewConstants.GRPC_CLIENT_RETRIES_VIEW,
+                  RpcViewConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL_VIEW,
+                  RpcViewConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_VIEW,
+                  RpcViewConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL_VIEW);
+
+  @VisibleForTesting
   static final ImmutableSet<View> GRPC_SERVER_BASIC_VIEWS_SET =
       ImmutableSet.of(
           RpcViewConstants.GRPC_SERVER_SERVER_LATENCY_VIEW,
@@ -184,6 +193,24 @@ public final class RpcViews {
   @VisibleForTesting
   static void registerClientGrpcViews(ViewManager viewManager) {
     for (View view : GRPC_CLIENT_VIEWS_SET) {
+      viewManager.registerView(view);
+    }
+  }
+
+  /**
+   * Registers client retry gRPC views.
+   *
+   * <p>It is recommended to call this method before doing any RPC call to avoid missing stats.
+   *
+   * @since 0.28
+   */
+  public static void registerClientRetryGrpcViews() {
+    registerClientRetryGrpcViews(Stats.getViewManager());
+  }
+
+  @VisibleForTesting
+  static void registerClientRetryGrpcViews(ViewManager viewManager) {
+    for (View view : GRPC_CLIENT_RETRY_VIEWS_SET) {
       viewManager.registerView(view);
     }
   }

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -146,12 +146,12 @@ public final class RpcViews {
 
   @VisibleForTesting
   static final ImmutableSet<View> GRPC_CLIENT_RETRY_VIEWS_SET =
-          ImmutableSet.of(
-                  RpcViewConstants.GRPC_CLIENT_RETRIES_PER_CALL_VIEW,
-                  RpcViewConstants.GRPC_CLIENT_RETRIES_VIEW,
-                  RpcViewConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL_VIEW,
-                  RpcViewConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_VIEW,
-                  RpcViewConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL_VIEW);
+      ImmutableSet.of(
+          RpcViewConstants.GRPC_CLIENT_RETRIES_PER_CALL_VIEW,
+          RpcViewConstants.GRPC_CLIENT_RETRIES_VIEW,
+          RpcViewConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL_VIEW,
+          RpcViewConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_VIEW,
+          RpcViewConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL_VIEW);
 
   @VisibleForTesting
   static final ImmutableSet<View> GRPC_SERVER_BASIC_VIEWS_SET =

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcViews.java
@@ -202,7 +202,7 @@ public final class RpcViews {
    *
    * <p>It is recommended to call this method before doing any RPC call to avoid missing stats.
    *
-   * @since 0.28
+   * @since 0.31.0
    */
   public static void registerClientRetryGrpcViews() {
     registerClientRetryGrpcViews(Stats.getViewManager());

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
@@ -57,6 +57,9 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRIES_PER_CALL).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL).isNotNull();
 
     // Test server measurement descriptors.
     assertThat(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT).isNotNull();

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -67,7 +67,7 @@ public final class RpcViewConstantsTest {
             8192.0, 16384.0, 32768.0, 65536.0)
         .inOrder();
     assertThat(RpcViewConstants.RETRY_COUNT_PER_CALL_BUCKET_BOUNDARIES)
-        .containsExactly(1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 100.0, 1000.0)
+        .containsExactly(1.0, 2.0, 3.0, 4.0, 5.0)
         .inOrder();
 
     // Test Aggregations

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -66,6 +66,9 @@ public final class RpcViewConstantsTest {
             0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0, 1024.0, 2048.0, 4096.0,
             8192.0, 16384.0, 32768.0, 65536.0)
         .inOrder();
+    assertThat(RpcViewConstants.RETRY_COUNT_PER_CALL_BUCKET_BOUNDARIES)
+        .containsExactly(1.0, 2.0, 3.0, 4.0, 5.0, 10.0, 100.0, 1000.0)
+        .inOrder();
 
     // Test Aggregations
     assertThat(RpcViewConstants.MEAN).isEqualTo(Mean.create());
@@ -82,7 +85,10 @@ public final class RpcViewConstantsTest {
         .isEqualTo(
             Distribution.create(
                 BucketBoundaries.create(RpcViewConstants.RPC_COUNT_BUCKET_BOUNDARIES)));
-
+    assertThat(RpcViewConstants.AGGREGATION_WITH_COUNT_RETRY_HISTOGRAM)
+        .isEqualTo(
+            Distribution.create(
+                BucketBoundaries.create(RpcViewConstants.RETRY_COUNT_PER_CALL_BUCKET_BOUNDARIES)));
     // Test Duration and Window
     assertThat(RpcViewConstants.MINUTE).isEqualTo(Duration.create(60, 0));
     assertThat(RpcViewConstants.HOUR).isEqualTo(Duration.create(60 * 60, 0));

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewConstantsTest.java
@@ -112,7 +112,11 @@ public final class RpcViewConstantsTest {
     assertThat(RpcViewConstants.GRPC_CLIENT_SENT_MESSAGES_PER_METHOD_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_RECEIVED_MESSAGES_PER_METHOD_VIEW).isNotNull();
     assertThat(RpcViewConstants.GRPC_CLIENT_SERVER_LATENCY_VIEW).isNotNull();
-    assertThat(RpcViewConstants.GRPC_CLIENT_STARTED_RPC_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_RETRIES_PER_CALL_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_RETRIES_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_VIEW).isNotNull();
+    assertThat(RpcViewConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL_VIEW).isNotNull();
 
     // Test server distribution view descriptors.
     assertThat(RpcViewConstants.RPC_SERVER_ERROR_COUNT_VIEW).isNotNull();

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
@@ -84,6 +84,14 @@ public class RpcViewsTest {
   }
 
   @Test
+  public void registerClientRetryGrpcViews() {
+    FakeViewManager fakeViewManager = new FakeViewManager();
+    RpcViews.registerClientRetryGrpcViews(fakeViewManager);
+    assertThat(fakeViewManager.getRegisteredViews())
+            .containsExactlyElementsIn(RpcViews.GRPC_CLIENT_RETRY_VIEWS_SET);
+  }
+
+  @Test
   public void registerServerGrpcViews() {
     FakeViewManager fakeViewManager = new FakeViewManager();
     RpcViews.registerServerGrpcViews(fakeViewManager);

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcViewsTest.java
@@ -88,7 +88,7 @@ public class RpcViewsTest {
     FakeViewManager fakeViewManager = new FakeViewManager();
     RpcViews.registerClientRetryGrpcViews(fakeViewManager);
     assertThat(fakeViewManager.getRegisteredViews())
-            .containsExactlyElementsIn(RpcViews.GRPC_CLIENT_RETRY_VIEWS_SET);
+        .containsExactlyElementsIn(RpcViews.GRPC_CLIENT_RETRY_VIEWS_SET);
   }
 
   @Test


### PR DESCRIPTION
Based on my [conversation](https://gitter.im/grpc/grpc?at=61a4e26bc2cc0e5343d657d8) with the grpc-java core team, the retry stats implementation of grpc-java is complete but lacks opencensus views. This PR adds them according to the measures and views outlined in the [A45-retry-stats](https://github.com/grpc/proposal/blob/master/A45-retry-stats.md#metrics-to-expose) proposal.


Some open questions:
- ~Given that `maxAttempts` maxes out at 5 in [A6-client-retries](https://github.com/grpc/proposal/blob/master/A6-client-retries.md#validation-of-retrypolicy) should we specify a tighter set of buckets for the views (possibly [0, 5]) that use a distribution aggregation~ (resolved)
- Do we need hourly and minute views for these stats? I can add them but I've left them off for now
- I followed the views outlined in the spec but it seems `GRPC_CLIENT_RETRIES_VIEW` and `GRPC_CLIENT_TRANSPARENT_RETRIES_VIEW` could be derived from their per-call counterparts
- I chose `0.28` for the `@since` annotation in the javadoc but maybe it should be the next minor version