### PR TITLE
Upgrade ubuntu runner to latest

### DIFF
--- a/.github/workflows/build-checker.yml
+++ b/.github/workflows/build-checker.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build Checker
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/build-gradle-examples.yml
+++ b/.github/workflows/build-gradle-examples.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build Gradle Examples Ubuntu
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/build-maven-examples.yml
+++ b/.github/workflows/build-maven-examples.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build Maven Examples Ubuntu
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2.3.4
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,12 +14,12 @@ jobs:
       matrix:
         os:
           - macos-latest
-          - ubuntu-18.04
+          - ubuntu-latest
         java:
           - 8
           # TODO: Java 11 build doesn't work due to Java7 target.
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-latest
             java: 8
             coverage: true
     steps:


### PR DESCRIPTION
18.04 runner is deprecated https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/
