### PR TITLE
Stackdriver exporter: add workload.googleapis.com as a supported external domain

### DIFF
--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
@@ -44,8 +44,8 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
   private static final Logger logger =
       Logger.getLogger(CreateMetricDescriptorExporter.class.getName());
   private static final ImmutableSet<String> SUPPORTED_EXTERNAL_DOMAINS =
-      ImmutableSet.<String>of("custom.googleapis.com", "external.googleapis.com",
-      "workload.googleapis.com");
+      ImmutableSet.<String>of(
+          "custom.googleapis.com", "external.googleapis.com", "workload.googleapis.com");
   private static final String GOOGLE_APIS_DOMAIN_SUFFIX = "googleapis.com";
 
   private final String projectId;

--- a/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
+++ b/exporters/stats/stackdriver/src/main/java/io/opencensus/exporter/stats/stackdriver/CreateMetricDescriptorExporter.java
@@ -44,7 +44,8 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
   private static final Logger logger =
       Logger.getLogger(CreateMetricDescriptorExporter.class.getName());
   private static final ImmutableSet<String> SUPPORTED_EXTERNAL_DOMAINS =
-      ImmutableSet.<String>of("custom.googleapis.com", "external.googleapis.com");
+      ImmutableSet.<String>of("custom.googleapis.com", "external.googleapis.com",
+      "workload.googleapis.com");
   private static final String GOOGLE_APIS_DOMAIN_SUFFIX = "googleapis.com";
 
   private final String projectId;
@@ -166,8 +167,8 @@ final class CreateMetricDescriptorExporter extends MetricExporter {
     if (!metricDomain.endsWith(GOOGLE_APIS_DOMAIN_SUFFIX)) {
       return false; // domains like "my.org" are not Stackdriver built-in metrics.
     }
-    // All googleapis.com domains except "custom.googleapis.com" or "external.googleapis.com"
-    // are built-in metrics.
+    // All googleapis.com domains except "custom.googleapis.com", "external.googleapis.com",
+    // or "workload.googleapis.com" are built-in metrics.
     return !SUPPORTED_EXTERNAL_DOMAINS.contains(metricDomain);
   }
 }


### PR DESCRIPTION
This allows metric descriptors to be created for metrics in that domain