### PR TITLE
fix: Shutdown Stackdriver MetricServiceClient properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+- fix: Shutdown `MetricServiceClient` properly on `StackdriverStatsExporter.unregister()` (#2007)
+
 ## 0.28.3 - 2021-01-12
 
 - fix: Return public access to unsafe `ContextUtils` api.  Remove bincompat issue from 0.27.1. (#2072)


### PR DESCRIPTION
Using the default configuration of `StackdriverStatsConfiguration`, a `MetricServiceClient` is initialized by the `StackdriverStatsExporter`.

This client was never closed, this will be done now when the `StackdriverStatsExporter.unregister()` method is called.

If a custom `MetricServiceStub` is given by the user, it will *not* be closed as the user should be in charge of it.

This should fix #2007.