### PR TITLE
Update and weaken Log4J2 dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -166,7 +166,7 @@ subprojects {
         googleAuthVersion = '0.20.0'
         googleCloudBetaVersion = '0.100.0-beta'
         googleCloudGaVersion = '1.82.0'
-        log4j2Version = '2.11.1'
+        log4j2Version = '2.15.0'
         signalfxVersion = '0.0.48'
         springBoot2Version = '2.1.5.RELEASE'
         springBootVersion = '1.5.15.RELEASE'

--- a/contrib/log_correlation/log4j2/build.gradle
+++ b/contrib/log_correlation/log4j2/build.gradle
@@ -6,7 +6,8 @@ dependencies {
     compile project(':opencensus-api')
     compileOnly libraries.log4j2
 
-    testCompile libraries.guava
+    testCompile libraries.guava,
+                libraries.log4j2
 
     signature "org.codehaus.mojo.signature:java16:+@signature"
 }

--- a/contrib/log_correlation/log4j2/build.gradle
+++ b/contrib/log_correlation/log4j2/build.gradle
@@ -3,8 +3,8 @@ description = 'OpenCensus Log4j 2 Log Correlation'
 apply plugin: 'java'
 
 dependencies {
-    compile project(':opencensus-api'),
-            libraries.log4j2
+    compile project(':opencensus-api')
+    compileOnly libraries.log4j2
 
     testCompile libraries.guava
 


### PR DESCRIPTION
* Use the more recent 2.15.0 as baseline
* For the published package, express a provided dependency
  rather than actually pulling in Log4J2 ourselves
