### PR TITLE
add ability to attach custom headers to traces

### DIFF
--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporter.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporter.java
@@ -81,7 +81,7 @@ public final class OcAgentTraceExporter {
               configuration.getRetryInterval(),
               configuration.getEnableConfig(),
               configuration.getDeadline(),
-                  configuration.getHeaders());
+              configuration.getHeaders());
       registerInternal(newHandler);
     }
   }

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporter.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporter.java
@@ -80,7 +80,8 @@ public final class OcAgentTraceExporter {
               configuration.getSslContext(),
               configuration.getRetryInterval(),
               configuration.getEnableConfig(),
-              configuration.getDeadline());
+              configuration.getDeadline(),
+                  configuration.getHeaders());
       registerInternal(newHandler);
     }
   }

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfiguration.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfiguration.java
@@ -19,6 +19,7 @@ package io.opencensus.exporter.trace.ocagent;
 import com.google.auto.value.AutoValue;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import io.netty.handler.ssl.SslContext;
 import io.opencensus.common.Duration;
 import javax.annotation.Nullable;
@@ -111,6 +112,12 @@ public abstract class OcAgentTraceExporterConfiguration {
    * @since 0.22
    */
   public abstract Duration getDeadline();
+
+  /**
+   * Returns custom headers to attach as gRPC metadata.
+   * @return
+   */
+  public abstract ImmutableMap<String, String> getHeaders();
 
   /**
    * Returns a new {@link Builder}.
@@ -209,6 +216,13 @@ public abstract class OcAgentTraceExporterConfiguration {
     abstract OcAgentTraceExporterConfiguration autoBuild();
 
     abstract Duration getDeadline();
+
+    abstract ImmutableMap.Builder<String, String> headersBuilder();
+
+    public final Builder addHeader(String key, String value) {
+      headersBuilder().put(key, value);
+      return this;
+    }
 
     /**
      * Builds a {@link OcAgentTraceExporterConfiguration}.

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfiguration.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfiguration.java
@@ -113,10 +113,7 @@ public abstract class OcAgentTraceExporterConfiguration {
    */
   public abstract Duration getDeadline();
 
-  /**
-   * Returns custom headers to attach as gRPC metadata.
-   * @return
-   */
+  /** Returns custom headers to attach as gRPC metadata. */
   public abstract ImmutableMap<String, String> getHeaders();
 
   /**

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterHandler.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterHandler.java
@@ -18,8 +18,10 @@ package io.opencensus.exporter.trace.ocagent;
 
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.Metadata;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
+import io.grpc.stub.MetadataUtils;
 import io.netty.handler.ssl.SslContext;
 import io.opencensus.common.Duration;
 import io.opencensus.exporter.trace.util.TimeLimitedHandler;
@@ -28,6 +30,7 @@ import io.opencensus.proto.agent.trace.v1.ExportTraceServiceRequest;
 import io.opencensus.proto.agent.trace.v1.TraceServiceGrpc;
 import io.opencensus.trace.export.SpanData;
 import java.util.Collection;
+import java.util.Map;
 import java.util.logging.Logger;
 import javax.annotation.Nullable;
 
@@ -42,6 +45,7 @@ final class OcAgentTraceExporterHandler extends TimeLimitedHandler {
   private final Node node;
   private final Boolean useInsecure;
   @Nullable private final SslContext sslContext;
+  private final Map<String, String> headers;
 
   @javax.annotation.Nullable
   private OcAgentTraceServiceExportRpcHandler exportRpcHandler; // Thread-safe
@@ -53,12 +57,14 @@ final class OcAgentTraceExporterHandler extends TimeLimitedHandler {
       @Nullable SslContext sslContext,
       Duration retryInterval,
       boolean enableConfig,
-      Duration deadline) {
+      Duration deadline,
+      Map<String, String> headers) {
     super(deadline, EXPORT_SPAN_NAME);
     this.endPoint = endPoint;
     this.node = OcAgentNodeUtils.getNodeInfo(serviceName);
     this.useInsecure = useInsecure;
     this.sslContext = sslContext;
+    this.headers = headers;
   }
 
   @Override
@@ -67,7 +73,7 @@ final class OcAgentTraceExporterHandler extends TimeLimitedHandler {
       // If not connected, try to initiate a new connection when a new batch of spans arrive.
       // Export RPC doesn't respect the retry interval.
       TraceServiceGrpc.TraceServiceStub stub =
-          getTraceServiceStub(endPoint, useInsecure, sslContext);
+          getTraceServiceStub(endPoint, useInsecure, sslContext, headers);
       exportRpcHandler = createExportRpcHandlerAndConnect(stub, node);
     }
 
@@ -104,7 +110,7 @@ final class OcAgentTraceExporterHandler extends TimeLimitedHandler {
   // Creates a TraceServiceStub with the given parameters.
   // One stub can be used for both Export RPC and Config RPC.
   private static TraceServiceGrpc.TraceServiceStub getTraceServiceStub(
-      String endPoint, Boolean useInsecure, SslContext sslContext) {
+      String endPoint, Boolean useInsecure, SslContext sslContext, Map<String, String> headers) {
     ManagedChannelBuilder<?> channelBuilder;
     if (useInsecure) {
       channelBuilder = ManagedChannelBuilder.forTarget(endPoint).usePlaintext();
@@ -115,6 +121,10 @@ final class OcAgentTraceExporterHandler extends TimeLimitedHandler {
               .sslContext(sslContext);
     }
     ManagedChannel channel = channelBuilder.build();
-    return TraceServiceGrpc.newStub(channel);
+    Metadata metadata = new Metadata();
+    for(Map.Entry<String, String> e : headers.entrySet()) {
+      metadata.put(Metadata.Key.of(e.getKey(), Metadata.ASCII_STRING_MARSHALLER), e.getValue());
+    }
+    return TraceServiceGrpc.newStub(channel).withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
   }
 }

--- a/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterHandler.java
+++ b/exporters/trace/ocagent/src/main/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterHandler.java
@@ -122,9 +122,10 @@ final class OcAgentTraceExporterHandler extends TimeLimitedHandler {
     }
     ManagedChannel channel = channelBuilder.build();
     Metadata metadata = new Metadata();
-    for(Map.Entry<String, String> e : headers.entrySet()) {
+    for (Map.Entry<String, String> e : headers.entrySet()) {
       metadata.put(Metadata.Key.of(e.getKey(), Metadata.ASCII_STRING_MARSHALLER), e.getValue());
     }
-    return TraceServiceGrpc.newStub(channel).withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
+    return TraceServiceGrpc.newStub(channel)
+        .withInterceptors(MetadataUtils.newAttachHeadersInterceptor(metadata));
   }
 }

--- a/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfigurationTest.java
+++ b/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfigurationTest.java
@@ -60,6 +60,7 @@ public class OcAgentTraceExporterConfigurationTest {
             .setRetryInterval(oneMinute)
             .setEnableConfig(false)
             .setDeadline(oneMinute)
+                .addHeader("foo", "bar")
             .build();
     assertThat(configuration.getEndPoint()).isEqualTo("192.168.0.1:50051");
     assertThat(configuration.getServiceName()).isEqualTo("service");
@@ -68,5 +69,6 @@ public class OcAgentTraceExporterConfigurationTest {
     assertThat(configuration.getRetryInterval()).isEqualTo(oneMinute);
     assertThat(configuration.getEnableConfig()).isFalse();
     assertThat(configuration.getDeadline()).isEqualTo(oneMinute);
+    assertThat(configuration.getHeaders()).containsExactly("foo", "bar");
   }
 }

--- a/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfigurationTest.java
+++ b/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterConfigurationTest.java
@@ -60,7 +60,7 @@ public class OcAgentTraceExporterConfigurationTest {
             .setRetryInterval(oneMinute)
             .setEnableConfig(false)
             .setDeadline(oneMinute)
-                .addHeader("foo", "bar")
+            .addHeader("foo", "bar")
             .build();
     assertThat(configuration.getEndPoint()).isEqualTo("192.168.0.1:50051");
     assertThat(configuration.getServiceName()).isEqualTo("service");

--- a/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterIntegrationTest.java
+++ b/exporters/trace/ocagent/src/test/java/io/opencensus/exporter/trace/ocagent/OcAgentTraceExporterIntegrationTest.java
@@ -37,13 +37,12 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.Executor;
+import javax.annotation.concurrent.GuardedBy;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-
-import javax.annotation.concurrent.GuardedBy;
 
 /** End-to-end integration test for {@link OcAgentTraceExporter}. */
 @RunWith(JUnit4.class)
@@ -63,7 +62,10 @@ public class OcAgentTraceExporterIntegrationTest {
     fakeOcAgentTraceServiceGrpc = new FakeOcAgentTraceServiceGrpcImpl();
     headerInterceptor = new HeaderInterceptor();
     agent =
-        getServer(OcAgentTraceExporterConfiguration.DEFAULT_END_POINT, fakeOcAgentTraceServiceGrpc, headerInterceptor);
+        getServer(
+            OcAgentTraceExporterConfiguration.DEFAULT_END_POINT,
+            fakeOcAgentTraceServiceGrpc,
+            headerInterceptor);
   }
 
   @After
@@ -165,8 +167,9 @@ public class OcAgentTraceExporterIntegrationTest {
       assertThat(exportedSpanNames).contains("second-iteration-child-" + i);
     }
 
-    for(Metadata metadata : headerInterceptor.getReceivedMetadata()) {
-      Metadata.Key<String> key = Metadata.Key.of(TEST_METADATA_HEADER, Metadata.ASCII_STRING_MARSHALLER);
+    for (Metadata metadata : headerInterceptor.getReceivedMetadata()) {
+      Metadata.Key<String> key =
+          Metadata.Key.of(TEST_METADATA_HEADER, Metadata.ASCII_STRING_MARSHALLER);
       assertThat(metadata.containsKey(key)).isTrue();
       assertThat(metadata.get(key)).isEqualTo(TEST_METADATA_VALUE);
     }
@@ -201,7 +204,9 @@ public class OcAgentTraceExporterIntegrationTest {
     }
   }
 
-  private static Server getServer(String endPoint, BindableService service, HeaderInterceptor headerInterceptor) throws IOException {
+  private static Server getServer(
+      String endPoint, BindableService service, HeaderInterceptor headerInterceptor)
+      throws IOException {
     ServerBuilder<?> builder = NettyServerBuilder.forAddress(parseEndpoint(endPoint));
     Executor executor = MoreExecutors.directExecutor();
     builder.executor(executor);
@@ -222,8 +227,10 @@ public class OcAgentTraceExporterIntegrationTest {
   private static class HeaderInterceptor implements ServerInterceptor {
     @GuardedBy("this")
     private final List<Metadata> receivedMetadata = new ArrayList<>();
+
     @Override
-    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+        ServerCall<ReqT, RespT> call, Metadata headers, ServerCallHandler<ReqT, RespT> next) {
       addReceivedMetadata(headers);
       return next.startCall(call, headers);
     }


### PR DESCRIPTION
This change adds the ability to attach custom gRPC metadata headers to trace requests.

The Go library has a WithHeaders() option with this functionality: https://pkg.go.dev/contrib.go.opencensus.io/exporter/ocagent#WithHeaders