### PR TITLE
Fix retry stat measures to match those in grpc-java exactly

### DIFF
--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -244,9 +244,7 @@ public final class RpcMeasureConstants {
    */
   public static final MeasureLong GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL =
       Measure.MeasureLong.create(
-          "grpc.io/client/transparent_retries_per_call",
-          "Transparent retries per call",
-          COUNT);
+          "grpc.io/client/transparent_retries_per_call", "Transparent retries per call", COUNT);
 
   /**
    * {@link Measure} for total time of delay while there is no active attempt during the client

--- a/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
+++ b/contrib/grpc_metrics/src/main/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstants.java
@@ -235,7 +235,7 @@ public final class RpcMeasureConstants {
    */
   public static final MeasureLong GRPC_CLIENT_RETRIES_PER_CALL =
       Measure.MeasureLong.create(
-          "grpc.io/client/retries_per_call", "Number of retries per call.", COUNT);
+          "grpc.io/client/retries_per_call", "Number of retries per call", COUNT);
 
   /**
    * {@link Measure} for total number of transparent retries made during the client call.
@@ -245,7 +245,7 @@ public final class RpcMeasureConstants {
   public static final MeasureLong GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL =
       Measure.MeasureLong.create(
           "grpc.io/client/transparent_retries_per_call",
-          "Number of transparent retries per call.",
+          "Transparent retries per call",
           COUNT);
 
   /**
@@ -254,9 +254,9 @@ public final class RpcMeasureConstants {
    *
    * @since 0.28
    */
-  public static final MeasureLong GRPC_CLIENT_RETRY_DELAY_PER_CALL =
-      Measure.MeasureLong.create(
-          "grpc.io/client/retry_delay_per_call", "Retry delay per call.", MILLISECOND);
+  public static final MeasureDouble GRPC_CLIENT_RETRY_DELAY_PER_CALL =
+      Measure.MeasureDouble.create(
+          "grpc.io/client/retry_delay_per_call", "Retry delay per call", MILLISECOND);
 
   /**
    * {@link Measure} for gRPC client error counts.

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
@@ -18,7 +18,6 @@ package io.opencensus.contrib.grpc.metrics;
 
 import static com.google.common.truth.Truth.assertThat;
 
-import io.opencensus.stats.Measure;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -58,22 +57,9 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS).isNotNull();
-
-    // Test client retry measurement descriptors.
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRIES_PER_CALL)
-        .isEqualTo(
-            Measure.MeasureLong.create(
-                "grpc.io/client/retries_per_call", "Number of retries per call", "1"));
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL)
-        .isEqualTo(
-            Measure.MeasureLong.create(
-                "grpc.io/client/transparent_retries_per_call",
-                "Transparent retries per call",
-                "1"));
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL)
-        .isEqualTo(
-            Measure.MeasureDouble.create(
-                "grpc.io/client/retry_delay_per_call", "Retry delay per call", "ms"));
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRIES_PER_CALL).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL).isNotNull();
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL).isNotNull();
 
     // Test server measurement descriptors.
     assertThat(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT).isNotNull();

--- a/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
+++ b/contrib/grpc_metrics/src/test/java/io/opencensus/contrib/grpc/metrics/RpcMeasureConstantsTest.java
@@ -18,6 +18,7 @@ package io.opencensus.contrib.grpc.metrics;
 
 import static com.google.common.truth.Truth.assertThat;
 
+import io.opencensus.stats.Measure;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -57,9 +58,22 @@ public class RpcMeasureConstantsTest {
     assertThat(RpcMeasureConstants.GRPC_CLIENT_SERVER_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_ROUNDTRIP_LATENCY).isNotNull();
     assertThat(RpcMeasureConstants.GRPC_CLIENT_STARTED_RPCS).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRIES_PER_CALL).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL).isNotNull();
-    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL).isNotNull();
+
+    // Test client retry measurement descriptors.
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRIES_PER_CALL)
+        .isEqualTo(
+            Measure.MeasureLong.create(
+                "grpc.io/client/retries_per_call", "Number of retries per call", "1"));
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_TRANSPARENT_RETRIES_PER_CALL)
+        .isEqualTo(
+            Measure.MeasureLong.create(
+                "grpc.io/client/transparent_retries_per_call",
+                "Transparent retries per call",
+                "1"));
+    assertThat(RpcMeasureConstants.GRPC_CLIENT_RETRY_DELAY_PER_CALL)
+        .isEqualTo(
+            Measure.MeasureDouble.create(
+                "grpc.io/client/retry_delay_per_call", "Retry delay per call", "ms"));
 
     // Test server measurement descriptors.
     assertThat(RpcMeasureConstants.RPC_SERVER_ERROR_COUNT).isNotNull();


### PR DESCRIPTION
- fixes the retry stat measure to match those in grpc-java exactly as defined in [CensusStatsModule](https://github.com/grpc/grpc-java/blob/v1.44.0/census/src/main/java/io/grpc/census/CensusStatsModule.java#L401-L409)
  - it wasn't obvious to me that the description field for a measure has a meaningful purpose beyond describing the measure and because they didn't match what was in grpc-java #2084 did not have the intended effect
- corrects type of `GRPC_CLIENT_RETRY_DELAY_PER_CALL` from `MeasureLong` to `MeasureDouble` 

In the medium term grpc-java should reference the retry stat `Measure`s defined in opencensus-java instead of creating its own, although these are referenced in a file called [DeprecatedCensusConstants.java](https://github.com/grpc/grpc-java/blob/v1.44.0/census/src/main/java/io/grpc/census/internal/DeprecatedCensusConstants.java) so i'm not sure what the long-term goal there is.

