### PR TITLE
POC: Allow limit the number of samples in InProcessSampledSpanStoreImpl

### DIFF
--- a/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
+++ b/api/src/main/java/io/opencensus/trace/export/SampledSpanStore.java
@@ -74,6 +74,18 @@ public abstract class SampledSpanStore {
   public abstract Summary getSummary();
 
   /**
+   * Sets the maximum number of Spans in th {@code SampledSpanStore}.
+   *
+   * Should be a positive number. The {@code SampledSpanStore} can only grow in size.
+   *
+   * @param maxNumberOfSpans the maximum number of Spans in th {@code SampledSpanStore}.
+   * @throws IllegalArgumentException if {@code maxNumberOfSpans} is negative or zero.
+   */
+  public void setMaxNumberOfSpans(int maxNumberOfSpans) {
+    // HAS NO EFFECT UNLESS IMPLEMENTED
+  }
+
+  /**
    * Returns a list of succeeded spans (spans with {@link Status} equal to {@link Status#OK}) that
    * match the {@code filter}.
    *
@@ -139,7 +151,7 @@ public abstract class SampledSpanStore {
    */
   public abstract Set<String> getRegisteredSpanNamesForCollection();
 
-  /**
+    /**
    * The summary of all available data.
    *
    * @since 0.5


### PR DESCRIPTION
Some of our production systems were OOME-imng because `InProcessSampledSpanStoreImpl` is unbounded. This PR adds an API to limit the number of span names for which samples will be collected.